### PR TITLE
create-cluster: Update help text for etcd encryption

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -207,7 +207,8 @@ func init() {
 		&args.etcdEncryption,
 		"etcd-encryption",
 		false,
-		"Enable etcd encryption for your cluster to provide an additional layer of data security.",
+		"Add etcd encryption. By default etcd data is encrypted at rest. "+
+			"This option configures etcd encryption on top of existing storage encryption.",
 	)
 
 	flags.StringVar(


### PR DESCRIPTION
Since etcd is already encrypted and this flag provides a secondary layer
of encryption, we note that in the help text. This also shows up in the
interactive help.