### PR TITLE
create: Add missing flags to re-create script

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,7 +27,6 @@ linters:
   - golint
   - govet
   - ineffassign
-  - interfacer
   - lll
   - megacheck
   - misspell

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1260,6 +1260,9 @@ func buildCommand(spec clusterprovider.Spec) string {
 	if spec.ExternalID != "" {
 		command += fmt.Sprintf(" --external-id %s", spec.ExternalID)
 	}
+	if spec.SupportRoleARN != "" {
+		command += fmt.Sprintf(" --support-role-arn %s", spec.SupportRoleARN)
+	}
 	if len(spec.OperatorIAMRoles) > 0 {
 		for _, role := range spec.OperatorIAMRoles {
 			command += fmt.Sprintf(" --operator-iam-roles %s,%s,%s", role.Name, role.Namespace, role.RoleARN)
@@ -1328,7 +1331,9 @@ func buildCommand(spec clusterprovider.Spec) string {
 	if spec.HostPrefix != 0 {
 		command += fmt.Sprintf(" --host-prefix %d", spec.HostPrefix)
 	}
-	if spec.Private != nil && *spec.Private {
+	if spec.PrivateLink != nil && *spec.PrivateLink {
+		command += " --private-link"
+	} else if spec.Private != nil && *spec.Private {
 		command += " --private"
 	}
 	if len(spec.SubnetIds) > 0 {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -646,7 +646,6 @@ func createClusterSpec(ocmClusterClient *cmv1.ClustersClient,
 	return clusterSpec, nil
 }
 
-// nolint:interfacer
 func IsEmptyCIDR(cidr net.IPNet) bool {
 	return cidr.String() == "<nil>"
 }


### PR DESCRIPTION
A few flags were missing from the re-create command output.

Also since the interfacer has been deprecated due to it being prone to bad suggestions, we remove it from this repository.

