### PR TITLE
cluster-admins: Remove explicit enable

### DIFF
--- a/cmd/list/user/cmd.go
+++ b/cmd/list/user/cmd.go
@@ -121,19 +121,17 @@ func run(_ *cobra.Command, _ []string) {
 	}
 
 	var clusterAdmins []*cmv1.User
-	if cluster.ClusterAdminEnabled() {
-		reporter.Debugf("Loading users for cluster '%s'", clusterKey)
-		// Load cluster-admins for this cluster
-		clusterAdmins, err = ocm.GetUsers(clustersCollection, cluster.ID(), "cluster-admins")
-		if err != nil {
-			reporter.Errorf("Failed to get cluster-admins for cluster '%s': %v", clusterKey, err)
-			os.Exit(1)
-		}
-		// Remove cluster-admin user
-		for i, user := range clusterAdmins {
-			if user.ID() == "cluster-admin" {
-				clusterAdmins = append(clusterAdmins[:i], clusterAdmins[i+1:]...)
-			}
+	reporter.Debugf("Loading users for cluster '%s'", clusterKey)
+	// Load cluster-admins for this cluster
+	clusterAdmins, err = ocm.GetUsers(clustersCollection, cluster.ID(), "cluster-admins")
+	if err != nil {
+		reporter.Errorf("Failed to get cluster-admins for cluster '%s': %v", clusterKey, err)
+		os.Exit(1)
+	}
+	// Remove cluster-admin user
+	for i, user := range clusterAdmins {
+		if user.ID() == "cluster-admin" {
+			clusterAdmins = append(clusterAdmins[:i], clusterAdmins[i+1:]...)
 		}
 	}
 

--- a/docs/rosa_edit_cluster.md
+++ b/docs/rosa_edit_cluster.md
@@ -16,9 +16,6 @@ rosa edit cluster [flags]
   # Edit a cluster named "mycluster" to make it private
   rosa edit cluster mycluster --private
 
-  # Enable the cluster-admins group using the --cluster flag
-  rosa edit cluster --cluster=mycluster --enable-cluster-admins
-
   # Edit all options interactively
   rosa edit cluster -c mycluster --interactive
 ```
@@ -26,10 +23,9 @@ rosa edit cluster [flags]
 ### Options
 
 ```
-  -c, --cluster string          Name or ID of the cluster to edit.
-      --private                 Restrict master API endpoint to direct, private connectivity.
-      --enable-cluster-admins   Enable the cluster-admins role for your cluster.
-  -h, --help                    help for cluster
+  -c, --cluster string   Name or ID of the cluster to edit.
+      --private          Restrict master API endpoint to direct, private connectivity.
+  -h, --help             help for cluster
 ```
 
 ### Options inherited from parent commands

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -74,9 +74,6 @@ type Spec struct {
 	// Properties
 	CustomProperties map[string]string
 
-	// Access control config
-	ClusterAdmins *bool
-
 	// Simulate creating a cluster but don't actually create it
 	DryRun *bool
 
@@ -251,11 +248,6 @@ func UpdateCluster(client *cmv1.ClustersClient, clusterKey string, creatorARN st
 					Listening(cmv1.ListeningMethodExternal),
 			)
 		}
-	}
-
-	// Toggle cluster-admins group
-	if config.ClusterAdmins != nil {
-		clusterBuilder = clusterBuilder.ClusterAdminEnabled(*config.ClusterAdmins)
 	}
 
 	clusterSpec, err := clusterBuilder.Build()


### PR DESCRIPTION
Because adding a user to cluster-admins already requires manual
intervention, enabling it first seems superfluous and can lead to
customer friction. We remove this requirement and the associated flag,
and immediately allow customers to grant users the cluster-admin role
without the need for an explicit opt-in for a cluster.