### PR TITLE
idp: Allow empty URL and CA Path in interactive mode

### DIFF
--- a/cmd/create/idp/github.go
+++ b/cmd/create/idp/github.go
@@ -197,12 +197,6 @@ func buildGithubIdp(cmd *cobra.Command,
 				Question: "CA file path",
 				Help:     cmd.Flags().Lookup("ca").Usage,
 				Default:  caPath,
-				Validators: []interactive.Validator{
-					func(val interface{}) error {
-						_, err := ioutil.ReadFile(fmt.Sprintf("%v", val))
-						return err
-					},
-				},
 			})
 			if err != nil {
 				return idpBuilder, fmt.Errorf("Expected a valid certificate bundle: %s", err)

--- a/cmd/create/idp/gitlab.go
+++ b/cmd/create/idp/gitlab.go
@@ -107,12 +107,6 @@ func buildGitlabIdp(cmd *cobra.Command,
 			Question: "CA file path",
 			Help:     cmd.Flags().Lookup("ca").Usage,
 			Default:  caPath,
-			Validators: []interactive.Validator{
-				func(val interface{}) error {
-					_, err := ioutil.ReadFile(fmt.Sprintf("%v", val))
-					return err
-				},
-			},
 		})
 		if err != nil {
 			return idpBuilder, fmt.Errorf("Expected a valid certificate bundle: %s", err)

--- a/cmd/create/idp/ldap.go
+++ b/cmd/create/idp/ldap.go
@@ -94,12 +94,6 @@ func buildLdapIdp(cmd *cobra.Command,
 			Question: "CA file path",
 			Help:     cmd.Flags().Lookup("ca").Usage,
 			Default:  caPath,
-			Validators: []interactive.Validator{
-				func(val interface{}) error {
-					_, err := ioutil.ReadFile(fmt.Sprintf("%v", val))
-					return err
-				},
-			},
 		})
 		if err != nil {
 			return idpBuilder, fmt.Errorf("Expected a valid certificate bundle: %s", err)

--- a/cmd/create/idp/openid.go
+++ b/cmd/create/idp/openid.go
@@ -111,12 +111,6 @@ func buildOpenidIdp(cmd *cobra.Command,
 			Question: "CA file path",
 			Help:     cmd.Flags().Lookup("ca").Usage,
 			Default:  caPath,
-			Validators: []interactive.Validator{
-				func(val interface{}) error {
-					_, err := ioutil.ReadFile(fmt.Sprintf("%v", val))
-					return err
-				},
-			},
 		})
 		if err != nil {
 			return idpBuilder, fmt.Errorf("Expected a valid certificate bundle: %s", err)

--- a/pkg/interactive/validation.go
+++ b/pkg/interactive/validation.go
@@ -46,8 +46,14 @@ func compose(validators []Validator) survey.Validator {
 
 // IsURL validates whether the given value is a valid URL
 func IsURL(val interface{}) error {
-	_, err := url.ParseRequestURI(fmt.Sprintf("%v", val))
-	return err
+	if s, ok := val.(string); ok {
+		if s == "" {
+			return nil
+		}
+		_, err := url.ParseRequestURI(fmt.Sprintf("%v", val))
+		return err
+	}
+	return fmt.Errorf("can only validate strings, got %v", val)
 }
 
 // IsCert validates whether the given filepath is a valid cert file


### PR DESCRIPTION
The URL/Cert validators should not determine whether the field is
required. As such, they should succeed on an empty string and defer to
the Required validator if necessary.