### PR TITLE
addons: Enforce interactive mode if required params are missing

### DIFF
--- a/cmd/install/cmd.go
+++ b/cmd/install/cmd.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openshift/rosa/cmd/install/addon"
 	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/confirm"
+	"github.com/openshift/rosa/pkg/interactive"
 )
 
 var Cmd = &cobra.Command{
@@ -36,4 +37,5 @@ func init() {
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)
 	confirm.AddFlag(flags)
+	interactive.AddFlag(flags)
 }

--- a/pkg/arguments/arguments.go
+++ b/pkg/arguments/arguments.go
@@ -29,6 +29,8 @@ import (
 	"github.com/openshift/rosa/pkg/debug"
 )
 
+var hasUnknownFlags bool
+
 // ParseUnknownFlags parses all flags from the CLI, including
 // unknown ones, and adds them to the current command tree
 func ParseUnknownFlags(cmd *cobra.Command, argv []string) error {
@@ -43,6 +45,7 @@ func ParseUnknownFlags(cmd *cobra.Command, argv []string) error {
 			flags.BoolVar(&boolVal, prevArg, false, "")
 			flags.Set(prevArg, "true")
 			prevArg = ""
+			hasUnknownFlags = true
 		}
 
 		switch {
@@ -61,6 +64,7 @@ func ParseUnknownFlags(cmd *cobra.Command, argv []string) error {
 			flags.StringVar(&strVal, prevArg, "", "")
 			flags.Set(prevArg, arg)
 			prevArg = ""
+			hasUnknownFlags = true
 			continue
 		// A long flag with an '=' separated value
 		case strings.HasPrefix(arg, "--") && strings.Contains(arg, "="):
@@ -70,12 +74,18 @@ func ParseUnknownFlags(cmd *cobra.Command, argv []string) error {
 				var strVal string
 				flags.StringVar(&strVal, val[0], "", "")
 				flags.Set(val[0], val[1])
+				hasUnknownFlags = true
 			}
 			continue
 		}
 	}
 
 	return flags.Parse(argv)
+}
+
+// HasUnknownFlags returns whether the flag parser detected any unknown flags
+func HasUnknownFlags() bool {
+	return hasUnknownFlags
 }
 
 // AddDebugFlag adds the '--debug' flag to the given set of command line flags.


### PR DESCRIPTION
If the user sets all required addon parameters as command-line flags, we
can safely skip the interactive mode. Otherwise we enable it.