### PR TITLE
aws: Log event when creating client with STS credentials

### DIFF
--- a/cmd/verify/permissions/cmd.go
+++ b/cmd/verify/permissions/cmd.go
@@ -17,6 +17,7 @@ limitations under the License.
 package permissions
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -59,16 +60,6 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
-	// Create the AWS client:
-	client, err := aws.NewClient().
-		Logger(logger).
-		Region(region).
-		Build()
-	if err != nil {
-		reporter.Errorf("Error creating AWS client: %v", err)
-		os.Exit(1)
-	}
-
 	// Create the client for the OCM API:
 	ocmConnection, err := ocm.NewConnection().
 		Logger(logger).
@@ -79,6 +70,20 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 	defer ocmConnection.Close()
 	ocmClient := ocmConnection.ClustersMgmt().V1()
+
+	// Create the AWS client:
+	client, err := aws.NewClient().
+		Logger(logger).
+		Region(region).
+		Build()
+	if err != nil {
+		// FIXME Hack to capture errors due to using STS accounts
+		if strings.Contains(fmt.Sprintf("%s", err), "STS") {
+			ocm.LogEvent(ocmClient, "ROSAInitCredentialsSTS")
+		}
+		reporter.Errorf("Error creating AWS client: %v", err)
+		os.Exit(1)
+	}
 
 	reporter.Infof("Validating SCP policies...")
 	ok, err := client.ValidateSCP(nil)


### PR DESCRIPTION
Since we want to capture all instances of a client being created with
STS credentials, we move things around and parse the error coming from
the AWS client for the "STS" string, then we log an event for it.