### PR TITLE
Disable `maligned` linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,7 +29,6 @@ linters:
   - ineffassign
   - interfacer
   - lll
-  - maligned
   - megacheck
   - misspell
   - structcheck


### PR DESCRIPTION
It limits the order of struct members, e.g.:

    struct of size 320 bytes could be of size 312 bytes (maligned)

Such micro-optimizations are not interesting for this project IMHO.

@zgalor @vkareh please review.