### PR TITLE
addons: When setting CLI params skip unset values

### DIFF
--- a/cmd/edit/addon/cmd.go
+++ b/cmd/edit/addon/cmd.go
@@ -199,10 +199,12 @@ func run(cmd *cobra.Command, argv []string) {
 		}
 
 		var val string
+		var hasVal bool
 		// If value is already set in the CLI, ignore interactive prompt
 		flag := cmd.Flags().Lookup(param.ID())
 		if flag != nil {
 			val = flag.Value.String()
+			hasVal = true
 		} else if interactive.Enabled() {
 			// Set default value based on existing parameter, otherwise use parameter default
 			dflt := param.DefaultValue()
@@ -250,18 +252,20 @@ func run(cmd *cobra.Command, argv []string) {
 				reporter.Errorf("Expected a valid value for '%s': %v", param.ID(), err)
 				os.Exit(1)
 			}
+			hasVal = true
 		}
 
-		val = strings.Trim(val, " ")
-		if val != "" && param.Validation() != "" {
-			isValid, err := regexp.MatchString(param.Validation(), val)
-			if err != nil || !isValid {
-				reporter.Errorf("Expected %v to match /%s/", val, param.Validation())
-				os.Exit(1)
+		if hasVal {
+			val = strings.Trim(val, " ")
+			if val != "" && param.Validation() != "" {
+				isValid, err := regexp.MatchString(param.Validation(), val)
+				if err != nil || !isValid {
+					reporter.Errorf("Expected %v to match /%s/", val, param.Validation())
+					os.Exit(1)
+				}
 			}
+			params = append(params, clusterprovider.AddOnParam{Key: param.ID(), Val: val})
 		}
-
-		params = append(params, clusterprovider.AddOnParam{Key: param.ID(), Val: val})
 
 		return true
 	})


### PR DESCRIPTION
If a user sets all required addon parameters in the CLI in
non-interactive mode, we skip the prompt non-required ones. Since the
prompt is not shown, we should avoid sending these values as part of the
API request.