### PR TITLE
arguments: Move region and profile flags

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -34,6 +34,7 @@ import (
 	v "github.com/openshift/rosa/cmd/validations"
 	"github.com/openshift/rosa/pkg/aws"
 
+	"github.com/openshift/rosa/pkg/arguments"
 	clusterprovider "github.com/openshift/rosa/pkg/cluster"
 	"github.com/openshift/rosa/pkg/confirm"
 	"github.com/openshift/rosa/pkg/interactive"
@@ -126,13 +127,7 @@ func init() {
 		false,
 		"Deploy to multiple data centers.",
 	)
-	flags.StringVarP(
-		&args.region,
-		"region",
-		"r",
-		"",
-		"AWS region where your worker pool will be located. (overrides the AWS_REGION environment variable)",
-	)
+	arguments.AddRegionFlag(flags)
 	flags.StringVar(
 		&args.version,
 		"version",
@@ -350,7 +345,7 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	// Get AWS region
-	region, err := aws.GetRegion(args.region)
+	region, err := aws.GetRegion(arguments.GetRegion())
 	if err != nil {
 		reporter.Errorf("Error getting region: %v", err)
 		os.Exit(1)

--- a/cmd/create/cmd.go
+++ b/cmd/create/cmd.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openshift/rosa/cmd/create/idp"
 	"github.com/openshift/rosa/cmd/create/ingress"
 	"github.com/openshift/rosa/cmd/create/machinepool"
+	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/confirm"
 	"github.com/openshift/rosa/pkg/interactive"
 )
@@ -43,6 +44,7 @@ func init() {
 	Cmd.AddCommand(machinepool.Cmd)
 
 	flags := Cmd.PersistentFlags()
+	arguments.AddProfileFlag(flags)
 	confirm.AddFlag(flags)
 	interactive.AddFlag(flags)
 }

--- a/cmd/describe/cmd.go
+++ b/cmd/describe/cmd.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openshift/rosa/cmd/describe/addon"
 	"github.com/openshift/rosa/cmd/describe/admin"
 	"github.com/openshift/rosa/cmd/describe/cluster"
+	"github.com/openshift/rosa/pkg/arguments"
 )
 
 var Cmd = &cobra.Command{
@@ -34,4 +35,7 @@ func init() {
 	Cmd.AddCommand(addon.Cmd)
 	Cmd.AddCommand(admin.Cmd)
 	Cmd.AddCommand(cluster.Cmd)
+
+	flags := Cmd.PersistentFlags()
+	arguments.AddProfileFlag(flags)
 }

--- a/cmd/dlt/cmd.go
+++ b/cmd/dlt/cmd.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openshift/rosa/cmd/dlt/ingress"
 	"github.com/openshift/rosa/cmd/dlt/machinepool"
 	"github.com/openshift/rosa/cmd/dlt/upgrade"
+	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/confirm"
 )
 
@@ -36,13 +37,14 @@ var Cmd = &cobra.Command{
 }
 
 func init() {
-	flags := Cmd.PersistentFlags()
-	confirm.AddFlag(flags)
-
 	Cmd.AddCommand(admin.Cmd)
 	Cmd.AddCommand(cluster.Cmd)
 	Cmd.AddCommand(idp.Cmd)
 	Cmd.AddCommand(ingress.Cmd)
 	Cmd.AddCommand(machinepool.Cmd)
 	Cmd.AddCommand(upgrade.Cmd)
+
+	flags := Cmd.PersistentFlags()
+	arguments.AddProfileFlag(flags)
+	confirm.AddFlag(flags)
 }

--- a/cmd/edit/cmd.go
+++ b/cmd/edit/cmd.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openshift/rosa/cmd/edit/cluster"
 	"github.com/openshift/rosa/cmd/edit/ingress"
 	"github.com/openshift/rosa/cmd/edit/machinepool"
+	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/interactive"
 )
 
@@ -33,10 +34,11 @@ var Cmd = &cobra.Command{
 }
 
 func init() {
-	flags := Cmd.PersistentFlags()
-	interactive.AddFlag(flags)
-
 	Cmd.AddCommand(cluster.Cmd)
 	Cmd.AddCommand(ingress.Cmd)
 	Cmd.AddCommand(machinepool.Cmd)
+
+	flags := Cmd.PersistentFlags()
+	arguments.AddProfileFlag(flags)
+	interactive.AddFlag(flags)
 }

--- a/cmd/grant/cmd.go
+++ b/cmd/grant/cmd.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/cmd/grant/user"
+	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/interactive"
 )
 
@@ -30,8 +31,9 @@ var Cmd = &cobra.Command{
 }
 
 func init() {
-	flags := Cmd.PersistentFlags()
-	interactive.AddFlag(flags)
-
 	Cmd.AddCommand(user.Cmd)
+
+	flags := Cmd.PersistentFlags()
+	arguments.AddProfileFlag(flags)
+	interactive.AddFlag(flags)
 }

--- a/cmd/initialize/cmd.go
+++ b/cmd/initialize/cmd.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift/rosa/cmd/verify/oc"
 	"github.com/openshift/rosa/cmd/verify/permissions"
 	"github.com/openshift/rosa/cmd/verify/quota"
+	"github.com/openshift/rosa/pkg/arguments"
 
 	"github.com/openshift/rosa/pkg/aws"
 	clusterprovider "github.com/openshift/rosa/pkg/cluster"
@@ -57,14 +58,6 @@ func init() {
 	flags := Cmd.Flags()
 	flags.SortFlags = false
 
-	flags.StringVarP(
-		&args.region,
-		"region",
-		"r",
-		"",
-		"AWS region in which verify quota and permissions (overrides the AWS_REGION environment variable)",
-	)
-
 	flags.BoolVar(
 		&args.deleteStack,
 		"delete-stack",
@@ -74,6 +67,9 @@ func init() {
 
 	// Force-load all flags from `login` into `init`
 	flags.AddFlagSet(login.Cmd.Flags())
+
+	arguments.AddProfileFlag(flags)
+	arguments.AddRegionFlag(flags)
 }
 
 func run(cmd *cobra.Command, argv []string) {

--- a/cmd/install/cmd.go
+++ b/cmd/install/cmd.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/cmd/install/addon"
+	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/confirm"
 )
 
@@ -33,5 +34,6 @@ func init() {
 	Cmd.AddCommand(addon.Cmd)
 
 	flags := Cmd.PersistentFlags()
+	arguments.AddProfileFlag(flags)
 	confirm.AddFlag(flags)
 }

--- a/cmd/list/cmd.go
+++ b/cmd/list/cmd.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openshift/rosa/cmd/list/upgrade"
 	"github.com/openshift/rosa/cmd/list/user"
 	"github.com/openshift/rosa/cmd/list/version"
+	"github.com/openshift/rosa/pkg/arguments"
 )
 
 var Cmd = &cobra.Command{
@@ -46,4 +47,7 @@ func init() {
 	Cmd.AddCommand(upgrade.Cmd)
 	Cmd.AddCommand(user.Cmd)
 	Cmd.AddCommand(version.Cmd)
+
+	flags := Cmd.PersistentFlags()
+	arguments.AddProfileFlag(flags)
 }

--- a/cmd/logs/cmd.go
+++ b/cmd/logs/cmd.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/openshift/rosa/cmd/logs/install"
 	"github.com/openshift/rosa/cmd/logs/uninstall"
+	"github.com/openshift/rosa/pkg/arguments"
 )
 
 var Cmd = &cobra.Command{
@@ -38,4 +39,7 @@ var Cmd = &cobra.Command{
 func init() {
 	Cmd.AddCommand(install.Cmd)
 	Cmd.AddCommand(uninstall.Cmd)
+
+	flags := Cmd.PersistentFlags()
+	arguments.AddProfileFlag(flags)
 }

--- a/cmd/revoke/cmd.go
+++ b/cmd/revoke/cmd.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/cmd/revoke/user"
+	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/confirm"
 )
 
@@ -30,8 +31,9 @@ var Cmd = &cobra.Command{
 }
 
 func init() {
-	flags := Cmd.PersistentFlags()
-	confirm.AddFlag(flags)
-
 	Cmd.AddCommand(user.Cmd)
+
+	flags := Cmd.PersistentFlags()
+	arguments.AddProfileFlag(flags)
+	confirm.AddFlag(flags)
 }

--- a/cmd/rosa/main.go
+++ b/cmd/rosa/main.go
@@ -62,7 +62,6 @@ func init() {
 	// Add the command line flags:
 	fs := root.PersistentFlags()
 	arguments.AddDebugFlag(fs)
-	arguments.AddProfileFlag(fs)
 
 	// Register the subcommands:
 	root.AddCommand(completion.Cmd)

--- a/cmd/uninstall/cmd.go
+++ b/cmd/uninstall/cmd.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/cmd/uninstall/addon"
+	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/confirm"
 )
 
@@ -33,5 +34,6 @@ func init() {
 	Cmd.AddCommand(addon.Cmd)
 
 	flags := Cmd.PersistentFlags()
+	arguments.AddProfileFlag(flags)
 	confirm.AddFlag(flags)
 }

--- a/cmd/upgrade/cmd.go
+++ b/cmd/upgrade/cmd.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/cmd/upgrade/cluster"
+	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/interactive"
 )
 
@@ -33,5 +34,6 @@ func init() {
 	Cmd.AddCommand(cluster.Cmd)
 
 	flags := Cmd.PersistentFlags()
+	arguments.AddProfileFlag(flags)
 	interactive.AddFlag(flags)
 }

--- a/cmd/verify/cmd.go
+++ b/cmd/verify/cmd.go
@@ -30,21 +30,7 @@ var Cmd = &cobra.Command{
 	Long:  "Verify resources are configured correctly for cluster install",
 }
 
-var args struct {
-	region string
-}
-
 func init() {
-	flags := Cmd.PersistentFlags()
-
-	flags.StringVarP(
-		&args.region,
-		"region",
-		"r",
-		"",
-		"AWS region in which to run (overrides the AWS_REGION environment variable)",
-	)
-
 	Cmd.AddCommand(oc.Cmd)
 	Cmd.AddCommand(permissions.Cmd)
 	Cmd.AddCommand(quota.Cmd)

--- a/cmd/verify/permissions/cmd.go
+++ b/cmd/verify/permissions/cmd.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/logging"
 	rprtr "github.com/openshift/rosa/pkg/reporter"
@@ -39,12 +40,19 @@ var Cmd = &cobra.Command{
 	Run: run,
 }
 
-func run(cmd *cobra.Command, argv []string) {
+func init() {
+	flags := Cmd.Flags()
+
+	arguments.AddProfileFlag(flags)
+	arguments.AddRegionFlag(flags)
+}
+
+func run(cmd *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
 	logger := logging.CreateLoggerOrExit(reporter)
 
 	// Get AWS region
-	region, err := aws.GetRegion(cmd.Flags().Lookup("region").Value.String())
+	region, err := aws.GetRegion(arguments.GetRegion())
 	if err != nil {
 		reporter.Errorf("Error getting region: %v", err)
 		os.Exit(1)

--- a/cmd/verify/quota/cmd.go
+++ b/cmd/verify/quota/cmd.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/logging"
 	rprtr "github.com/openshift/rosa/pkg/reporter"
@@ -38,12 +39,19 @@ var Cmd = &cobra.Command{
 	Run: run,
 }
 
-func run(cmd *cobra.Command, argv []string) {
+func init() {
+	flags := Cmd.Flags()
+
+	arguments.AddRegionFlag(flags)
+	arguments.AddProfileFlag(flags)
+}
+
+func run(cmd *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
 	logger := logging.CreateLoggerOrExit(reporter)
 
 	// Get AWS region
-	region, err := aws.GetRegion(cmd.Flags().Lookup("region").Value.String())
+	region, err := aws.GetRegion(arguments.GetRegion())
 	if err != nil {
 		reporter.Errorf("Error getting region: %v", err)
 		os.Exit(1)

--- a/cmd/whoami/cmd.go
+++ b/cmd/whoami/cmd.go
@@ -24,6 +24,7 @@ import (
 	amsv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/logging"
 	"github.com/openshift/rosa/pkg/ocm"
@@ -38,6 +39,11 @@ var Cmd = &cobra.Command{
 	Example: `  # Displays user information
   rosa whoami`,
 	Run: run,
+}
+
+func init() {
+	flags := Cmd.PersistentFlags()
+	arguments.AddProfileFlag(flags)
 }
 
 func run(_ *cobra.Command, _ []string) {

--- a/docs/rosa.md
+++ b/docs/rosa.md
@@ -9,10 +9,9 @@ Command line tool for Red Hat OpenShift Service on AWS.
 ### Options
 
 ```
-      --debug            Enable debug mode.
-  -h, --help             help for rosa
-      --profile string   Use a specific AWS profile from your credential file.
-  -v, --v Level          log level for V logs
+      --debug     Enable debug mode.
+  -h, --help      help for rosa
+  -v, --v Level   log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/rosa_completion.md
+++ b/docs/rosa_completion.md
@@ -27,9 +27,8 @@ rosa completion [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug            Enable debug mode.
-      --profile string   Use a specific AWS profile from your credential file.
-  -v, --v Level          log level for V logs
+      --debug     Enable debug mode.
+  -v, --v Level   log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/rosa_create.md
+++ b/docs/rosa_create.md
@@ -9,17 +9,17 @@ Create a resource from stdin
 ### Options
 
 ```
-  -h, --help          help for create
-  -i, --interactive   Enable interactive mode.
-  -y, --yes           Automatically answer yes to confirm operation.
+  -h, --help             help for create
+  -i, --interactive      Enable interactive mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -y, --yes              Automatically answer yes to confirm operation.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --debug            Enable debug mode.
-      --profile string   Use a specific AWS profile from your credential file.
-  -v, --v Level          log level for V logs
+      --debug     Enable debug mode.
+  -v, --v Level   log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/rosa_create_cluster.md
+++ b/docs/rosa_create_cluster.md
@@ -25,7 +25,7 @@ rosa create cluster [flags]
 ```
   -c, --cluster-name string           Name of the cluster. This will be used when generating a sub-domain for your cluster on openshiftapps.com.
       --multi-az                      Deploy to multiple data centers.
-  -r, --region string                 AWS region where your worker pool will be located. (overrides the AWS_REGION environment variable)
+      --region string                 Use a specific AWS region, overriding the AWS_REGION environment variable.
       --version string                Version of OpenShift that will be used to install the cluster, for example "4.3.10"
       --channel-group string          Channel group is the name of the group where this image belongs, for example "stable" or "fast". (default "stable")
       --compute-machine-type string   Instance type for the compute nodes. Determines the amount of memory and vCPU allocated to each compute node.

--- a/docs/rosa_delete.md
+++ b/docs/rosa_delete.md
@@ -9,16 +9,16 @@ Delete a specific resource
 ### Options
 
 ```
-  -h, --help   help for delete
-  -y, --yes    Automatically answer yes to confirm operation.
+  -h, --help             help for delete
+      --profile string   Use a specific AWS profile from your credential file.
+  -y, --yes              Automatically answer yes to confirm operation.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --debug            Enable debug mode.
-      --profile string   Use a specific AWS profile from your credential file.
-  -v, --v Level          log level for V logs
+      --debug     Enable debug mode.
+  -v, --v Level   log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/rosa_describe.md
+++ b/docs/rosa_describe.md
@@ -9,15 +9,15 @@ Show details of a specific resource
 ### Options
 
 ```
-  -h, --help   help for describe
+  -h, --help             help for describe
+      --profile string   Use a specific AWS profile from your credential file.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --debug            Enable debug mode.
-      --profile string   Use a specific AWS profile from your credential file.
-  -v, --v Level          log level for V logs
+      --debug     Enable debug mode.
+  -v, --v Level   log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/rosa_download.md
+++ b/docs/rosa_download.md
@@ -15,9 +15,8 @@ Download necessary tools for using your cluster
 ### Options inherited from parent commands
 
 ```
-      --debug            Enable debug mode.
-      --profile string   Use a specific AWS profile from your credential file.
-  -v, --v Level          log level for V logs
+      --debug     Enable debug mode.
+  -v, --v Level   log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/rosa_download_openshift-client.md
+++ b/docs/rosa_download_openshift-client.md
@@ -26,9 +26,8 @@ rosa download openshift-client [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug            Enable debug mode.
-      --profile string   Use a specific AWS profile from your credential file.
-  -v, --v Level          log level for V logs
+      --debug     Enable debug mode.
+  -v, --v Level   log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/rosa_edit.md
+++ b/docs/rosa_edit.md
@@ -9,16 +9,16 @@ Edit a specific resource
 ### Options
 
 ```
-  -h, --help          help for edit
-  -i, --interactive   Enable interactive mode.
+  -h, --help             help for edit
+  -i, --interactive      Enable interactive mode.
+      --profile string   Use a specific AWS profile from your credential file.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --debug            Enable debug mode.
-      --profile string   Use a specific AWS profile from your credential file.
-  -v, --v Level          log level for V logs
+      --debug     Enable debug mode.
+  -v, --v Level   log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/rosa_grant.md
+++ b/docs/rosa_grant.md
@@ -9,16 +9,16 @@ Grant role to a specific resource
 ### Options
 
 ```
-  -h, --help          help for grant
-  -i, --interactive   Enable interactive mode.
+  -h, --help             help for grant
+  -i, --interactive      Enable interactive mode.
+      --profile string   Use a specific AWS profile from your credential file.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --debug            Enable debug mode.
-      --profile string   Use a specific AWS profile from your credential file.
-  -v, --v Level          log level for V logs
+      --debug     Enable debug mode.
+  -v, --v Level   log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/rosa_init.md
+++ b/docs/rosa_init.md
@@ -24,7 +24,6 @@ rosa init [flags]
 ### Options
 
 ```
-  -r, --region string          AWS region in which verify quota and permissions (overrides the AWS_REGION environment variable)
       --delete-stack           Deletes stack template applied to your AWS account during the 'init' command.
                                
       --client-id string       OpenID client identifier. The default value is 'cloud-services'.
@@ -33,15 +32,16 @@ rosa init [flags]
       --scope strings          OpenID scope. If this option is used it will replace completely the default scopes. Can be repeated multiple times to specify multiple scopes. (default [openid])
   -t, --token string           Access or refresh token generated from https://cloud.redhat.com/openshift/token/rosa.
       --token-url string       OpenID token URL. The default value is 'https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token'.
+      --profile string         Use a specific AWS profile from your credential file.
+      --region string          Use a specific AWS region, overriding the AWS_REGION environment variable.
   -h, --help                   help for init
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --debug            Enable debug mode.
-      --profile string   Use a specific AWS profile from your credential file.
-  -v, --v Level          log level for V logs
+      --debug     Enable debug mode.
+  -v, --v Level   log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/rosa_install.md
+++ b/docs/rosa_install.md
@@ -9,16 +9,16 @@ Installs a resource into a cluster
 ### Options
 
 ```
-  -h, --help   help for install
-  -y, --yes    Automatically answer yes to confirm operation.
+  -h, --help             help for install
+      --profile string   Use a specific AWS profile from your credential file.
+  -y, --yes              Automatically answer yes to confirm operation.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --debug            Enable debug mode.
-      --profile string   Use a specific AWS profile from your credential file.
-  -v, --v Level          log level for V logs
+      --debug     Enable debug mode.
+  -v, --v Level   log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/rosa_list.md
+++ b/docs/rosa_list.md
@@ -9,15 +9,15 @@ List all resources of a specific type
 ### Options
 
 ```
-  -h, --help   help for list
+  -h, --help             help for list
+      --profile string   Use a specific AWS profile from your credential file.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --debug            Enable debug mode.
-      --profile string   Use a specific AWS profile from your credential file.
-  -v, --v Level          log level for V logs
+      --debug     Enable debug mode.
+  -v, --v Level   log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/rosa_login.md
+++ b/docs/rosa_login.md
@@ -41,9 +41,8 @@ rosa login [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug            Enable debug mode.
-      --profile string   Use a specific AWS profile from your credential file.
-  -v, --v Level          log level for V logs
+      --debug     Enable debug mode.
+  -v, --v Level   log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/rosa_logout.md
+++ b/docs/rosa_logout.md
@@ -19,9 +19,8 @@ rosa logout [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug            Enable debug mode.
-      --profile string   Use a specific AWS profile from your credential file.
-  -v, --v Level          log level for V logs
+      --debug     Enable debug mode.
+  -v, --v Level   log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/rosa_logs.md
+++ b/docs/rosa_logs.md
@@ -19,15 +19,15 @@ Show installation or uninstallation logs for a cluster
 ### Options
 
 ```
-  -h, --help   help for logs
+  -h, --help             help for logs
+      --profile string   Use a specific AWS profile from your credential file.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --debug            Enable debug mode.
-      --profile string   Use a specific AWS profile from your credential file.
-  -v, --v Level          log level for V logs
+      --debug     Enable debug mode.
+  -v, --v Level   log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/rosa_revoke.md
+++ b/docs/rosa_revoke.md
@@ -9,16 +9,16 @@ Revoke role from a specific resource
 ### Options
 
 ```
-  -h, --help   help for revoke
-  -y, --yes    Automatically answer yes to confirm operation.
+  -h, --help             help for revoke
+      --profile string   Use a specific AWS profile from your credential file.
+  -y, --yes              Automatically answer yes to confirm operation.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --debug            Enable debug mode.
-      --profile string   Use a specific AWS profile from your credential file.
-  -v, --v Level          log level for V logs
+      --debug     Enable debug mode.
+  -v, --v Level   log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/rosa_uninstall.md
+++ b/docs/rosa_uninstall.md
@@ -9,16 +9,16 @@ Uninstalls a resource from a cluster
 ### Options
 
 ```
-  -h, --help   help for uninstall
-  -y, --yes    Automatically answer yes to confirm operation.
+  -h, --help             help for uninstall
+      --profile string   Use a specific AWS profile from your credential file.
+  -y, --yes              Automatically answer yes to confirm operation.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --debug            Enable debug mode.
-      --profile string   Use a specific AWS profile from your credential file.
-  -v, --v Level          log level for V logs
+      --debug     Enable debug mode.
+  -v, --v Level   log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/rosa_upgrade.md
+++ b/docs/rosa_upgrade.md
@@ -9,16 +9,16 @@ Upgrade a resource
 ### Options
 
 ```
-  -h, --help          help for upgrade
-  -i, --interactive   Enable interactive mode.
+  -h, --help             help for upgrade
+  -i, --interactive      Enable interactive mode.
+      --profile string   Use a specific AWS profile from your credential file.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --debug            Enable debug mode.
-      --profile string   Use a specific AWS profile from your credential file.
-  -v, --v Level          log level for V logs
+      --debug     Enable debug mode.
+  -v, --v Level   log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/rosa_verify.md
+++ b/docs/rosa_verify.md
@@ -9,16 +9,14 @@ Verify resources are configured correctly for cluster install
 ### Options
 
 ```
-  -h, --help            help for verify
-  -r, --region string   AWS region in which to run (overrides the AWS_REGION environment variable)
+  -h, --help   help for verify
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --debug            Enable debug mode.
-      --profile string   Use a specific AWS profile from your credential file.
-  -v, --v Level          log level for V logs
+      --debug     Enable debug mode.
+  -v, --v Level   log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/rosa_verify_openshift-client.md
+++ b/docs/rosa_verify_openshift-client.md
@@ -26,10 +26,8 @@ rosa verify openshift-client [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug            Enable debug mode.
-      --profile string   Use a specific AWS profile from your credential file.
-  -r, --region string    AWS region in which to run (overrides the AWS_REGION environment variable)
-  -v, --v Level          log level for V logs
+      --debug     Enable debug mode.
+  -v, --v Level   log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/rosa_verify_permissions.md
+++ b/docs/rosa_verify_permissions.md
@@ -23,16 +23,16 @@ rosa verify permissions [flags]
 ### Options
 
 ```
-  -h, --help   help for permissions
+  -h, --help             help for permissions
+      --profile string   Use a specific AWS profile from your credential file.
+      --region string    Use a specific AWS region, overriding the AWS_REGION environment variable.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --debug            Enable debug mode.
-      --profile string   Use a specific AWS profile from your credential file.
-  -r, --region string    AWS region in which to run (overrides the AWS_REGION environment variable)
-  -v, --v Level          log level for V logs
+      --debug     Enable debug mode.
+  -v, --v Level   log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/rosa_verify_quota.md
+++ b/docs/rosa_verify_quota.md
@@ -23,16 +23,16 @@ rosa verify quota [flags]
 ### Options
 
 ```
-  -h, --help   help for quota
+  -h, --help             help for quota
+      --profile string   Use a specific AWS profile from your credential file.
+      --region string    Use a specific AWS region, overriding the AWS_REGION environment variable.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --debug            Enable debug mode.
-      --profile string   Use a specific AWS profile from your credential file.
-  -r, --region string    AWS region in which to run (overrides the AWS_REGION environment variable)
-  -v, --v Level          log level for V logs
+      --debug     Enable debug mode.
+  -v, --v Level   log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/rosa_version.md
+++ b/docs/rosa_version.md
@@ -19,9 +19,8 @@ rosa version [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug            Enable debug mode.
-      --profile string   Use a specific AWS profile from your credential file.
-  -v, --v Level          log level for V logs
+      --debug     Enable debug mode.
+  -v, --v Level   log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/rosa_whoami.md
+++ b/docs/rosa_whoami.md
@@ -20,15 +20,15 @@ rosa whoami [flags]
 ### Options
 
 ```
-  -h, --help   help for whoami
+  -h, --help             help for whoami
+      --profile string   Use a specific AWS profile from your credential file.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --debug            Enable debug mode.
-      --profile string   Use a specific AWS profile from your credential file.
-  -v, --v Level          log level for V logs
+      --debug     Enable debug mode.
+  -v, --v Level   log level for V logs
 ```
 
 ### SEE ALSO

--- a/pkg/arguments/arguments.go
+++ b/pkg/arguments/arguments.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/openshift/rosa/pkg/aws/profile"
+	"github.com/openshift/rosa/pkg/aws/region"
 	"github.com/openshift/rosa/pkg/debug"
 )
 
@@ -33,4 +34,17 @@ func AddDebugFlag(fs *pflag.FlagSet) {
 // AddProfileFlag adds the '--profile' flag to the given set of command line flags.
 func AddProfileFlag(fs *pflag.FlagSet) {
 	profile.AddFlag(fs)
+}
+
+func GetProfile() string {
+	return profile.Profile()
+}
+
+// AddRegionFlag adds the '--region' flag to the given set of command line flags.
+func AddRegionFlag(fs *pflag.FlagSet) {
+	region.AddFlag(fs)
+}
+
+func GetRegion() string {
+	return region.Region()
 }

--- a/pkg/aws/region/flag.go
+++ b/pkg/aws/region/flag.go
@@ -1,0 +1,50 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains functions used to implement the '--region' command line option.
+
+package region
+
+import (
+	"os"
+
+	"github.com/spf13/pflag"
+)
+
+// AddFlag adds the debug flag to the given set of command line flags.
+func AddFlag(flags *pflag.FlagSet) {
+	flags.StringVar(
+		&region,
+		"region",
+		"",
+		"Use a specific AWS region, overriding the AWS_REGION environment variable.",
+	)
+}
+
+// Region returns a string with the name of the AWS region being used.
+func Region() string {
+	if region != "" {
+		return region
+	}
+	awsRegion := os.Getenv("AWS_REGION")
+	if awsRegion != "" {
+		return awsRegion
+	}
+	return ""
+}
+
+// region is a string flag that indicates which AWS region is being used.
+var region string


### PR DESCRIPTION
Instead of blanket-enabling the `--region` and `--profile` flags, we add
them to the commands that benefit from them. This avoid confusion by
removing them from the help entries of non-relevant commands.