### PR TITLE
cluster: Remove suggestion to run init

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -352,8 +352,8 @@ func createClusterSpec(config Spec, awsClient aws.Client) (*cmv1.Cluster, error)
 	// Create the access key for the AWS user:
 	awsAccessKey, err := awsClient.GetAWSAccessKeys()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get access keys for user '%s': %v\n"+
-			"Run 'rosa init' and try again", aws.AdminUserName, err)
+		return nil, fmt.Errorf("Failed to get access keys for user '%s': %v",
+			aws.AdminUserName, err)
 	}
 	reporter.Debugf("Access key identifier is '%s'", awsAccessKey.AccessKeyID)
 	reporter.Debugf("Secret access key is '%s'", awsAccessKey.SecretAccessKey)


### PR DESCRIPTION
Since the AWS credentials are not longer generated during 'init',
suggesting to the user to run 'init' is misleading.