### PR TITLE
Release v0.1.4

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,28 @@
 This document describes the relevant changes between releases of the `moactl`
 command line tool.
 
+== 0.1.4 Jan 6 2021
+
+- Adding Orange team members to OWNERS file
+- Update OWNERS
+- aws: Advise user to run init for failed credentials
+- init: Advise user to run init for failed credentials
+- user: Determine if user exists before revoking
+- rosa: Rename repository from moactl to rosa
+- create-cluster: Set default version
+- multi-az: Validate that compute nodes are multiple of 3
+- login: Hide 'env' parameter
+- cluster: Show warnings when user makes cluster private
+- replicas: Fix local validation for worker nodes and machinepool replicas
+- describe-cluster: Display scheduled upgrades
+- login: Add link to retrieve tokens
+- Disable `maligned` linter
+- Fix formatting and add generated docs
+- Add autoscaling support
+- addons: Enable all commands
+- addons: Use install command instead of create
+- addons: Allow listing of all available addons
+
 == 0.1.3 Dec 4 2020
 
 - create: Ask user before showing subnets

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.1.3"
+const Version = "0.1.4"


### PR DESCRIPTION
- Adding Orange team members to OWNERS file
- Update OWNERS
- aws: Advise user to run init for failed credentials
- init: Advise user to run init for failed credentials
- user: Determine if user exists before revoking
- rosa: Rename repository from moactl to rosa
- create-cluster: Set default version
- multi-az: Validate that compute nodes are multiple of 3
- login: Hide 'env' parameter
- cluster: Show warnings when user makes cluster private
- replicas: Fix local validation for worker nodes and machinepool replicas
- describe-cluster: Display scheduled upgrades
- login: Add link to retrieve tokens
- Disable `maligned` linter
- Fix formatting and add generated docs
- Add autoscaling support
- addons: Enable all commands
- addons: Use install command instead of create
- addons: Allow listing of all available addons