### PR TITLE
OSD-4362: add additional debug information verify permissions

### DIFF
--- a/cmd/verify/permissions/cmd.go
+++ b/cmd/verify/permissions/cmd.go
@@ -64,6 +64,8 @@ func run(cmd *cobra.Command, argv []string) {
 	if err != nil {
 		reporter.Errorf("Unable to validate SCP policies")
 		reporter.Errorf("%v", err)
+		reporter.Infof("Verify your user's AWS account permissions")
+		reporter.Infof("You can set it up correctly by running aws iam attach-user-policy --user-name <username> --policy-arn \"arn:aws:iam::aws:policy/AdministratorAccess\" ")
 		os.Exit(1)
 	}
 	if !ok {

--- a/cmd/verify/permissions/cmd.go
+++ b/cmd/verify/permissions/cmd.go
@@ -64,8 +64,10 @@ func run(cmd *cobra.Command, argv []string) {
 	if err != nil {
 		reporter.Errorf("Unable to validate SCP policies")
 		reporter.Errorf("%v", err)
-		reporter.Infof("Verify your user's AWS account permissions")
-		reporter.Infof("You can set it up correctly by running aws iam attach-user-policy --user-name <username> --policy-arn \"arn:aws:iam::aws:policy/AdministratorAccess\" ")
+		permissionErrMessage := `Verify your user's AWS account permissions
+                You can set it up correctly by running
+                aws iam attach-user-policy --user-name <username> --policy-arn \"arn:aws:iam::aws:policy/AdministratorAccess\"`
+		reporter.Infof(permissionErrMessage)
 		os.Exit(1)
 	}
 	if !ok {


### PR DESCRIPTION
This is very much a monkey patch to give users a pointer where to go if the permission verify fails.
