### PR TITLE
errors: Display legal terms URL

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -554,5 +554,11 @@ func handleErr(res *ocmerrors.Error, err error) error {
 	if msg == "" {
 		msg = err.Error()
 	}
+	// Hack to always display the correct terms and conditions message
+	if res.Code() == "CLUSTERS-MGMT-451" {
+		msg = "You must accept the Terms and Conditions in order to continue.\n" +
+			"Go to https://www.redhat.com/wapps/tnc/ackrequired?site=ocm&event=register\n" +
+			"Once you accept the terms, you will need to retry the action that was blocked."
+	}
 	return errors.New(msg)
 }


### PR DESCRIPTION
To display the complete terms acceptance error, which includes the URL
in the details, we intercept the 451 error code and display a static
link to the terms and conditions app.