### PR TITLE
create-cluster: Replace account role ARNs with account roles prefix

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -244,6 +244,8 @@ func run(cmd *cobra.Command, _ []string) {
 			reporter.Errorf("There was an error creating the account roles: %s", err)
 			os.Exit(1)
 		}
+		command := fmt.Sprintf("rosa create cluster --account-roles-prefix %s", prefix)
+		reporter.Infof("To create a cluster with these roles, run the following command:\n%s", command)
 	case "manual":
 		ocmClient.LogEvent("ROSACreateAccountRolesModeManual")
 		err = generatePolicyFiles(reporter, version, env)
@@ -440,7 +442,6 @@ func buildCommands(prefix string, permissionsBoundary string, version string) st
 func createRoles(reporter *rprtr.Object, awsClient aws.Client,
 	prefix string, permissionsBoundary string,
 	version string, accountID string, env string) error {
-	command := []string{"rosa create cluster"}
 	for file, role := range aws.AccountRoles {
 		name := getRoleName(prefix, role.Name)
 
@@ -467,7 +468,6 @@ func createRoles(reporter *rprtr.Object, awsClient aws.Client,
 			return err
 		}
 		reporter.Infof("Created role '%s' with ARN '%s'", name, roleARN)
-		command = append(command, fmt.Sprintf("\t--%s %s", role.Flag, roleARN))
 
 		filename = fmt.Sprintf("sts_%s_permission_policy.json", file)
 		path = fmt.Sprintf("templates/policies/%s/%s", version, filename)
@@ -508,9 +508,6 @@ func createRoles(reporter *rprtr.Object, awsClient aws.Client,
 			reporter.Infof("Created policy with ARN '%s'", policyArn)
 		}
 	}
-
-	reporter.Infof("To create a cluster with these roles, run the following command:\n%s",
-		strings.Join(command, " \\\n"))
 
 	return nil
 }

--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -244,8 +244,8 @@ func run(cmd *cobra.Command, _ []string) {
 			reporter.Errorf("There was an error creating the account roles: %s", err)
 			os.Exit(1)
 		}
-		command := fmt.Sprintf("rosa create cluster --account-roles-prefix %s", prefix)
-		reporter.Infof("To create a cluster with these roles, run the following command:\n%s", command)
+		reporter.Infof("To create a cluster with these roles, run the following command:\n" +
+			"rosa create cluster --sts")
 	case "manual":
 		ocmClient.LogEvent("ROSACreateAccountRolesModeManual")
 		err = generatePolicyFiles(reporter, version, env)

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -83,6 +83,7 @@ type Client interface {
 	AttachRolePolicy(roleName string, policyARN string) error
 	CreateOpenIDConnectProvider(issuerURL string, thumbprint string) (string, error)
 	HasOpenIDConnectProvider(issuerURL string, accountID string) (bool, error)
+	FindRoleARNs(roleType string, version string) ([]string, error)
 	FindPolicyARN(operator Operator, version string) (string, error)
 }
 


### PR DESCRIPTION
Since we generate account roles with a predictable pattern, we can determine the proper role ARNs from a single prefix. This simplifies input when creating STS clusters.

Also add a `--sts` flag. This allows the CLI to use sane defaults based on whether the user wants to deploy a cluster using IAM or STS models.