### PR TITLE
aws: Add helpful error message when using STS credentials

### DIFF
--- a/pkg/aws/utils.go
+++ b/pkg/aws/utils.go
@@ -36,6 +36,11 @@ func GetRegion(region string) (string, error) {
 func getClientDetails(awsClient *awsClient) (*iam.User, bool, error) {
 	rootUser := false
 
+	_, err := awsClient.ValidateCredentials()
+	if err != nil {
+		return nil, rootUser, err
+	}
+
 	user, err := awsClient.iamClient.GetUser(nil)
 	if err != nil {
 		return nil, rootUser, err


### PR DESCRIPTION
Currently we don't support using STS users to create ROSA clusters. This PR will better inform the user of the issue. 

Old error message:

 `E: Error creating AWS client: ValidationError: Must specify userName when calling with non-User credentials`

New error message:

```
E: Error creating AWS client: The AWS Access Key ID AAAFFFDSDDDSSSSSS is associated with with STS credentials ARN arn:aws:sts::11223344556612:assumed-role/Role/SREAccess
STS users are not supported, please set AWS credentials to use an IAM user
```

Feel free to make suggestions on the error message. 