### PR TITLE
login: Hide 'env' parameter

### DIFF
--- a/cmd/login/cmd.go
+++ b/cmd/login/cmd.go
@@ -55,11 +55,8 @@ var Cmd = &cobra.Command{
 		"\t3. Environment variable (OCM_TOKEN)\n"+
 		"\t4. Configuration file\n"+
 		"\t5. Command-line prompt\n", uiTokenPage),
-	Example: `  # Login to the OpenShift staging API with an existing token
-  rosa login --env staging --token=$OFFLINE_ACCESS_TOKEN
-
-  # Switch environments with an already logged-in account
-  rosa login --env production`,
+	Example: `  # Login to the OpenShift API with an existing token
+  rosa login --token=$OFFLINE_ACCESS_TOKEN`,
 	Run: run,
 }
 
@@ -103,6 +100,7 @@ func init() {
 		"Environment of the API gateway. The value can be the complete URL or an alias. "+
 			"The valid aliases are 'production', 'staging' and 'integration'.",
 	)
+	flags.MarkHidden("env")
 	flags.StringVarP(
 		&args.token,
 		"token",

--- a/docs/rosa_init.md
+++ b/docs/rosa_init.md
@@ -29,7 +29,6 @@ rosa init [flags]
                                
       --client-id string       OpenID client identifier. The default value is 'cloud-services'.
       --client-secret string   OpenID client secret.
-      --env string             Environment of the API gateway. The value can be the complete URL or an alias. The valid aliases are 'production', 'staging' and 'integration'. (default "https://api.openshift.com")
       --insecure               Enables insecure communication with the server. This disables verification of TLS certificates and host names.
       --scope strings          OpenID scope. If this option is used it will replace completely the default scopes. Can be repeated multiple times to specify multiple scopes. (default [openid])
   -t, --token string           Access or refresh token.

--- a/docs/rosa_login.md
+++ b/docs/rosa_login.md
@@ -22,11 +22,8 @@ rosa login [flags]
 ### Examples
 
 ```
-  # Login to the OpenShift staging API with an existing token
-  rosa login --env staging --token=$OFFLINE_ACCESS_TOKEN
-
-  # Switch environments with an already logged-in account
-  rosa login --env production
+  # Login to the OpenShift API with an existing token
+  rosa login --token=$OFFLINE_ACCESS_TOKEN
 ```
 
 ### Options
@@ -34,7 +31,6 @@ rosa login [flags]
 ```
       --client-id string       OpenID client identifier. The default value is 'cloud-services'.
       --client-secret string   OpenID client secret.
-      --env string             Environment of the API gateway. The value can be the complete URL or an alias. The valid aliases are 'production', 'staging' and 'integration'. (default "https://api.openshift.com")
   -h, --help                   help for login
       --insecure               Enables insecure communication with the server. This disables verification of TLS certificates and host names.
       --scope strings          OpenID scope. If this option is used it will replace completely the default scopes. Can be repeated multiple times to specify multiple scopes. (default [openid])


### PR DESCRIPTION
Since end-users should not have access to our integration and staging
environments, there's no need to expose the '--env' parameter.