### PR TITLE
addons: Send empty string when CIDR is nil

### DIFF
--- a/cmd/edit/addon/cmd.go
+++ b/cmd/edit/addon/cmd.go
@@ -217,6 +217,9 @@ func run(cmd *cobra.Command, argv []string) {
 				}
 				cidrVal, err = interactive.GetIPNet(input)
 				val = cidrVal.String()
+				if val == "<nil>" {
+					val = ""
+				}
 			case "number":
 				var numVal int
 				input.Default, _ = strconv.Atoi(dflt)

--- a/cmd/install/addon/cmd.go
+++ b/cmd/install/addon/cmd.go
@@ -186,6 +186,9 @@ func run(cmd *cobra.Command, argv []string) {
 					}
 					cidrVal, err = interactive.GetIPNet(input)
 					val = cidrVal.String()
+					if val == "<nil>" {
+						val = ""
+					}
 				case "number":
 					var numVal int
 					input.Default, _ = strconv.Atoi(param.DefaultValue())


### PR DESCRIPTION
When a nil IPNet is parsed, it returns a string "<nil>". This breaks
validation in the API when determining whether the addon parameter has
any data, so we set it as "" in that case.