### PR TITLE
Remove asset build dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ export CGO_ENABLED=0
 unexport GOFLAGS
 
 .PHONY: build
-rosa: generate
+rosa:
 	go build ./cmd/rosa
 
 .PHONY: test


### PR DESCRIPTION
Since assets are rebuilt as part of the development flow, there is no
need to have it as a hard dependency on the main build process. This
simplifies build requirements on automated pipelines.