### PR TITLE
Reduce EBS quota checks

### DIFF
--- a/pkg/aws/quota.go
+++ b/pkg/aws/quota.go
@@ -51,7 +51,7 @@ var serviceQuotaServices = []quota{
 		ServiceCode:  "ebs",
 		QuotaCode:    "L-D18FCD1D",
 		QuotaName:    "General Purpose SSD (gp2) volume storage",
-		DesiredValue: aws.Float64(300.0),
+		DesiredValue: aws.Float64(50.0),
 	},
 	{
 		ServiceCode:  "ebs",
@@ -69,7 +69,7 @@ var serviceQuotaServices = []quota{
 		ServiceCode:  "ebs",
 		QuotaCode:    "L-FD252861",
 		QuotaName:    "Provisioned IOPS SSD (io1) volume storage",
-		DesiredValue: aws.Float64(300.0),
+		DesiredValue: aws.Float64(50.0),
 	},
 	{
 		ServiceCode:  "elasticloadbalancing",


### PR DESCRIPTION
Recent changes in AWS quota have caused the EBS quota checks to fail. This PR allows the quota checks to pass, this requires testing as the low quota likely will prevent a cluster install.

I'm going to open this PR and put it on hold until we work with AWS to figure out the correct path forward. 