### PR TITLE
Update URLs for upcoming move to console.redhat.com

### DIFF
--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -35,7 +35,7 @@ import (
 
 const (
 	StageURL      = "https://qaprodauth.cloud.redhat.com/openshift/details/s/"
-	ProductionURL = "https://cloud.redhat.com/openshift/details/s/"
+	ProductionURL = "https://console.redhat.com/openshift/details/s/"
 	StageEnv      = "https://api.stage.openshift.com"
 	ProductionEnv = "https://api.openshift.com"
 )

--- a/cmd/login/cmd.go
+++ b/cmd/login/cmd.go
@@ -31,7 +31,7 @@ import (
 )
 
 // #nosec G101
-const uiTokenPage = "https://cloud.redhat.com/openshift/token/rosa"
+const uiTokenPage = "https://console.redhat.com/openshift/token/rosa"
 
 var args struct {
 	tokenURL     string
@@ -55,7 +55,7 @@ var Cmd = &cobra.Command{
 		"\t4. Configuration file\n"+
 		"\t5. Command-line prompt\n", uiTokenPage),
 	Example: "  # Login to the OpenShift API with an existing token generated from " +
-		`https://cloud.redhat.com/openshift/token/rosa
+		`https://console.redhat.com/openshift/token/rosa
   rosa login --token=$OFFLINE_ACCESS_TOKEN`,
 	Run: run,
 }
@@ -106,7 +106,7 @@ func init() {
 		"token",
 		"t",
 		"",
-		"Access or refresh token generated from https://cloud.redhat.com/openshift/token/rosa.",
+		"Access or refresh token generated from https://console.redhat.com/openshift/token/rosa.",
 	)
 	flags.BoolVar(
 		&args.insecure,


### PR DESCRIPTION
The new URL already works so it's safe to merge & release this,
and since users take time to upgrade the CLI, better sooner IMHO.

* internal `StageURL` has not moved yet, will need separate update.

related to https://github.com/openshift-online/ocm-cli/pull/294, https://issues.redhat.com/browse/OSDOCS-2290

