### PR TITLE
cluster: Show warnings when user makes cluster private

### DIFF
--- a/cmd/create/cmd.go
+++ b/cmd/create/cmd.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openshift/rosa/cmd/create/idp"
 	"github.com/openshift/rosa/cmd/create/ingress"
 	"github.com/openshift/rosa/cmd/create/machinepool"
+	"github.com/openshift/rosa/pkg/confirm"
 	"github.com/openshift/rosa/pkg/interactive"
 )
 
@@ -44,5 +45,6 @@ func init() {
 	Cmd.AddCommand(machinepool.Cmd)
 
 	flags := Cmd.PersistentFlags()
+	confirm.AddFlag(flags)
 	interactive.AddFlag(flags)
 }

--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -165,6 +165,15 @@ func run(_ *cobra.Command, argv []string) {
 	if clusterName == "" {
 		clusterName = cluster.Name()
 	}
+
+	isPrivate := "No"
+	ingresses, err := ocm.GetIngresses(clustersCollection, cluster.ID())
+	for _, ingress := range ingresses {
+		if ingress.Default() && ingress.Listening() == cmv1.ListeningMethodInternal {
+			isPrivate = "Yes"
+		}
+	}
+
 	detailsPage := getDetailsLink(ocmConnection.URL())
 	// Print short cluster description:
 	str := fmt.Sprintf(""+
@@ -179,6 +188,7 @@ func run(_ *cobra.Command, argv []string) {
 		"Region:                     %s\n"+
 		"State:                      %s %s\n"+
 		"Channel Group:              %s\n"+
+		"Private:                    %s\n"+
 		"Created:                    %s\n",
 		clusterName,
 		cluster.Name(), cluster.DNS().BaseDomain(),
@@ -191,6 +201,7 @@ func run(_ *cobra.Command, argv []string) {
 		cluster.Region().ID(),
 		cluster.State(), phase,
 		cluster.Version().ChannelGroup(),
+		isPrivate,
 		cluster.CreationTimestamp().Format("Jan _2 2006 15:04:05 MST"),
 	)
 

--- a/docs/rosa_create.md
+++ b/docs/rosa_create.md
@@ -11,6 +11,7 @@ Create a resource from stdin
 ```
   -h, --help          help for create
   -i, --interactive   Enable interactive mode.
+  -y, --yes           Automatically answer yes to confirm operation.
 ```
 
 ### Options inherited from parent commands

--- a/docs/rosa_create_admin.md
+++ b/docs/rosa_create_admin.md
@@ -31,6 +31,7 @@ rosa create admin [flags]
   -i, --interactive      Enable interactive mode.
       --profile string   Use a specific AWS profile from your credential file.
   -v, --v Level          log level for V logs
+  -y, --yes              Automatically answer yes to confirm operation.
 ```
 
 ### SEE ALSO

--- a/docs/rosa_create_cluster.md
+++ b/docs/rosa_create_cluster.md
@@ -49,6 +49,7 @@ rosa create cluster [flags]
   -i, --interactive      Enable interactive mode.
       --profile string   Use a specific AWS profile from your credential file.
   -v, --v Level          log level for V logs
+  -y, --yes              Automatically answer yes to confirm operation.
 ```
 
 ### SEE ALSO

--- a/docs/rosa_create_idp.md
+++ b/docs/rosa_create_idp.md
@@ -64,6 +64,7 @@ rosa create idp [flags]
   -i, --interactive      Enable interactive mode.
       --profile string   Use a specific AWS profile from your credential file.
   -v, --v Level          log level for V logs
+  -y, --yes              Automatically answer yes to confirm operation.
 ```
 
 ### SEE ALSO

--- a/docs/rosa_create_ingress.md
+++ b/docs/rosa_create_ingress.md
@@ -39,6 +39,7 @@ rosa create ingress [flags]
   -i, --interactive      Enable interactive mode.
       --profile string   Use a specific AWS profile from your credential file.
   -v, --v Level          log level for V logs
+  -y, --yes              Automatically answer yes to confirm operation.
 ```
 
 ### SEE ALSO

--- a/docs/rosa_create_machinepool.md
+++ b/docs/rosa_create_machinepool.md
@@ -42,6 +42,7 @@ rosa create machinepool [flags]
   -i, --interactive      Enable interactive mode.
       --profile string   Use a specific AWS profile from your credential file.
   -v, --v Level          log level for V logs
+  -y, --yes              Automatically answer yes to confirm operation.
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
Since users will not be able to access private clusters unless they
configure their network settings in AWS, we warn them whenever creating
a private cluster (or editing a cluster to make it private).

We also display whether the cluster is private in the 'describe cluster'
output.

Demo: https://asciinema.org/a/EtUqEPWae07r2Fj8stIzJ9Wa0