### PR TITLE
logs: Exit once done watching logs

### DIFF
--- a/cmd/logs/install/cmd.go
+++ b/cmd/logs/install/cmd.go
@@ -202,7 +202,7 @@ func run(cmd *cobra.Command, argv []string) {
 			}
 			if state == cmv1.ClusterStateReady {
 				reporter.Infof("Cluster '%s' is now ready", clusterKey)
-				return true
+				os.Exit(0)
 			}
 			printLog(logResponse.Body(), spin)
 			return false

--- a/cmd/logs/uninstall/cmd.go
+++ b/cmd/logs/uninstall/cmd.go
@@ -176,7 +176,8 @@ func run(cmd *cobra.Command, argv []string) {
 		response, err := ocmClient.PollUninstallLogs(cluster.ID(), func(logResponse *cmv1.LogGetResponse) bool {
 			state, err := ocmClient.GetClusterState(cluster.ID())
 			if err != nil || state == cmv1.ClusterState("") {
-				return true
+				reporter.Infof("Cluster '%s' completed uninstallation", clusterKey)
+				os.Exit(0)
 			}
 			printLog(logResponse.Body(), spin)
 			return false


### PR DESCRIPTION
This fixes exiting during log watch after uninstalling a cluster. It also fixes exiting any log watch on Windows.