### PR TITLE
Trim user-provided machine-friendly names

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -284,7 +284,7 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	// Get cluster name
-	clusterName := args.clusterName
+	clusterName := strings.Trim(args.clusterName, " \t")
 
 	if clusterName == "" && !interactive.Enabled() {
 		interactive.Enable()
@@ -303,6 +303,10 @@ func run(cmd *cobra.Command, _ []string) {
 			os.Exit(1)
 		}
 	}
+
+	// Trim names to remove any leading/trailing invisible characters
+	clusterName = strings.Trim(clusterName, " \t")
+
 	if !clusterprovider.IsValidClusterName(clusterName) {
 		reporter.Errorf("Cluster name must consist" +
 			" of no more than 15 lowercase alphanumeric characters or '-', " +

--- a/cmd/create/idp/cmd.go
+++ b/cmd/create/idp/cmd.go
@@ -369,7 +369,7 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 	}
 
-	idpName := args.idpName
+	idpName := strings.Trim(args.idpName, " \t")
 
 	// Auto-generate a name if none provided
 	if !cmd.Flags().Changed("name") {
@@ -394,6 +394,7 @@ func run(cmd *cobra.Command, _ []string) {
 			os.Exit(1)
 		}
 	}
+	idpName = strings.Trim(idpName, " \t")
 
 	var idpBuilder cmv1.IdentityProviderBuilder
 	switch idpType {

--- a/cmd/create/machinepool/cmd.go
+++ b/cmd/create/machinepool/cmd.go
@@ -205,7 +205,7 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	// Machine pool name:
-	name := args.name
+	name := strings.Trim(args.name, " \t")
 	if name == "" && !interactive.Enabled() {
 		interactive.Enable()
 		reporter.Infof("Enabling interactive mode")
@@ -221,6 +221,7 @@ func run(cmd *cobra.Command, _ []string) {
 			os.Exit(1)
 		}
 	}
+	name = strings.Trim(name, " \t")
 	if !machinePoolKeyRE.MatchString(name) {
 		reporter.Errorf("Expected a valid name for the machine pool")
 		os.Exit(1)


### PR DESCRIPTION
To ensure that the names of clusters/idps/machinepools all have
invisible characters stripped, we trim them as soon as we read them from
the argument flags and after they are read from the interactive mode.