### PR TITLE
Add permissions command to verify

### DIFF
--- a/cmd/initialize/cmd.go
+++ b/cmd/initialize/cmd.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/moactl/cmd/login"
+	"github.com/openshift/moactl/cmd/verify/permissions"
 	"github.com/openshift/moactl/cmd/verify/quota"
 
 	"github.com/openshift/moactl/pkg/aws"
@@ -67,6 +68,8 @@ func init() {
 	flags.AddFlagSet(login.Cmd.Flags())
 	// Force-load all flags from `verify` into `init`
 	flags.AddFlagSet(quota.Cmd.Flags())
+	// Force-load all flags from `permissions` into `init`
+	flags.AddFlagSet(permissions.Cmd.Flags())
 }
 
 func run(cmd *cobra.Command, argv []string) {
@@ -191,17 +194,9 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(0)
 	}
 
-	// Validate SCP policies for current user's account
-	reporter.Infof("Validating SCP policies...")
-	ok, err = client.ValidateSCP()
-	if err != nil {
-		reporter.Errorf("Error validating SCP policies: %v", err)
-		os.Exit(1)
-	}
-	if !ok {
-		reporter.Warnf("Failed to validate SCP policies. Will try to continue anyway...")
-	}
-	reporter.Infof("SCP/IAM permissions validated...")
+	// Validate AWS SCP/IAM Permissions
+	// Call `verify permisisons` as partof init
+	permissions.Cmd.Run(cmd, argv)
 
 	// Validate AWS quota
 	// Call `verify quota` as part of init

--- a/cmd/verify/cmd.go
+++ b/cmd/verify/cmd.go
@@ -19,6 +19,7 @@ package verify
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/moactl/cmd/verify/permissions"
 	"github.com/openshift/moactl/cmd/verify/quota"
 )
 
@@ -30,4 +31,5 @@ var Cmd = &cobra.Command{
 
 func init() {
 	Cmd.AddCommand(quota.Cmd)
+	Cmd.AddCommand(permissions.Cmd)
 }

--- a/cmd/verify/permissions/cmd.go
+++ b/cmd/verify/permissions/cmd.go
@@ -1,0 +1,77 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package permissions
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/moactl/pkg/aws"
+	"github.com/openshift/moactl/pkg/logging"
+	rprtr "github.com/openshift/moactl/pkg/reporter"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "permissions",
+	Short: "Verify AWS permissions are ok for cluster install",
+	Long:  "Verify AWS permissions are ok for cluster install",
+	Example: `  # Verify resources needed to create a cluster are configured as expected
+
+  # Verify AWS permissions are configured correctly
+  moactl verify permissions`,
+	Run: run,
+}
+
+func run(cmd *cobra.Command, argv []string) {
+	// Create the reporter:
+	reporter, err := rprtr.New().
+		Build()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create reporter: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Create the logger:
+	logger, err := logging.NewLogger().Build()
+	if err != nil {
+		reporter.Errorf("Failed to create logger: %v", err)
+		os.Exit(1)
+	}
+
+	// Create the AWS client:
+	client, err := aws.NewClient().
+		Logger(logger).
+		Build()
+	if err != nil {
+		reporter.Errorf("Error creating AWS client: %v", err)
+		os.Exit(1)
+	}
+
+	reporter.Infof("Validating SCP policies...")
+	ok, err := client.ValidateSCP()
+	if err != nil {
+		reporter.Errorf("Unable to validate SCP policies")
+		reporter.Errorf("%v", err)
+		os.Exit(1)
+	}
+	if !ok {
+		reporter.Warnf("Failed to validate SCP policies. Will try to continue anyway...")
+	}
+	reporter.Infof("AWS SCP policies ok")
+}

--- a/docs/moactl_verify.md
+++ b/docs/moactl_verify.md
@@ -22,5 +22,6 @@ Verify resources are configured correctly for cluster install
 ### SEE ALSO
 
 * [moactl](moactl.md)	 - 
+* [moactl verify permissions](moactl_verify_permissions.md)	 - Verify AWS permissions are ok for cluster install
 * [moactl verify quota](moactl_verify_quota.md)	 - Verify AWS quota is ok for cluster install
 

--- a/docs/moactl_verify_permissions.md
+++ b/docs/moactl_verify_permissions.md
@@ -1,0 +1,38 @@
+## moactl verify permissions
+
+Verify AWS permissions are ok for cluster install
+
+### Synopsis
+
+Verify AWS permissions are ok for cluster install
+
+```
+moactl verify permissions [flags]
+```
+
+### Examples
+
+```
+  # Verify resources needed to create a cluster are configured as expected
+
+  # Verify AWS permissions are configured correctly
+  moactl verify permissions
+```
+
+### Options
+
+```
+  -h, --help   help for permissions
+```
+
+### Options inherited from parent commands
+
+```
+      --debug     Enable debug mode.
+  -v, --v Level   log level for V logs
+```
+
+### SEE ALSO
+
+* [moactl verify](moactl_verify.md)	 - Verify resources are configured correctly for cluster install
+

--- a/pkg/aws/permissions.go
+++ b/pkg/aws/permissions.go
@@ -1,5 +1,14 @@
 package aws
 
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/openshift/moactl/assets"
+)
+
 // PermissionGroup is the group of permissions needed by cluster creation, operation, or teardown.
 type PermissionGroup string
 
@@ -21,6 +30,12 @@ type PolicyDocument struct {
 	Statement []PolicyStatement `json:"statement"`
 }
 
+// SimulateParams captures any additional details that should be used
+// when simulating permissions.
+type SimulateParams struct {
+	Region string
+}
+
 const (
 	// PermissionCreateBase is a base set of permissions required in all installs where the installer creates resources.
 	PermissionCreateBase PermissionGroup = "create-base"
@@ -38,6 +53,7 @@ const (
 	region = "eu-central-1"
 )
 
+// Permissions list of permissions required to install a cluster
 var permissions = map[PermissionGroup][]string{
 	// Base set of permissions required for cluster creation
 	PermissionCreateBase: {
@@ -224,4 +240,125 @@ var permissions = map[PermissionGroup][]string{
 		"ec2:DisassociateRouteTable",
 		"ec2:ReplaceRouteTableAssociation",
 	},
+}
+
+// checkPermissionsUsingQueryClient will use queryClient to query whether the credentials in targetClient can perform the actions
+// listed in the statementEntries. queryClient will need iam:GetUser and iam:SimulatePrincipalPolicy
+func checkPermissionsUsingQueryClient(queryClient, targetClient *awsClient, policyDocument PolicyDocument,
+	params *SimulateParams) (bool, error) {
+
+	// Ignoring isRoot here since we only warn the user that its not best pratice to use it.
+	// TODO: Add a check for isRoot in the initalizer
+	targetUser, _, err := getClientDetails(targetClient)
+	if err != nil {
+		return false, fmt.Errorf("error gathering AWS credentials details: %v", err)
+	}
+
+	allowList := []*string{}
+	for _, statement := range policyDocument.Statement {
+		for _, action := range statement.Action {
+			allowList = append(allowList, aws.String(action))
+		}
+	}
+
+	input := &iam.SimulatePrincipalPolicyInput{
+		PolicySourceArn: targetUser.Arn,
+		ActionNames:     allowList,
+		ContextEntries:  []*iam.ContextEntry{},
+	}
+
+	if params != nil {
+		if params.Region != "" {
+			input.ContextEntries = append(input.ContextEntries, &iam.ContextEntry{
+				ContextKeyName:   aws.String("aws:RequestedRegion"),
+				ContextKeyType:   aws.String("stringList"),
+				ContextKeyValues: []*string{aws.String(params.Region)},
+			})
+		}
+	}
+
+	// Either all actions are allowed and we'll return 'true', or it's a failure
+	allClear := true
+	// Collect all failed actions
+	var failedActions []string
+
+	err = queryClient.iamClient.SimulatePrincipalPolicyPages(input, func(response *iam.SimulatePolicyResponse, lastPage bool) bool {
+
+		for _, result := range response.EvaluationResults {
+			if *result.EvalDecision != "allowed" {
+				// Don't bail out after the first failure, so we can log the full list
+				// of failed/denied actions
+				failedActions = append(failedActions, *result.EvalActionName)
+				allClear = false
+			}
+		}
+		return !lastPage
+	})
+	if err != nil {
+		return false, fmt.Errorf("error simulating policy: %v", err)
+	}
+
+	if !allClear {
+		return false, fmt.Errorf("actions not allowed with tested credentials: %v", failedActions)
+	}
+
+	return true, nil
+
+}
+
+func validatePolicyDocuments(queryClient, targetClient *awsClient, policyDocuments []PolicyDocument, sParams *SimulateParams) (bool, error) {
+	permissionsOk := true
+
+	for _, policyDocument := range policyDocuments {
+		permissionsOk, err := checkPermissionsUsingQueryClient(queryClient, targetClient, policyDocument, sParams)
+		if err != nil {
+			return false, err
+		}
+		if !permissionsOk {
+			return false, fmt.Errorf("Unable to validate permissions in %s", policyDocument.ID)
+		}
+
+	}
+
+	return permissionsOk, nil
+}
+
+// generatePolicyDocument generates an IAM policy Document from a list of actions
+func generatePolicyDocument(actions []string, id *string) PolicyDocument {
+	policyDocument := PolicyDocument{}
+
+	if id != nil {
+		policyDocument.ID = aws.StringValue(id)
+	}
+
+	for _, action := range actions {
+		policyStatement := PolicyStatement{
+			Effect:   "Allow",
+			Action:   []string{action},
+			Resource: []string{"*"},
+		}
+		policyDocument.Statement = append(policyDocument.Statement, policyStatement)
+	}
+
+	return policyDocument
+}
+
+// readSCPPolicy reads a SCP policy from file into a Policy Document
+// SCP policies are structured the same as a IAM Policy Document the contain
+// IAM Policy Statements
+func readSCPPolicy(policyDocumentPath string) PolicyDocument {
+
+	policyDocumentFile, err := assets.Asset(policyDocumentPath)
+	if err != nil {
+		fmt.Println(fmt.Errorf("Unable to load file: %s", policyDocumentPath))
+	}
+
+	policyDocument := PolicyDocument{}
+
+	err = json.Unmarshal([]byte(policyDocumentFile), &policyDocument)
+	if err != nil {
+		fmt.Println(fmt.Errorf("Error unmarshalling statement: %v", err))
+	}
+
+	return policyDocument
 }

--- a/pkg/aws/utils.go
+++ b/pkg/aws/utils.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -11,76 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/openshift/moactl/assets"
 )
-
-// SimulateParams captures any additional details that should be used
-// when simulating permissions.
-type SimulateParams struct {
-	Region string
-}
-
-// CheckPermissionsUsingQueryClient will use queryClient to query whether the credentials in targetClient can perform the actions
-// listed in the statementEntries. queryClient will need iam:GetUser and iam:SimulatePrincipalPolicy
-func CheckPermissionsUsingQueryClient(queryClient, targetClient *awsClient, policyDocument PolicyDocument,
-	params *SimulateParams) (bool, error) {
-
-	// Ignoring isRoot here since we only warn the user that its not best pratice to use it.
-	// TODO: Add a check for isRoot in the initalizer
-	targetUser, _, err := getClientDetails(targetClient)
-	if err != nil {
-		return false, fmt.Errorf("error gathering AWS credentials details: %v", err)
-	}
-
-	allowList := []*string{}
-	for _, statement := range policyDocument.Statement {
-		for _, action := range statement.Action {
-			allowList = append(allowList, aws.String(action))
-		}
-	}
-
-	input := &iam.SimulatePrincipalPolicyInput{
-		PolicySourceArn: targetUser.Arn,
-		ActionNames:     allowList,
-		ContextEntries:  []*iam.ContextEntry{},
-	}
-
-	if params != nil {
-		if params.Region != "" {
-			input.ContextEntries = append(input.ContextEntries, &iam.ContextEntry{
-				ContextKeyName:   aws.String("aws:RequestedRegion"),
-				ContextKeyType:   aws.String("stringList"),
-				ContextKeyValues: []*string{aws.String(params.Region)},
-			})
-		}
-	}
-
-	// Either all actions are allowed and we'll return 'true', or it's a failure
-	allClear := true
-	// Collect all failed actions
-	var failedActions []string
-
-	err = queryClient.iamClient.SimulatePrincipalPolicyPages(input, func(response *iam.SimulatePolicyResponse, lastPage bool) bool {
-
-		for _, result := range response.EvaluationResults {
-			if *result.EvalDecision != "allowed" {
-				// Don't bail out after the first failure, so we can log the full list
-				// of failed/denied actions
-				failedActions = append(failedActions, *result.EvalActionName)
-				allClear = false
-			}
-		}
-		return !lastPage
-	})
-	if err != nil {
-		return false, fmt.Errorf("error simulating policy: %v", err)
-	}
-
-	if !allClear {
-		return false, fmt.Errorf("actions not allowed with tested credentials: %v", failedActions)
-	}
-
-	return true, nil
-
-}
 
 // GetRegion will return a region selected by the user or given as a default to the AWS client.
 // If the region given is empty, it will first attempt to use the default, and, failing that, will
@@ -123,46 +52,6 @@ func getClientDetails(awsClient *awsClient) (*iam.User, bool, error) {
 	return user.User, rootUser, nil
 }
 
-// generatePolicyDocument generates an IAM policy Document from a list of actions
-func generatePolicyDocument(actions []string, id *string) PolicyDocument {
-	policyDocument := PolicyDocument{}
-
-	if id != nil {
-		policyDocument.ID = aws.StringValue(id)
-	}
-
-	for _, action := range actions {
-		policyStatement := PolicyStatement{
-			Effect:   "Allow",
-			Action:   []string{action},
-			Resource: []string{"*"},
-		}
-		policyDocument.Statement = append(policyDocument.Statement, policyStatement)
-	}
-
-	return policyDocument
-}
-
-// ReadSCPPolicy reads a SCP policy from file into a Policy Document
-// SCP policies are structured the same as a IAM Policy Document the contain
-// IAM Policy Statements
-func readSCPPolicy(policyDocumentPath string) PolicyDocument {
-
-	policyDocumentFile, err := assets.Asset(policyDocumentPath)
-	if err != nil {
-		fmt.Println(fmt.Errorf("Unable to load file: %s", policyDocumentPath))
-	}
-
-	policyDocument := PolicyDocument{}
-
-	err = json.Unmarshal([]byte(policyDocumentFile), &policyDocument)
-	if err != nil {
-		fmt.Println(fmt.Errorf("Error unmarshalling statement: %v", err))
-	}
-
-	return policyDocument
-}
-
 // Build cloudformation stack input
 func buildStackInput(cfTemplateBody, stackName string) *cloudformation.CreateStackInput {
 	// Special cloudformation capabilities are required to craete IAM resources in AWS
@@ -188,21 +77,4 @@ func readCFTemplate() (string, error) {
 	}
 
 	return string(cfTemplate), nil
-}
-
-func validatePolicyDocuments(queryClient, targetClient *awsClient, policyDocuments []PolicyDocument, sParams *SimulateParams) (bool, error) {
-	permissionsOk := true
-
-	for _, policyDocument := range policyDocuments {
-		permissionsOk, err := CheckPermissionsUsingQueryClient(queryClient, targetClient, policyDocument, sParams)
-		if err != nil {
-			return false, err
-		}
-		if !permissionsOk {
-			return false, fmt.Errorf("Unable to validate permissions in %s", policyDocument.ID)
-		}
-
-	}
-
-	return permissionsOk, nil
 }


### PR DESCRIPTION
This PR adds the permissions command to `moactl verify` and also refactors placement of some of the permissions code.