### PR TITLE
Release v1.0.1

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,15 @@
 This document describes the relevant changes between releases of the `rosa`
 command line tool.
 
+== 1.0.1 Mar 18 2021
+
+- arguments: Parse help flag when overriding flag parsing
+- revoke: Fix example and help text
+- grant: Remove unnecessary interactive flag
+- addons: When setting CLI params skip unset values
+- upgrade: Display expected format in error
+- addons: Display availability
+
 == 1.0.0 Mar 16 2021
 
 - addons: Allow editing of addon parameters

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "1.0.0"
+const Version = "1.0.1"


### PR DESCRIPTION
- arguments: Parse help flag when overriding flag parsing
- revoke: Fix example and help text
- grant: Remove unnecessary interactive flag
- addons: When setting CLI params skip unset values
- upgrade: Display expected format in error
- addons: Display availability