### PR TITLE
args: Clean up argument and flag requirements

### DIFF
--- a/cmd/create/cmd.go
+++ b/cmd/create/cmd.go
@@ -29,7 +29,7 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:     "create RESOURCE [flags]",
+	Use:     "create",
 	Aliases: []string{"add"},
 	Short:   "Create a resource from stdin",
 	Long:    "Create a resource from stdin",

--- a/cmd/describe/addon/cmd.go
+++ b/cmd/describe/addon/cmd.go
@@ -31,26 +31,26 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:     "addon [ID|NAME]",
+	Use:     "addon ID",
 	Aliases: []string{"add-on"},
 	Short:   "Show details of an add-on",
 	Long:    "Show details of an add-on",
 	Example: `  # Describe an add-on named "codeready-workspaces"
   rosa describe addon codeready-workspaces`,
 	Run: run,
+	Args: func(_ *cobra.Command, argv []string) error {
+		if len(argv) != 1 {
+			return fmt.Errorf(
+				"Expected exactly one command line argument containing the identifier of the add-on")
+		}
+		return nil
+	},
 }
 
 func run(_ *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
 	logger := logging.CreateLoggerOrExit(reporter)
 
-	// Check command line arguments:
-	if len(argv) != 1 {
-		reporter.Errorf(
-			"Expected exactly one command line argument or flag containing the identifier of the add-on",
-		)
-		os.Exit(1)
-	}
 	addOnID := argv[0]
 
 	// Create the client for the OCM API:

--- a/cmd/describe/admin/cmd.go
+++ b/cmd/describe/admin/cmd.go
@@ -38,7 +38,7 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:   "admin [ID|NAME]",
+	Use:   "admin",
 	Short: "Show details of the cluster-admin user",
 	Long:  "Show details of the cluster-admin user and a command to login to the cluster",
 	Example: `  # Describe cluster-admin user of a cluster named mycluster

--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -45,7 +45,7 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:   "cluster [ID|NAME]",
+	Use:   "cluster",
 	Short: "Show details of a cluster",
 	Long:  "Show details of a cluster",
 	Example: `  # Describe a cluster named "mycluster"
@@ -66,25 +66,14 @@ func init() {
 		"",
 		"Name or ID of the cluster to describe.",
 	)
+	Cmd.MarkFlagRequired("cluster")
 }
 
-func run(_ *cobra.Command, argv []string) {
+func run(_ *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
 	logger := logging.CreateLoggerOrExit(reporter)
 
-	// Check command line arguments:
 	clusterKey := args.clusterKey
-	if clusterKey == "" {
-		if len(argv) != 1 {
-			reporter.Errorf(
-				"Expected exactly one command line argument or flag containing the name " +
-					"or identifier of the cluster",
-			)
-			os.Exit(1)
-		}
-		clusterKey = argv[0]
-	}
-
 	// Check that the cluster key (name, identifier or external identifier) given by the user
 	// is reasonably safe so that there is no risk of SQL injection:
 	if !clusterprovider.IsValidClusterKey(clusterKey) {

--- a/cmd/describe/cmd.go
+++ b/cmd/describe/cmd.go
@@ -25,7 +25,7 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:   "describe RESOURCE [flags]",
+	Use:   "describe",
 	Short: "Show details of a specific resource",
 	Long:  "Show details of a specific resource",
 }

--- a/cmd/dlt/cluster/cmd.go
+++ b/cmd/dlt/cluster/cmd.go
@@ -38,7 +38,7 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:   "cluster [ID|NAME]",
+	Use:   "cluster",
 	Short: "Delete cluster",
 	Long:  "Delete cluster.",
 	Example: `  # Delete a cluster named "mycluster"
@@ -59,6 +59,7 @@ func init() {
 		"",
 		"Name or ID of the cluster to delete.",
 	)
+	Cmd.MarkFlagRequired("cluster")
 
 	flags.BoolVar(
 		&args.watch,
@@ -68,23 +69,11 @@ func init() {
 	)
 }
 
-func run(cmd *cobra.Command, argv []string) {
+func run(cmd *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
 	logger := logging.CreateLoggerOrExit(reporter)
 
-	// Check command line arguments:
 	clusterKey := args.clusterKey
-	if clusterKey == "" {
-		if len(argv) != 1 {
-			reporter.Errorf(
-				"Expected exactly one command line argument or flag containing the name " +
-					"or identifier of the cluster",
-			)
-			os.Exit(1)
-		}
-		clusterKey = argv[0]
-	}
-
 	// Check that the cluster key (name, identifier or external identifier) given by the user
 	// is reasonably safe so that there is no risk of SQL injection:
 	if !clusterprovider.IsValidClusterKey(clusterKey) {

--- a/cmd/dlt/cmd.go
+++ b/cmd/dlt/cmd.go
@@ -29,7 +29,7 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:     "delete RESOURCE [flags]",
+	Use:     "delete",
 	Aliases: []string{"remove"},
 	Short:   "Delete a specific resource",
 	Long:    "Delete a specific resource",

--- a/cmd/dlt/idp/cmd.go
+++ b/cmd/dlt/idp/cmd.go
@@ -17,6 +17,7 @@ limitations under the License.
 package idp
 
 import (
+	"fmt"
 	"os"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -34,13 +35,21 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:     "idp [IDP NAME]",
+	Use:     "idp ID",
 	Aliases: []string{"idps"},
 	Short:   "Delete cluster IDPs",
 	Long:    "Delete a specific identity provider for a cluster.",
 	Example: `  # Delete an identity provider named github-1
   rosa delete idp github-1 --cluster=mycluster`,
 	Run: run,
+	Args: func(_ *cobra.Command, argv []string) error {
+		if len(argv) != 1 {
+			return fmt.Errorf(
+				"Expected exactly one command line parameter containing the name of the identity provider",
+			)
+		}
+		return nil
+	},
 }
 
 func init() {
@@ -60,20 +69,7 @@ func run(_ *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
 	logger := logging.CreateLoggerOrExit(reporter)
 
-	// Check command line arguments:
-	if len(argv) != 1 {
-		reporter.Errorf(
-			"Expected exactly one command line parameters containing the name " +
-				"of the Identity provider.",
-		)
-		os.Exit(1)
-	}
-
 	idpName := argv[0]
-	if idpName == "" {
-		reporter.Errorf("Identity provider name is required.")
-		os.Exit(1)
-	}
 
 	// Check that the cluster key (name, identifier or external identifier) given by the user
 	// is reasonably safe so that there is no risk of SQL injection:

--- a/cmd/dlt/ingress/cmd.go
+++ b/cmd/dlt/ingress/cmd.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ingress
 
 import (
+	"fmt"
 	"os"
 	"regexp"
 
@@ -39,7 +40,7 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:     "ingress",
+	Use:     "ingress ID",
 	Aliases: []string{"ingresses", "route", "routes"},
 	Short:   "Delete cluster ingress",
 	Long:    "Delete the additional non-default application router for a cluster.",
@@ -49,6 +50,14 @@ var Cmd = &cobra.Command{
   # Delete secondary ingress using the sub-domain name
   rosa delete ingress --cluster=mycluster apps2`,
 	Run: run,
+	Args: func(_ *cobra.Command, argv []string) error {
+		if len(argv) != 1 {
+			return fmt.Errorf(
+				"Expected exactly one command line parameter containing the id of the ingress",
+			)
+		}
+		return nil
+	},
 }
 
 func init() {
@@ -67,14 +76,6 @@ func init() {
 func run(_ *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
 	logger := logging.CreateLoggerOrExit(reporter)
-
-	// Check command line arguments:
-	if len(argv) != 1 {
-		reporter.Errorf(
-			"Expected exactly one command line parameter containing the id of the ingress",
-		)
-		os.Exit(1)
-	}
 
 	ingressID := argv[0]
 	if !ingressKeyRE.MatchString(ingressID) {

--- a/cmd/dlt/machinepool/cmd.go
+++ b/cmd/dlt/machinepool/cmd.go
@@ -17,6 +17,7 @@ limitations under the License.
 package machinepool
 
 import (
+	"fmt"
 	"os"
 	"regexp"
 
@@ -39,13 +40,21 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:     "machinepool",
+	Use:     "machinepool ID",
 	Aliases: []string{"machinepools", "machine-pool", "machine-pools"},
 	Short:   "Delete machine pool",
 	Long:    "Delete the additional machine pool from a cluster.",
 	Example: `  # Delete machine pool with ID mp-1 from a cluster named 'mycluster'
   rosa delete machinepool --cluster=mycluster mp-1`,
 	Run: run,
+	Args: func(_ *cobra.Command, argv []string) error {
+		if len(argv) != 1 {
+			return fmt.Errorf(
+				"Expected exactly one command line parameter containing the id of the machine pool",
+			)
+		}
+		return nil
+	},
 }
 
 func init() {
@@ -64,14 +73,6 @@ func init() {
 func run(_ *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
 	logger := logging.CreateLoggerOrExit(reporter)
-
-	// Check command line arguments:
-	if len(argv) != 1 {
-		reporter.Errorf(
-			"Expected exactly one command line parameter containing the id of the machine pool",
-		)
-		os.Exit(1)
-	}
 
 	machinePoolID := argv[0]
 	if !machinePoolKeyRE.MatchString(machinePoolID) {

--- a/cmd/download/cmd.go
+++ b/cmd/download/cmd.go
@@ -23,7 +23,7 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:   "download RESOURCE [flags]",
+	Use:   "download",
 	Short: "Download necessary tools for using your cluster",
 	Long:  "Download necessary tools for using your cluster",
 }

--- a/cmd/edit/cluster/cmd.go
+++ b/cmd/edit/cluster/cmd.go
@@ -68,6 +68,7 @@ func init() {
 		"",
 		"Name or ID of the cluster to edit.",
 	)
+	Cmd.MarkFlagRequired("cluster")
 
 	// Basic options
 	flags.StringVar(
@@ -95,22 +96,10 @@ func init() {
 	)
 }
 
-func run(cmd *cobra.Command, argv []string) {
+func run(cmd *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
 
-	// Check command line arguments:
 	clusterKey := args.clusterKey
-	if clusterKey == "" {
-		if len(argv) != 1 {
-			reporter.Errorf(
-				"Expected exactly one command line argument or flag containing the name " +
-					"or identifier of the cluster",
-			)
-			os.Exit(1)
-		}
-		clusterKey = argv[0]
-	}
-
 	// Check that the cluster key (name, identifier or external identifier) given by the user
 	// is reasonably safe so that there is no risk of SQL injection:
 	if !clusterprovider.IsValidClusterKey(clusterKey) {

--- a/cmd/edit/cmd.go
+++ b/cmd/edit/cmd.go
@@ -26,7 +26,7 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:     "edit RESOURCE [flags]",
+	Use:     "edit",
 	Aliases: []string{"update"},
 	Short:   "Edit a specific resource",
 	Long:    "Edit a specific resource",

--- a/cmd/edit/ingress/cmd.go
+++ b/cmd/edit/ingress/cmd.go
@@ -44,7 +44,7 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:     "ingress",
+	Use:     "ingress ID",
 	Aliases: []string{"route"},
 	Short:   "Edit the additional cluster ingress",
 	Long:    "Edit the additional non-default application router for a cluster.",
@@ -57,6 +57,14 @@ var Cmd = &cobra.Command{
   # Update the default ingress using the sub-domain identifier
   rosa edit ingress --private=false --cluster=mycluster apps`,
 	Run: run,
+	Args: func(_ *cobra.Command, argv []string) error {
+		if len(argv) != 1 {
+			return fmt.Errorf(
+				"Expected exactly one command line parameter containing the id of the ingress",
+			)
+		}
+		return nil
+	},
 }
 
 func init() {
@@ -90,14 +98,6 @@ func init() {
 func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
 	logger := logging.CreateLoggerOrExit(reporter)
-
-	// Check command line arguments:
-	if len(argv) != 1 {
-		reporter.Errorf(
-			"Expected exactly one command line parameter containing the id of the ingress",
-		)
-		os.Exit(1)
-	}
 
 	ingressID := argv[0]
 	if !ingressKeyRE.MatchString(ingressID) {

--- a/cmd/edit/machinepool/cmd.go
+++ b/cmd/edit/machinepool/cmd.go
@@ -17,6 +17,7 @@ limitations under the License.
 package machinepool
 
 import (
+	"fmt"
 	"os"
 	"regexp"
 
@@ -44,7 +45,7 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:     "machinepool",
+	Use:     "machinepool ID",
 	Aliases: []string{"machinepools", "machine-pool", "machine-pools"},
 	Short:   "Edit machine pool",
 	Long:    "Edit machine pools on a cluster.",
@@ -53,6 +54,14 @@ var Cmd = &cobra.Command{
   # Enable autoscaling and Set 3-5 replicas on machine pool 'mp1' on cluster 'mycluster'
   rosa edit machinepool --enable-autoscaling --min-replicas=3 --max-replicas=5 --cluster=mycluster mp1`,
 	Run: run,
+	Args: func(_ *cobra.Command, argv []string) error {
+		if len(argv) != 1 {
+			return fmt.Errorf(
+				"Expected exactly one command line parameter containing the id of the machine pool",
+			)
+		}
+		return nil
+	},
 }
 
 func init() {
@@ -99,14 +108,6 @@ func init() {
 func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
 	logger := logging.CreateLoggerOrExit(reporter)
-
-	// Check command line arguments:
-	if len(argv) != 1 {
-		reporter.Errorf(
-			"Expected exactly one command line parameter containing the id of the machine pool",
-		)
-		os.Exit(1)
-	}
 
 	machinePoolID := argv[0]
 	if !machinePoolKeyRE.MatchString(machinePoolID) {

--- a/cmd/grant/cmd.go
+++ b/cmd/grant/cmd.go
@@ -24,7 +24,7 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:   "grant RESOURCE [flags]",
+	Use:   "grant",
 	Short: "Grant role to a specific resource",
 	Long:  "Grant role to a specific resource",
 }

--- a/cmd/grant/user/cmd.go
+++ b/cmd/grant/user/cmd.go
@@ -35,7 +35,7 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:     "user ROLE [flags]",
+	Use:     "user ROLE",
 	Aliases: []string{"role"},
 	Short:   "Grant user access to cluster",
 	Long:    "Grant user access to cluster under a specific role",
@@ -45,6 +45,15 @@ var Cmd = &cobra.Command{
   # Grant dedicated-admins role to a user
   rosa grant user dedicated-admin --user=myusername --cluster=mycluster`,
 	Run: run,
+	Args: func(_ *cobra.Command, argv []string) error {
+		if len(argv) != 1 {
+			return fmt.Errorf(
+				"Expected exactly one command line argument containing the name " +
+					"of the group or role to grant the user.",
+			)
+		}
+		return nil
+	},
 }
 
 var validRoles = []string{"cluster-admins", "dedicated-admins"}
@@ -97,13 +106,6 @@ func run(_ *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
-	if len(argv) != 1 {
-		reporter.Errorf(
-			"Expected exactly one command line argument or flag containing the name " +
-				"of the group or role to grant the user.",
-		)
-		os.Exit(1)
-	}
 	role := argv[0]
 	// Allow role aliases
 	for _, validAlias := range validRolesAliases {

--- a/cmd/install/addon/cmd.go
+++ b/cmd/install/addon/cmd.go
@@ -17,6 +17,7 @@ limitations under the License.
 package addon
 
 import (
+	"fmt"
 	"net"
 	"os"
 	"regexp"
@@ -40,13 +41,19 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:     "addon",
+	Use:     "addon ID",
 	Aliases: []string{"addons", "add-on", "add-ons"},
 	Short:   "Install add-ons on cluster",
 	Long:    "Install Red Hat managed add-ons on a cluster",
 	Example: `  # Add the CodeReady Workspaces add-on installation to the cluster
   rosa install addon --cluster=mycluster codeready-workspaces`,
 	Run: run,
+	Args: func(_ *cobra.Command, argv []string) error {
+		if len(argv) != 1 {
+			return fmt.Errorf("Expected exactly one command line parameter containing the id of the add-on")
+		}
+		return nil
+	},
 }
 
 func init() {
@@ -67,17 +74,7 @@ func run(_ *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
 	logger := logging.CreateLoggerOrExit(reporter)
 
-	// Check command line arguments:
-	if len(argv) != 1 {
-		reporter.Errorf("Expected exactly one command line parameters containing the identifier of the add-on.")
-		os.Exit(1)
-	}
-
 	addOnID := argv[0]
-	if addOnID == "" {
-		reporter.Errorf("Add-on ID is required.")
-		os.Exit(1)
-	}
 
 	// Check that the cluster key (name, identifier or external identifier) given by the user
 	// is reasonably safe so that there is no risk of SQL injection:

--- a/cmd/install/cmd.go
+++ b/cmd/install/cmd.go
@@ -24,7 +24,7 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:   "install RESOURCE [flags]",
+	Use:   "install",
 	Short: "Installs a resource into a cluster",
 	Long:  "Installs a resource into a cluster",
 }

--- a/cmd/list/cluster/cmd.go
+++ b/cmd/list/cluster/cmd.go
@@ -41,7 +41,8 @@ var Cmd = &cobra.Command{
 	Long:    "List clusters.",
 	Example: `  # List all clusters
   rosa list clusters`,
-	Run: run,
+	Args: cobra.NoArgs,
+	Run:  run,
 }
 
 func init() {
@@ -57,15 +58,9 @@ func init() {
 	)
 }
 
-func run(_ *cobra.Command, argv []string) {
+func run(_ *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
 	logger := logging.CreateLoggerOrExit(reporter)
-
-	// Check command line arguments:
-	if len(argv) != 0 {
-		reporter.Errorf("Expected exactly zero command line parameters")
-		os.Exit(1)
-	}
 
 	// Create the AWS client:
 	awsClient, err := aws.NewClient().

--- a/cmd/list/cmd.go
+++ b/cmd/list/cmd.go
@@ -31,7 +31,7 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:   "list RESOURCE",
+	Use:   "list",
 	Short: "List all resources of a specific type",
 	Long:  "List all resources of a specific type",
 }

--- a/cmd/logs/cmd.go
+++ b/cmd/logs/cmd.go
@@ -24,7 +24,7 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:     "logs RESOURCE",
+	Use:     "logs",
 	Aliases: []string{"log"},
 	Short:   "Show installation or uninstallation logs for a cluster",
 	Long:    "Show installation or uninstallation logs for a cluster",

--- a/cmd/logs/install/cmd.go
+++ b/cmd/logs/install/cmd.go
@@ -41,7 +41,7 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:   "install [ID|NAME]",
+	Use:   "install",
 	Short: "Show cluster installation logs",
 	Long:  "Show cluster installation logs",
 	Example: `  # Show last 100 install log lines for a cluster named "mycluster"
@@ -62,6 +62,7 @@ func init() {
 		"",
 		"Name or ID of the cluster to get logs for.",
 	)
+	Cmd.MarkFlagRequired("cluster")
 
 	flags.IntVar(
 		&args.tail,
@@ -79,7 +80,7 @@ func init() {
 	)
 }
 
-func run(cmd *cobra.Command, argv []string) {
+func run(cmd *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
 	logger := logging.CreateLoggerOrExit(reporter)
 
@@ -89,17 +90,6 @@ func run(cmd *cobra.Command, argv []string) {
 
 	// Check command line arguments:
 	clusterKey := args.clusterKey
-	if clusterKey == "" {
-		if len(argv) != 1 {
-			reporter.Errorf(
-				"Expected exactly one command line argument or flag containing the name " +
-					"or identifier of the cluster",
-			)
-			os.Exit(1)
-		}
-		clusterKey = argv[0]
-	}
-
 	// Check that the cluster key (name, identifier or external identifier) given by the user
 	// is reasonably safe so that there is no risk of SQL injection:
 	if !clusterprovider.IsValidClusterKey(clusterKey) {

--- a/cmd/logs/uninstall/cmd.go
+++ b/cmd/logs/uninstall/cmd.go
@@ -41,7 +41,7 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:   "uninstall [ID|NAME]",
+	Use:   "uninstall",
 	Short: "Show cluster uninstallation logs",
 	Long:  "Show cluster uninstallation logs",
 	Example: `  # Show last 100 uninstall log lines for a cluster named "mycluster"
@@ -62,6 +62,7 @@ func init() {
 		"",
 		"Name or ID of the cluster to get logs for.",
 	)
+	Cmd.MarkFlagRequired("cluster")
 
 	flags.IntVar(
 		&args.tail,
@@ -79,7 +80,7 @@ func init() {
 	)
 }
 
-func run(cmd *cobra.Command, argv []string) {
+func run(cmd *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
 	logger := logging.CreateLoggerOrExit(reporter)
 
@@ -87,19 +88,7 @@ func run(cmd *cobra.Command, argv []string) {
 	// We check the flag value this way to allow other commands to watch logs
 	watch := cmd.Flags().Lookup("watch").Value.String() == "true"
 
-	// Check command line arguments:
 	clusterKey := args.clusterKey
-	if clusterKey == "" {
-		if len(argv) != 1 {
-			reporter.Errorf(
-				"Expected exactly one command line argument or flag containing the name " +
-					"or identifier of the cluster",
-			)
-			os.Exit(1)
-		}
-		clusterKey = argv[0]
-	}
-
 	// Check that the cluster key (name, identifier or external identifier) given by the user
 	// is reasonably safe so that there is no risk of SQL injection:
 	if !clusterprovider.IsValidClusterKey(clusterKey) {

--- a/cmd/revoke/cmd.go
+++ b/cmd/revoke/cmd.go
@@ -24,7 +24,7 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:   "revoke RESOURCE [flags]",
+	Use:   "revoke",
 	Short: "Revoke role from a specific resource",
 	Long:  "Revoke role from a specific resource",
 }

--- a/cmd/revoke/user/cmd.go
+++ b/cmd/revoke/user/cmd.go
@@ -35,7 +35,7 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:     "user ROLE [flags]",
+	Use:     "user ROLE",
 	Aliases: []string{"role"},
 	Short:   "Revoke role from users",
 	Long:    "Revoke role from cluster user",
@@ -45,6 +45,15 @@ var Cmd = &cobra.Command{
   # Revoke dedicated-admin role from a user
   rosa revoke user dedicate-admins --user=myusername --cluster=mycluster`,
 	Run: run,
+	Args: func(_ *cobra.Command, argv []string) error {
+		if len(argv) != 1 {
+			return fmt.Errorf(
+				"Expected exactly one command line argument containing the name " +
+					"of the group or role to grant the user.",
+			)
+		}
+		return nil
+	},
 }
 
 var validRoles = []string{"cluster-admins", "dedicated-admins"}
@@ -93,14 +102,6 @@ func run(_ *cobra.Command, argv []string) {
 		reporter.Errorf(
 			"username '%s' isn't valid: it must contain only letters, digits, dashes and underscores",
 			username,
-		)
-		os.Exit(1)
-	}
-
-	if len(argv) != 1 {
-		reporter.Errorf(
-			"Expected exactly one command line argument or flag containing the name " +
-				"of the group or role to grant the user.",
 		)
 		os.Exit(1)
 	}

--- a/cmd/uninstall/addon/cmd.go
+++ b/cmd/uninstall/addon/cmd.go
@@ -17,6 +17,7 @@ limitations under the License.
 package addon
 
 import (
+	"fmt"
 	"os"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -35,13 +36,19 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:     "addon",
+	Use:     "addon ID",
 	Aliases: []string{"addons", "add-on", "add-ons"},
 	Short:   "Uninstall add-on from cluster",
 	Long:    "Uninstall Red Hat managed add-on from a cluster",
 	Example: `  # Remove the CodeReady Workspaces add-on installation from the cluster
   rosa uninstall addon --cluster=mycluster codeready-workspaces`,
 	Run: run,
+	Args: func(_ *cobra.Command, argv []string) error {
+		if len(argv) != 1 {
+			return fmt.Errorf("Expected exactly one command line parameter containing the id of the add-on")
+		}
+		return nil
+	},
 }
 
 func init() {
@@ -53,7 +60,7 @@ func init() {
 		"cluster",
 		"c",
 		"",
-		"Name or ID of the cluster to add the IdP to (required).",
+		"Name or ID of the cluster to uninstall the add-on from (required).",
 	)
 	Cmd.MarkFlagRequired("cluster")
 }
@@ -62,17 +69,7 @@ func run(_ *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
 	logger := logging.CreateLoggerOrExit(reporter)
 
-	// Check command line arguments:
-	if len(argv) != 1 {
-		reporter.Errorf("Expected exactly one command line parameters containing the identifier of the add-on.")
-		os.Exit(1)
-	}
-
 	addOnID := argv[0]
-	if addOnID == "" {
-		reporter.Errorf("Add-on ID is required.")
-		os.Exit(1)
-	}
 
 	// Check that the cluster key (name, identifier or external identifier) given by the user
 	// is reasonably safe so that there is no risk of SQL injection:

--- a/cmd/uninstall/cmd.go
+++ b/cmd/uninstall/cmd.go
@@ -24,7 +24,7 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:   "uninstall RESOURCE [flags]",
+	Use:   "uninstall",
 	Short: "Uninstalls a resource from a cluster",
 	Long:  "Uninstalls a resource from a cluster",
 }

--- a/cmd/upgrade/cmd.go
+++ b/cmd/upgrade/cmd.go
@@ -24,7 +24,7 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:   "upgrade RESOURCE [flags]",
+	Use:   "upgrade",
 	Short: "Upgrade a resource",
 	Long:  "Upgrade a resource",
 }

--- a/cmd/verify/cmd.go
+++ b/cmd/verify/cmd.go
@@ -25,7 +25,7 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:   "verify RESOURCE [flags]",
+	Use:   "verify",
 	Short: "Verify resources are configured correctly for cluster install",
 	Long:  "Verify resources are configured correctly for cluster install",
 }

--- a/docs/rosa_delete_cluster.md
+++ b/docs/rosa_delete_cluster.md
@@ -7,7 +7,7 @@ Delete cluster
 Delete cluster.
 
 ```
-rosa delete cluster [ID|NAME] [flags]
+rosa delete cluster [flags]
 ```
 
 ### Examples

--- a/docs/rosa_delete_idp.md
+++ b/docs/rosa_delete_idp.md
@@ -7,7 +7,7 @@ Delete cluster IDPs
 Delete a specific identity provider for a cluster.
 
 ```
-rosa delete idp [IDP NAME] [flags]
+rosa delete idp ID [flags]
 ```
 
 ### Examples

--- a/docs/rosa_delete_ingress.md
+++ b/docs/rosa_delete_ingress.md
@@ -7,7 +7,7 @@ Delete cluster ingress
 Delete the additional non-default application router for a cluster.
 
 ```
-rosa delete ingress [flags]
+rosa delete ingress ID [flags]
 ```
 
 ### Examples

--- a/docs/rosa_delete_machinepool.md
+++ b/docs/rosa_delete_machinepool.md
@@ -7,7 +7,7 @@ Delete machine pool
 Delete the additional machine pool from a cluster.
 
 ```
-rosa delete machinepool [flags]
+rosa delete machinepool ID [flags]
 ```
 
 ### Examples

--- a/docs/rosa_describe_addon.md
+++ b/docs/rosa_describe_addon.md
@@ -7,7 +7,7 @@ Show details of an add-on
 Show details of an add-on
 
 ```
-rosa describe addon [ID|NAME] [flags]
+rosa describe addon ID [flags]
 ```
 
 ### Examples

--- a/docs/rosa_describe_admin.md
+++ b/docs/rosa_describe_admin.md
@@ -7,7 +7,7 @@ Show details of the cluster-admin user
 Show details of the cluster-admin user and a command to login to the cluster
 
 ```
-rosa describe admin [ID|NAME] [flags]
+rosa describe admin [flags]
 ```
 
 ### Examples

--- a/docs/rosa_describe_cluster.md
+++ b/docs/rosa_describe_cluster.md
@@ -7,7 +7,7 @@ Show details of a cluster
 Show details of a cluster
 
 ```
-rosa describe cluster [ID|NAME] [flags]
+rosa describe cluster [flags]
 ```
 
 ### Examples

--- a/docs/rosa_edit_ingress.md
+++ b/docs/rosa_edit_ingress.md
@@ -7,7 +7,7 @@ Edit the additional cluster ingress
 Edit the additional non-default application router for a cluster.
 
 ```
-rosa edit ingress [flags]
+rosa edit ingress ID [flags]
 ```
 
 ### Examples

--- a/docs/rosa_edit_machinepool.md
+++ b/docs/rosa_edit_machinepool.md
@@ -7,7 +7,7 @@ Edit machine pool
 Edit machine pools on a cluster.
 
 ```
-rosa edit machinepool [flags]
+rosa edit machinepool ID [flags]
 ```
 
 ### Examples

--- a/docs/rosa_install_addon.md
+++ b/docs/rosa_install_addon.md
@@ -7,7 +7,7 @@ Install add-ons on cluster
 Install Red Hat managed add-ons on a cluster
 
 ```
-rosa install addon [flags]
+rosa install addon ID [flags]
 ```
 
 ### Examples

--- a/docs/rosa_logs_install.md
+++ b/docs/rosa_logs_install.md
@@ -7,7 +7,7 @@ Show cluster installation logs
 Show cluster installation logs
 
 ```
-rosa logs install [ID|NAME] [flags]
+rosa logs install [flags]
 ```
 
 ### Examples

--- a/docs/rosa_logs_uninstall.md
+++ b/docs/rosa_logs_uninstall.md
@@ -7,7 +7,7 @@ Show cluster uninstallation logs
 Show cluster uninstallation logs
 
 ```
-rosa logs uninstall [ID|NAME] [flags]
+rosa logs uninstall [flags]
 ```
 
 ### Examples

--- a/docs/rosa_uninstall_addon.md
+++ b/docs/rosa_uninstall_addon.md
@@ -7,7 +7,7 @@ Uninstall add-on from cluster
 Uninstall Red Hat managed add-on from a cluster
 
 ```
-rosa uninstall addon [flags]
+rosa uninstall addon ID [flags]
 ```
 
 ### Examples
@@ -20,7 +20,7 @@ rosa uninstall addon [flags]
 ### Options
 
 ```
-  -c, --cluster string   Name or ID of the cluster to add the IdP to (required).
+  -c, --cluster string   Name or ID of the cluster to uninstall the add-on from (required).
   -h, --help             help for addon
 ```
 


### PR DESCRIPTION
For arguments that are required, ensure that they are validated prior to
running the command. Also standardize how they are validated so that
cobra can pick up a missing argument and show the command usage help.