### PR TITLE
upgrade: Validate node drain grace period

### DIFF
--- a/cmd/upgrade/cluster/cmd.go
+++ b/cmd/upgrade/cluster/cmd.go
@@ -330,6 +330,18 @@ func run(cmd *cobra.Command, _ []string) {
 			os.Exit(1)
 		}
 	}
+	isValidNodeDrainGracePeriod := false
+	for _, nodeDrainOption := range nodeDrainOptions {
+		if nodeDrainGracePeriod == nodeDrainOption {
+			isValidNodeDrainGracePeriod = true
+			break
+		}
+	}
+	if !isValidNodeDrainGracePeriod {
+		reporter.Errorf("Expected a valid node drain grace period. Options are [%s]",
+			strings.Join(nodeDrainOptions, ", "))
+		os.Exit(1)
+	}
 	nodeDrainParsed := strings.Split(nodeDrainGracePeriod, " ")
 	nodeDrainValue, err := strconv.ParseFloat(nodeDrainParsed[0], 64)
 	if err != nil {


### PR DESCRIPTION
Since only a few specific values are allowed, we check that user-entered
values match one of the allowed values.