### PR TITLE
cmd: Use Run instead of PreRun

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -798,7 +798,7 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 	reporter.Infof("To view a list of clusters and their status, run 'rosa list clusters'")
 
-	cluster, err := clusterprovider.CreateCluster(ocmClient.Clusters(), clusterConfig)
+	_, err = clusterprovider.CreateCluster(ocmClient.Clusters(), clusterConfig)
 	if err != nil {
 		if args.dryRun {
 			reporter.Errorf("Creating cluster '%s' should fail: %s", clusterName, err)
@@ -822,7 +822,7 @@ func run(cmd *cobra.Command, _ []string) {
 			"for more information.")
 
 	if args.watch {
-		installLogs.Cmd.Run(cmd, []string{cluster.ID()})
+		installLogs.Cmd.Run(installLogs.Cmd, []string{clusterName})
 	} else {
 		reporter.Infof(
 			"To determine when your cluster is Ready, run 'rosa describe cluster -c %s'.",
@@ -834,7 +834,7 @@ func run(cmd *cobra.Command, _ []string) {
 		)
 	}
 
-	clusterdescribe.Cmd.Run(cmd, []string{cluster.ID()})
+	clusterdescribe.Cmd.Run(clusterdescribe.Cmd, []string{clusterName})
 }
 
 // Validate OpenShift versions

--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -54,12 +54,6 @@ var Cmd = &cobra.Command{
   # Describe a cluster using the --cluster flag
   rosa describe cluster --cluster=mycluster`,
 	Run: run,
-	PreRun: func(cmd *cobra.Command, argv []string) {
-		// Allow the command to be called programmatically
-		if len(argv) == 1 && !cmd.Flag("cluster").Changed {
-			args.clusterKey = argv[0]
-		}
-	},
 }
 
 func init() {
@@ -75,9 +69,14 @@ func init() {
 	Cmd.MarkFlagRequired("cluster")
 }
 
-func run(_ *cobra.Command, _ []string) {
+func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
 	logger := logging.CreateLoggerOrExit(reporter)
+
+	// Allow the command to be called programmatically
+	if len(argv) == 1 && !cmd.Flag("cluster").Changed {
+		args.clusterKey = argv[0]
+	}
 
 	clusterKey := args.clusterKey
 	// Check that the cluster key (name, identifier or external identifier) given by the user

--- a/cmd/dlt/cluster/cmd.go
+++ b/cmd/dlt/cluster/cmd.go
@@ -123,7 +123,7 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	reporter.Debugf("Deleting cluster '%s'", clusterKey)
-	cluster, err := clusterprovider.DeleteCluster(clustersCollection, clusterKey, awsCreator.ARN)
+	_, err = clusterprovider.DeleteCluster(clustersCollection, clusterKey, awsCreator.ARN)
 	if err != nil {
 		reporter.Errorf("Failed to delete cluster '%s': %v", clusterKey, err)
 		os.Exit(1)
@@ -131,7 +131,7 @@ func run(cmd *cobra.Command, _ []string) {
 	reporter.Infof("Cluster '%s' will start uninstalling now", clusterKey)
 
 	if args.watch {
-		uninstallLogs.Cmd.Run(cmd, []string{cluster.ID()})
+		uninstallLogs.Cmd.Run(uninstallLogs.Cmd, []string{clusterKey})
 	} else {
 		reporter.Infof(
 			"To watch your cluster uninstallation logs, run 'rosa logs uninstall -c %s --watch'",

--- a/cmd/logs/install/cmd.go
+++ b/cmd/logs/install/cmd.go
@@ -50,13 +50,6 @@ var Cmd = &cobra.Command{
   # Show install logs for a cluster using the --cluster flag
   rosa logs install --cluster=mycluster`,
 	Run: run,
-	PreRun: func(cmd *cobra.Command, argv []string) {
-		// Allow the command to be called programmatically
-		if len(argv) == 1 && !cmd.Flag("cluster").Changed {
-			args.clusterKey = argv[0]
-			args.watch = true
-		}
-	},
 }
 
 func init() {
@@ -87,7 +80,7 @@ func init() {
 	)
 }
 
-func run(cmd *cobra.Command, _ []string) {
+func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
 	logger := logging.CreateLoggerOrExit(reporter)
 
@@ -95,7 +88,12 @@ func run(cmd *cobra.Command, _ []string) {
 	// We check the flag value this way to allow other commands to watch logs
 	watch := cmd.Flags().Lookup("watch").Value.String() == "true"
 
-	// Check command line arguments:
+	// Allow the command to be called programmatically
+	if len(argv) == 1 && !cmd.Flag("cluster").Changed {
+		args.clusterKey = argv[0]
+		watch = true
+	}
+
 	clusterKey := args.clusterKey
 	// Check that the cluster key (name, identifier or external identifier) given by the user
 	// is reasonably safe so that there is no risk of SQL injection:

--- a/cmd/logs/uninstall/cmd.go
+++ b/cmd/logs/uninstall/cmd.go
@@ -50,13 +50,6 @@ var Cmd = &cobra.Command{
   # Show uninstall logs for a cluster using the --cluster flag
   rosa logs uninstall --cluster=mycluster`,
 	Run: run,
-	PreRun: func(cmd *cobra.Command, argv []string) {
-		// Allow the command to be called programmatically
-		if len(argv) == 1 && !cmd.Flag("cluster").Changed {
-			args.clusterKey = argv[0]
-			args.watch = true
-		}
-	},
 }
 
 func init() {
@@ -87,13 +80,19 @@ func init() {
 	)
 }
 
-func run(cmd *cobra.Command, _ []string) {
+func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
 	logger := logging.CreateLoggerOrExit(reporter)
 
 	// Determine whether the user wants to watch logs streaming.
 	// We check the flag value this way to allow other commands to watch logs
 	watch := cmd.Flags().Lookup("watch").Value.String() == "true"
+
+	// Allow the command to be called programmatically
+	if len(argv) == 1 && !cmd.Flag("cluster").Changed {
+		args.clusterKey = argv[0]
+		watch = true
+	}
 
 	clusterKey := args.clusterKey
 	// Check that the cluster key (name, identifier or external identifier) given by the user


### PR DESCRIPTION
For programmatically-called commands, we should only rely on Run, as
PreRun would need to be explicitly called. Otherwise the command will
not have access to the argument flags.