### PR TITLE
There is no "user" anymore

### DIFF
--- a/cmd/create/idp/cmd.go
+++ b/cmd/create/idp/cmd.go
@@ -442,7 +442,7 @@ func run(cmd *cobra.Command, _ []string) {
 	reporter.Infof(
 		"Identity Provider '%s' has been created.\n"+
 			"   It will take up to 1 minute for this configuration to be enabled.\n"+
-			"   To add cluster administrators, see 'rosa create user --help'.\n"+
+			"   To add cluster administrators, see 'rosa create admin --help'.\n"+
 			"   To login into the console, open %s and click on %s.",
 		idpName, cluster.Console().URL(), idpName,
 	)

--- a/cmd/create/idp/cmd.go
+++ b/cmd/create/idp/cmd.go
@@ -442,7 +442,7 @@ func run(cmd *cobra.Command, _ []string) {
 	reporter.Infof(
 		"Identity Provider '%s' has been created.\n"+
 			"   It will take up to 1 minute for this configuration to be enabled.\n"+
-			"   To add cluster administrators, see 'rosa create admin --help'.\n"+
+			"   To add cluster administrators, see 'rosa grant user --help'.\n"+
 			"   To login into the console, open %s and click on %s.",
 		idpName, cluster.Console().URL(), idpName,
 	)


### PR DESCRIPTION
To create an administrator user it's `admin` not `user`.
It also seems that `user` isn't available anymore either.

Signed-off-by: JJ Asghar <awesome@ibm.com>