### PR TITLE
reporter: Determine whether output is meant for terminal

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -217,8 +217,10 @@ func run(cmd *cobra.Command, _ []string) {
 			os.Exit(1)
 		}
 
-		reporter.Infof("All policy files saved to the current directory")
-		reporter.Infof("Run the following commands to create the account roles and policies:\n")
+		if reporter.IsTerminal() {
+			reporter.Infof("All policy files saved to the current directory")
+			reporter.Infof("Run the following commands to create the account roles and policies:\n")
+		}
 
 		commands := buildCommands(prefix, version)
 		fmt.Println(commands)

--- a/cmd/create/oidcprovider/cmd.go
+++ b/cmd/create/oidcprovider/cmd.go
@@ -208,13 +208,17 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 	case "manual":
 		ocmClient.LogEvent("ROSACreateOIDCProviderModeManual")
-		reporter.Infof("Run the following commands to create the OIDC provider:\n")
 
 		commands, err := buildCommands(reporter, cluster)
 		if err != nil {
 			reporter.Errorf("There was an error building the list of resources: %s", err)
 			os.Exit(1)
 		}
+
+		if reporter.IsTerminal() {
+			reporter.Infof("Run the following commands to create the OIDC provider:\n")
+		}
+
 		fmt.Println(commands)
 	default:
 		reporter.Errorf("Invalid mode. Allowed values are %s", modes)

--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -218,13 +218,17 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 	case "manual":
 		ocmClient.LogEvent("ROSACreateOperatorRolesModeManual")
-		reporter.Infof("Run the following commands to create the operator roles:\n")
 
 		commands, err := buildCommands(reporter, prefix, cluster, creator.AccountID)
 		if err != nil {
 			reporter.Errorf("There was an error building the list of resources: %s", err)
 			os.Exit(1)
 		}
+
+		if reporter.IsTerminal() {
+			reporter.Infof("Run the following commands to create the operator roles:\n")
+		}
+
 		fmt.Println(commands)
 	default:
 		reporter.Errorf("Invalid mode. Allowed values are %s", modes)

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -107,6 +107,16 @@ func (r *Object) useColors() bool {
 	return runtime.GOOS != "windows"
 }
 
+// Determine whether the reporter output is meant for the terminal
+// or whether it's piped or redirected to a file.
+func (r *Object) IsTerminal() bool {
+	stdout, err := os.Stdout.Stat()
+	if err != nil {
+		return true
+	}
+	return (stdout.Mode()&os.ModeDevice != 0) && (stdout.Mode()&os.ModeNamedPipe == 0)
+}
+
 // CreateReporterOrExit creates the reportor instance or exits to the console
 // noting the error on failure.
 func CreateReporterOrExit() *Object {


### PR DESCRIPTION
The output of certain commands can be piped or directed to a file for
processing. In this case we want to avoid info-level output, as it
interferes with the actual command output.