### PR TITLE
cluster: Use correct privacy flag on describe

### DIFF
--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -168,11 +168,8 @@ func run(_ *cobra.Command, argv []string) {
 	}
 
 	isPrivate := "No"
-	ingresses, err := ocm.GetIngresses(ocmClient.Clusters(), cluster.ID())
-	for _, ingress := range ingresses {
-		if ingress.Default() && ingress.Listening() == cmv1.ListeningMethodInternal {
-			isPrivate = "Yes"
-		}
+	if cluster.API().Listening() == cmv1.ListeningMethodInternal {
+		isPrivate = "Yes"
 	}
 
 	scheduledUpgrade, err := upgrades.GetScheduledUpgrade(ocmClient, cluster.ID())

--- a/cmd/edit/cluster/cmd.go
+++ b/cmd/edit/cluster/cmd.go
@@ -196,7 +196,9 @@ func run(cmd *cobra.Command, argv []string) {
 		privateValue = cluster.API().Listening() == cmv1.ListeningMethodInternal
 	}
 
-	privateWarning := "You will not be able to access your cluster until you edit network settings in your cloud provider."
+	privateWarning := "You will not be able to access your cluster until you edit network settings " +
+		"in your cloud provider. To also change the privacy setting of the application router " +
+		"endpoints, use the 'rosa edit ingress' command."
 	if isInteractive {
 		privateValue, err = interactive.GetBool(interactive.Input{
 			Question: "Private cluster",
@@ -209,7 +211,7 @@ func run(cmd *cobra.Command, argv []string) {
 		}
 		private = &privateValue
 	} else if privateValue {
-		reporter.Warnf("You are choosing to make your cluster private. %s", privateWarning)
+		reporter.Warnf("You are choosing to make your cluster API private. %s", privateWarning)
 		if !confirm.Confirm("set cluster '%s' as private", clusterKey) {
 			os.Exit(0)
 		}


### PR DESCRIPTION
Also provide a better warning regarding API versus Ingress when setting
a cluster as private.