### PR TITLE
account-roles: Ensure that roles and policies can be upgraded

### DIFF
--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -250,7 +250,7 @@ func createRoles(reporter *rprtr.Object, awsClient aws.Client,
 		}
 
 		reporter.Debugf("Creating role '%s'", roleName)
-		roleARN, err := awsClient.EnsureRole(roleName, policy, map[string]string{
+		roleARN, err := awsClient.EnsureRole(roleName, policy, version, map[string]string{
 			tags.ClusterID:        cluster.ID(),
 			tags.OpenShiftVersion: version,
 			tags.RolePrefix:       prefix,

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -75,9 +75,9 @@ type Client interface {
 	ValidateQuota() (bool, error)
 	TagUserRegion(username string, region string) error
 	GetClusterRegionTagForUser(username string) (string, error)
-	EnsureRole(name string, policy string, tagList map[string]string) (string, error)
+	EnsureRole(name string, policy string, version string, tagList map[string]string) (string, error)
 	PutRolePolicy(roleName string, policyName string, policy string) error
-	EnsurePolicy(name string, document string, tagList map[string]string) error
+	EnsurePolicy(policyArn string, document string, version string, tagList map[string]string) (string, error)
 	AttachRolePolicy(roleName string, policyARN string) error
 	CreateOpenIDConnectProvider(issuerURL string, thumbprint string) (string, error)
 	HasOpenIDConnectProvider(issuerURL string, accountID string) (bool, error)


### PR DESCRIPTION
If a customer creates roles and policies for OpenShift 4.7 clusters and
then decides to upgrade to 4.8, we need to ensure that they can re-run
the initialization commands that will update the resources to be
compatible. Since later versions are a superset of older versions, we
enforce upgrading and ignore downgrade requests.