### PR TITLE
cluster: Move cluster creation to cluster package.

### DIFF
--- a/pkg/aws/utils.go
+++ b/pkg/aws/utils.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/openshift/moactl/assets"
@@ -79,6 +80,24 @@ func CheckPermissionsUsingQueryClient(queryClient, targetClient *awsClient, poli
 
 	return true, nil
 
+}
+
+// GetRegion will return a region selected by the user or given as a default to the AWS client.
+// If the region given is empty, it will first attempt to use the default, and, failing that, will
+// prompt for user input.
+func GetRegion(region string) (string, error) {
+	if region == "" {
+		defaultSession, err := session.NewSessionWithOptions(session.Options{
+			SharedConfigState: session.SharedConfigEnable,
+		})
+
+		if err != nil {
+			return "", fmt.Errorf("error creating default session for AWS client: %v", err)
+		}
+
+		region = *defaultSession.Config.Region
+	}
+	return region, nil
 }
 
 // getClientDetails will return the *iam.User associated with the provided client's credentials,


### PR DESCRIPTION
Cluster creation has been moved to the cluster package. In order to
facilitate this, a config object has been created that packages up the
various cluster config options. This will allow for e2e testing a little
better than before, as all of the MOA specific cluster spec logic will
be housed in moactl.

Note: This has been tested and works as expected.