### PR TITLE
roles: Update trust policy

### DIFF
--- a/assets/bindata.go
+++ b/assets/bindata.go
@@ -347,7 +347,9 @@ var _templatesPolicies47Operator_iam_role_policyJson = []byte(`{
       "Principal": {
         "Federated": "%{oidc_provider_arn}"
       },
-      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Action": [
+        "sts:AssumeRoleWithWebIdentity"
+      ],
       "Condition": {
         "StringEquals": {
           "%{issuer_url}:aud": "openshift"
@@ -1057,7 +1059,9 @@ var _templatesPolicies48Operator_iam_role_policyJson = []byte(`{
       "Principal": {
         "Federated": "%{oidc_provider_arn}"
       },
-      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Action": [
+        "sts:AssumeRoleWithWebIdentity"
+      ],
       "Condition": {
         "StringEquals": {
           "%{issuer_url}:sub": [ "%{service_accounts}" ]
@@ -1769,7 +1773,9 @@ var _templatesPolicies49Operator_iam_role_policyJson = []byte(`{
       "Principal": {
         "Federated": "%{oidc_provider_arn}"
       },
-      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Action": [
+        "sts:AssumeRoleWithWebIdentity"
+      ],
       "Condition": {
         "StringEquals": {
           "%{issuer_url}:sub": [ "%{service_accounts}" ]
@@ -2450,7 +2456,9 @@ var _templatesPoliciesSts_installer_trust_policyJson = []byte(`{
         {
             "Effect": "Allow",
             "Principal": {
-                "AWS": "arn:aws:iam::%{aws_account_id}:role/RH-Managed-OpenShift-Installer"
+                "AWS": [
+                    "arn:aws:iam::%{aws_account_id}:role/RH-Managed-OpenShift-Installer"
+                ]
             },
             "Action": [
                 "sts:AssumeRole"
@@ -2481,7 +2489,9 @@ var _templatesPoliciesSts_instance_controlplane_trust_policyJson = []byte(`{
         {
             "Effect": "Allow",
             "Principal": {
-                "Service": "ec2.amazonaws.com"
+                "Service": [
+                    "ec2.amazonaws.com"
+                ]
             },
             "Action": [
                 "sts:AssumeRole"
@@ -2512,7 +2522,9 @@ var _templatesPoliciesSts_instance_worker_trust_policyJson = []byte(`{
         {
             "Effect": "Allow",
             "Principal": {
-                "Service": "ec2.amazonaws.com"
+                "Service": [
+                    "ec2.amazonaws.com"
+                ]
             },
             "Action": [
                 "sts:AssumeRole"
@@ -2543,7 +2555,9 @@ var _templatesPoliciesSts_support_trust_policyJson = []byte(`{
         {
             "Effect": "Allow",
             "Principal": {
-                "AWS": "arn:aws:iam::%{aws_account_id}:role/RH-Technical-Support-Access"
+                "AWS": [
+                    "arn:aws:iam::%{aws_account_id}:role/RH-Technical-Support-Access"
+                ]
             },
             "Action": [
                 "sts:AssumeRole"

--- a/templates/policies/4.7/operator_iam_role_policy.json
+++ b/templates/policies/4.7/operator_iam_role_policy.json
@@ -6,7 +6,9 @@
       "Principal": {
         "Federated": "%{oidc_provider_arn}"
       },
-      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Action": [
+        "sts:AssumeRoleWithWebIdentity"
+      ],
       "Condition": {
         "StringEquals": {
           "%{issuer_url}:aud": "openshift"

--- a/templates/policies/4.8/operator_iam_role_policy.json
+++ b/templates/policies/4.8/operator_iam_role_policy.json
@@ -6,7 +6,9 @@
       "Principal": {
         "Federated": "%{oidc_provider_arn}"
       },
-      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Action": [
+        "sts:AssumeRoleWithWebIdentity"
+      ],
       "Condition": {
         "StringEquals": {
           "%{issuer_url}:sub": [ "%{service_accounts}" ]

--- a/templates/policies/4.9/operator_iam_role_policy.json
+++ b/templates/policies/4.9/operator_iam_role_policy.json
@@ -6,7 +6,9 @@
       "Principal": {
         "Federated": "%{oidc_provider_arn}"
       },
-      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Action": [
+        "sts:AssumeRoleWithWebIdentity"
+      ],
       "Condition": {
         "StringEquals": {
           "%{issuer_url}:sub": [ "%{service_accounts}" ]

--- a/templates/policies/sts_installer_trust_policy.json
+++ b/templates/policies/sts_installer_trust_policy.json
@@ -4,7 +4,9 @@
         {
             "Effect": "Allow",
             "Principal": {
-                "AWS": "arn:aws:iam::%{aws_account_id}:role/RH-Managed-OpenShift-Installer"
+                "AWS": [
+                    "arn:aws:iam::%{aws_account_id}:role/RH-Managed-OpenShift-Installer"
+                ]
             },
             "Action": [
                 "sts:AssumeRole"

--- a/templates/policies/sts_instance_controlplane_trust_policy.json
+++ b/templates/policies/sts_instance_controlplane_trust_policy.json
@@ -4,7 +4,9 @@
         {
             "Effect": "Allow",
             "Principal": {
-                "Service": "ec2.amazonaws.com"
+                "Service": [
+                    "ec2.amazonaws.com"
+                ]
             },
             "Action": [
                 "sts:AssumeRole"

--- a/templates/policies/sts_instance_worker_trust_policy.json
+++ b/templates/policies/sts_instance_worker_trust_policy.json
@@ -4,7 +4,9 @@
         {
             "Effect": "Allow",
             "Principal": {
-                "Service": "ec2.amazonaws.com"
+                "Service": [
+                    "ec2.amazonaws.com"
+                ]
             },
             "Action": [
                 "sts:AssumeRole"

--- a/templates/policies/sts_support_trust_policy.json
+++ b/templates/policies/sts_support_trust_policy.json
@@ -4,7 +4,9 @@
         {
             "Effect": "Allow",
             "Principal": {
-                "AWS": "arn:aws:iam::%{aws_account_id}:role/RH-Technical-Support-Access"
+                "AWS": [
+                    "arn:aws:iam::%{aws_account_id}:role/RH-Technical-Support-Access"
+                ]
             },
             "Action": [
                 "sts:AssumeRole"


### PR DESCRIPTION
When creating roles in AWS, if the role already exists, instead of
ignoring the update we ensure that the new trust policy contains the
combination of what was there and the new one. That way the new policy
does not override the old one.