### PR TITLE
interactive: Output command to rerun cluster creation

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -433,18 +433,18 @@ func createClusterSpec(config Spec, awsClient aws.Client) (*cmv1.Cluster, error)
 		clusterBuilder = clusterBuilder.Nodes(clusterNodesBuilder)
 	}
 
-	if !cidrIsEmpty(config.MachineCIDR) ||
-		!cidrIsEmpty(config.ServiceCIDR) ||
-		!cidrIsEmpty(config.PodCIDR) ||
+	if !IsEmptyCIDR(config.MachineCIDR) ||
+		!IsEmptyCIDR(config.ServiceCIDR) ||
+		!IsEmptyCIDR(config.PodCIDR) ||
 		config.HostPrefix != 0 {
 		networkBuilder := cmv1.NewNetwork()
-		if !cidrIsEmpty(config.MachineCIDR) {
+		if !IsEmptyCIDR(config.MachineCIDR) {
 			networkBuilder = networkBuilder.MachineCIDR(config.MachineCIDR.String())
 		}
-		if !cidrIsEmpty(config.ServiceCIDR) {
+		if !IsEmptyCIDR(config.ServiceCIDR) {
 			networkBuilder = networkBuilder.ServiceCIDR(config.ServiceCIDR.String())
 		}
-		if !cidrIsEmpty(config.PodCIDR) {
+		if !IsEmptyCIDR(config.PodCIDR) {
 			networkBuilder = networkBuilder.PodCIDR(config.PodCIDR.String())
 		}
 		if config.HostPrefix != 0 {
@@ -493,7 +493,8 @@ func createClusterSpec(config Spec, awsClient aws.Client) (*cmv1.Cluster, error)
 	return clusterSpec, nil
 }
 
-func cidrIsEmpty(cidr net.IPNet) bool {
+// nolint:interfacer
+func IsEmptyCIDR(cidr net.IPNet) bool {
 	return cidr.String() == "<nil>"
 }
 


### PR DESCRIPTION
In the case where a user went through the interactive mode and the
cluster failed installation, they would need to go through the entire
interactive prompt again until their cluster succeeds. To simplify this
scenario, the cluster creation process now prints out a populated
command to re-create a cluster with the same parameters.

This is useful even if the cluster does not fail installation to allow
for reproducible clusters.

Demo: https://asciinema.org/a/qu9pOxdo49lF9iJO4JraIPgUn