### PR TITLE
aws: Filter clusters by AWS account ID

### DIFF
--- a/cmd/create/admin/cmd.go
+++ b/cmd/create/admin/cmd.go
@@ -112,7 +112,7 @@ func run(cmd *cobra.Command, _ []string) {
 
 	// Try to find the cluster:
 	reporter.Debugf("Loading cluster '%s'", clusterKey)
-	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator.ARN)
+	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator)
 	if err != nil {
 		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
 		os.Exit(1)

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -365,7 +365,7 @@ func run(cmd *cobra.Command, _ []string) {
 
 	tempAWSClient := aws.GetAWSClientForUserRegion(reporter, logger)
 
-	creator, err := tempAWSClient.GetCreator()
+	awsCreator, err := tempAWSClient.GetCreator()
 	if err != nil {
 		reporter.Errorf("Unable to get IAM credentials: %v", err)
 		os.Exit(1)
@@ -410,7 +410,7 @@ func run(cmd *cobra.Command, _ []string) {
 	// AWS ARN Role
 	roleARN := args.roleARN
 
-	if !interactive.Enabled() && creator.IsSTS && roleARN == "" {
+	if !interactive.Enabled() && awsCreator.IsSTS && roleARN == "" {
 		err = interactive.PrintHelp(interactive.Help{
 			Message: "Since your AWS credentials are returning an STS ARN you can only " +
 				"create STS clusters. Otherwise, switch to IAM credentials.",
@@ -428,7 +428,7 @@ func run(cmd *cobra.Command, _ []string) {
 			Question: "Role ARN",
 			Help:     cmd.Flags().Lookup("role-arn").Usage,
 			Default:  roleARN,
-			Required: creator.IsSTS,
+			Required: awsCreator.IsSTS,
 		})
 		if err != nil {
 			reporter.Errorf("Expected a valid ARN: %s", err)

--- a/cmd/create/idp/cmd.go
+++ b/cmd/create/idp/cmd.go
@@ -329,7 +329,7 @@ func run(cmd *cobra.Command, _ []string) {
 
 	// Try to find the cluster:
 	reporter.Debugf("Loading cluster '%s'", clusterKey)
-	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator.ARN)
+	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator)
 	if err != nil {
 		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
 		os.Exit(1)

--- a/cmd/create/ingress/cmd.go
+++ b/cmd/create/ingress/cmd.go
@@ -153,7 +153,7 @@ func run(cmd *cobra.Command, _ []string) {
 
 	// Try to find the cluster:
 	reporter.Debugf("Loading cluster '%s'", clusterKey)
-	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator.ARN)
+	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator)
 	if err != nil {
 		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
 		os.Exit(1)

--- a/cmd/create/machinepool/cmd.go
+++ b/cmd/create/machinepool/cmd.go
@@ -191,7 +191,7 @@ func run(cmd *cobra.Command, _ []string) {
 
 	// Try to find the cluster:
 	reporter.Debugf("Loading cluster '%s'", clusterKey)
-	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator.ARN)
+	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator)
 	if err != nil {
 		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
 		os.Exit(1)

--- a/cmd/describe/admin/cmd.go
+++ b/cmd/describe/admin/cmd.go
@@ -107,7 +107,7 @@ func run(cmd *cobra.Command, _ []string) {
 
 	// Try to find the cluster:
 	reporter.Debugf("Loading cluster '%s'", clusterKey)
-	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator.ARN)
+	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator)
 	if err != nil {
 		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
 		os.Exit(1)

--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -129,7 +129,7 @@ func run(cmd *cobra.Command, argv []string) {
 
 	// Try to find the cluster:
 	reporter.Debugf("Loading cluster '%s'", clusterKey)
-	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator.ARN)
+	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator)
 	if err != nil {
 		reporter.Errorf(fmt.Sprintf("Failed to get cluster '%s': %v", clusterKey, err))
 		os.Exit(1)

--- a/cmd/dlt/admin/cmd.go
+++ b/cmd/dlt/admin/cmd.go
@@ -108,7 +108,7 @@ func run(cmd *cobra.Command, _ []string) {
 
 	// Try to find the cluster:
 	reporter.Debugf("Loading cluster '%s'", clusterKey)
-	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator.ARN)
+	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator)
 	if err != nil {
 		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
 		os.Exit(1)

--- a/cmd/dlt/cluster/cmd.go
+++ b/cmd/dlt/cluster/cmd.go
@@ -120,7 +120,7 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	reporter.Debugf("Deleting cluster '%s'", clusterKey)
-	_, err = ocmClient.DeleteCluster(clusterKey, awsCreator.ARN)
+	_, err = ocmClient.DeleteCluster(clusterKey, awsCreator)
 	if err != nil {
 		reporter.Errorf("Failed to delete cluster '%s': %v", clusterKey, err)
 		os.Exit(1)

--- a/cmd/dlt/idp/cmd.go
+++ b/cmd/dlt/idp/cmd.go
@@ -115,7 +115,7 @@ func run(_ *cobra.Command, argv []string) {
 
 	// Try to find the cluster:
 	reporter.Debugf("Loading cluster '%s'", clusterKey)
-	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator.ARN)
+	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator)
 	if err != nil {
 		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
 		os.Exit(1)

--- a/cmd/dlt/ingress/cmd.go
+++ b/cmd/dlt/ingress/cmd.go
@@ -130,7 +130,7 @@ func run(_ *cobra.Command, argv []string) {
 
 	// Try to find the cluster:
 	reporter.Debugf("Loading cluster '%s'", clusterKey)
-	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator.ARN)
+	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator)
 	if err != nil {
 		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
 		os.Exit(1)

--- a/cmd/dlt/machinepool/cmd.go
+++ b/cmd/dlt/machinepool/cmd.go
@@ -129,7 +129,7 @@ func run(_ *cobra.Command, argv []string) {
 
 	// Try to find the cluster:
 	reporter.Debugf("Loading cluster '%s'", clusterKey)
-	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator.ARN)
+	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator)
 	if err != nil {
 		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
 		os.Exit(1)

--- a/cmd/dlt/upgrade/cmd.go
+++ b/cmd/dlt/upgrade/cmd.go
@@ -105,7 +105,7 @@ func run(cmd *cobra.Command, _ []string) {
 
 	// Try to find the cluster:
 	reporter.Debugf("Loading cluster '%s'", clusterKey)
-	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator.ARN)
+	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator)
 	if err != nil {
 		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
 		os.Exit(1)

--- a/cmd/edit/addon/cmd.go
+++ b/cmd/edit/addon/cmd.go
@@ -127,7 +127,7 @@ func run(cmd *cobra.Command, argv []string) {
 
 	// Try to find the cluster:
 	reporter.Debugf("Loading cluster '%s'", clusterKey)
-	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator.ARN)
+	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator)
 	if err != nil {
 		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
 		os.Exit(1)
@@ -144,7 +144,7 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
-	addOnInstallation, err := ocmClient.GetAddOnInstallation(clusterKey, awsCreator.ARN, addOnID)
+	addOnInstallation, err := ocmClient.GetAddOnInstallation(clusterKey, awsCreator, addOnID)
 	if err != nil {
 		reporter.Errorf("Failed to get add-on '%s' installation: %v", addOnID, err)
 		os.Exit(1)
@@ -266,7 +266,7 @@ func run(cmd *cobra.Command, argv []string) {
 	})
 
 	reporter.Debugf("Updating add-on parameters for '%s' on cluster '%s'", addOnID, clusterKey)
-	err = ocmClient.UpdateAddOnInstallation(clusterKey, awsCreator.ARN, addOnID, params)
+	err = ocmClient.UpdateAddOnInstallation(clusterKey, awsCreator, addOnID, params)
 	if err != nil {
 		reporter.Errorf("Failed to update add-on installation '%s' for cluster '%s': %v", addOnID, clusterKey, err)
 		os.Exit(1)

--- a/cmd/edit/cluster/cmd.go
+++ b/cmd/edit/cluster/cmd.go
@@ -156,7 +156,7 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	reporter.Debugf("Loading cluster '%s'", clusterKey)
-	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator.ARN)
+	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator)
 	if err != nil {
 		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
 		os.Exit(1)
@@ -210,7 +210,7 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	reporter.Debugf("Updating cluster '%s'", clusterKey)
-	err = ocmClient.UpdateCluster(clusterKey, awsCreator.ARN, clusterConfig)
+	err = ocmClient.UpdateCluster(clusterKey, awsCreator, clusterConfig)
 	if err != nil {
 		reporter.Errorf("Failed to update cluster: %v", err)
 		os.Exit(1)

--- a/cmd/edit/ingress/cmd.go
+++ b/cmd/edit/ingress/cmd.go
@@ -189,7 +189,7 @@ func run(cmd *cobra.Command, argv []string) {
 
 	// Try to find the cluster:
 	reporter.Debugf("Loading cluster '%s'", clusterKey)
-	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator.ARN)
+	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator)
 	if err != nil {
 		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
 		os.Exit(1)
@@ -206,7 +206,7 @@ func run(cmd *cobra.Command, argv []string) {
 			Private: private,
 		}
 
-		err = ocmClient.UpdateCluster(clusterKey, awsCreator.ARN, clusterConfig)
+		err = ocmClient.UpdateCluster(clusterKey, awsCreator, clusterConfig)
 		if err != nil {
 			reporter.Errorf("Failed to update cluster API on cluster '%s': %v", clusterKey, err)
 			os.Exit(1)

--- a/cmd/edit/machinepool/cmd.go
+++ b/cmd/edit/machinepool/cmd.go
@@ -178,7 +178,7 @@ func run(cmd *cobra.Command, argv []string) {
 
 	// Try to find the cluster:
 	reporter.Debugf("Loading cluster '%s'", clusterKey)
-	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator.ARN)
+	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator)
 	if err != nil {
 		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
 		os.Exit(1)
@@ -224,7 +224,7 @@ func run(cmd *cobra.Command, argv []string) {
 		}
 
 		reporter.Debugf("Updating machine pool '%s' on cluster '%s'", machinePoolID, clusterKey)
-		err = ocmClient.UpdateCluster(clusterKey, awsCreator.ARN, clusterConfig)
+		err = ocmClient.UpdateCluster(clusterKey, awsCreator, clusterConfig)
 		if err != nil {
 			reporter.Errorf("Failed to update machine pool '%s' on cluster '%s': %s",
 				machinePoolID, clusterKey, err)

--- a/cmd/grant/user/cmd.go
+++ b/cmd/grant/user/cmd.go
@@ -172,7 +172,7 @@ func run(_ *cobra.Command, argv []string) {
 
 	// Try to find the cluster:
 	reporter.Debugf("Loading cluster '%s'", clusterKey)
-	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator.ARN)
+	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator)
 	if err != nil {
 		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
 		os.Exit(1)

--- a/cmd/initialize/cmd.go
+++ b/cmd/initialize/cmd.go
@@ -200,7 +200,7 @@ func run(cmd *cobra.Command, argv []string) {
 		}
 
 		// Check whether the account has clusters:
-		hasClusters, err := ocmClient.HasClusters(awsCreator.ARN)
+		hasClusters, err := ocmClient.HasClusters(awsCreator)
 		if err != nil {
 			reporter.Errorf("Failed to check for clusters: %v", err)
 			os.Exit(1)

--- a/cmd/install/addon/cmd.go
+++ b/cmd/install/addon/cmd.go
@@ -129,7 +129,7 @@ func run(cmd *cobra.Command, argv []string) {
 
 	// Try to find the cluster:
 	reporter.Debugf("Loading cluster '%s'", clusterKey)
-	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator.ARN)
+	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator)
 	if err != nil {
 		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
 		os.Exit(1)
@@ -140,7 +140,7 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
-	addOn, err := ocmClient.GetAddOnInstallation(clusterKey, awsCreator.ARN, addOnID)
+	addOn, err := ocmClient.GetAddOnInstallation(clusterKey, awsCreator, addOnID)
 	if addOn != nil {
 		reporter.Warnf("Addon '%s' is already installed on cluster '%s'", addOnID, clusterKey)
 		os.Exit(0)
@@ -243,7 +243,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	reporter.Debugf("Installing add-on '%s' on cluster '%s'", addOnID, clusterKey)
-	err = ocmClient.InstallAddOn(clusterKey, awsCreator.ARN, addOnID, params)
+	err = ocmClient.InstallAddOn(clusterKey, awsCreator, addOnID, params)
 	if err != nil {
 		reporter.Errorf("Failed to add add-on installation '%s' for cluster '%s': %v", addOnID, clusterKey, err)
 		os.Exit(1)

--- a/cmd/list/addon/cmd.go
+++ b/cmd/list/addon/cmd.go
@@ -131,7 +131,7 @@ func run(_ *cobra.Command, _ []string) {
 
 	// Try to find the cluster:
 	reporter.Debugf("Loading cluster '%s'", clusterKey)
-	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator.ARN)
+	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator)
 	if err != nil {
 		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
 		os.Exit(1)

--- a/cmd/list/cluster/cmd.go
+++ b/cmd/list/cluster/cmd.go
@@ -84,7 +84,7 @@ func run(_ *cobra.Command, _ []string) {
 	}()
 
 	// Retrieve the list of clusters:
-	clusters, err := ocmClient.GetClusters(awsCreator.ARN, 1000)
+	clusters, err := ocmClient.GetClusters(awsCreator, 1000)
 	if err != nil {
 		reporter.Errorf("Failed to get clusters: %v", err)
 		os.Exit(1)

--- a/cmd/list/idp/cmd.go
+++ b/cmd/list/idp/cmd.go
@@ -106,7 +106,7 @@ func run(_ *cobra.Command, _ []string) {
 
 	// Try to find the cluster:
 	reporter.Debugf("Loading cluster '%s'", clusterKey)
-	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator.ARN)
+	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator)
 	if err != nil {
 		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
 		os.Exit(1)

--- a/cmd/list/ingress/cmd.go
+++ b/cmd/list/ingress/cmd.go
@@ -106,7 +106,7 @@ func run(_ *cobra.Command, _ []string) {
 
 	// Try to find the cluster:
 	reporter.Debugf("Loading cluster '%s'", clusterKey)
-	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator.ARN)
+	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator)
 	if err != nil {
 		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
 		os.Exit(1)

--- a/cmd/list/machinepool/cmd.go
+++ b/cmd/list/machinepool/cmd.go
@@ -106,7 +106,7 @@ func run(_ *cobra.Command, _ []string) {
 
 	// Try to find the cluster:
 	reporter.Debugf("Loading cluster '%s'", clusterKey)
-	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator.ARN)
+	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator)
 	if err != nil {
 		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
 		os.Exit(1)

--- a/cmd/list/upgrade/cmd.go
+++ b/cmd/list/upgrade/cmd.go
@@ -105,7 +105,7 @@ func run(_ *cobra.Command, _ []string) {
 
 	// Try to find the cluster:
 	reporter.Debugf("Loading cluster '%s'", clusterKey)
-	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator.ARN)
+	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator)
 	if err != nil {
 		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
 		os.Exit(1)

--- a/cmd/list/user/cmd.go
+++ b/cmd/list/user/cmd.go
@@ -110,7 +110,7 @@ func run(_ *cobra.Command, _ []string) {
 
 	// Try to find the cluster:
 	reporter.Debugf("Loading cluster '%s'", clusterKey)
-	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator.ARN)
+	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator)
 	if err != nil {
 		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
 		os.Exit(1)

--- a/cmd/logs/install/cmd.go
+++ b/cmd/logs/install/cmd.go
@@ -138,7 +138,7 @@ func run(cmd *cobra.Command, argv []string) {
 
 	// Try to find the cluster:
 	reporter.Debugf("Loading cluster '%s'", clusterKey)
-	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator.ARN)
+	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator)
 	if err != nil {
 		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
 		os.Exit(1)

--- a/cmd/logs/uninstall/cmd.go
+++ b/cmd/logs/uninstall/cmd.go
@@ -137,7 +137,7 @@ func run(cmd *cobra.Command, argv []string) {
 
 	// Try to find the cluster:
 	reporter.Debugf("Loading cluster '%s'", clusterKey)
-	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator.ARN)
+	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator)
 	if err != nil {
 		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
 		os.Exit(1)

--- a/cmd/revoke/user/cmd.go
+++ b/cmd/revoke/user/cmd.go
@@ -161,7 +161,7 @@ func run(_ *cobra.Command, argv []string) {
 
 	// Try to find the cluster:
 	reporter.Debugf("Loading cluster '%s'", clusterKey)
-	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator.ARN)
+	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator)
 	if err != nil {
 		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
 		os.Exit(1)

--- a/cmd/uninstall/addon/cmd.go
+++ b/cmd/uninstall/addon/cmd.go
@@ -114,7 +114,7 @@ func run(_ *cobra.Command, argv []string) {
 
 	// Try to find the cluster:
 	reporter.Debugf("Loading cluster '%s'", clusterKey)
-	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator.ARN)
+	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator)
 	if err != nil {
 		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
 		os.Exit(1)
@@ -125,7 +125,7 @@ func run(_ *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
-	addOn, err := ocmClient.GetAddOnInstallation(clusterKey, awsCreator.ARN, addOnID)
+	addOn, err := ocmClient.GetAddOnInstallation(clusterKey, awsCreator, addOnID)
 	if addOn == nil {
 		reporter.Warnf("Addon '%s' is not installed on cluster '%s'", addOnID, clusterKey)
 		os.Exit(0)
@@ -136,7 +136,7 @@ func run(_ *cobra.Command, argv []string) {
 	}
 
 	reporter.Debugf("Uninstalling add-on '%s' from cluster '%s'", addOnID, clusterKey)
-	err = ocmClient.UninstallAddOn(clusterKey, awsCreator.ARN, addOnID)
+	err = ocmClient.UninstallAddOn(clusterKey, awsCreator, addOnID)
 	if err != nil {
 		reporter.Errorf("Failed to remove add-on installation '%s' from cluster '%s': %s", addOnID, clusterKey, err)
 		os.Exit(1)

--- a/cmd/upgrade/cluster/cmd.go
+++ b/cmd/upgrade/cluster/cmd.go
@@ -157,7 +157,7 @@ func run(cmd *cobra.Command, _ []string) {
 
 	// Try to find the cluster:
 	reporter.Debugf("Loading cluster '%s'", clusterKey)
-	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator.ARN)
+	cluster, err := ocmClient.GetCluster(clusterKey, awsCreator)
 	if err != nil {
 		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
 		os.Exit(1)
@@ -371,7 +371,7 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
-	err = ocmClient.UpdateCluster(cluster.ID(), awsCreator.ARN, clusterSpec)
+	err = ocmClient.UpdateCluster(cluster.ID(), awsCreator, clusterSpec)
 	if err != nil {
 		reporter.Errorf("Failed to update cluster '%s': %v", clusterKey, err)
 		os.Exit(1)

--- a/pkg/ocm/addons.go
+++ b/pkg/ocm/addons.go
@@ -19,6 +19,8 @@ package ocm
 import (
 	amsv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
+	"github.com/openshift/rosa/pkg/aws"
 )
 
 type AddOnParam struct {
@@ -38,9 +40,9 @@ type ClusterAddOn struct {
 	State string
 }
 
-func (c *Client) InstallAddOn(clusterKey string, creatorARN string, addOnID string,
+func (c *Client) InstallAddOn(clusterKey string, creator *aws.Creator, addOnID string,
 	params []AddOnParam) error {
-	cluster, err := c.GetCluster(clusterKey, creatorARN)
+	cluster, err := c.GetCluster(clusterKey, creator)
 	if err != nil {
 		return err
 	}
@@ -76,8 +78,8 @@ func (c *Client) InstallAddOn(clusterKey string, creatorARN string, addOnID stri
 	return nil
 }
 
-func (c *Client) UninstallAddOn(clusterKey string, creatorARN string, addOnID string) error {
-	cluster, err := c.GetCluster(clusterKey, creatorARN)
+func (c *Client) UninstallAddOn(clusterKey string, creator *aws.Creator, addOnID string) error {
+	cluster, err := c.GetCluster(clusterKey, creator)
 	if err != nil {
 		return err
 	}
@@ -96,9 +98,9 @@ func (c *Client) UninstallAddOn(clusterKey string, creatorARN string, addOnID st
 	return nil
 }
 
-func (c *Client) GetAddOnInstallation(clusterKey string, creatorARN string,
+func (c *Client) GetAddOnInstallation(clusterKey string, creator *aws.Creator,
 	addOnID string) (*cmv1.AddOnInstallation, error) {
-	cluster, err := c.GetCluster(clusterKey, creatorARN)
+	cluster, err := c.GetCluster(clusterKey, creator)
 	if err != nil {
 		return nil, err
 	}
@@ -117,9 +119,9 @@ func (c *Client) GetAddOnInstallation(clusterKey string, creatorARN string,
 	return response.Body(), nil
 }
 
-func (c *Client) UpdateAddOnInstallation(clusterKey string, creatorARN string, addOnID string,
+func (c *Client) UpdateAddOnInstallation(clusterKey string, creator *aws.Creator, addOnID string,
 	params []AddOnParam) error {
-	cluster, err := c.GetCluster(clusterKey, creatorARN)
+	cluster, err := c.GetCluster(clusterKey, creator)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
To determine what clusters a user should be able to see, we no longer
limit the filtering to the creator ARN. Instead, we determine what AWS
account was the cluster installed in based on the creator ARN and the
role ARN (for STS clusters). This allows OCM organizations to see and
manage clusters created by different users within the same OCM
organization and same AWS account.