### PR TITLE
machines: Sort machine types by CPU cores

### DIFF
--- a/pkg/ocm/machines/machines.go
+++ b/pkg/ocm/machines/machines.go
@@ -32,7 +32,7 @@ func GetMachineTypes(client *cmv1.Client) (machineTypes []*cmv1.MachineType, err
 		var response *cmv1.MachineTypesListResponse
 		response, err = collection.List().
 			Search("cloud_provider.id = 'aws'").
-			Order("size desc").
+			Order("cpu asc").
 			Page(page).
 			Size(size).
 			Send()


### PR DESCRIPTION
Since size is an arbitrary string, sorting by it means that 'xlarge' and
'small' are next to one another. CPU cores is already used to determine
the size, and sorting by it is more consistent.