### PR TITLE
Release v1.0.6

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,14 @@
 This document describes the relevant changes between releases of the `rosa`
 command line tool.
 
+== 1.0.6 May 12 2021
+
+- Enable PrivateLink on clusters
+- PrivateLink: Hide references to PrivateLink
+- Correctly use the --disable-scp-checks parameter when supplied to init command
+- Add support for STS clusters
+- describe: Output OIDC Endpoint URL if available
+
 == 1.0.5 Apr 16 2021
 
 - init: Use correct region instead of default

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "1.0.5"
+const Version = "1.0.6"


### PR DESCRIPTION
- Enable PrivateLink on clusters
- PrivateLink: Hide references to PrivateLink
- Correctly use the --disable-scp-checks parameter when supplied to init command
- Add support for STS clusters
- describe: Output OIDC Endpoint URL if available