### PR TITLE
cluster: Add hidden flag to set cluster flavour

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -64,6 +64,7 @@ var args struct {
 	region             string
 	version            string
 	channelGroup       string
+	flavour            string
 
 	// Scaling options
 	computeMachineType string
@@ -141,6 +142,15 @@ func init() {
 		versions.DefaultChannelGroup,
 		"Channel group is the name of the group where this image belongs, for example \"stable\" or \"fast\".",
 	)
+
+	flags.StringVar(
+		&args.flavour,
+		"flavour",
+		"osd-4",
+		"Set of predefined properties of a cluster",
+	)
+	flags.MarkHidden("flavour")
+
 	flags.StringVar(
 		&args.expirationTime,
 		"expiration-time",
@@ -652,7 +662,7 @@ func run(cmd *cobra.Command, _ []string) {
 	var dMachinecidr *net.IPNet
 	var dPodcidr *net.IPNet
 	var dServicecidr *net.IPNet
-	dMachinecidr, dPodcidr, dServicecidr, dhostPrefix := ocm.GetDefaultClusterFlavors(ocmClient)
+	dMachinecidr, dPodcidr, dServicecidr, dhostPrefix := ocm.GetDefaultClusterFlavors(ocmClient, args.flavour)
 
 	// Machine CIDR:
 	machineCIDR := args.machineCIDR
@@ -735,6 +745,7 @@ func run(cmd *cobra.Command, _ []string) {
 		MultiAZ:            multiAZ,
 		Version:            version,
 		ChannelGroup:       channelGroup,
+		Flavour:            args.flavour,
 		Expiration:         expiration,
 		ComputeMachineType: computeMachineType,
 		ComputeNodes:       computeNodes,

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -50,6 +50,7 @@ type Spec struct {
 	Version      string
 	ChannelGroup string
 	Expiration   time.Time
+	Flavour      string
 
 	// Scaling config
 	ComputeMachineType string
@@ -383,6 +384,10 @@ func createClusterSpec(config Spec, awsClient aws.Client) (*cmv1.Cluster, error)
 		Region(
 			cmv1.NewCloudRegion().
 				ID(config.Region),
+		).
+		Flavour(
+			cmv1.NewFlavour().
+				ID(config.Flavour),
 		).
 		Properties(clusterProperties)
 

--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -306,14 +306,17 @@ func handleErr(res *ocmerrors.Error, err error) error {
 	return errors.New(msg)
 }
 
-func GetDefaultClusterFlavors(ocmClient *cmv1.Client) (dMachinecidr *net.IPNet, dPodcidr *net.IPNet,
+func GetDefaultClusterFlavors(ocmClient *cmv1.Client, flavour string) (dMachinecidr *net.IPNet, dPodcidr *net.IPNet,
 	dServicecidr *net.IPNet, dhostPrefix int) {
-	flavourGetResponse, _ := ocmClient.Flavours().Flavour("osd-4").Get().Send()
+	flavourGetResponse, err := ocmClient.Flavours().Flavour(flavour).Get().Send()
+	if err != nil {
+		flavourGetResponse, _ = ocmClient.Flavours().Flavour("osd-4").Get().Send()
+	}
 	network, ok := flavourGetResponse.Body().GetNetwork()
 	if !ok {
 		return nil, nil, nil, 0
 	}
-	_, dMachinecidr, err := net.ParseCIDR(network.MachineCIDR())
+	_, dMachinecidr, err = net.ParseCIDR(network.MachineCIDR())
 	if err != nil {
 		dMachinecidr = nil
 	}


### PR DESCRIPTION
Usage: `rosa create cluster --flavour=scale-test-r` (default is `[osd-4](https://issues.redhat.com/browse/osd-4)`)