### PR TITLE
create-operatorroles: Auto-find policies for roles

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -64,7 +64,7 @@ func init() {
 	flags.StringVar(
 		&args.prefix,
 		"prefix",
-		"ManagedOpenShift",
+		aws.DefaultPrefix,
 		"User-defined prefix for all generated AWS resources",
 	)
 

--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -271,7 +271,8 @@ func createRoles(reporter *rprtr.Object, awsClient aws.Client,
 		reporter.Debugf("Attaching permission policy '%s' to role '%s'", policyARN, roleName)
 		err = awsClient.AttachRolePolicy(roleName, policyARN)
 		if err != nil {
-			return err
+			return fmt.Errorf("Failed to attach role policy. Check your prefix or run "+
+				"'rosa create account-roles' to create the necessary policies: %s", err)
 		}
 	}
 

--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -68,8 +68,8 @@ func init() {
 	flags.StringVar(
 		&args.prefix,
 		"prefix",
-		"ManagedOpenShift",
-		"User-defined prefix for generated AWS roles. Leave empty to use the cluster name.",
+		"",
+		"User-defined prefix for generated AWS operator policies. Leave empty to attempt to find them automatically.",
 	)
 
 	flags.StringVar(
@@ -173,21 +173,17 @@ func run(cmd *cobra.Command, _ []string) {
 			Question: "Role prefix",
 			Help:     cmd.Flags().Lookup("prefix").Usage,
 			Default:  prefix,
-			Required: true,
 		})
 		if err != nil {
 			reporter.Errorf("Expected a valid role prefix: %s", err)
 			os.Exit(1)
 		}
 	}
-	if prefix == "" {
-		prefix = cluster.Name()
-	}
 	if len(prefix) > 32 {
 		reporter.Errorf("Expected a prefix with no more than 32 characters")
 		os.Exit(1)
 	}
-	if !aws.RoleNameRE.MatchString(prefix) {
+	if prefix != "" && !aws.RoleNameRE.MatchString(prefix) {
 		reporter.Errorf("Expected a valid role prefix matching %s", aws.RoleNameRE.String())
 		os.Exit(1)
 	}
@@ -253,7 +249,6 @@ func createRoles(reporter *rprtr.Object, awsClient aws.Client,
 		roleARN, err := awsClient.EnsureRole(roleName, policy, version, map[string]string{
 			tags.ClusterID:        cluster.ID(),
 			tags.OpenShiftVersion: version,
-			tags.RolePrefix:       prefix,
 			"operator_namespace":  operator.Namespace,
 			"operator_name":       operator.Name,
 		})
@@ -262,7 +257,16 @@ func createRoles(reporter *rprtr.Object, awsClient aws.Client,
 		}
 		reporter.Infof("Created role '%s' with ARN '%s'", roleName, roleARN)
 
-		policyARN := getPolicyARN(accountID, prefix, operator.Namespace, operator.Name)
+		policyARN := ""
+		if prefix == "" {
+			policyARN, err = awsClient.FindPolicyARN(operator, version)
+			if err != nil {
+				return err
+			}
+		}
+		if policyARN == "" {
+			policyARN = getPolicyARN(accountID, prefix, operator.Namespace, operator.Name)
+		}
 
 		reporter.Debugf("Attaching permission policy '%s' to role '%s'", policyARN, roleName)
 		err = awsClient.AttachRolePolicy(roleName, policyARN)
@@ -372,6 +376,9 @@ func getRoleName(cluster *cmv1.Cluster, operator aws.Operator) string {
 }
 
 func getPolicyARN(accountID string, prefix string, namespace string, name string) string {
+	if prefix == "" {
+		prefix = aws.DefaultPrefix
+	}
 	policy := fmt.Sprintf("%s-%s-%s", prefix, namespace, name)
 	if len(policy) > 64 {
 		policy = policy[0:64]

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -81,6 +81,7 @@ type Client interface {
 	AttachRolePolicy(roleName string, policyARN string) error
 	CreateOpenIDConnectProvider(issuerURL string, thumbprint string) (string, error)
 	HasOpenIDConnectProvider(issuerURL string, accountID string) (bool, error)
+	FindPolicyARN(operator Operator, version string) (string, error)
 }
 
 // ClientBuilder contains the information and logic needed to build a new AWS client.


### PR DESCRIPTION
Since the operator role policies created through 'rosa create
account-roles' are tagged with the operator metadata, we can drop the
requirement for a user-set prefix and instead automatically find the
corresponding policy.