### PR TITLE
Remove unnecessary SCP checks

### DIFF
--- a/assets/bindata.go
+++ b/assets/bindata.go
@@ -2279,7 +2279,7 @@ var _templatesPoliciesOsd_scp_policyJson = []byte(`{
     "Id": "OSD SCP Policy Document",
     "Statement": [
         {
-            "Sid": "Stmt1543327396000",
+            "Sid": "AllowEC2",
             "Effect": "Allow",
             "Action": [
                 "ec2:*"
@@ -2289,7 +2289,7 @@ var _templatesPoliciesOsd_scp_policyJson = []byte(`{
             ]
         },
         {
-            "Sid": "Stmt1543327408000",
+            "Sid": "AllowAutoscaling",
             "Effect": "Allow",
             "Action": [
                 "autoscaling:*"
@@ -2299,7 +2299,7 @@ var _templatesPoliciesOsd_scp_policyJson = []byte(`{
             ]
         },
         {
-            "Sid": "Stmt1543327417000",
+            "Sid": "AllowS3",
             "Effect": "Allow",
             "Action": [
                 "s3:*"
@@ -2309,7 +2309,7 @@ var _templatesPoliciesOsd_scp_policyJson = []byte(`{
             ]
         },
         {
-            "Sid": "Stmt1543327428000",
+            "Sid": "AllowIAM",
             "Effect": "Allow",
             "Action": [
                 "iam:*"
@@ -2319,7 +2319,7 @@ var _templatesPoliciesOsd_scp_policyJson = []byte(`{
             ]
         },
         {
-            "Sid": "Stmt1543327656000",
+            "Sid": "AllowELB",
             "Effect": "Allow",
             "Action": [
                 "elasticloadbalancing:*"
@@ -2329,17 +2329,7 @@ var _templatesPoliciesOsd_scp_policyJson = []byte(`{
             ]
         },
         {
-            "Sid": "Stmt1546616571000",
-            "Effect": "Allow",
-            "Action": [
-                "directconnect:*"
-            ],
-            "Resource": [
-                "*"
-            ]
-        },
-        {
-            "Sid": "Stmt1543327666000",
+            "Sid": "AllowCloudWatch",
             "Effect": "Allow",
             "Action": [
                 "cloudwatch:*"
@@ -2349,7 +2339,7 @@ var _templatesPoliciesOsd_scp_policyJson = []byte(`{
             ]
         },
         {
-            "Sid": "Stmt1543327671000",
+            "Sid": "AllowCloudWatchEvents",
             "Effect": "Allow",
             "Action": [
                 "events:*"
@@ -2359,7 +2349,7 @@ var _templatesPoliciesOsd_scp_policyJson = []byte(`{
             ]
         },
         {
-            "Sid": "Stmt1543327675000",
+            "Sid": "AllowCloudWatchLogs",
             "Effect": "Allow",
             "Action": [
                 "logs:*"
@@ -2369,7 +2359,7 @@ var _templatesPoliciesOsd_scp_policyJson = []byte(`{
             ]
         },
         {
-            "Sid": "Stmt1543327772000",
+            "Sid": "AllowSupport",
             "Effect": "Allow",
             "Action": [
                 "support:*"
@@ -2379,7 +2369,7 @@ var _templatesPoliciesOsd_scp_policyJson = []byte(`{
             ]
         },
         {
-            "Sid": "Stmt1543327781000",
+            "Sid": "AllowKMS",
             "Effect": "Allow",
             "Action": [
                 "kms:*"
@@ -2389,7 +2379,7 @@ var _templatesPoliciesOsd_scp_policyJson = []byte(`{
             ]
         },
         {
-            "Sid": "Stmt1548175905000",
+            "Sid": "AllowSTS",
             "Effect": "Allow",
             "Action": [
                 "sts:*"
@@ -2399,7 +2389,7 @@ var _templatesPoliciesOsd_scp_policyJson = []byte(`{
             ]
         },
         {
-            "Sid": "AllowTagging",
+            "Sid": "AllowTag",
             "Effect": "Allow",
             "Action": [
                 "tag:*"
@@ -2413,6 +2403,20 @@ var _templatesPoliciesOsd_scp_policyJson = []byte(`{
             "Effect": "Allow",
             "Action": [
                 "route53:*"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Sid": "AllowServiceQuotas",
+            "Effect": "Allow",
+            "Action": [
+                "servicequotas:ListServices",
+                "servicequotas:GetRequestedServiceQuotaChange",
+                "servicequotas:GetServiceQuota",
+                "servicequotas:RequestServiceQuotaIncrease",
+                "servicequotas:ListServiceQuotas"
             ],
             "Resource": [
                 "*"

--- a/assets/bindata.go
+++ b/assets/bindata.go
@@ -2399,26 +2399,6 @@ var _templatesPoliciesOsd_scp_policyJson = []byte(`{
             ]
         },
         {
-            "Sid": "Stmt1543327792000",
-            "Effect": "Allow",
-            "Action": [
-                "cur:*"
-            ],
-            "Resource": [
-                "*"
-            ]
-        },
-        {
-            "Sid": "Stmt1543327798000",
-            "Effect": "Allow",
-            "Action": [
-                "ce:*"
-            ],
-            "Resource": [
-                "*"
-            ]
-        },
-        {
             "Sid": "AllowTagging",
             "Effect": "Allow",
             "Action": [
@@ -2433,17 +2413,6 @@ var _templatesPoliciesOsd_scp_policyJson = []byte(`{
             "Effect": "Allow",
             "Action": [
                 "route53:*"
-            ],
-            "Resource": [
-                "*"
-            ]
-        },
-        {
-            "Sid": "Stmt1543327831000",
-            "Effect": "Allow",
-            "Action": [
-                "aws-portal:ViewAccount",
-                "aws-portal:ViewUsage"
             ],
             "Resource": [
                 "*"

--- a/templates/policies/osd_scp_policy.json
+++ b/templates/policies/osd_scp_policy.json
@@ -3,7 +3,7 @@
     "Id": "OSD SCP Policy Document",
     "Statement": [
         {
-            "Sid": "Stmt1543327396000",
+            "Sid": "AllowEC2",
             "Effect": "Allow",
             "Action": [
                 "ec2:*"
@@ -13,7 +13,7 @@
             ]
         },
         {
-            "Sid": "Stmt1543327408000",
+            "Sid": "AllowAutoscaling",
             "Effect": "Allow",
             "Action": [
                 "autoscaling:*"
@@ -23,7 +23,7 @@
             ]
         },
         {
-            "Sid": "Stmt1543327417000",
+            "Sid": "AllowS3",
             "Effect": "Allow",
             "Action": [
                 "s3:*"
@@ -33,7 +33,7 @@
             ]
         },
         {
-            "Sid": "Stmt1543327428000",
+            "Sid": "AllowIAM",
             "Effect": "Allow",
             "Action": [
                 "iam:*"
@@ -43,7 +43,7 @@
             ]
         },
         {
-            "Sid": "Stmt1543327656000",
+            "Sid": "AllowELB",
             "Effect": "Allow",
             "Action": [
                 "elasticloadbalancing:*"
@@ -53,17 +53,7 @@
             ]
         },
         {
-            "Sid": "Stmt1546616571000",
-            "Effect": "Allow",
-            "Action": [
-                "directconnect:*"
-            ],
-            "Resource": [
-                "*"
-            ]
-        },
-        {
-            "Sid": "Stmt1543327666000",
+            "Sid": "AllowCloudWatch",
             "Effect": "Allow",
             "Action": [
                 "cloudwatch:*"
@@ -73,7 +63,7 @@
             ]
         },
         {
-            "Sid": "Stmt1543327671000",
+            "Sid": "AllowCloudWatchEvents",
             "Effect": "Allow",
             "Action": [
                 "events:*"
@@ -83,7 +73,7 @@
             ]
         },
         {
-            "Sid": "Stmt1543327675000",
+            "Sid": "AllowCloudWatchLogs",
             "Effect": "Allow",
             "Action": [
                 "logs:*"
@@ -93,7 +83,7 @@
             ]
         },
         {
-            "Sid": "Stmt1543327772000",
+            "Sid": "AllowSupport",
             "Effect": "Allow",
             "Action": [
                 "support:*"
@@ -103,7 +93,7 @@
             ]
         },
         {
-            "Sid": "Stmt1543327781000",
+            "Sid": "AllowKMS",
             "Effect": "Allow",
             "Action": [
                 "kms:*"
@@ -113,7 +103,7 @@
             ]
         },
         {
-            "Sid": "Stmt1548175905000",
+            "Sid": "AllowSTS",
             "Effect": "Allow",
             "Action": [
                 "sts:*"
@@ -123,7 +113,7 @@
             ]
         },
         {
-            "Sid": "AllowTagging",
+            "Sid": "AllowTag",
             "Effect": "Allow",
             "Action": [
                 "tag:*"
@@ -137,6 +127,20 @@
             "Effect": "Allow",
             "Action": [
                 "route53:*"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Sid": "AllowServiceQuotas",
+            "Effect": "Allow",
+            "Action": [
+                "servicequotas:ListServices",
+                "servicequotas:GetRequestedServiceQuotaChange",
+                "servicequotas:GetServiceQuota",
+                "servicequotas:RequestServiceQuotaIncrease",
+                "servicequotas:ListServiceQuotas"
             ],
             "Resource": [
                 "*"

--- a/templates/policies/osd_scp_policy.json
+++ b/templates/policies/osd_scp_policy.json
@@ -123,26 +123,6 @@
             ]
         },
         {
-            "Sid": "Stmt1543327792000",
-            "Effect": "Allow",
-            "Action": [
-                "cur:*"
-            ],
-            "Resource": [
-                "*"
-            ]
-        },
-        {
-            "Sid": "Stmt1543327798000",
-            "Effect": "Allow",
-            "Action": [
-                "ce:*"
-            ],
-            "Resource": [
-                "*"
-            ]
-        },
-        {
             "Sid": "AllowTagging",
             "Effect": "Allow",
             "Action": [
@@ -157,17 +137,6 @@
             "Effect": "Allow",
             "Action": [
                 "route53:*"
-            ],
-            "Resource": [
-                "*"
-            ]
-        },
-        {
-            "Sid": "Stmt1543327831000",
-            "Effect": "Allow",
-            "Action": [
-                "aws-portal:ViewAccount",
-                "aws-portal:ViewUsage"
             ],
             "Resource": [
                 "*"


### PR DESCRIPTION
Since we only use SCP checks to verify whether a cluster can be created,
we need to only query for the strictly necessary permissions.

Ref: https://cloud.redhat.com/dedicated/ccs
