### PR TITLE
replicas: Fix local validation for worker nodes and machinepool replicas

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -510,9 +510,20 @@ func run(cmd *cobra.Command, _ []string) {
 			os.Exit(1)
 		}
 	}
-	if multiAZ && computeNodes%3 != 0 {
-		reporter.Errorf("Multi AZ clusters require that the number of compute nodes be a multiple of 3")
-		os.Exit(1)
+	if multiAZ {
+		if computeNodes < 3 {
+			reporter.Errorf("The number of compute nodes needs to be at least 3")
+			os.Exit(1)
+		}
+		if computeNodes%3 != 0 {
+			reporter.Errorf("Multi AZ clusters require that the number of compute nodes be a multiple of 3")
+			os.Exit(1)
+		}
+	} else {
+		if computeNodes < 2 {
+			reporter.Errorf("The number of compute nodes needs to be at least 2")
+			os.Exit(1)
+		}
 	}
 
 	// Validate all remaining flags:

--- a/cmd/create/machinepool/cmd.go
+++ b/cmd/create/machinepool/cmd.go
@@ -212,6 +212,14 @@ func run(cmd *cobra.Command, _ []string) {
 			os.Exit(1)
 		}
 	}
+	if replicas < 0 {
+		reporter.Errorf("The number of machine pool replicas needs to be a positive integer")
+		os.Exit(1)
+	}
+	if cluster.MultiAZ() && replicas%3 != 0 {
+		reporter.Errorf("Multi AZ clusters require that the number of machine pool replicas be a multiple of 3")
+		os.Exit(1)
+	}
 
 	// Machine pool instance type:
 	instanceType := args.instanceType

--- a/cmd/edit/machinepool/cmd.go
+++ b/cmd/edit/machinepool/cmd.go
@@ -151,13 +151,20 @@ func run(cmd *cobra.Command, argv []string) {
 			reporter.Errorf("Expected a valid number of replicas: %s", err)
 			os.Exit(1)
 		}
-		if replicas < 2 {
-			reporter.Errorf("Default machine pool requires at least 2 compute nodes")
-			os.Exit(1)
-		}
-		if cluster.MultiAZ() && replicas%3 != 0 {
-			reporter.Errorf("Multi AZ clusters require that the number of compute nodes be a multiple of 3")
-			os.Exit(1)
+		if cluster.MultiAZ() {
+			if replicas < 3 {
+				reporter.Errorf("Default machine pool requires at least 3 compute nodes")
+				os.Exit(1)
+			}
+			if replicas%3 != 0 {
+				reporter.Errorf("Multi AZ clusters require that the number of compute nodes be a multiple of 3")
+				os.Exit(1)
+			}
+		} else {
+			if replicas < 2 {
+				reporter.Errorf("Default machine pool requires at least 2 compute nodes")
+				os.Exit(1)
+			}
 		}
 
 		clusterConfig := c.Spec{ComputeNodes: replicas}
@@ -197,8 +204,12 @@ func run(cmd *cobra.Command, argv []string) {
 		reporter.Errorf("Expected a valid number of replicas: %s", err)
 		os.Exit(1)
 	}
+	if replicas < 0 {
+		reporter.Errorf("The number of machine pool replicas needs to be a positive integer")
+		os.Exit(1)
+	}
 	if cluster.MultiAZ() && replicas%3 != 0 {
-		reporter.Errorf("Multi AZ clusters require that the number of MachinePool replicas be a multiple of 3")
+		reporter.Errorf("Multi AZ clusters require that the number of machine pool replicas be a multiple of 3")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
This change disallows entering negative numbers on any machine pool
replicas, and will validate the minimum required number of nodes based
on the cluster type and machine pool type.