### PR TITLE
Allow setting 0 replicas to autoscaling machine pool (Not default)

### DIFF
--- a/cmd/create/machinepool/cmd.go
+++ b/cmd/create/machinepool/cmd.go
@@ -271,8 +271,8 @@ func run(cmd *cobra.Command, _ []string) {
 				os.Exit(1)
 			}
 		}
-		if minReplicas < 1 {
-			reporter.Errorf("min-replicas must be greater or equal to the number of zones")
+		if minReplicas < 0 {
+			reporter.Errorf("min-replicas must be a non-negative integer.")
 			os.Exit(1)
 		}
 		if cluster.MultiAZ() && minReplicas%3 != 0 {

--- a/cmd/edit/machinepool/cmd.go
+++ b/cmd/edit/machinepool/cmd.go
@@ -261,8 +261,8 @@ func run(cmd *cobra.Command, argv []string) {
 		machinePool.Replicas(), machinePool.Autoscaling())
 
 	if !autoscaling && replicas < 0 ||
-		(autoscaling && cmd.Flags().Changed("min-replicas") && minReplicas < 1) {
-		reporter.Errorf("The number of machine pool replicas needs to be a positive integer")
+		(autoscaling && cmd.Flags().Changed("min-replicas") && minReplicas < 0) {
+		reporter.Errorf("The number of machine pool replicas needs to be a non-negative integer")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
This is blocked until this is supported in CS backend