### PR TITLE
ingress: Allow using sub-domain identifier

### DIFF
--- a/cmd/dlt/ingress/cmd.go
+++ b/cmd/dlt/ingress/cmd.go
@@ -32,7 +32,7 @@ import (
 
 // Regular expression to used to make sure that the identifier given by the
 // user is safe and that it there is no risk of SQL injection:
-var ingressKeyRE = regexp.MustCompile(`^[a-z0-9]{4}$`)
+var ingressKeyRE = regexp.MustCompile(`^[a-z0-9]{3,5}$`)
 
 var args struct {
 	clusterKey string
@@ -44,7 +44,10 @@ var Cmd = &cobra.Command{
 	Short:   "Delete cluster ingress",
 	Long:    "Delete the additional non-default application router for a cluster.",
 	Example: `  # Delete ingress with ID a1b2 from a cluster named 'mycluster'
-  moactl delete ingress --cluster=mycluster a1b2`,
+  moactl delete ingress --cluster=mycluster a1b2
+
+  # Delete secondary ingress using the sub-domain name
+  moactl delete ingress --cluster=mycluster apps2`,
 	Run: run,
 }
 
@@ -157,6 +160,12 @@ func run(_ *cobra.Command, argv []string) {
 
 	var ingress *cmv1.Ingress
 	for _, item := range ingresses {
+		if ingressID == "apps" && item.Default() {
+			ingress = item
+		}
+		if ingressID == "apps2" && !item.Default() {
+			ingress = item
+		}
 		if item.ID() == ingressID {
 			ingress = item
 		}

--- a/cmd/edit/ingress/cmd.go
+++ b/cmd/edit/ingress/cmd.go
@@ -34,7 +34,7 @@ import (
 
 // Regular expression to used to make sure that the identifier given by the
 // user is safe and that it there is no risk of SQL injection:
-var ingressKeyRE = regexp.MustCompile(`^[a-z0-9]{3,4}$`)
+var ingressKeyRE = regexp.MustCompile(`^[a-z0-9]{3,5}$`)
 
 var args struct {
 	clusterKey string
@@ -47,11 +47,14 @@ var Cmd = &cobra.Command{
 	Aliases: []string{"route"},
 	Short:   "Edit the additional cluster ingress",
 	Long:    "Edit the additional non-default application router for a cluster.",
-	Example: `  # Make additional ingress private on a cluster named 'mycluster'
-  moactl edit ingress --private --cluster=mycluster
+	Example: `  # Make additional ingress with ID 'a1b2' private on a cluster named 'mycluster'
+  moactl edit ingress --private --cluster=mycluster a1b2
 
-  # Update the router selectors for the additional ingress
-  moactl edit ingress --label-match=foo=bar --cluster=mycluster`,
+  # Update the router selectors for the additional ingress with ID 'a1b2'
+  moactl edit ingress --label-match=foo=bar --cluster=mycluster a1b2
+
+  # Update the default ingress using the sub-domain identifier
+  moactl edit ingress --private=false --cluster=mycluster apps`,
 	Run: run,
 }
 
@@ -210,6 +213,12 @@ func run(cmd *cobra.Command, argv []string) {
 
 	var ingress *cmv1.Ingress
 	for _, item := range ingresses {
+		if ingressID == "apps" && item.Default() {
+			ingress = item
+		}
+		if ingressID == "apps2" && !item.Default() {
+			ingress = item
+		}
 		if item.ID() == ingressID {
 			ingress = item
 		}

--- a/docs/moactl_delete_ingress.md
+++ b/docs/moactl_delete_ingress.md
@@ -15,6 +15,9 @@ moactl delete ingress [flags]
 ```
   # Delete ingress with ID a1b2 from a cluster named 'mycluster'
   moactl delete ingress --cluster=mycluster a1b2
+
+  # Delete secondary ingress using the sub-domain name
+  moactl delete ingress --cluster=mycluster apps2
 ```
 
 ### Options

--- a/docs/moactl_edit_ingress.md
+++ b/docs/moactl_edit_ingress.md
@@ -13,11 +13,14 @@ moactl edit ingress [flags]
 ### Examples
 
 ```
-  # Make additional ingress private on a cluster named 'mycluster'
-  moactl edit ingress --private --cluster=mycluster
+  # Make additional ingress with ID 'a1b2' private on a cluster named 'mycluster'
+  moactl edit ingress --private --cluster=mycluster a1b2
 
-  # Update the router selectors for the additional ingress
-  moactl edit ingress --label-match=foo=bar --cluster=mycluster
+  # Update the router selectors for the additional ingress with ID 'a1b2'
+  moactl edit ingress --label-match=foo=bar --cluster=mycluster a1b2
+
+  # Update the default ingress using the sub-domain identifier
+  moactl edit ingress --private=false --cluster=mycluster apps
 ```
 
 ### Options


### PR DESCRIPTION
When editing or deleting an ingress, we currently need to use the
auto-generated ID. Since the sub-domain is consistent for all routes and
ingress endpoints (api, apps, apps2), we allow it to be used instead of
the identifier. This also allows for some level of automation.