### PR TITLE
cluster-admin: Format the success message

### DIFF
--- a/cmd/create/admin/cmd.go
+++ b/cmd/create/admin/cmd.go
@@ -183,12 +183,12 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
-	reporter.Infof("Admin account has been added to cluster '%s'. "+
-		"It may take up to a minute for the account to become active.", clusterKey)
+	reporter.Infof("Admin account has been added to cluster '%s'.", clusterKey)
 	reporter.Infof("Please securely store this generated password. " +
 		"If you lose this password you can delete and recreate the cluster admin user.")
-	reporter.Infof("To login, run the following command:\n"+
-		"   oc login %s \\\n   --username %s \\\n   --password %s", cluster.API().URL(), username, password)
+	reporter.Infof("To login, run the following command:\n\n"+
+		"   oc login %s --username %s --password %s\n", cluster.API().URL(), username, password)
+	reporter.Infof("It may take up to a minute for the account to become active.")
 }
 
 func generateRandomPassword(length int) (string, error) {


### PR DESCRIPTION
This makes the copy-pasteable command to work on Windows and makes it
clear that it will take some time to sync the new user credentials.