### PR TITLE
user: Avoid calling API after failed validation

### DIFF
--- a/cmd/grant/user/cmd.go
+++ b/cmd/grant/user/cmd.go
@@ -120,6 +120,7 @@ func run(_ *cobra.Command, argv []string) {
 	}
 	if !isRoleValid {
 		reporter.Errorf("Expected at least one of %s", validRoles)
+		os.Exit(1)
 	}
 
 	// Create the AWS client:

--- a/cmd/revoke/user/cmd.go
+++ b/cmd/revoke/user/cmd.go
@@ -120,6 +120,7 @@ func run(_ *cobra.Command, argv []string) {
 	}
 	if !isRoleValid {
 		reporter.Errorf("Expected at least one of %s", validRoles)
+		os.Exit(1)
 	}
 
 	// Create the AWS client:


### PR DESCRIPTION
If local validation fails, there is no need to call the API as it is
expected to fail again.