### PR TITLE
addon: Validation message should show parameter name

### DIFF
--- a/cmd/install/addon/cmd.go
+++ b/cmd/install/addon/cmd.go
@@ -182,7 +182,7 @@ func run(_ *cobra.Command, argv []string) {
 				val, err = interactive.GetString(input)
 			}
 			if err != nil {
-				reporter.Errorf("Expected a valid value for '%s': %v", param.ID(), err)
+				reporter.Errorf("Expected a valid value for '%s': %v", param.Name(), err)
 				os.Exit(1)
 			}
 


### PR DESCRIPTION
Currently when an addon parameter fails validation it shows the ID,
which might be confusing for some users. This changes it to the
displayed name to make it more user-friendly.