### PR TITLE
upgrade: Display upgrade state whenever showing existing upgrades

### DIFF
--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -166,7 +166,7 @@ func run(cmd *cobra.Command, argv []string) {
 		isPrivate = "Yes"
 	}
 
-	scheduledUpgrade, err := upgrades.GetScheduledUpgrade(ocmClient, cluster.ID())
+	scheduledUpgrade, upgradeState, err := upgrades.GetScheduledUpgrade(ocmClient, cluster.ID())
 	if err != nil {
 		reporter.Errorf("Failed to get scheduled upgrades for cluster '%s': %v", clusterKey, err)
 		os.Exit(1)
@@ -255,8 +255,9 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 	if scheduledUpgrade != nil {
 		str = fmt.Sprintf("%s"+
-			"Scheduled Upgrade:          %s on %s\n",
+			"Scheduled Upgrade:          %s %s on %s\n",
 			str,
+			upgradeState.Value(),
 			scheduledUpgrade.Version(),
 			scheduledUpgrade.NextRun().Format("2006-01-02 15:04 MST"),
 		)

--- a/cmd/dlt/upgrade/cmd.go
+++ b/cmd/dlt/upgrade/cmd.go
@@ -120,7 +120,7 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
-	scheduledUpgrade, err := upgrades.GetScheduledUpgrade(ocmClient, cluster.ID())
+	scheduledUpgrade, _, err := upgrades.GetScheduledUpgrade(ocmClient, cluster.ID())
 	if err != nil {
 		reporter.Errorf("Failed to get scheduled upgrades for cluster '%s': %v", clusterKey, err)
 		os.Exit(1)

--- a/cmd/list/upgrade/cmd.go
+++ b/cmd/list/upgrade/cmd.go
@@ -135,7 +135,7 @@ func run(_ *cobra.Command, _ []string) {
 	latestRev := latestInCurrentMinor(versions.GetVersionID(cluster), availableUpgrades)
 
 	reporter.Debugf("Loading scheduled upgrades for cluster '%s'", clusterKey)
-	scheduledUpgrade, err := upgrades.GetScheduledUpgrade(ocmClient, cluster.ID())
+	scheduledUpgrade, upgradeState, err := upgrades.GetScheduledUpgrade(ocmClient, cluster.ID())
 	if err != nil {
 		reporter.Errorf("Failed to get scheduled upgrades for cluster '%s': %v", clusterKey, err)
 		os.Exit(1)
@@ -150,7 +150,8 @@ func run(_ *cobra.Command, _ []string) {
 			notes = "recommended"
 		}
 		if availableUpgrade == scheduledUpgrade.Version() {
-			notes = fmt.Sprintf("scheduled for %s", scheduledUpgrade.NextRun().Format("2006-01-02 15:04 MST"))
+			notes = fmt.Sprintf("%s for %s", upgradeState.Value(),
+				scheduledUpgrade.NextRun().Format("2006-01-02 15:04 MST"))
 		}
 		fmt.Fprintf(writer, "%s\t%s\n", availableUpgrade, notes)
 	}

--- a/cmd/upgrade/cluster/cmd.go
+++ b/cmd/upgrade/cluster/cmd.go
@@ -174,13 +174,14 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
-	scheduledUpgrade, err := upgrades.GetScheduledUpgrade(ocmClient, cluster.ID())
+	scheduledUpgrade, upgradeState, err := upgrades.GetScheduledUpgrade(ocmClient, cluster.ID())
 	if err != nil {
 		reporter.Errorf("Failed to get scheduled upgrades for cluster '%s': %v", clusterKey, err)
 		os.Exit(1)
 	}
 	if scheduledUpgrade != nil {
-		reporter.Warnf("There is already a scheduled upgrade to version %s on %s",
+		reporter.Warnf("There is already a %s upgrade to version %s on %s",
+			upgradeState.Value(),
 			scheduledUpgrade.Version(),
 			scheduledUpgrade.NextRun().Format("2006-01-02 15:04 MST"),
 		)


### PR DESCRIPTION
Instead of always referring to a 'scheduled upgrade', we now use the
actual upgrade state to display 'pending upgrade', 'started upgrade',
etc.