### PR TITLE
versions: Align version list with cluster creation

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -390,7 +390,7 @@ func run(cmd *cobra.Command, _ []string) {
 	channelGroup := args.channelGroup
 	versionList, err := getVersionList(ocmClient, channelGroup)
 	if err != nil {
-		reporter.Errorf(fmt.Sprintf("%s", err))
+		reporter.Errorf("%s", err)
 		os.Exit(1)
 	}
 	if version == "" {

--- a/cmd/list/version/cmd.go
+++ b/cmd/list/version/cmd.go
@@ -19,6 +19,7 @@ package version
 import (
 	"fmt"
 	"os"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
@@ -90,16 +91,20 @@ func run(cmd *cobra.Command, _ []string) {
 
 	// Create the writer that will be used to print the tabulated results:
 	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintf(writer, "ID\t\tDEFAULT\n")
+	fmt.Fprintf(writer, "VERSION\t\tDEFAULT\n")
 
 	for _, version := range versions {
 		if !version.Enabled() {
 			continue
 		}
+		isDefault := "no"
+		if version.Default() {
+			isDefault = "yes"
+		}
 		fmt.Fprintf(writer,
-			"%s\t\t%t\n",
-			version.ID(),
-			version.Default(),
+			"%s\t\t%s\n",
+			strings.TrimPrefix(version.ID(), "openshift-v"),
+			isDefault,
 		)
 	}
 	writer.Flush()


### PR DESCRIPTION
When listing available versions, the format should match the expected
input when creating a cluster.