### PR TITLE
logs: Filter out misleading output

### DIFF
--- a/cmd/logs/install/cmd.go
+++ b/cmd/logs/install/cmd.go
@@ -244,6 +244,10 @@ func findNextLines(logs *cmv1.Log) string {
 	}
 	// Find where the new logs and the last line overlap
 	for i, line := range lines {
+		// Remove lines containing misleading output
+		if strings.Contains(line, "KUBECONFIG") || strings.Contains(line, "REDACTED") {
+			lines[i] = ""
+		}
 		if lastLine != "" && line == lastLine {
 			// Remove any duplicate lines
 			lines = lines[i+1:]


### PR DESCRIPTION
Since logs are forwarded directly from the installer, we remove log
lines containing misleading KUBECONFIG instrutions as well as lines
already redacted by Hive.