### PR TITLE
addons: Uninstall and custom parameters

### DIFF
--- a/cmd/describe/addon/cmd.go
+++ b/cmd/describe/addon/cmd.go
@@ -22,6 +22,7 @@ import (
 	"regexp"
 	"strings"
 
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/pkg/logging"
@@ -81,7 +82,7 @@ func run(_ *cobra.Command, argv []string) {
 	}
 
 	// Print add-on description:
-	fmt.Printf(""+
+	fmt.Printf("ADD-ON\n"+
 		"ID:               %s\n"+
 		"Name:             %s\n"+
 		"Description:      %s\n"+
@@ -98,6 +99,44 @@ func run(_ *cobra.Command, argv []string) {
 		addOn.InstallMode(),
 	)
 	fmt.Println()
+
+	if addOn.Parameters().Len() > 0 {
+		fmt.Printf("ADD-ON PARAMETERS\n")
+		addOn.Parameters().Each(func(param *cmv1.AddOnParameter) bool {
+			if !param.Enabled() {
+				return true
+			}
+			fmt.Printf(""+
+				"- ID:             %s\n"+
+				"  Name:           %s\n"+
+				"  Description:    %s\n"+
+				"  Type:           %s\n"+
+				"  Required:       %s\n"+
+				"  Editable:       %s\n",
+				param.ID(),
+				param.Name(),
+				wrapText(param.Description()),
+				param.ValueType(),
+				printBool(param.Required()),
+				printBool(param.Editable()),
+			)
+			if param.DefaultValue() != "" {
+				fmt.Printf("  Default Value:  %s\n", param.DefaultValue())
+			}
+			if param.Validation() != "" {
+				fmt.Printf("  Validation:     /%s/\n", param.Validation())
+			}
+			fmt.Println()
+			return true
+		})
+	}
+}
+
+func printBool(val bool) string {
+	if val {
+		return "yes"
+	}
+	return "no"
 }
 
 func wrapText(text string) string {

--- a/cmd/install/addon/cmd.go
+++ b/cmd/install/addon/cmd.go
@@ -17,7 +17,10 @@ limitations under the License.
 package addon
 
 import (
+	"net"
 	"os"
+	"regexp"
+	"strconv"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
@@ -25,6 +28,7 @@ import (
 	"github.com/openshift/rosa/pkg/aws"
 	clusterprovider "github.com/openshift/rosa/pkg/cluster"
 	"github.com/openshift/rosa/pkg/confirm"
+	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/logging"
 	"github.com/openshift/rosa/pkg/ocm"
 	rprtr "github.com/openshift/rosa/pkg/reporter"
@@ -117,11 +121,11 @@ func run(_ *cobra.Command, argv []string) {
 	}()
 
 	// Get the client for the OCM collection of clusters:
-	clustersCollection := ocmConnection.ClustersMgmt().V1().Clusters()
+	ocmClient := ocmConnection.ClustersMgmt().V1()
 
 	// Try to find the cluster:
 	reporter.Debugf("Loading cluster '%s'", clusterKey)
-	cluster, err := ocm.GetCluster(clustersCollection, clusterKey, awsCreator.ARN)
+	cluster, err := ocm.GetCluster(ocmClient.Clusters(), clusterKey, awsCreator.ARN)
 	if err != nil {
 		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
 		os.Exit(1)
@@ -132,15 +136,71 @@ func run(_ *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
-	reporter.Warnf("Once installed, add-ons cannot be uninstalled")
-	if confirm.Confirm("install add-on '%s' on cluster '%s'", addOnID, clusterKey) {
-		reporter.Debugf("Installing add-on '%s' on cluster '%s'", addOnID, clusterKey)
-		err = clusterprovider.InstallAddOn(clustersCollection, clusterKey, awsCreator.ARN, addOnID)
-		if err != nil {
-			reporter.Errorf("Failed to add add-on installation '%s' for cluster '%s': %s", addOnID, clusterKey, err)
-			os.Exit(1)
-		}
-		reporter.Infof("Add-on '%s' is now installing. To check the status run 'rosa list addons -c %s'",
-			addOnID, clusterKey)
+	if !confirm.Confirm("install add-on '%s' on cluster '%s'", addOnID, clusterKey) {
+		os.Exit(0)
 	}
+
+	parameters, err := clusterprovider.GetAddOnParameters(ocmClient.Addons(), addOnID)
+	if err != nil {
+		reporter.Errorf("Failed to get add-on '%s' parameters: %v", addOnID, err)
+		os.Exit(1)
+	}
+
+	var params []clusterprovider.AddOnParam
+	if parameters.Len() > 0 {
+		parameters.Each(func(param *cmv1.AddOnParameter) bool {
+			input := interactive.Input{
+				Question: param.Name(),
+				Help:     param.Description(),
+				Default:  param.DefaultValue(),
+				Required: param.Required(),
+			}
+
+			var val string
+			switch param.ValueType() {
+			case "boolean":
+				var boolVal bool
+				boolVal, err = interactive.GetBool(input)
+				if boolVal {
+					val = "true"
+				} else {
+					val = "false"
+				}
+			case "cidr":
+				var cidrVal net.IPNet
+				cidrVal, err = interactive.GetIPNet(input)
+				val = cidrVal.String()
+			case "number":
+				var numVal int
+				numVal, err = interactive.GetInt(input)
+				val = strconv.Itoa(numVal)
+			case "string":
+				val, err = interactive.GetString(input)
+			}
+			if err != nil {
+				reporter.Errorf("Expected a valid value for '%s': %v", param.ID(), err)
+				os.Exit(1)
+			}
+
+			if param.Validation() != "" {
+				isValid, err := regexp.MatchString(param.Validation(), val)
+				if err != nil || !isValid {
+					reporter.Errorf("Expected %v to match /%s/", val, param.Validation())
+					os.Exit(1)
+				}
+			}
+
+			params = append(params, clusterprovider.AddOnParam{Key: param.ID(), Val: val})
+
+			return true
+		})
+	}
+
+	reporter.Debugf("Installing add-on '%s' on cluster '%s'", addOnID, clusterKey)
+	err = clusterprovider.InstallAddOn(ocmClient.Clusters(), clusterKey, awsCreator.ARN, addOnID, params)
+	if err != nil {
+		reporter.Errorf("Failed to add add-on installation '%s' for cluster '%s': %v", addOnID, clusterKey, err)
+		os.Exit(1)
+	}
+	reporter.Infof("Add-on '%s' is now installing. To check the status run 'rosa list addons -c %s'", addOnID, clusterKey)
 }

--- a/cmd/rosa/main.go
+++ b/cmd/rosa/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/openshift/rosa/cmd/logout"
 	"github.com/openshift/rosa/cmd/logs"
 	"github.com/openshift/rosa/cmd/revoke"
+	"github.com/openshift/rosa/cmd/uninstall"
 	"github.com/openshift/rosa/cmd/upgrade"
 	"github.com/openshift/rosa/cmd/verify"
 	"github.com/openshift/rosa/cmd/version"
@@ -79,6 +80,7 @@ func init() {
 	root.AddCommand(logout.Cmd)
 	root.AddCommand(logs.Cmd)
 	root.AddCommand(revoke.Cmd)
+	root.AddCommand(uninstall.Cmd)
 	root.AddCommand(upgrade.Cmd)
 	root.AddCommand(verify.Cmd)
 	root.AddCommand(version.Cmd)

--- a/cmd/uninstall/addon/cmd.go
+++ b/cmd/uninstall/addon/cmd.go
@@ -1,0 +1,147 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package addon
+
+import (
+	"os"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/aws"
+	clusterprovider "github.com/openshift/rosa/pkg/cluster"
+	"github.com/openshift/rosa/pkg/confirm"
+	"github.com/openshift/rosa/pkg/logging"
+	"github.com/openshift/rosa/pkg/ocm"
+	rprtr "github.com/openshift/rosa/pkg/reporter"
+)
+
+var args struct {
+	clusterKey string
+}
+
+var Cmd = &cobra.Command{
+	Use:     "addon",
+	Aliases: []string{"addons", "add-on", "add-ons"},
+	Short:   "Uninstall add-on from cluster",
+	Long:    "Uninstall Red Hat managed add-on from a cluster",
+	Example: `  # Remove the CodeReady Workspaces add-on installation from the cluster
+  rosa uninstall addon --cluster=mycluster codeready-workspaces`,
+	Run: run,
+}
+
+func init() {
+	flags := Cmd.Flags()
+	confirm.AddFlag(flags)
+
+	flags.StringVarP(
+		&args.clusterKey,
+		"cluster",
+		"c",
+		"",
+		"Name or ID of the cluster to add the IdP to (required).",
+	)
+	Cmd.MarkFlagRequired("cluster")
+}
+
+func run(_ *cobra.Command, argv []string) {
+	reporter := rprtr.CreateReporterOrExit()
+	logger := logging.CreateLoggerOrExit(reporter)
+
+	// Check command line arguments:
+	if len(argv) != 1 {
+		reporter.Errorf("Expected exactly one command line parameters containing the identifier of the add-on.")
+		os.Exit(1)
+	}
+
+	addOnID := argv[0]
+	if addOnID == "" {
+		reporter.Errorf("Add-on ID is required.")
+		os.Exit(1)
+	}
+
+	// Check that the cluster key (name, identifier or external identifier) given by the user
+	// is reasonably safe so that there is no risk of SQL injection:
+	clusterKey := args.clusterKey
+	if !ocm.IsValidClusterKey(clusterKey) {
+		reporter.Errorf(
+			"Cluster name, identifier or external identifier '%s' isn't valid: it "+
+				"must contain only letters, digits, dashes and underscores",
+			clusterKey,
+		)
+		os.Exit(1)
+	}
+
+	// Create the AWS client:
+	awsClient, err := aws.NewClient().
+		Logger(logger).
+		Build()
+	if err != nil {
+		reporter.Errorf("Failed to create AWS client: %v", err)
+		os.Exit(1)
+	}
+
+	awsCreator, err := awsClient.GetCreator()
+	if err != nil {
+		reporter.Errorf("Failed to get AWS creator: %v", err)
+		os.Exit(1)
+	}
+
+	// Create the client for the OCM API:
+	ocmConnection, err := ocm.NewConnection().
+		Logger(logger).
+		Build()
+	if err != nil {
+		reporter.Errorf("Failed to create OCM connection: %v", err)
+		os.Exit(1)
+	}
+	defer func() {
+		err = ocmConnection.Close()
+		if err != nil {
+			reporter.Errorf("Failed to close OCM connection: %v", err)
+		}
+	}()
+
+	// Get the client for the OCM collection of clusters:
+	ocmClient := ocmConnection.ClustersMgmt().V1()
+
+	// Try to find the cluster:
+	reporter.Debugf("Loading cluster '%s'", clusterKey)
+	cluster, err := ocm.GetCluster(ocmClient.Clusters(), clusterKey, awsCreator.ARN)
+	if err != nil {
+		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
+		os.Exit(1)
+	}
+
+	if cluster.State() != cmv1.ClusterStateReady {
+		reporter.Errorf("Cluster '%s' is not yet ready", clusterKey)
+		os.Exit(1)
+	}
+
+	if !confirm.Confirm("uninstall add-on '%s' from cluster '%s'", addOnID, clusterKey) {
+		os.Exit(0)
+	}
+
+	reporter.Debugf("Uninstalling add-on '%s' from cluster '%s'", addOnID, clusterKey)
+	err = clusterprovider.UninstallAddOn(ocmClient.Clusters(), clusterKey, awsCreator.ARN, addOnID)
+	if err != nil {
+		reporter.Errorf("Failed to remove add-on installation '%s' from cluster '%s': %s", addOnID, clusterKey, err)
+		os.Exit(1)
+	}
+	reporter.Infof("Add-on '%s' is now uninstalling. To check the status run 'rosa list addons -c %s'",
+		addOnID, clusterKey)
+}

--- a/cmd/uninstall/cmd.go
+++ b/cmd/uninstall/cmd.go
@@ -1,0 +1,37 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package uninstall
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/cmd/uninstall/addon"
+	"github.com/openshift/rosa/pkg/confirm"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "uninstall RESOURCE [flags]",
+	Short: "Uninstalls a resource from a cluster",
+	Long:  "Uninstalls a resource from a cluster",
+}
+
+func init() {
+	Cmd.AddCommand(addon.Cmd)
+
+	flags := Cmd.PersistentFlags()
+	confirm.AddFlag(flags)
+}

--- a/docs/rosa.md
+++ b/docs/rosa.md
@@ -31,6 +31,7 @@ Command line tool for Red Hat OpenShift Service on AWS.
 * [rosa logout](rosa_logout.md)	 - Log out
 * [rosa logs](rosa_logs.md)	 - Show installation or uninstallation logs for a cluster
 * [rosa revoke](rosa_revoke.md)	 - Revoke role from a specific resource
+* [rosa uninstall](rosa_uninstall.md)	 - Uninstalls a resource from a cluster
 * [rosa upgrade](rosa_upgrade.md)	 - Upgrade a resource
 * [rosa verify](rosa_verify.md)	 - Verify resources are configured correctly for cluster install
 * [rosa version](rosa_version.md)	 - Prints the version of the tool

--- a/docs/rosa_uninstall.md
+++ b/docs/rosa_uninstall.md
@@ -1,0 +1,28 @@
+## rosa uninstall
+
+Uninstalls a resource from a cluster
+
+### Synopsis
+
+Uninstalls a resource from a cluster
+
+### Options
+
+```
+  -h, --help   help for uninstall
+  -y, --yes    Automatically answer yes to confirm operation.
+```
+
+### Options inherited from parent commands
+
+```
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
+```
+
+### SEE ALSO
+
+* [rosa](rosa.md)	 - Command line tool for ROSA.
+* [rosa uninstall addon](rosa_uninstall_addon.md)	 - Uninstall add-on from cluster
+

--- a/docs/rosa_uninstall_addon.md
+++ b/docs/rosa_uninstall_addon.md
@@ -1,0 +1,39 @@
+## rosa uninstall addon
+
+Uninstall add-on from cluster
+
+### Synopsis
+
+Uninstall Red Hat managed add-on from a cluster
+
+```
+rosa uninstall addon [flags]
+```
+
+### Examples
+
+```
+  # Remove the CodeReady Workspaces add-on installation from the cluster
+  rosa uninstall addon --cluster=mycluster codeready-workspaces
+```
+
+### Options
+
+```
+  -c, --cluster string   Name or ID of the cluster to add the IdP to (required).
+  -h, --help             help for addon
+```
+
+### Options inherited from parent commands
+
+```
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
+  -y, --yes              Automatically answer yes to confirm operation.
+```
+
+### SEE ALSO
+
+* [rosa uninstall](rosa_uninstall.md)	 - Uninstalls a resource from a cluster
+

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.7.0
-	github.com/openshift-online/ocm-sdk-go v0.1.150
+	github.com/openshift-online/ocm-sdk-go v0.1.152
 	github.com/prometheus/common v0.11.1 // indirect
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -279,10 +279,8 @@ github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
-github.com/openshift-online/ocm-sdk-go v0.1.146 h1:6HQj+BwWk08PrZVoxk52QWjVLNMafGKBMmZMir46zyM=
-github.com/openshift-online/ocm-sdk-go v0.1.146/go.mod h1:3i3a/LEYtC7DMor3N94PTPn1+0qq+Fk+iLjt1Z0WVCs=
-github.com/openshift-online/ocm-sdk-go v0.1.150 h1:z3rcSmYmbU3PpP9DhpQRkL8ngHFBTR59zOOjVinCTtM=
-github.com/openshift-online/ocm-sdk-go v0.1.150/go.mod h1:wtDv/a2arfeFkYpgQg6J7axTwXkrlSifaVRWeZkUZzo=
+github.com/openshift-online/ocm-sdk-go v0.1.152 h1:CcY43aaw7G1DFutegD5q4I4tN0DhP/0MHNF2bfE4yLc=
+github.com/openshift-online/ocm-sdk-go v0.1.152/go.mod h1:wtDv/a2arfeFkYpgQg6J7axTwXkrlSifaVRWeZkUZzo=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -306,6 +306,20 @@ func InstallAddOn(client *cmv1.ClustersClient, clusterKey string, creatorARN str
 	return nil
 }
 
+func UninstallAddOn(client *cmv1.ClustersClient, clusterKey string, creatorARN string, addOnID string) error {
+	cluster, err := GetCluster(client, clusterKey, creatorARN)
+	if err != nil {
+		return err
+	}
+
+	response, err := client.Cluster(cluster.ID()).Addons().Addoninstallation(addOnID).Delete().Send()
+	if err != nil {
+		return handleErr(response.Error(), err)
+	}
+
+	return nil
+}
+
 func createClusterSpec(config Spec, awsClient aws.Client) (*cmv1.Cluster, error) {
 	reporter, err := rprtr.New().
 		Build()


### PR DESCRIPTION
Since some add-ons require custom parameters before installation, we
iterate through the list generating interactive prompts for those
parameters. Those parameters are then sent as part of the payload to the
add-on installation API and will be available in the cluster's addon
target namespace.

Also, since OCM now supports uninstalling addons from any managed cluster, we
enable this new command for ROSA clusters.