### PR TITLE
machinepools: Display default machine pool as Default

### DIFF
--- a/cmd/dlt/machinepool/cmd.go
+++ b/cmd/dlt/machinepool/cmd.go
@@ -75,7 +75,7 @@ func run(_ *cobra.Command, argv []string) {
 	logger := logging.CreateLoggerOrExit(reporter)
 
 	machinePoolID := argv[0]
-	if !machinePoolKeyRE.MatchString(machinePoolID) {
+	if machinePoolID != "Default" && !machinePoolKeyRE.MatchString(machinePoolID) {
 		reporter.Errorf("Expected a valid identifier for the machine pool")
 		os.Exit(1)
 	}
@@ -92,7 +92,7 @@ func run(_ *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
-	if machinePoolID == "default" {
+	if machinePoolID == "Default" {
 		reporter.Errorf("Machine pool '%s' cannot be deleted from cluster '%s'", machinePoolID, clusterKey)
 		os.Exit(1)
 	}

--- a/cmd/edit/machinepool/cmd.go
+++ b/cmd/edit/machinepool/cmd.go
@@ -110,7 +110,7 @@ func run(cmd *cobra.Command, argv []string) {
 	logger := logging.CreateLoggerOrExit(reporter)
 
 	machinePoolID := argv[0]
-	if !machinePoolKeyRE.MatchString(machinePoolID) {
+	if machinePoolID != "Default" && !machinePoolKeyRE.MatchString(machinePoolID) {
 		reporter.Errorf("Expected a valid identifier for the machine pool")
 		os.Exit(1)
 	}
@@ -170,7 +170,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// Editing the default machine pool is a different process
-	if machinePoolID == "default" {
+	if machinePoolID == "Default" {
 		autoscaling, replicas, minReplicas, maxReplicas := getReplicas(cmd, reporter, machinePoolID,
 			cluster.Nodes().AutoscaleCompute())
 

--- a/cmd/list/machinepool/cmd.go
+++ b/cmd/list/machinepool/cmd.go
@@ -133,7 +133,7 @@ func run(_ *cobra.Command, _ []string) {
 
 	fmt.Fprintf(writer, "ID\tAUTOSCALING\tREPLICAS\tINSTANCE TYPE\tLABELS\t\tTAINTS\t\tAVAILABILITY ZONES\n")
 	fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\t\t%s\t\t%s\n",
-		"default",
+		"Default",
 		printAutoscaling(cluster.Nodes().AutoscaleCompute()),
 		printReplicas(cluster.Nodes().AutoscaleCompute(), cluster.Nodes().Compute()),
 		cluster.Nodes().ComputeMachineType().ID(),


### PR DESCRIPTION
This aligns it with the OCM Web UI and avoids possible confusion.