### PR TITLE
add multi-az status to describe

### DIFF
--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -210,6 +210,7 @@ func run(_ *cobra.Command, argv []string) {
 		"Console URL:                %s\n"+
 		"%s"+
 		"Region:                     %s\n"+
+		"Multi-AZ:                   %t\n"+
 		"State:                      %s %s\n"+
 		"Channel Group:              %s\n"+
 		"Private:                    %s\n"+
@@ -224,6 +225,7 @@ func run(_ *cobra.Command, argv []string) {
 		cluster.Console().URL(),
 		nodesStr,
 		cluster.Region().ID(),
+		cluster.MultiAZ(),
 		cluster.State(), phase,
 		cluster.Version().ChannelGroup(),
 		isPrivate,


### PR DESCRIPTION
@jonquilwilliams this will help with your multiAZ PR https://github.com/openshift/managed-openshift-docs/pull/13

> $ ./rosa describe cluster jeder-log-prod1                                                          
Name:                       jeder-log-prod1                                                                                             
OpenShift Version:          4.6.8                                                                                                       
DNS:                        jeder-log-prod1.tg7j.p1.openshiftapps.com                                                                   
ID:                         1i7naeu990l3ark4u9jeae7pjl86nc0b                                                                            
External ID:                68e3c382-9471-4417-8a34-ad3679a37a77                                                                        
AWS Account:                810538604510                                                                                                
API URL:                    https://api.jeder-log-prod1.tg7j.p1.openshiftapps.com:6443                                                  
Console URL:                https://console-openshift-console.apps.jeder-log-prod1.tg7j.p1.openshiftapps.com                            
Nodes:                      Master: 3, Infra: 2, Compute: 2                                                                             
Region:                     us-west-2                                                                                                   
Multi-AZ:                   false                                                                                                       
State:                      ready                                                                                                       
Channel Group:              stable                                                                                                      
Private:                    No                                                                                                          
Created:                    Jan 15 2021 16:30:55 UTC                                                                                    
Details Page:               https://cloud.redhat.com/openshift/details/1i7naeu990l3ark4u9jeae7pjl86nc0b    