### PR TITLE
addons: Check existence of addon installation before installing

### DIFF
--- a/cmd/install/addon/cmd.go
+++ b/cmd/install/addon/cmd.go
@@ -144,6 +144,12 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
+	addOn, err := clusterprovider.GetAddOnInstallation(ocmClient.Clusters(), clusterKey, awsCreator.ARN, addOnID)
+	if addOn != nil {
+		reporter.Warnf("Addon '%s' is already installed on cluster '%s'", addOnID, clusterKey)
+		os.Exit(0)
+	}
+
 	if !confirm.Confirm("install add-on '%s' on cluster '%s'", addOnID, clusterKey) {
 		os.Exit(0)
 	}

--- a/cmd/uninstall/addon/cmd.go
+++ b/cmd/uninstall/addon/cmd.go
@@ -129,6 +129,12 @@ func run(_ *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
+	addOn, err := clusterprovider.GetAddOnInstallation(ocmClient.Clusters(), clusterKey, awsCreator.ARN, addOnID)
+	if addOn == nil {
+		reporter.Warnf("Addon '%s' is not installed on cluster '%s'", addOnID, clusterKey)
+		os.Exit(0)
+	}
+
 	if !confirm.Confirm("uninstall add-on '%s' from cluster '%s'", addOnID, clusterKey) {
 		os.Exit(0)
 	}


### PR DESCRIPTION
If an addon installation exists, we should not attempt re-installation.
Similarly, if an addon installation does not exist, there is no reason
to uninstall it.