### PR TITLE
arguments: Parse help flag when overriding flag parsing

### DIFF
--- a/cmd/edit/addon/cmd.go
+++ b/cmd/edit/addon/cmd.go
@@ -52,7 +52,7 @@ var Cmd = &cobra.Command{
 	Args: func(cmd *cobra.Command, argv []string) error {
 		err := arguments.ParseUnknownFlags(cmd, argv)
 		if err != nil {
-			return fmt.Errorf("Failed to parse flags: %v", err)
+			return err
 		}
 
 		if len(cmd.Flags().Args()) != 1 {

--- a/cmd/install/addon/cmd.go
+++ b/cmd/install/addon/cmd.go
@@ -53,7 +53,7 @@ var Cmd = &cobra.Command{
 	Args: func(cmd *cobra.Command, argv []string) error {
 		err := arguments.ParseUnknownFlags(cmd, argv)
 		if err != nil {
-			return fmt.Errorf("Failed to parse flags: %v", err)
+			return err
 		}
 
 		if len(cmd.Flags().Args()) != 1 {

--- a/pkg/arguments/arguments.go
+++ b/pkg/arguments/arguments.go
@@ -80,7 +80,25 @@ func ParseUnknownFlags(cmd *cobra.Command, argv []string) error {
 		}
 	}
 
-	return flags.Parse(argv)
+	err := flags.Parse(argv)
+	if err != nil {
+		return err
+	}
+
+	// If help is called, regardless of other flags, return we want help.
+	// Also say we need help if the command isn't runnable.
+	helpVal, err := cmd.Flags().GetBool("help")
+	if err != nil {
+		// should be impossible to get here as we always declare a help
+		// flag in InitDefaultHelpFlag()
+		cmd.Println("\"help\" flag declared as non-bool. Please correct your code")
+		return err
+	}
+	if helpVal {
+		return pflag.ErrHelp
+	}
+
+	return nil
 }
 
 // HasUnknownFlags returns whether the flag parser detected any unknown flags


### PR DESCRIPTION
Since we are overriding cobra's flag parsing function, we need to also
check whether the --help/-h flag is being passed in the CLI. The cobra
executor expects the raw error to match and so we also avoid wrapping
the flag parsing error.