### PR TITLE
addons: Use integer for numeric params

### DIFF
--- a/cmd/edit/addon/cmd.go
+++ b/cmd/edit/addon/cmd.go
@@ -214,10 +214,10 @@ func run(cmd *cobra.Command, argv []string) {
 				cidrVal, err = interactive.GetIPNet(input)
 				val = cidrVal.String()
 			case "number":
-				var numVal float64
-				input.Default, _ = strconv.ParseFloat(dflt, 64)
-				numVal, err = interactive.GetFloat(input)
-				val = fmt.Sprintf("%f", numVal)
+				var numVal int
+				input.Default, _ = strconv.Atoi(dflt)
+				numVal, err = interactive.GetInt(input)
+				val = fmt.Sprintf("%d", numVal)
 			case "string":
 				input.Default = dflt
 				val, err = interactive.GetString(input)

--- a/cmd/install/addon/cmd.go
+++ b/cmd/install/addon/cmd.go
@@ -187,10 +187,10 @@ func run(cmd *cobra.Command, argv []string) {
 					cidrVal, err = interactive.GetIPNet(input)
 					val = cidrVal.String()
 				case "number":
-					var numVal float64
-					input.Default, _ = strconv.ParseFloat(param.DefaultValue(), 64)
-					numVal, err = interactive.GetFloat(input)
-					val = fmt.Sprintf("%f", numVal)
+					var numVal int
+					input.Default, _ = strconv.Atoi(param.DefaultValue())
+					numVal, err = interactive.GetInt(input)
+					val = fmt.Sprintf("%d", numVal)
 				case "string":
 					input.Default = param.DefaultValue()
 					val, err = interactive.GetString(input)


### PR DESCRIPTION
There is currently no use case for float values as addon parameters, and
setting them as integers looks better from the UX point of view.