### PR TITLE
version: Align sort with OCM version list

### DIFF
--- a/cmd/list/version/cmd.go
+++ b/cmd/list/version/cmd.go
@@ -91,7 +91,7 @@ func run(cmd *cobra.Command, _ []string) {
 
 	// Create the writer that will be used to print the tabulated results:
 	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintf(writer, "VERSION\t\tDEFAULT\n")
+	fmt.Fprintf(writer, "VERSION\t\tDEFAULT\t\tAVAILABLE UPGRADES\n")
 
 	for _, version := range versions {
 		if !version.Enabled() {
@@ -102,9 +102,10 @@ func run(cmd *cobra.Command, _ []string) {
 			isDefault = "yes"
 		}
 		fmt.Fprintf(writer,
-			"%s\t\t%s\n",
-			strings.TrimPrefix(version.ID(), "openshift-v"),
+			"%s\t\t%s\t\t%s\n",
+			version.RawID(),
 			isDefault,
+			strings.Join(version.AvailableUpgrades(), ", "),
 		)
 	}
 	writer.Flush()

--- a/pkg/ocm/versions/versions.go
+++ b/pkg/ocm/versions/versions.go
@@ -38,7 +38,7 @@ func GetVersions(client *cmv1.Client, channelGroup string) (versions []*cmv1.Ver
 		var response *cmv1.VersionsListResponse
 		response, err = collection.List().
 			Search(filter).
-			Order("default desc, id asc").
+			Order("default desc, id desc").
 			Page(page).
 			Size(size).
 			Send()


### PR DESCRIPTION
When selecting the default version for any cluster, we align the
selection query with OCM. This ensures that the selected version is the
closest ROSA-enabled one to the current default for OSD.

We also display available upgrades when listing versions.