### PR TITLE
describe: Add cluster network configuration

### DIFF
--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -215,46 +215,65 @@ func run(cmd *cobra.Command, argv []string) {
 	// Determine whether there is any auto-scaling in the cluster
 	if minNodes == maxNodes {
 		nodesStr = fmt.Sprintf(""+
-			"Nodes:                      Master: %d, Infra: %d, Compute: %d\n",
-			cluster.Nodes().Master(), cluster.Nodes().Infra(), minNodes,
+			"Nodes:\n"+
+			" - Master:                  %d\n"+
+			" - Infra:                   %d\n"+
+			" - Compute:                 %d (%s)\n",
+			cluster.Nodes().Master(),
+			cluster.Nodes().Infra(),
+			minNodes, cluster.Nodes().ComputeMachineType().ID(),
 		)
 	} else {
 		nodesStr = fmt.Sprintf(""+
-			"Nodes:                      Master: %d, Infra: %d, Compute (Autoscaled): %d-%d\n",
-			cluster.Nodes().Master(), cluster.Nodes().Infra(), minNodes, maxNodes,
+			"Nodes:\n"+
+			" - Master:                  %d\n"+
+			" - Infra:                   %d\n"+
+			" - Compute (Autoscaled):    %d-%d (%s)\n",
+			cluster.Nodes().Master(),
+			cluster.Nodes().Infra(),
+			minNodes, maxNodes, cluster.Nodes().ComputeMachineType().ID(),
 		)
 	}
 
 	// Print short cluster description:
 	str := fmt.Sprintf(""+
 		"Name:                       %s\n"+
-		"OpenShift Version:          %s\n"+
-		"DNS:                        %s.%s\n"+
 		"ID:                         %s\n"+
 		"External ID:                %s\n"+
+		"OpenShift Version:          %s\n"+
+		"Channel Group:              %s\n"+
+		"DNS:                        %s.%s\n"+
 		"AWS Account:                %s\n"+
 		"API URL:                    %s\n"+
 		"Console URL:                %s\n"+
-		"%s"+
 		"Region:                     %s\n"+
 		"Multi-AZ:                   %t\n"+
+		"%s"+
+		"Network:\n"+
+		" - Service CIDR:            %s\n"+
+		" - Machine CIDR:            %s\n"+
+		" - Pod CIDR:                %s\n"+
+		" - Host Prefix:             /%d\n"+
 		"State:                      %s %s\n"+
-		"Channel Group:              %s\n"+
 		"Private:                    %s\n"+
 		"Created:                    %s\n",
 		clusterName,
-		cluster.OpenshiftVersion(),
-		cluster.Name(), cluster.DNS().BaseDomain(),
 		cluster.ID(),
 		cluster.ExternalID(),
+		cluster.OpenshiftVersion(),
+		cluster.Version().ChannelGroup(),
+		cluster.Name(), cluster.DNS().BaseDomain(),
 		creatorARN.AccountID,
 		cluster.API().URL(),
 		cluster.Console().URL(),
-		nodesStr,
 		cluster.Region().ID(),
 		cluster.MultiAZ(),
+		nodesStr,
+		cluster.Network().ServiceCIDR(),
+		cluster.Network().MachineCIDR(),
+		cluster.Network().PodCIDR(),
+		cluster.Network().HostPrefix(),
 		cluster.State(), phase,
-		cluster.Version().ChannelGroup(),
 		isPrivate,
 		cluster.CreationTimestamp().Format("Jan _2 2006 15:04:05 MST"),
 	)


### PR DESCRIPTION
Also reformat the output to display data in a more organized way.

Example output:
```
$ rosa describe cluster -c vkareh-rosa
Name:                       vkareh-rosa
ID:                         1jegmk19749k70qjt44otfncl6gi96p4
External ID:                75ecee0e-5ea0-49dd-934a-07671660f0df
OpenShift Version:          4.6.1
Channel Group:              stable
DNS:                        vkareh-rosa.4bei.i1.devshift.org
AWS Account:                765374464689
API URL:                    https://example.com/veryfakeapi
Console URL:                https://https://example.com/veryfakewebconsole
Region:                     us-east-1
Multi-AZ:                   false
Nodes:
 - Master:                  3
 - Infra:                   2
 - Compute:                 3 (m5.xlarge)
Network:
 - Service CIDR:            172.30.0.0/16
 - Machine CIDR:            10.0.0.0/16
 - Pod CIDR:                10.128.0.0/14
 - Host Prefix:             /23
State:                      ready 
Private:                    No
Created:                    Mar 15 2021 12:55:46 UTC

```