### PR TITLE
Fix broken docs.openshift links

### DIFF
--- a/cmd/create/idp/cmd.go
+++ b/cmd/create/idp/cmd.go
@@ -462,7 +462,8 @@ func getMappingMethod(cmd *cobra.Command, mappingMethod string) (string, error) 
 	if interactive.Enabled() {
 		usage := fmt.Sprintf("%s\n  For more information see the documentation:\n  %s",
 			cmd.Flags().Lookup("mapping-method").Usage,
-			"https://docs.openshift.com/dedicated/4/authentication/dedicated-understanding-authentication.html")
+			"https://docs.openshift.com/dedicated/identity_providers/"+
+				"config-identity-providers.html#understanding-idp_config-identity-providers")
 		mappingMethod, err = interactive.GetOption(interactive.Input{
 			Question: "Mapping method",
 			Help:     usage,

--- a/cmd/create/idp/ldap.go
+++ b/cmd/create/idp/ldap.go
@@ -36,8 +36,8 @@ func buildLdapIdp(cmd *cobra.Command,
 	ldapIDs := args.ldapIDs
 
 	if ldapURL == "" || ldapIDs == "" {
-		instructionsURL := "https://docs.openshift.com/dedicated/4/authentication/" +
-			"identity_providers/configuring-ldap-identity-provider.html"
+		instructionsURL := "https://docs.openshift.com/dedicated/identity_providers/" +
+			"config-identity-providers.html#config-ldap-idp_config-identity-providers"
 		err = interactive.PrintHelp(interactive.Help{
 			Message: "To use LDAP as an identity provider, you must first register the application:",
 			Steps: []string{

--- a/cmd/create/idp/openid.go
+++ b/cmd/create/idp/openid.go
@@ -43,8 +43,8 @@ func buildOpenidIdp(cmd *cobra.Command,
 		(email == "" && name == "" && username == "")
 
 	if isInteractive {
-		instructionsURL := "https://docs.openshift.com/dedicated/4/authentication/" +
-			"identity_providers/configuring-oidc-identity-provider.html"
+		instructionsURL := "https://docs.openshift.com/dedicated/identity_providers/" +
+			"config-identity-providers.html#config-openid-idp_config-identity-providers"
 		oauthURL := strings.Replace(cluster.Console().URL(), "console-openshift-console", "oauth-openshift", 1)
 		err = interactive.PrintHelp(interactive.Help{
 			Message: "To use OpenID as an identity provider, you must first register the application:",


### PR DESCRIPTION
- Fix dead links pointing to `docs.openshift` which always redirect to https://docs.openshift.com/dedicated/welcome/index.html
   - New links should redirect to the new locations of the appropriate sections on `docs.openshift`