### PR TITLE
confirm: Add confirmation prompt with default of 'Y'

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -395,7 +395,7 @@ func createRoles(reporter *rprtr.Object, awsClient aws.Client,
 	for file, role := range aws.AccountRoles {
 		name := getRoleName(prefix, role.Name)
 
-		if !confirm.Confirm("create the '%s' role", name) {
+		if !confirm.Prompt(true, "Create the '%s' role?", name) {
 			continue
 		}
 
@@ -435,7 +435,7 @@ func createRoles(reporter *rprtr.Object, awsClient aws.Client,
 		}
 	}
 
-	if confirm.Confirm("create the operator policies for OpenShift %s", version) {
+	if confirm.Prompt(true, "Create the operator policies for OpenShift %s?", version) {
 		for credrequest, operator := range aws.CredentialRequests {
 			policyArn := getPolicyARN(accountID, prefix, operator.Namespace, operator.Name)
 

--- a/cmd/create/oidcprovider/cmd.go
+++ b/cmd/create/oidcprovider/cmd.go
@@ -197,7 +197,7 @@ func run(cmd *cobra.Command, _ []string) {
 	switch mode {
 	case "auto":
 		reporter.Infof("Creating OIDC provider using '%s'", creator.ARN)
-		if !confirm.Confirm("create the OIDC provider for cluster '%s'", clusterKey) {
+		if !confirm.Prompt(true, "Create the OIDC provider for cluster '%s'?", clusterKey) {
 			os.Exit(0)
 		}
 		err = createProvider(reporter, awsClient, cluster)

--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -236,7 +236,7 @@ func createRoles(reporter *rprtr.Object, awsClient aws.Client,
 			return fmt.Errorf("Failed to find operator IAM role")
 		}
 
-		if !confirm.Confirm("create the '%s' role", roleName) {
+		if !confirm.Prompt(true, "Create the '%s' role?", roleName) {
 			continue
 		}
 

--- a/pkg/interactive/confirm/confirm.go
+++ b/pkg/interactive/confirm/confirm.go
@@ -37,12 +37,17 @@ func AddFlag(flags *pflag.FlagSet) {
 }
 
 func Confirm(q string, v ...interface{}) bool {
+	msg := fmt.Sprintf("Are you sure you want to %s?", fmt.Sprintf(q, v...))
+	return Prompt(false, msg)
+}
+
+func Prompt(dflt bool, q string, v ...interface{}) bool {
 	if yes {
 		return yes
 	}
 	prompt := &survey.Confirm{
-		Message: fmt.Sprintf("Are you sure you want to %s?", fmt.Sprintf(q, v...)),
-		Default: false,
+		Message: fmt.Sprintf(q, v...),
+		Default: dflt,
 	}
 	response := false
 	survey.AskOne(prompt, &response, survey.WithValidator(survey.Required))


### PR DESCRIPTION
This is useful for non-destructive operations that echo the intention of
the user when running the command.