### PR TITLE
describe: Display description during Pending state

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -399,7 +399,7 @@ func run(cmd *cobra.Command, _ []string) {
 
 	// AWS ARN Role
 	roleARN := args.roleARN
-	if interactive.Enabled() {
+	if roleARN != "" && interactive.Enabled() {
 		roleARN, err = interactive.GetString(interactive.Input{
 			Question: "Role ARN",
 			Help:     cmd.Flags().Lookup("role-arn").Usage,

--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -149,6 +149,10 @@ func run(cmd *cobra.Command, argv []string) {
 
 	if cluster.State() == cmv1.ClusterStatePending {
 		phase = "(Preparing account)"
+		status, _ := clusterprovider.GetClusterStatus(ocmClient.Clusters(), cluster.ID())
+		if status.Description() != "" {
+			phase = fmt.Sprintf("(%s)", status.Description())
+		}
 	}
 
 	if cluster.State() == cmv1.ClusterStateInstalling {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -207,6 +207,14 @@ func GetCluster(client *cmv1.ClustersClient, clusterKey string, creatorARN strin
 	}
 }
 
+func GetClusterStatus(client *cmv1.ClustersClient, clusterID string) (*cmv1.ClusterStatus, error) {
+	response, err := client.Cluster(clusterID).Status().Get().Send()
+	if err != nil || response.Body() == nil {
+		return nil, err
+	}
+	return response.Body(), nil
+}
+
 func UpdateCluster(client *cmv1.ClustersClient, clusterKey string, creatorARN string, config Spec) error {
 	cluster, err := GetCluster(client, clusterKey, creatorARN)
 	if err != nil {


### PR DESCRIPTION
By default OCM is 'Preparing account' during 'Pending', but if we
override the state description, we should show that instead.

Example:
```
$ rosa describe cluster -c vkareh-sts | grep State
State:                      pending (Waiting for OIDC configuration)
```