### PR TITLE
events: Track mode for AWS resource creation

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -198,6 +198,7 @@ func run(cmd *cobra.Command, _ []string) {
 
 	switch mode {
 	case "auto":
+		ocmClient.LogEvent("ROSACreateAccountRolesModeAuto")
 		reporter.Infof("Creating roles using '%s'", creator.ARN)
 		err = createRoles(reporter, awsClient, prefix, version, creator.AccountID, env)
 		if err != nil {
@@ -205,6 +206,7 @@ func run(cmd *cobra.Command, _ []string) {
 			os.Exit(1)
 		}
 	case "manual":
+		ocmClient.LogEvent("ROSACreateAccountRolesModeManual")
 		err = generatePolicyFiles(reporter, version, env)
 		if err != nil {
 			reporter.Errorf("There was an error generating the policy files: %s", err)

--- a/cmd/create/oidcprovider/cmd.go
+++ b/cmd/create/oidcprovider/cmd.go
@@ -196,6 +196,7 @@ func run(cmd *cobra.Command, _ []string) {
 
 	switch mode {
 	case "auto":
+		ocmClient.LogEvent("ROSACreateOIDCProviderModeAuto")
 		reporter.Infof("Creating OIDC provider using '%s'", creator.ARN)
 		if !confirm.Confirm("create the OIDC provider for cluster '%s'", clusterKey) {
 			os.Exit(0)
@@ -206,6 +207,7 @@ func run(cmd *cobra.Command, _ []string) {
 			os.Exit(1)
 		}
 	case "manual":
+		ocmClient.LogEvent("ROSACreateOIDCProviderModeManual")
 		reporter.Infof("Run the following commands to create the OIDC provider:\n")
 
 		commands, err := buildCommands(reporter, cluster)

--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -205,6 +205,7 @@ func run(cmd *cobra.Command, _ []string) {
 
 	switch mode {
 	case "auto":
+		ocmClient.LogEvent("ROSACreateOperatorRolesModeAuto")
 		reporter.Infof("Creating roles using '%s'", creator.ARN)
 		err = createRoles(reporter, awsClient, prefix, cluster, creator.AccountID)
 		if err != nil {
@@ -212,6 +213,7 @@ func run(cmd *cobra.Command, _ []string) {
 			os.Exit(1)
 		}
 	case "manual":
+		ocmClient.LogEvent("ROSACreateOperatorRolesModeManual")
 		reporter.Infof("Run the following commands to create the operator roles:\n")
 
 		commands, err := buildCommands(reporter, prefix, cluster, creator.AccountID)


### PR DESCRIPTION
We want to have insight on whether users prefer automatic versus manual
mode, as moving forward we want to be able to provide more options for
resource creation.

Relevant: https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/3223