### PR TITLE
output: Add flag for JSON and YAML output

### DIFF
--- a/cmd/list/cluster/cmd.go
+++ b/cmd/list/cluster/cmd.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/logging"
 	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/output"
 	rprtr "github.com/openshift/rosa/pkg/reporter"
 )
 
@@ -46,6 +47,7 @@ func init() {
 	flags.SortFlags = false
 
 	arguments.AddRegionFlag(flags)
+	output.AddFlag(Cmd)
 }
 
 func run(_ *cobra.Command, _ []string) {
@@ -88,6 +90,15 @@ func run(_ *cobra.Command, _ []string) {
 	if err != nil {
 		reporter.Errorf("Failed to get clusters: %v", err)
 		os.Exit(1)
+	}
+
+	if output.HasFlag() {
+		err = output.Print(clusters)
+		if err != nil {
+			reporter.Errorf("%s", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
 	}
 
 	if len(clusters) == 0 {

--- a/cmd/list/idp/cmd.go
+++ b/cmd/list/idp/cmd.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/logging"
 	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/output"
 	rprtr "github.com/openshift/rosa/pkg/reporter"
 )
 
@@ -56,6 +57,8 @@ func init() {
 		"Name or ID of the cluster to list the IdPs of (required).",
 	)
 	Cmd.MarkFlagRequired("cluster")
+
+	output.AddFlag(Cmd)
 }
 
 func run(_ *cobra.Command, _ []string) {
@@ -123,6 +126,15 @@ func run(_ *cobra.Command, _ []string) {
 	if err != nil {
 		reporter.Errorf("Failed to get identity providers for cluster '%s': %v", clusterKey, err)
 		os.Exit(1)
+	}
+
+	if output.HasFlag() {
+		err = output.Print(idps)
+		if err != nil {
+			reporter.Errorf("%s", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
 	}
 
 	if len(idps) == 0 {

--- a/cmd/list/ingress/cmd.go
+++ b/cmd/list/ingress/cmd.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/logging"
 	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/output"
 	rprtr "github.com/openshift/rosa/pkg/reporter"
 )
 
@@ -56,6 +57,8 @@ func init() {
 		"Name or ID of the cluster to list the routes of (required).",
 	)
 	Cmd.MarkFlagRequired("cluster")
+
+	output.AddFlag(Cmd)
 }
 
 func run(_ *cobra.Command, _ []string) {
@@ -123,6 +126,15 @@ func run(_ *cobra.Command, _ []string) {
 	if err != nil {
 		reporter.Errorf("Failed to get ingresses for cluster '%s': %v", clusterKey, err)
 		os.Exit(1)
+	}
+
+	if output.HasFlag() {
+		err = output.Print(ingresses)
+		if err != nil {
+			reporter.Errorf("%s", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
 	}
 
 	if len(ingresses) == 0 {

--- a/cmd/list/instancetypes/cmd.go
+++ b/cmd/list/instancetypes/cmd.go
@@ -21,10 +21,12 @@ import (
 	"os"
 	"text/tabwriter"
 
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/pkg/logging"
 	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/output"
 	rprtr "github.com/openshift/rosa/pkg/reporter"
 )
 
@@ -36,6 +38,10 @@ var Cmd = &cobra.Command{
 	Example: `  # List all instance types
   rosa list instance-types`,
 	Run: run,
+}
+
+func init() {
+	output.AddFlag(Cmd)
 }
 
 func run(cmd *cobra.Command, _ []string) {
@@ -63,6 +69,19 @@ func run(cmd *cobra.Command, _ []string) {
 	if err != nil {
 		reporter.Errorf("Failed to fetch instance types: %v", err)
 		os.Exit(1)
+	}
+
+	if output.HasFlag() {
+		var instanceTypes []*cmv1.MachineType
+		for _, machine := range machineTypes {
+			instanceTypes = append(instanceTypes, machine.MachineType)
+		}
+		err = output.Print(instanceTypes)
+		if err != nil {
+			reporter.Errorf("%s", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
 	}
 
 	if len(machineTypes) == 0 {

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/briandowns/spinner v1.11.1
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dustin/go-humanize v1.0.0
+	github.com/ghodss/yaml v1.0.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/mock v1.4.3
 	github.com/hashicorp/go-version v1.3.0

--- a/pkg/output/flag.go
+++ b/pkg/output/flag.go
@@ -1,0 +1,55 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains functions used to implement the '--output' command line option.
+
+package output
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var o string
+
+var formats = []string{"json", "yaml"}
+
+// AddFlag adds the interactive flag to the given set of command line flags.
+func AddFlag(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(
+		&o,
+		"output",
+		"o",
+		"",
+		fmt.Sprintf("Output format. Allowed formats are %s", formats),
+	)
+
+	cmd.RegisterFlagCompletionFunc("output", completion)
+}
+
+func completion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return formats, cobra.ShellCompDirectiveDefault
+}
+
+func HasFlag() bool {
+	return o != ""
+}
+
+// Enabled retursn a boolean flag that indicates if the interactive mode is enabled.
+func Output() string {
+	return o
+}

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -1,0 +1,119 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains functions used to implement the '--output' command line option.
+
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+
+	"github.com/ghodss/yaml"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"gitlab.com/c0b/go-ordered-json"
+)
+
+func Print(resource interface{}) error {
+	var b bytes.Buffer
+	switch reflect.TypeOf(resource).String() {
+	case "[]*v1.CloudRegion":
+		if cloudRegions, ok := resource.([]*cmv1.CloudRegion); ok {
+			cmv1.MarshalCloudRegionList(cloudRegions, &b)
+		}
+	case "*v1.Cluster":
+		if cluster, ok := resource.(*cmv1.Cluster); ok {
+			cmv1.MarshalCluster(cluster, &b)
+		}
+	case "[]*v1.Cluster":
+		if clusters, ok := resource.([]*cmv1.Cluster); ok {
+			cmv1.MarshalClusterList(clusters, &b)
+		}
+	case "[]*v1.IdentityProvider":
+		if idps, ok := resource.([]*cmv1.IdentityProvider); ok {
+			cmv1.MarshalIdentityProviderList(idps, &b)
+		}
+	case "[]*v1.Ingress":
+		if ingresses, ok := resource.([]*cmv1.Ingress); ok {
+			cmv1.MarshalIngressList(ingresses, &b)
+		}
+	case "[]*v1.MachinePool":
+		if machinePools, ok := resource.([]*cmv1.MachinePool); ok {
+			cmv1.MarshalMachinePoolList(machinePools, &b)
+		}
+	case "[]*v1.MachineType":
+		if machineTypes, ok := resource.([]*cmv1.MachineType); ok {
+			cmv1.MarshalMachineTypeList(machineTypes, &b)
+		}
+	case "[]*v1.Version":
+		if versions, ok := resource.([]*cmv1.Version); ok {
+			cmv1.MarshalVersionList(versions, &b)
+		}
+	}
+	str, err := parseResource(b)
+	if err != nil {
+		return err
+	}
+	fmt.Print(str)
+	return nil
+}
+
+func parseResource(body bytes.Buffer) (string, error) {
+	switch o {
+	case "json":
+		var out bytes.Buffer
+		prettifyJSON(&out, body.Bytes())
+		return out.String(), nil
+	case "yaml":
+		out, err := yaml.JSONToYAML(body.Bytes())
+		if err != nil {
+			return "", err
+		}
+		return string(out), nil
+	default:
+		return "", fmt.Errorf("Unknown format '%s'. Valid formats are %s", o, formats)
+	}
+}
+
+func prettifyJSON(stream io.Writer, body []byte) error {
+	if len(body) == 0 {
+		return nil
+	}
+	data := ordered.NewOrderedMap()
+	err := json.Unmarshal(body, data)
+	if err != nil {
+		return dumpBytes(stream, body)
+	}
+	return dumpJSON(stream, data)
+}
+
+func dumpBytes(stream io.Writer, data []byte) error {
+	_, err := stream.Write(data)
+	if err != nil {
+		return err
+	}
+	_, err = stream.Write([]byte("\n"))
+	return err
+}
+
+func dumpJSON(stream io.Writer, data *ordered.OrderedMap) error {
+	encoder := json.NewEncoder(stream)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(data)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -73,6 +73,7 @@ github.com/dustin/go-humanize
 # github.com/fatih/color v1.7.0
 github.com/fatih/color
 # github.com/ghodss/yaml v1.0.0
+## explicit
 github.com/ghodss/yaml
 # github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b => github.com/kubermatic/glog-logrus v0.0.0-20180829085450-3fa5b9870d1d
 ## explicit


### PR DESCRIPTION
To use this, you can call `rosa describe cluster -c foo -o json` or `rosa list regions --output yaml`, etc. It also has autocomplete (if you have it enabled) so that you can do `--output [tab][tab]` and auto-complete the `json`/`yaml` parts.