### PR TITLE
Add missing region flags

### DIFF
--- a/cmd/create/idp/cmd.go
+++ b/cmd/create/idp/cmd.go
@@ -26,6 +26,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/logging"
@@ -98,6 +99,8 @@ var Cmd = &cobra.Command{
 func init() {
 	flags := Cmd.Flags()
 	flags.SortFlags = false
+
+	arguments.AddRegionFlag(flags)
 
 	flags.StringVarP(
 		&args.clusterKey,
@@ -284,8 +287,16 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
+	// Get AWS region
+	region, err := aws.GetRegion(arguments.GetRegion())
+	if err != nil {
+		reporter.Errorf("Error getting region: %v", err)
+		os.Exit(1)
+	}
+
 	// Create the AWS client:
 	awsClient, err := aws.NewClient().
+		Region(region).
 		Logger(logger).
 		Build()
 	if err != nil {

--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
 	clusterprovider "github.com/openshift/rosa/pkg/cluster"
 	"github.com/openshift/rosa/pkg/logging"
@@ -59,6 +60,8 @@ var Cmd = &cobra.Command{
 func init() {
 	flags := Cmd.Flags()
 
+	arguments.AddRegionFlag(flags)
+
 	flags.StringVarP(
 		&args.clusterKey,
 		"cluster",
@@ -90,8 +93,16 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
+	// Get AWS region
+	region, err := aws.GetRegion(arguments.GetRegion())
+	if err != nil {
+		reporter.Errorf("Error getting region: %v", err)
+		os.Exit(1)
+	}
+
 	// Create the AWS client:
 	awsClient, err := aws.NewClient().
+		Region(region).
 		Logger(logger).
 		Build()
 	if err != nil {

--- a/cmd/dlt/cluster/cmd.go
+++ b/cmd/dlt/cluster/cmd.go
@@ -23,6 +23,7 @@ import (
 
 	uninstallLogs "github.com/openshift/rosa/cmd/logs/uninstall"
 
+	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
 	clusterprovider "github.com/openshift/rosa/pkg/cluster"
 	"github.com/openshift/rosa/pkg/confirm"
@@ -51,6 +52,8 @@ var Cmd = &cobra.Command{
 
 func init() {
 	flags := Cmd.Flags()
+
+	arguments.AddRegionFlag(flags)
 
 	flags.StringVarP(
 		&args.clusterKey,
@@ -87,6 +90,7 @@ func run(cmd *cobra.Command, _ []string) {
 
 	// Create the AWS client:
 	awsClient, err := aws.NewClient().
+		Region(arguments.GetRegion()).
 		Logger(logger).
 		Build()
 	if err != nil {

--- a/cmd/grant/user/cmd.go
+++ b/cmd/grant/user/cmd.go
@@ -23,6 +23,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/logging"
 	"github.com/openshift/rosa/pkg/ocm"
@@ -61,6 +62,8 @@ var validRolesAliases = []string{"cluster-admin", "dedicated-admin"}
 
 func init() {
 	flags := Cmd.Flags()
+
+	arguments.AddRegionFlag(flags)
 
 	flags.StringVarP(
 		&args.clusterKey,
@@ -125,8 +128,16 @@ func run(_ *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
+	// Get AWS region
+	region, err := aws.GetRegion(arguments.GetRegion())
+	if err != nil {
+		reporter.Errorf("Error getting region: %v", err)
+		os.Exit(1)
+	}
+
 	// Create the AWS client:
 	awsClient, err := aws.NewClient().
+		Region(region).
 		Logger(logger).
 		Build()
 	if err != nil {

--- a/cmd/list/user/cmd.go
+++ b/cmd/list/user/cmd.go
@@ -25,6 +25,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/logging"
 	"github.com/openshift/rosa/pkg/ocm"
@@ -47,6 +48,8 @@ var Cmd = &cobra.Command{
 
 func init() {
 	flags := Cmd.Flags()
+
+	arguments.AddRegionFlag(flags)
 
 	flags.StringVarP(
 		&args.clusterKey,
@@ -76,6 +79,7 @@ func run(_ *cobra.Command, _ []string) {
 
 	// Create the AWS client:
 	awsClient, err := aws.NewClient().
+		Region(arguments.GetRegion()).
 		Logger(logger).
 		Build()
 	if err != nil {


### PR DESCRIPTION
A few commands were missing the ability to provide a region flag if it wasn't set in the config or ENV, this fixes that.