### PR TITLE
addons: Allow installation parameters in CLI

### DIFF
--- a/cmd/install/addon/cmd.go
+++ b/cmd/install/addon/cmd.go
@@ -27,6 +27,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
 	clusterprovider "github.com/openshift/rosa/pkg/cluster"
 	"github.com/openshift/rosa/pkg/confirm"
@@ -47,9 +48,15 @@ var Cmd = &cobra.Command{
 	Long:    "Install Red Hat managed add-ons on a cluster",
 	Example: `  # Add the CodeReady Workspaces add-on installation to the cluster
   rosa install addon --cluster=mycluster codeready-workspaces`,
-	Run: run,
-	Args: func(_ *cobra.Command, argv []string) error {
-		if len(argv) != 1 {
+	Run:                run,
+	DisableFlagParsing: true,
+	Args: func(cmd *cobra.Command, argv []string) error {
+		err := arguments.ParseUnknownFlags(cmd, argv)
+		if err != nil {
+			return fmt.Errorf("Failed to parse flags: %v", err)
+		}
+
+		if len(cmd.Flags().Args()) != 1 {
 			return fmt.Errorf("Expected exactly one command line parameter containing the id of the add-on")
 		}
 		return nil
@@ -65,15 +72,18 @@ func init() {
 		"cluster",
 		"c",
 		"",
-		"Name or ID of the cluster to add the IdP to (required).",
+		"Name or ID of the cluster to install the addon to (required).",
 	)
 	Cmd.MarkFlagRequired("cluster")
 }
 
-func run(_ *cobra.Command, argv []string) {
+func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
 	logger := logging.CreateLoggerOrExit(reporter)
 
+	// Parse out CLI flags, then override positional arguments
+	_ = cmd.Flags().Parse(argv)
+	argv = cmd.Flags().Args()
 	addOnID := argv[0]
 
 	// Check that the cluster key (name, identifier or external identifier) given by the user
@@ -147,48 +157,51 @@ func run(_ *cobra.Command, argv []string) {
 	var params []clusterprovider.AddOnParam
 	if parameters.Len() > 0 {
 		parameters.Each(func(param *cmv1.AddOnParameter) bool {
-			input := interactive.Input{
-				Question: param.Name(),
-				Help:     param.Description(),
-				Required: param.Required(),
-			}
-
 			var val string
-			switch param.ValueType() {
-			case "boolean":
-				var boolVal bool
-				input.Default, _ = strconv.ParseBool(param.DefaultValue())
-				boolVal, err = interactive.GetBool(input)
-				if boolVal {
-					val = "true"
-				} else {
-					val = "false"
+			// If value is already set in the CLI, ignore interactive prompt
+			flag := cmd.Flags().Lookup(param.ID())
+			if flag != nil {
+				val = flag.Value.String()
+			} else {
+				input := interactive.Input{
+					Question: param.Name(),
+					Help:     fmt.Sprintf("%s: %s", param.ID(), param.Description()),
+					Required: param.Required(),
 				}
-			case "cidr":
-				var cidrVal net.IPNet
-				if param.DefaultValue() != "" {
-					_, defaultIDR, _ := net.ParseCIDR(param.DefaultValue())
-					input.Default = *defaultIDR
+				switch param.ValueType() {
+				case "boolean":
+					var boolVal bool
+					input.Default, _ = strconv.ParseBool(param.DefaultValue())
+					boolVal, err = interactive.GetBool(input)
+					if boolVal {
+						val = "true"
+					} else {
+						val = "false"
+					}
+				case "cidr":
+					var cidrVal net.IPNet
+					if param.DefaultValue() != "" {
+						_, defaultIDR, _ := net.ParseCIDR(param.DefaultValue())
+						input.Default = *defaultIDR
+					}
+					cidrVal, err = interactive.GetIPNet(input)
+					val = cidrVal.String()
+				case "number":
+					var numVal float64
+					input.Default, _ = strconv.ParseFloat(param.DefaultValue(), 64)
+					numVal, err = interactive.GetFloat(input)
+					val = fmt.Sprintf("%f", numVal)
+				case "string":
+					input.Default = param.DefaultValue()
+					val, err = interactive.GetString(input)
 				}
-				cidrVal, err = interactive.GetIPNet(input)
-				val = cidrVal.String()
-			case "number":
-				var numVal float64
-				input.Default, _ = strconv.ParseFloat(param.DefaultValue(), 64)
-				numVal, err = interactive.GetFloat(input)
-				val = fmt.Sprintf("%f", numVal)
-			case "string":
-				input.Default = param.DefaultValue()
-				val, err = interactive.GetString(input)
-			}
-			if err != nil {
-				reporter.Errorf("Expected a valid value for '%s': %v", param.Name(), err)
-				os.Exit(1)
+				if err != nil {
+					reporter.Errorf("Expected a valid value for '%s': %v", param.Name(), err)
+					os.Exit(1)
+				}
 			}
 
-			if val != "" {
-				val = strings.Trim(val, " ")
-			}
+			val = strings.Trim(val, " ")
 			if val != "" && param.Validation() != "" {
 				isValid, err := regexp.MatchString(param.Validation(), val)
 				if err != nil || !isValid {

--- a/pkg/arguments/arguments.go
+++ b/pkg/arguments/arguments.go
@@ -19,12 +19,64 @@ limitations under the License.
 package arguments
 
 import (
+	"strings"
+
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	"github.com/openshift/rosa/pkg/aws/profile"
 	"github.com/openshift/rosa/pkg/aws/region"
 	"github.com/openshift/rosa/pkg/debug"
 )
+
+// ParseUnknownFlags parses all flags from the CLI, including
+// unknown ones, and adds them to the current command tree
+func ParseUnknownFlags(cmd *cobra.Command, argv []string) error {
+	flags := cmd.Flags()
+
+	prevArg := ""
+	for _, arg := range argv {
+		// If there are two consecutive flags, assume we've already
+		// dealt with the previous one by setting it as 'true'.
+		if strings.HasPrefix(arg, "-") && prevArg != "" {
+			var boolVal bool
+			flags.BoolVar(&boolVal, prevArg, false, "")
+			flags.Set(prevArg, "true")
+			prevArg = ""
+		}
+
+		switch {
+		// A long flag with a space separated value
+		case strings.HasPrefix(arg, "--") && !strings.Contains(arg, "="):
+			arg = arg[2:]
+			// Skip EOF and known flags
+			if len(arg) == 0 || flags.Lookup(arg) != nil {
+				continue
+			}
+			prevArg = arg
+			continue
+		// The value for the previous flag
+		case prevArg != "":
+			var strVal string
+			flags.StringVar(&strVal, prevArg, "", "")
+			flags.Set(prevArg, arg)
+			prevArg = ""
+			continue
+		// A long flag with an '=' separated value
+		case strings.HasPrefix(arg, "--") && strings.Contains(arg, "="):
+			val := strings.Split(arg[2:], "=")
+			// Only consider unknown flags with values
+			if len(val) == 2 && flags.Lookup(val[0]) == nil {
+				var strVal string
+				flags.StringVar(&strVal, val[0], "", "")
+				flags.Set(val[0], val[1])
+			}
+			continue
+		}
+	}
+
+	return flags.Parse(argv)
+}
 
 // AddDebugFlag adds the '--debug' flag to the given set of command line flags.
 func AddDebugFlag(fs *pflag.FlagSet) {


### PR DESCRIPTION
To enable scriptin/automation for addon installation, we now support
passing arbitrary flags to the 'install|edit addon' commands. When these
flags match the addon parameter ID, they get set as the chosen value and
so the interactive mode can be skipped.