### PR TITLE
Increase golangci timeout to 5 minutes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ fmt:
 
 .PHONY: lint
 lint:
-	golangci-lint run
+	golangci-lint run --timeout 5m0s
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
I saw a couple of timeouts in CI for lint, increasing the timeout to a not unreasonable 5 minutes. Tests are currently passing ok maybe the infra was running a little slow? The default timeout for golangci is only 1 minute.

```
INFO[2021-05-25T21:53:02Z] Ran for 2m35s                                
ERRO[2021-05-25T21:53:02Z] Some steps failed:                           
ERRO[2021-05-25T21:53:02Z]   * could not run steps: step lint failed: test "lint" failed: the pod ci-op-8cpqs865/lint failed after 1m36s (failed containers: test): ContainerFailed one or more containers exited 
ERRO[2021-05-25T21:53:02Z] Container test exited with code 2, reason Error 
ERRO[2021-05-25T21:53:02Z] ---                                          
ERRO[2021-05-25T21:53:02Z] golangci-lint run                            
ERRO[2021-05-25T21:53:02Z] level=error msg="Timeout exceeded: try increasing it by passing --timeout option" 
ERRO[2021-05-25T21:53:02Z] make: *** [lint] Error 4                     
ERRO[2021-05-25T21:53:02Z] {"component":"entrypoint","error":"wrapped process failed: exit status 2","file":"prow/entrypoint/run.go:80","func":"k8s.io/test-infra/prow/entrypoint.Options.Run","level":"error","msg":"Error executing test process","severity":"error","time":"2021-05-25T21:52:58Z"} 
```