### PR TITLE
create-oidcprovider: Verify if OIDC Provider already exists

### DIFF
--- a/cmd/create/oidcprovider/cmd.go
+++ b/cmd/create/oidcprovider/cmd.go
@@ -167,6 +167,18 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(0)
 	}
 
+	oidcEndpointURL := cluster.AWS().STS().OIDCEndpointURL()
+	oidcProviderExists, err := awsClient.HasOpenIDConnectProvider(oidcEndpointURL, creator.AccountID)
+	if err != nil {
+		reporter.Errorf("Failed to verify if OIDC provider exists: %s", err)
+		os.Exit(1)
+	}
+	if oidcProviderExists {
+		reporter.Warnf("Cluster '%s' already has OIDC provider but has not yet started installation. "+
+			"Verify that the cluster operator roles exist and are configured correctly.", clusterKey)
+		os.Exit(1)
+	}
+
 	mode := args.mode
 	if interactive.Enabled() {
 		mode, err = interactive.GetOption(interactive.Input{

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -80,6 +80,7 @@ type Client interface {
 	EnsurePolicy(name string, document string, tagList map[string]string) error
 	AttachRolePolicy(roleName string, policyARN string) error
 	CreateOpenIDConnectProvider(issuerURL string, thumbprint string) (string, error)
+	HasOpenIDConnectProvider(issuerURL string, accountID string) (bool, error)
 }
 
 // ClientBuilder contains the information and logic needed to build a new AWS client.


### PR DESCRIPTION
If a cluster already has the OIDC provider configured, we skip trying to
re-create it. Also, if there is a configuration issue we expose it to
the user.