### PR TITLE
create-cluster: Set default version

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -348,6 +348,9 @@ func run(cmd *cobra.Command, _ []string) {
 		reporter.Errorf(fmt.Sprintf("%s", err))
 		os.Exit(1)
 	}
+	if version == "" {
+		version = versionList[0]
+	}
 	if interactive.Enabled() {
 		version, err = interactive.GetOption(interactive.Input{
 			Question: "OpenShift version",


### PR DESCRIPTION
If no version is set in the CLI, the interactive mode does not set
a proper default. This means that a user pressing [Enter] through the
prompts will end up _not_ selecting a version, even though it appears as
they do.