### PR TITLE
region: Move flag up a level

### DIFF
--- a/cmd/create/cmd.go
+++ b/cmd/create/cmd.go
@@ -51,5 +51,6 @@ func init() {
 
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)
+	arguments.AddRegionFlag(flags)
 	confirm.AddFlag(flags)
 }

--- a/cmd/create/idp/cmd.go
+++ b/cmd/create/idp/cmd.go
@@ -26,7 +26,6 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
-	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/logging"
@@ -99,8 +98,6 @@ var Cmd = &cobra.Command{
 func init() {
 	flags := Cmd.Flags()
 	flags.SortFlags = false
-
-	arguments.AddRegionFlag(flags)
 
 	flags.StringVarP(
 		&args.clusterKey,
@@ -289,16 +286,8 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
-	// Get AWS region
-	region, err := aws.GetRegion(arguments.GetRegion())
-	if err != nil {
-		reporter.Errorf("Error getting region: %v", err)
-		os.Exit(1)
-	}
-
 	// Create the AWS client:
 	awsClient, err := aws.NewClient().
-		Region(region).
 		Logger(logger).
 		Build()
 	if err != nil {

--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -24,7 +24,6 @@ import (
 	"github.com/spf13/cobra"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/logging"
 	"github.com/openshift/rosa/pkg/ocm"
@@ -56,7 +55,6 @@ var Cmd = &cobra.Command{
 func init() {
 	flags := Cmd.Flags()
 
-	arguments.AddRegionFlag(flags)
 	output.AddFlag(Cmd)
 
 	flags.StringVarP(
@@ -90,16 +88,8 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
-	// Get AWS region
-	region, err := aws.GetRegion(arguments.GetRegion())
-	if err != nil {
-		reporter.Errorf("Error getting region: %v", err)
-		os.Exit(1)
-	}
-
 	// Create the AWS client:
 	awsClient, err := aws.NewClient().
-		Region(region).
 		Logger(logger).
 		Build()
 	if err != nil {

--- a/cmd/describe/cmd.go
+++ b/cmd/describe/cmd.go
@@ -38,4 +38,5 @@ func init() {
 
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)
+	arguments.AddRegionFlag(flags)
 }

--- a/cmd/dlt/cluster/cmd.go
+++ b/cmd/dlt/cluster/cmd.go
@@ -23,7 +23,6 @@ import (
 
 	uninstallLogs "github.com/openshift/rosa/cmd/logs/uninstall"
 
-	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/logging"
@@ -48,8 +47,6 @@ var Cmd = &cobra.Command{
 
 func init() {
 	flags := Cmd.Flags()
-
-	arguments.AddRegionFlag(flags)
 
 	flags.StringVarP(
 		&args.clusterKey,
@@ -86,7 +83,6 @@ func run(cmd *cobra.Command, _ []string) {
 
 	// Create the AWS client:
 	awsClient, err := aws.NewClient().
-		Region(arguments.GetRegion()).
 		Logger(logger).
 		Build()
 	if err != nil {

--- a/cmd/dlt/cmd.go
+++ b/cmd/dlt/cmd.go
@@ -46,5 +46,6 @@ func init() {
 
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)
+	arguments.AddRegionFlag(flags)
 	confirm.AddFlag(flags)
 }

--- a/cmd/edit/cmd.go
+++ b/cmd/edit/cmd.go
@@ -42,5 +42,6 @@ func init() {
 
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)
+	arguments.AddRegionFlag(flags)
 	interactive.AddFlag(flags)
 }

--- a/cmd/grant/cmd.go
+++ b/cmd/grant/cmd.go
@@ -34,4 +34,5 @@ func init() {
 
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)
+	arguments.AddRegionFlag(flags)
 }

--- a/cmd/grant/user/cmd.go
+++ b/cmd/grant/user/cmd.go
@@ -23,7 +23,6 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
-	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/logging"
 	"github.com/openshift/rosa/pkg/ocm"
@@ -62,8 +61,6 @@ var validRolesAliases = []string{"cluster-admin", "dedicated-admin"}
 
 func init() {
 	flags := Cmd.Flags()
-
-	arguments.AddRegionFlag(flags)
 
 	flags.StringVarP(
 		&args.clusterKey,
@@ -132,16 +129,8 @@ func run(_ *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
-	// Get AWS region
-	region, err := aws.GetRegion(arguments.GetRegion())
-	if err != nil {
-		reporter.Errorf("Error getting region: %v", err)
-		os.Exit(1)
-	}
-
 	// Create the AWS client:
 	awsClient, err := aws.NewClient().
-		Region(region).
 		Logger(logger).
 		Build()
 	if err != nil {

--- a/cmd/hibernate/cluster/cmd.go
+++ b/cmd/hibernate/cluster/cmd.go
@@ -22,7 +22,6 @@ import (
 	"github.com/spf13/cobra"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/logging"
@@ -77,14 +76,8 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 	logger := logging.CreateLoggerOrExit(reporter)
 
-	region, err := aws.GetRegion(arguments.GetRegion())
-	if err != nil {
-		reporter.Errorf("Error getting region: %v", err)
-		os.Exit(1)
-	}
 	// Create the AWS client:
 	awsClient, err := aws.NewClient().
-		Region(region).
 		Logger(logger).
 		Build()
 	if err != nil {

--- a/cmd/hibernate/cmd.go
+++ b/cmd/hibernate/cmd.go
@@ -34,4 +34,5 @@ func init() {
 	Cmd.AddCommand(cluster.Cmd)
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)
+	arguments.AddRegionFlag(flags)
 }

--- a/cmd/install/cmd.go
+++ b/cmd/install/cmd.go
@@ -36,6 +36,7 @@ func init() {
 
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)
+	arguments.AddRegionFlag(flags)
 	confirm.AddFlag(flags)
 	interactive.AddFlag(flags)
 }

--- a/cmd/list/cluster/cmd.go
+++ b/cmd/list/cluster/cmd.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/logging"
 	"github.com/openshift/rosa/pkg/ocm"
@@ -46,7 +45,6 @@ func init() {
 	flags := Cmd.Flags()
 	flags.SortFlags = false
 
-	arguments.AddRegionFlag(flags)
 	output.AddFlag(Cmd)
 }
 
@@ -56,7 +54,6 @@ func run(_ *cobra.Command, _ []string) {
 
 	// Create the AWS client:
 	awsClient, err := aws.NewClient().
-		Region(arguments.GetRegion()).
 		Logger(logger).
 		Build()
 	if err != nil {

--- a/cmd/list/cmd.go
+++ b/cmd/list/cmd.go
@@ -52,4 +52,5 @@ func init() {
 
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)
+	arguments.AddRegionFlag(flags)
 }

--- a/cmd/list/user/cmd.go
+++ b/cmd/list/user/cmd.go
@@ -25,7 +25,6 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
-	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/logging"
 	"github.com/openshift/rosa/pkg/ocm"
@@ -48,8 +47,6 @@ var Cmd = &cobra.Command{
 
 func init() {
 	flags := Cmd.Flags()
-
-	arguments.AddRegionFlag(flags)
 
 	flags.StringVarP(
 		&args.clusterKey,
@@ -79,7 +76,6 @@ func run(_ *cobra.Command, _ []string) {
 
 	// Create the AWS client:
 	awsClient, err := aws.NewClient().
-		Region(arguments.GetRegion()).
 		Logger(logger).
 		Build()
 	if err != nil {

--- a/cmd/logs/cmd.go
+++ b/cmd/logs/cmd.go
@@ -42,4 +42,5 @@ func init() {
 
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)
+	arguments.AddRegionFlag(flags)
 }

--- a/cmd/resume/cluster/cmd.go
+++ b/cmd/resume/cluster/cmd.go
@@ -22,7 +22,6 @@ import (
 	"github.com/spf13/cobra"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/logging"
@@ -72,14 +71,8 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	logger := logging.CreateLoggerOrExit(reporter)
-	region, err := aws.GetRegion(arguments.GetRegion())
-	if err != nil {
-		reporter.Errorf("Error getting region: %v", err)
-		os.Exit(1)
-	}
 	// Create the AWS client:
 	awsClient, err := aws.NewClient().
-		Region(region).
 		Logger(logger).
 		Build()
 	if err != nil {

--- a/cmd/resume/cmd.go
+++ b/cmd/resume/cmd.go
@@ -34,4 +34,5 @@ func init() {
 	Cmd.AddCommand(cluster.Cmd)
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)
+	arguments.AddRegionFlag(flags)
 }

--- a/cmd/revoke/cmd.go
+++ b/cmd/revoke/cmd.go
@@ -35,5 +35,6 @@ func init() {
 
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)
+	arguments.AddRegionFlag(flags)
 	confirm.AddFlag(flags)
 }

--- a/cmd/uninstall/cmd.go
+++ b/cmd/uninstall/cmd.go
@@ -35,5 +35,6 @@ func init() {
 
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)
+	arguments.AddRegionFlag(flags)
 	confirm.AddFlag(flags)
 }

--- a/cmd/upgrade/cmd.go
+++ b/cmd/upgrade/cmd.go
@@ -35,5 +35,6 @@ func init() {
 
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)
+	arguments.AddRegionFlag(flags)
 	interactive.AddFlag(flags)
 }

--- a/cmd/whoami/cmd.go
+++ b/cmd/whoami/cmd.go
@@ -42,6 +42,7 @@ var Cmd = &cobra.Command{
 func init() {
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)
+	arguments.AddRegionFlag(flags)
 }
 
 func run(_ *cobra.Command, _ []string) {

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -43,6 +43,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/rosa/pkg/aws/profile"
+	regionflag "github.com/openshift/rosa/pkg/aws/region"
 	"github.com/openshift/rosa/pkg/aws/tags"
 	"github.com/openshift/rosa/pkg/logging"
 )
@@ -188,6 +189,14 @@ func (b *ClientBuilder) Build() (Client, error) {
 	}
 
 	var sess *session.Session
+
+	if b.region == nil || *b.region == "" {
+		region, err := GetRegion(regionflag.Region())
+		if err != nil {
+			return nil, err
+		}
+		b.region = aws.String(region)
+	}
 
 	// Create the AWS session:
 	if b.credentials != nil {


### PR DESCRIPTION
Also simplify code by removing the explicit set in every client
instantiation, and read the flag directly from the AWS client builder.