### PR TITLE
google: Only force interactive mode when necessary

### DIFF
--- a/cmd/create/idp/google.go
+++ b/cmd/create/idp/google.go
@@ -85,7 +85,7 @@ func buildGoogleIdp(cmd *cobra.Command,
 		ClientSecret(clientSecret)
 
 	hostedDomain := args.googleHostedDomain
-	if interactive.Enabled() || mappingMethod != "lookup" {
+	if interactive.Enabled() || (mappingMethod != "lookup" && hostedDomain == "") {
 		hostedDomain, err = interactive.GetString(interactive.Input{
 			Question: "Hosted domain",
 			Help:     cmd.Flags().Lookup("hosted-domain").Usage,


### PR DESCRIPTION
If hosted domain is supplied for mapping methods other than 'lookup', we
do not need to force interactive mode.