### PR TITLE
cluster: Allow the creation of fake clusters

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -40,6 +40,7 @@ import (
 	"github.com/openshift/rosa/pkg/logging"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/ocm/machines"
+	"github.com/openshift/rosa/pkg/ocm/properties"
 	"github.com/openshift/rosa/pkg/ocm/regions"
 	"github.com/openshift/rosa/pkg/ocm/versions"
 	rprtr "github.com/openshift/rosa/pkg/reporter"
@@ -51,6 +52,8 @@ var args struct {
 
 	// Simulate creating a cluster
 	dryRun bool
+	// Create a fake cluster with no AWS resources
+	fakeCluster bool
 
 	// Disable SCP checks in the installer
 	disableSCPChecks bool
@@ -245,6 +248,14 @@ func init() {
 		false,
 		"Simulate creating the cluster.",
 	)
+
+	flags.BoolVar(
+		&args.fakeCluster,
+		"fake-cluster",
+		false,
+		"Create a fake cluster that uses no AWS resources.",
+	)
+	flags.MarkHidden("fake-cluster")
 
 	flags.StringSliceVar(
 		&args.subnetIDs,
@@ -750,6 +761,11 @@ func run(cmd *cobra.Command, _ []string) {
 		DisableSCPChecks:   &args.disableSCPChecks,
 		AvailabilityZones:  availabilityZones,
 		SubnetIds:          subnetIDs,
+	}
+
+	if args.fakeCluster {
+		clusterConfig.CustomProperties = map[string]string{}
+		clusterConfig.CustomProperties[properties.FakeCluster] = "true"
 	}
 
 	reporter.Infof("Creating cluster '%s'", clusterName)

--- a/pkg/ocm/properties/properties.go
+++ b/pkg/ocm/properties/properties.go
@@ -27,3 +27,5 @@ const prefix = "rosa_"
 const CreatorARN = prefix + "creator_arn"
 
 const CLIVersion = prefix + "cli_version"
+
+const FakeCluster = "fake_cluster"


### PR DESCRIPTION
Since we have an internal flag to create fake clusters that consume no
AWS resources, we can expose that as a _hidden_ flag when creating
clusters.