### PR TITLE
interactive: Remove flag from global create

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -271,6 +271,8 @@ func init() {
 			"Subnets are comma separated, for example: --subnet-ids=subnet-1,subnet-2."+
 			"Leave empty for installer provisioned subnet IDs.",
 	)
+
+	interactive.AddFlag(flags)
 }
 
 func run(cmd *cobra.Command, _ []string) {

--- a/cmd/create/cmd.go
+++ b/cmd/create/cmd.go
@@ -26,7 +26,6 @@ import (
 	"github.com/openshift/rosa/cmd/create/machinepool"
 	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/confirm"
-	"github.com/openshift/rosa/pkg/interactive"
 )
 
 var Cmd = &cobra.Command{
@@ -46,5 +45,4 @@ func init() {
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)
 	confirm.AddFlag(flags)
-	interactive.AddFlag(flags)
 }

--- a/cmd/create/idp/cmd.go
+++ b/cmd/create/idp/cmd.go
@@ -269,6 +269,8 @@ func init() {
 		"",
 		"OpenID: List of scopes to request, in addition to the 'openid' scope, during the authorization token request.\n",
 	)
+
+	interactive.AddFlag(flags)
 }
 
 func run(cmd *cobra.Command, _ []string) {

--- a/cmd/create/ingress/cmd.go
+++ b/cmd/create/ingress/cmd.go
@@ -79,6 +79,8 @@ func init() {
 		"Label match for ingress. Format should be a comma-separated list of 'key=value'. "+
 			"If no label is specified, all routes will be exposed on both routers.",
 	)
+
+	interactive.AddFlag(flags)
 }
 
 func run(cmd *cobra.Command, _ []string) {

--- a/cmd/create/machinepool/cmd.go
+++ b/cmd/create/machinepool/cmd.go
@@ -139,6 +139,8 @@ func init() {
 		"Taints for machine pool. Format should be a comma-separated list of 'key=value:ScheduleType'. "+
 			"This list will overwrite any modifications made to Node taints on an ongoing basis.",
 	)
+
+	interactive.AddFlag(flags)
 }
 
 func run(cmd *cobra.Command, _ []string) {


### PR DESCRIPTION
Not all create commands support interactive mode, so instead of adding
it to all sub-commands, we add it to those that do.