### PR TITLE
Add support for machine pool spot instances

### DIFF
--- a/cmd/list/machinepool/cmd.go
+++ b/cmd/list/machinepool/cmd.go
@@ -212,7 +212,7 @@ func printSpot(mp *cmv1.MachinePool, showSpot bool) string {
 		if spot := mp.AWS().SpotMarketOptions(); spot != nil {
 			price := "on-demand"
 			if maxPrice, ok := spot.GetMaxPrice(); ok {
-				price = fmt.Sprintf("max $%.2f", maxPrice)
+				price = fmt.Sprintf("max $%g", maxPrice)
 			}
 			return fmt.Sprintf("Yes (%s)", price)
 		}

--- a/cmd/list/machinepool/cmd.go
+++ b/cmd/list/machinepool/cmd.go
@@ -158,9 +158,10 @@ func run(_ *cobra.Command, _ []string) {
 	// Create the writer that will be used to print the tabulated results:
 	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 
-	fmt.Fprintf(writer, "ID\tAUTOSCALING\tREPLICAS\tINSTANCE TYPE\tLABELS\t\tTAINTS\t\tAVAILABILITY ZONES\n")
+	fmt.Fprintf(writer, "ID\tAUTOSCALING\tREPLICAS\tINSTANCE TYPE\tLABELS\t\tTAINTS\t\tAVAILABILITY ZONES"+
+		"\t\tSPOT INSTANCES\n")
 	for _, machinePool := range machinePools {
-		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\t\t%s\t\t%s\n",
+		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\t\t%s\t\t%s\t\t%s\n",
 			machinePool.ID(),
 			printAutoscaling(machinePool.Autoscaling()),
 			printReplicas(machinePool.Autoscaling(), machinePool.Replicas()),
@@ -168,6 +169,7 @@ func run(_ *cobra.Command, _ []string) {
 			printLabels(machinePool.Labels()),
 			printTaints(machinePool.Taints()),
 			printAZ(machinePool.AvailabilityZones()),
+			printSpot(machinePool.AWS()),
 		)
 	}
 	writer.Flush()
@@ -176,6 +178,19 @@ func run(_ *cobra.Command, _ []string) {
 func printAutoscaling(autoscaling *cmv1.MachinePoolAutoscaling) string {
 	if autoscaling != nil {
 		return "Yes"
+	}
+	return "No"
+}
+
+func printSpot(aws *cmv1.AWSMachinePool) string {
+	if aws != nil {
+		if spot := aws.SpotMarketOptions(); spot != nil {
+			price := "on-demand"
+			if maxPrice, ok := spot.GetMaxPrice(); ok {
+				price = fmt.Sprintf("max $%.2f", maxPrice)
+			}
+			return fmt.Sprintf("Yes (%s)", price)
+		}
 	}
 	return "No"
 }

--- a/cmd/list/machinepool/cmd.go
+++ b/cmd/list/machinepool/cmd.go
@@ -158,8 +158,15 @@ func run(_ *cobra.Command, _ []string) {
 	// Create the writer that will be used to print the tabulated results:
 	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 
+	// Show spot details only if the cluster has spot machine pools
+	showSpot := isSpotCluster(machinePools)
+	var spotTitle string
+	if showSpot {
+		spotTitle = "SPOT INSTANCES"
+	}
+
 	fmt.Fprintf(writer, "ID\tAUTOSCALING\tREPLICAS\tINSTANCE TYPE\tLABELS\t\tTAINTS\t\tAVAILABILITY ZONES"+
-		"\t\tSPOT INSTANCES\n")
+		"\t\t%s\n", spotTitle)
 	for _, machinePool := range machinePools {
 		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\t\t%s\t\t%s\t\t%s\n",
 			machinePool.ID(),
@@ -169,10 +176,20 @@ func run(_ *cobra.Command, _ []string) {
 			printLabels(machinePool.Labels()),
 			printTaints(machinePool.Taints()),
 			printAZ(machinePool.AvailabilityZones()),
-			printSpot(machinePool.AWS()),
+			printSpot(machinePool, showSpot),
 		)
 	}
 	writer.Flush()
+}
+
+// true if at least one machine pool has spot instances
+func isSpotCluster(machinePools []*cmv1.MachinePool) bool {
+	for _, machinePool := range machinePools {
+		if machinePool.AWS() != nil && machinePool.AWS().SpotMarketOptions() != nil {
+			return true
+		}
+	}
+	return false
 }
 
 func printAutoscaling(autoscaling *cmv1.MachinePoolAutoscaling) string {
@@ -182,9 +199,17 @@ func printAutoscaling(autoscaling *cmv1.MachinePoolAutoscaling) string {
 	return "No"
 }
 
-func printSpot(aws *cmv1.AWSMachinePool) string {
-	if aws != nil {
-		if spot := aws.SpotMarketOptions(); spot != nil {
+func printSpot(mp *cmv1.MachinePool, showSpot bool) string {
+	if !showSpot {
+		return ""
+	}
+
+	if mp.ID() == "Default" {
+		return "N/A"
+	}
+
+	if mp.AWS() != nil {
+		if spot := mp.AWS().SpotMarketOptions(); spot != nil {
 			price := "on-demand"
 			if maxPrice, ok := spot.GetMaxPrice(); ok {
 				price = fmt.Sprintf("max $%.2f", maxPrice)

--- a/pkg/interactive/interactive.go
+++ b/pkg/interactive/interactive.go
@@ -123,7 +123,9 @@ func GetFloat(input Input) (a float64, err error) {
 	prompt := &survey.Input{
 		Message: fmt.Sprintf("%s:", question),
 		Help:    input.Help,
-		Default: dfltStr,
+	}
+	if input.Default != nil {
+		prompt.Default = dfltStr
 	}
 	var str string
 	if input.Required {


### PR DESCRIPTION
```
$ rosa create machinepool -c 1m1hjsebcs6sbnv3qs5m9u1k7nhhlc9m --name=mp-2 --replicas=2 --instance-type=m5.xlarge --use-spot-instances --spot-max-price=0.5
$ rosa create machinepool -c 1m1hjsebcs6sbnv3qs5m9u1k7nhhlc9m --name=mp-1 --replicas=2 --instance-type=m5.xlarge --use-spot-instances

$ rosa list machinepools -c 1m1hjsebcs6sbnv3qs5m9u1k7nhhlc9m
ID       AUTOSCALING  REPLICAS  INSTANCE TYPE  LABELS    TAINTS    AVAILABILITY ZONES    SPOT INSTANCES
Default  No           2         m5.xlarge                          us-east-1a            No
mp-2     No           2         m5.xlarge                          us-east-1a            Yes (max $0.50)
mp-1     No           2         m5.xlarge                          us-east-1a            Yes (on-demand)
```