### PR TITLE
logs-install: Do not redact install log output

### DIFF
--- a/cmd/logs/install/cmd.go
+++ b/cmd/logs/install/cmd.go
@@ -19,7 +19,6 @@ package install
 import (
 	"fmt"
 	"os"
-	"regexp"
 	"strings"
 	"time"
 
@@ -218,7 +217,6 @@ func run(cmd *cobra.Command, argv []string) {
 }
 
 var lastLine string
-var redact = regexp.MustCompile(`(?s:.*)KUBECONFIG(?s:.*)`)
 
 // Print next log lines
 func printLog(logs *cmv1.Log, spin *spinner.Spinner) {
@@ -242,10 +240,6 @@ func findNextLines(logs *cmv1.Log) string {
 	}
 	// Find where the new logs and the last line overlap
 	for i, line := range lines {
-		// Remove lines containing misleading output
-		if redact.MatchString(line) {
-			lines[i] = ""
-		}
 		if lastLine != "" && line == lastLine {
 			// Remove any duplicate lines
 			lines = lines[i+1:]


### PR DESCRIPTION
Since we do not control the installer output, redacting can lead to
missed log lines and cause confusion when debugging. Hive already
redacts private and sensitive data when necessary.