### PR TITLE
delete oidc provider and operator roles

### DIFF
--- a/cmd/dlt/accountroles/cmd.go
+++ b/cmd/dlt/accountroles/cmd.go
@@ -1,0 +1,224 @@
+/*
+  Copyright (c) 2021 Red Hat, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+*/
+
+package accountroles
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/interactive/confirm"
+	"github.com/openshift/rosa/pkg/logging"
+	"github.com/openshift/rosa/pkg/ocm"
+	rprtr "github.com/openshift/rosa/pkg/reporter"
+	"github.com/spf13/cobra"
+)
+
+var modes []string = []string{"auto", "manual"}
+
+var args struct {
+	roleName string
+	mode     string
+}
+
+var Cmd = &cobra.Command{
+	Use:     "account-roles",
+	Aliases: []string{"accountrole,account-role"},
+	Short:   "Delete Account Roles",
+	Long:    "Cleans up account roles from the current aws account.",
+	Example: `  # Delete Account roles"
+  rosa delete account-roles`,
+	Run: run,
+}
+
+func init() {
+	flags := Cmd.Flags()
+
+	flags.StringVar(
+		&args.mode,
+		"mode",
+		modes[0],
+		"How to perform the operation. Valid options are:\n"+
+			"auto: Account roles will be deleted automatically using the current AWS account\n"+
+			"manual: Command to delete the account roles will be output which can be used to delete manually",
+	)
+	Cmd.RegisterFlagCompletionFunc("mode", modeCompletion)
+
+	flags.StringVarP(
+		&args.roleName,
+		"role-name",
+		"c",
+		"",
+		"Account role name to be deleted.",
+	)
+
+	confirm.AddFlag(flags)
+}
+
+func modeCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return modes, cobra.ShellCompDirectiveDefault
+}
+
+func run(cmd *cobra.Command, _ []string) {
+	reporter := rprtr.CreateReporterOrExit()
+	logger := logging.CreateLoggerOrExit(reporter)
+
+	// Determine if interactive mode is needed
+	if !interactive.Enabled() && !cmd.Flags().Changed("mode") {
+		interactive.Enable()
+	}
+
+	// Create the AWS client:
+	awsClient, err := aws.NewClient().
+		Logger(logger).
+		Build()
+	if err != nil {
+		reporter.Errorf("Failed to create AWS client: %v", err)
+		os.Exit(1)
+	}
+
+	// Create the client for the OCM API:
+	ocmClient, err := ocm.NewClient().
+		Logger(logger).
+		Build()
+	if err != nil {
+		reporter.Errorf("Failed to create OCM connection: %v", err)
+		os.Exit(1)
+	}
+	defer func() {
+		err = ocmClient.Close()
+		if err != nil {
+			reporter.Errorf("Failed to close OCM connection: %v", err)
+		}
+	}()
+
+	env, err := ocm.GetEnv()
+	if err != nil {
+		reporter.Errorf("Error getting environment %s", err)
+		os.Exit(1)
+	}
+	creator, err := awsClient.GetCreator()
+	if err != nil {
+		reporter.Errorf("Failed to get IAM credentials: %s", err)
+		os.Exit(1)
+	}
+	clusters, err := ocmClient.GetClusters(creator, 1000)
+	if err != nil {
+		reporter.Errorf("Error getting clusters %s", err)
+		os.Exit(1)
+	}
+	finalRoleList := []string{}
+	if args.roleName == "" {
+		roles, err := awsClient.GetAccountRolesForCurrentEnv(env, creator.AccountID)
+		if err != nil {
+			reporter.Errorf("Error getting roles: %s", err)
+			os.Exit(1)
+		}
+		for _, role := range roles {
+			if !checkIfRoleExists(clusters, role) {
+				finalRoleList = append(finalRoleList, role.RoleName)
+			}
+		}
+		if len(finalRoleList) == 0 {
+			reporter.Errorf("There are no roles to be deleted")
+			os.Exit(1)
+		}
+	} else {
+		role, err := awsClient.GetAccountRoleForCurrentEnv(env, args.roleName)
+		if err != nil {
+			reporter.Errorf("Error getting role: %s", err)
+			os.Exit(1)
+		}
+		finalRoleList = append(finalRoleList, role)
+	}
+
+	// Determine if interactive mode is needed
+	if !interactive.Enabled() && !cmd.Flags().Changed("mode") {
+		interactive.Enable()
+	}
+	mode := args.mode
+	if interactive.Enabled() {
+		mode, err = interactive.GetOption(interactive.Input{
+			Question: "Account role deletion mode",
+			Help:     cmd.Flags().Lookup("mode").Usage,
+			Default:  mode,
+			Options:  modes,
+			Required: true,
+		})
+		if err != nil {
+			reporter.Errorf("Expected a valid Account role deletion mode: %s", err)
+			os.Exit(1)
+		}
+	}
+	switch mode {
+	case "auto":
+		ocmClient.LogEvent("ROSADeleteAccountRoleModeAuto")
+		for _, role := range finalRoleList {
+			if !confirm.Prompt(true, "Delete the account role '%s'?", role) {
+				continue
+			}
+			err := awsClient.DeleteAccountRole(role)
+			if err != nil {
+				reporter.Errorf("There was an error deleting the OIDC provider: %s", err)
+				continue
+			}
+		}
+	case "manual":
+		ocmClient.LogEvent("ROSADeleteAccountRoleModeManual")
+		policyMap, err := awsClient.GetAccountRolePolicies(finalRoleList)
+		if err != nil {
+			reporter.Errorf("There was an error getting the policy: %v", err)
+			os.Exit(1)
+		}
+		commands := buildCommand(finalRoleList, policyMap)
+		if reporter.IsTerminal() {
+			reporter.Infof("Run the following commands to delete the Operator roles:\n")
+		}
+		fmt.Println(commands)
+	}
+}
+
+func checkIfRoleExists(clusters []*cmv1.Cluster, role aws.Role) bool {
+	for _, cluster := range clusters {
+		if cluster.AWS().STS().RoleARN() == role.RoleARN ||
+			cluster.AWS().STS().SupportRoleARN() == role.RoleARN ||
+			cluster.AWS().STS().InstanceIAMRoles().MasterRoleARN() == role.RoleARN ||
+			cluster.AWS().STS().InstanceIAMRoles().WorkerRoleARN() == role.RoleARN {
+			return true
+		}
+	}
+	return false
+}
+
+func buildCommand(roleNames []string, policyMap map[string]string) string {
+	commands := []string{}
+	for _, roleName := range roleNames {
+		deletePolicy := fmt.Sprintf("aws iam delete-role-policy \\\n"+
+			"\t--role-name  %s  --policy-name  %s  \n\n",
+			roleName, policyMap[roleName])
+
+		deleteRole := fmt.Sprintf("aws iam delete-role \\\n"+
+			"\t--role-name  %s \n\n",
+			roleName)
+		commands = append(commands, deletePolicy, deleteRole)
+	}
+	return strings.Join(commands, "\n\n")
+}

--- a/cmd/dlt/cluster/cmd.go
+++ b/cmd/dlt/cluster/cmd.go
@@ -21,11 +21,12 @@ import (
 	"os"
 	"strings"
 
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
 	uninstallLogs "github.com/openshift/rosa/cmd/logs/uninstall"
-
 	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/logging"
 	"github.com/openshift/rosa/pkg/ocm"
@@ -35,6 +36,7 @@ import (
 var args struct {
 	// Watch logs during cluster uninstallation
 	watch bool
+	mode  string
 }
 
 var Cmd = &cobra.Command{
@@ -111,51 +113,40 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 	reporter.Infof("Cluster '%s' will start uninstalling now", clusterKey)
 
-	if args.watch {
-		uninstallLogs.Cmd.Run(uninstallLogs.Cmd, []string{clusterKey})
-	} else {
-		reporter.Infof(
-			"To watch your cluster uninstallation logs, run 'rosa logs uninstall -c %s --watch'",
-			clusterKey,
-		)
-	}
-
 	if cluster.AWS().STS().RoleARN() != "" {
+		interactive.Enable()
 		reporter.Infof(
 			"Your cluster '%s' will be deleted but the following object may remain",
 			clusterKey,
 		)
-		accountRoles := []string{}
-		accountRoles = append(accountRoles, cluster.AWS().STS().RoleARN())
-		if cluster.AWS().STS().SupportRoleARN() != "" {
-			accountRoles = append(accountRoles, cluster.AWS().STS().SupportRoleARN())
-		}
-		if cluster.AWS().STS().InstanceIAMRoles().MasterRoleARN() != "" {
-			accountRoles = append(accountRoles, cluster.AWS().STS().InstanceIAMRoles().MasterRoleARN())
-		}
-		if cluster.AWS().STS().InstanceIAMRoles().WorkerRoleARN() != "" {
-			accountRoles = append(accountRoles, cluster.AWS().STS().InstanceIAMRoles().WorkerRoleARN())
-		}
-		operatorRoles := []string{}
 		if len(cluster.AWS().STS().OperatorIAMRoles()) > 0 {
+			str := "Operator IAM Roles:"
 			for _, operatorIAMRole := range cluster.AWS().STS().OperatorIAMRoles() {
-				operatorRoles = append(operatorRoles, operatorIAMRole.RoleARN())
+				str = fmt.Sprintf("%s"+
+					" - %s\n", str,
+					operatorIAMRole.RoleARN())
 			}
+			reporter.Infof("%s", str)
 		}
-		reporter.Infof("Account Roles:\t\n%s", strings.Join(accountRoles, "\n"))
-		reporter.Infof("Operator IAM Roles:\n%s", strings.Join(operatorRoles, "\n"))
-		reporter.Infof("Delete these with `rosa delete operator-roles -c %s", clusterKey)
-		reporter.Infof("Delete these with `rosa delete oidc-provider -c %s", clusterKey)
-
-		accountRolesCmd := []string{}
-		for _, role := range accountRoles {
-			roleName := strings.Split(role, "/")
-			if len(roleName) > 1 {
-				accountRolesCmd = append(accountRolesCmd, fmt.Sprintf("rosa delete account-roles --role-name%s\n",
-					roleName[1]))
-			}
-		}
-		reporter.Infof("Only if you're certain you should delete account-roles with \n %s",
-			strings.Join(accountRolesCmd, "\n"))
+		reporter.Infof("OIDC Provider : %s\n", cluster.AWS().STS().OIDCEndpointURL())
+		reporter.Infof("Once the cluster is uninstalled use the following commands to remove the " +
+			"above aws resource.\n")
+		commands := buildCommands(cluster)
+		fmt.Print(commands, "\n")
 	}
+	if args.watch {
+		uninstallLogs.Cmd.Run(uninstallLogs.Cmd, []string{clusterKey})
+	} else {
+		reporter.Infof("To watch your cluster uninstallation logs, run 'rosa logs uninstall -c %s --watch'",
+			clusterKey,
+		)
+	}
+}
+
+func buildCommands(cluster *cmv1.Cluster) string {
+	commands := []string{}
+	deleteOperatorRole := fmt.Sprintf("\trosa delete operator-roles -c %s", cluster.ID())
+	deleteOIDCProvider := fmt.Sprintf("\trosa delete oidc-provider -c %s", cluster.ID())
+	commands = append(commands, deleteOperatorRole, deleteOIDCProvider)
+	return strings.Join(commands, "\n")
 }

--- a/cmd/dlt/cmd.go
+++ b/cmd/dlt/cmd.go
@@ -24,6 +24,8 @@ import (
 	"github.com/openshift/rosa/cmd/dlt/idp"
 	"github.com/openshift/rosa/cmd/dlt/ingress"
 	"github.com/openshift/rosa/cmd/dlt/machinepool"
+	"github.com/openshift/rosa/cmd/dlt/oidcprovider"
+	"github.com/openshift/rosa/cmd/dlt/operatorrole"
 	"github.com/openshift/rosa/cmd/dlt/upgrade"
 	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
@@ -43,6 +45,8 @@ func init() {
 	Cmd.AddCommand(ingress.Cmd)
 	Cmd.AddCommand(machinepool.Cmd)
 	Cmd.AddCommand(upgrade.Cmd)
+	Cmd.AddCommand(oidcprovider.Cmd)
+	Cmd.AddCommand(operatorrole.Cmd)
 
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)

--- a/cmd/dlt/cmd.go
+++ b/cmd/dlt/cmd.go
@@ -19,6 +19,7 @@ package dlt
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/rosa/cmd/dlt/accountroles"
 	"github.com/openshift/rosa/cmd/dlt/admin"
 	"github.com/openshift/rosa/cmd/dlt/cluster"
 	"github.com/openshift/rosa/cmd/dlt/idp"
@@ -47,6 +48,7 @@ func init() {
 	Cmd.AddCommand(upgrade.Cmd)
 	Cmd.AddCommand(oidcprovider.Cmd)
 	Cmd.AddCommand(operatorrole.Cmd)
+	Cmd.AddCommand(accountroles.Cmd)
 
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)

--- a/cmd/dlt/oidcprovider/cmd.go
+++ b/cmd/dlt/oidcprovider/cmd.go
@@ -1,0 +1,221 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oidcprovider
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/interactive/confirm"
+	"github.com/openshift/rosa/pkg/logging"
+	"github.com/openshift/rosa/pkg/ocm"
+	rprtr "github.com/openshift/rosa/pkg/reporter"
+)
+
+var modes []string = []string{"auto", "manual"}
+
+var args struct {
+	clusterKey string
+	mode       string
+}
+
+var Cmd = &cobra.Command{
+	Use:     "oidc-provider",
+	Aliases: []string{"oidcprovider"},
+	Short:   "Delete OIDC Provider",
+	Long:    "Cleans up OIDC provider of deleted STS cluster.",
+	Example: `  # Delete OIDC provider for cluster named "mycluster"
+  rosa delete oidc-provider --cluster=mycluster`,
+	Run: run,
+}
+
+func init() {
+	flags := Cmd.Flags()
+
+	flags.StringVarP(
+		&args.clusterKey,
+		"cluster",
+		"c",
+		"",
+		"Name or ID of the cluster (deleted/archived) to delete the OIDC provider from (required).",
+	)
+	Cmd.MarkFlagRequired("cluster")
+
+	flags.StringVar(
+		&args.mode,
+		"mode",
+		modes[0],
+		"How to perform the operation. Valid options are:\n"+
+			"auto: OIDC provider will be deleted using the current AWS account\n"+
+			"manual: Command to delete the OIDC provider will be output",
+	)
+	Cmd.RegisterFlagCompletionFunc("mode", modeCompletion)
+	confirm.AddFlag(flags)
+}
+
+func modeCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return modes, cobra.ShellCompDirectiveDefault
+}
+
+func run(cmd *cobra.Command, _ []string) {
+	reporter := rprtr.CreateReporterOrExit()
+	logger := logging.CreateLoggerOrExit(reporter)
+
+	// Check that the cluster key (name, identifier or external identifier) given by the user
+	// is reasonably safe so that there is no risk of SQL injection:
+	clusterKey := args.clusterKey
+	if !ocm.IsValidClusterKey(clusterKey) {
+		reporter.Errorf(
+			"Cluster name, identifier or external identifier '%s' isn't valid: it "+
+				"must contain only letters, digits, dashes and underscores",
+			clusterKey,
+		)
+		os.Exit(1)
+	}
+	// Create the AWS client:
+	awsClient, err := aws.NewClient().
+		Logger(logger).
+		Build()
+	if err != nil {
+		reporter.Errorf("Failed to create AWS client: %v", err)
+		os.Exit(1)
+	}
+
+	creator, err := awsClient.GetCreator()
+	if err != nil {
+		reporter.Errorf("Failed to get IAM credentials: %s", err)
+		os.Exit(1)
+	}
+	// Create the client for the OCM API:
+	ocmClient, err := ocm.NewClient().
+		Logger(logger).
+		Build()
+	if err != nil {
+		reporter.Errorf("Failed to create OCM connection: %v", err)
+		os.Exit(1)
+	}
+	defer func() {
+		err = ocmClient.Close()
+		if err != nil {
+			reporter.Errorf("Failed to close OCM connection: %v", err)
+		}
+	}()
+
+	// Try to find the cluster:
+	reporter.Debugf("Loading cluster '%s'", clusterKey)
+	clusters, err := ocmClient.GetArchivedCluster(clusterKey, creator)
+	// if err is nil or clusters list is empty or nil we check for cluster in "active" state
+	if err != nil || len(clusters) == 0 || (len(clusters) == 1 && clusters[0] == nil) {
+		c, err := ocmClient.GetCluster(clusterKey, creator)
+		if err != nil {
+			reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
+			os.Exit(1)
+		}
+		if c != nil && c.ID() != "" {
+			reporter.Errorf("Cluster '%s' is in '%s' state. Operator roles can be deleted only for the "+
+				"uninstalled clusters", c.ID(), c.State())
+			os.Exit(1)
+		}
+
+		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
+		os.Exit(1)
+	}
+	providerARNList := []string{}
+	for _, cluster := range clusters {
+		oidcEndpointURL := cluster.AWS().STS().OIDCEndpointURL()
+		if oidcEndpointURL == "" {
+			reporter.Errorf("Cluster '%s' doesn't have OIDC provider associated with it.Skipping!!", clusterKey)
+			continue
+		}
+		providerARN, err := getOIDCProviderARN(oidcEndpointURL, creator.AccountID)
+		if err != nil {
+			reporter.Errorf("Failed to get the OIDC provider for cluster '%s'.", clusterKey)
+			os.Exit(1)
+		}
+		providerARNList = append(providerARNList, providerARN)
+	}
+
+	// Determine if interactive mode is needed
+	if !interactive.Enabled() && !cmd.Flags().Changed("mode") {
+		interactive.Enable()
+	}
+	mode := args.mode
+	if interactive.Enabled() {
+		mode, err = interactive.GetOption(interactive.Input{
+			Question: "OIDC provider deletion mode",
+			Help:     cmd.Flags().Lookup("mode").Usage,
+			Default:  mode,
+			Options:  modes,
+			Required: true,
+		})
+		if err != nil {
+			reporter.Errorf("Expected a valid OIDC provider deletion mode: %s", err)
+			os.Exit(1)
+		}
+	}
+
+	switch mode {
+	case "auto":
+		ocmClient.LogEvent("ROSADeleteOIDCProviderModeAuto")
+		for _, providerARN := range providerARNList {
+			if !confirm.Prompt(true, "Delete the OIDC provider '%s'?", providerARN) {
+				continue
+			}
+			err := awsClient.DeleteOpenIDConnectProvider(providerARN)
+			if err != nil {
+				reporter.Errorf("There was an error deleting the OIDC provider: %s", err)
+				continue
+			}
+		}
+	case "manual":
+		ocmClient.LogEvent("ROSADeleteOIDCProviderModeManual")
+		commands := buildCommand(providerARNList)
+		if reporter.IsTerminal() {
+			reporter.Infof("Run the following commands to delete the OIDC provider:\n")
+		}
+		fmt.Println(commands)
+	default:
+		reporter.Errorf("Invalid mode. Allowed values are %s", modes)
+		os.Exit(1)
+	}
+}
+
+func buildCommand(providerARNList []string) string {
+	commands := []string{}
+	for _, providerARN := range providerARNList {
+		providerARNCmd := fmt.Sprintf("aws iam delete-open-id-connect-provider \\\n"+
+			"\t--open-id-connect-provider-arn %s \n\n",
+			providerARN)
+		commands = append(commands, providerARNCmd)
+	}
+	return strings.Join(commands, "\n\n")
+}
+
+func getOIDCProviderARN(oidcEndpointURL string, accountID string) (string, error) {
+	parsedIssuerURL, err := url.ParseRequestURI(oidcEndpointURL)
+	if err != nil {
+		return "", err
+	}
+	providerURL := fmt.Sprintf("%s%s", parsedIssuerURL.Host, parsedIssuerURL.Path)
+	oidcProviderARN := fmt.Sprintf("arn:aws:iam::%s:oidc-provider/%s", accountID, providerURL)
+	return oidcProviderARN, nil
+}

--- a/cmd/dlt/operatorrole/cmd.go
+++ b/cmd/dlt/operatorrole/cmd.go
@@ -18,6 +18,7 @@ package operatorrole
 
 import (
 	"fmt"
+
 	"os"
 	"strings"
 
@@ -187,7 +188,7 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 	case "manual":
 		ocmClient.LogEvent("ROSADeleteOperatorroleModeManual")
-		policyMap, err := awsClient.GetPolicyForOperatorRole(rolesList)
+		policyMap, err := awsClient.GetPolicies(rolesList)
 		if err != nil {
 			reporter.Errorf("There was an error getting the policy: %v", err)
 			os.Exit(1)
@@ -201,6 +202,15 @@ func run(cmd *cobra.Command, _ []string) {
 		reporter.Errorf("Invalid mode. Allowed values are %s", modes)
 		os.Exit(1)
 	}
+}
+
+func getRoleNames(operatorIAMRoles []*cmv1.OperatorIAMRole) []string {
+	roleNames := []string{}
+	for _, role := range operatorIAMRoles {
+		s := strings.Split(role.RoleARN(), "/")[1]
+		roleNames = append(roleNames, s)
+	}
+	return roleNames
 }
 
 func buildCommand(roleNames []string, policyMap map[string][]string) string {
@@ -219,13 +229,4 @@ func buildCommand(roleNames []string, policyMap map[string][]string) string {
 		commands = append(commands, detachPolicy, deleteRole)
 	}
 	return strings.Join(commands, "\n\n")
-}
-
-func getRoleNames(operatorIAMRoles []*cmv1.OperatorIAMRole) []string {
-	roleNames := []string{}
-	for _, role := range operatorIAMRoles {
-		s := strings.Split(role.RoleARN(), "/")[1]
-		roleNames = append(roleNames, s)
-	}
-	return roleNames
 }

--- a/cmd/dlt/operatorrole/cmd.go
+++ b/cmd/dlt/operatorrole/cmd.go
@@ -1,0 +1,231 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operatorrole
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/interactive/confirm"
+	"github.com/openshift/rosa/pkg/logging"
+	"github.com/openshift/rosa/pkg/ocm"
+	rprtr "github.com/openshift/rosa/pkg/reporter"
+	"github.com/spf13/cobra"
+)
+
+var modes []string = []string{"auto", "manual"}
+
+var args struct {
+	clusterKey string
+	mode       string
+}
+
+var Cmd = &cobra.Command{
+	Use:     "operator-roles",
+	Aliases: []string{"operatorrole"},
+	Short:   "Delete Operator Roles",
+	Long:    "Cleans up operator roles of deleted STS cluster.",
+	Example: `  # Delete Operator roles for cluster named "mycluster"
+  rosa delete operator-roles --cluster=mycluster`,
+	Run: run,
+}
+
+func init() {
+	flags := Cmd.Flags()
+
+	flags.StringVarP(
+		&args.clusterKey,
+		"cluster",
+		"c",
+		"",
+		"Name or ID of the cluster (deleted/archived) to delete the operator ID from (required).",
+	)
+	Cmd.MarkFlagRequired("cluster")
+
+	flags.StringVar(
+		&args.mode,
+		"mode",
+		modes[0],
+		"How to perform the operation. Valid options are:\n"+
+			"auto: Operator roles will be deleted automatically using the current AWS account\n"+
+			"manual: Command to delete the operator roles will be output which can be used to delete manually",
+	)
+	Cmd.RegisterFlagCompletionFunc("mode", modeCompletion)
+	confirm.AddFlag(flags)
+}
+
+func modeCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return modes, cobra.ShellCompDirectiveDefault
+}
+
+func run(cmd *cobra.Command, _ []string) {
+	reporter := rprtr.CreateReporterOrExit()
+	logger := logging.CreateLoggerOrExit(reporter)
+
+	// Check that the cluster key (name, identifier or external identifier) given by the user
+	// is reasonably safe so that there is no risk of SQL injection:
+	clusterKey := args.clusterKey
+	if !ocm.IsValidClusterKey(clusterKey) {
+		reporter.Errorf(
+			"Cluster name, identifier or external identifier '%s' isn't valid: it "+
+				"must contain only letters, digits, dashes and underscores",
+			clusterKey,
+		)
+		os.Exit(1)
+	}
+
+	// Determine if interactive mode is needed
+	if !interactive.Enabled() && !cmd.Flags().Changed("mode") {
+		interactive.Enable()
+	}
+
+	// Create the AWS client:
+	awsClient, err := aws.NewClient().
+		Logger(logger).
+		Build()
+	if err != nil {
+		reporter.Errorf("Failed to create AWS client: %v", err)
+		os.Exit(1)
+	}
+	creator, err := awsClient.GetCreator()
+	if err != nil {
+		reporter.Errorf("Failed to get IAM credentials: %s", err)
+		os.Exit(1)
+	}
+	// Create the client for the OCM API:
+	ocmClient, err := ocm.NewClient().
+		Logger(logger).
+		Build()
+	if err != nil {
+		reporter.Errorf("Failed to create OCM connection: %v", err)
+		os.Exit(1)
+	}
+	defer func() {
+		err = ocmClient.Close()
+		if err != nil {
+			reporter.Errorf("Failed to close OCM connection: %v", err)
+		}
+	}()
+	reporter.Debugf("Loading cluster '%s'", clusterKey)
+	clusters, err := ocmClient.GetArchivedCluster(clusterKey, creator)
+	if err != nil || len(clusters) == 0 || (len(clusters) == 1 && clusters[0] == nil) {
+		c, err := ocmClient.GetCluster(clusterKey, creator)
+		if err != nil {
+			reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
+			os.Exit(1)
+		}
+		if c != nil && c.ID() != "" {
+			reporter.Errorf("Cluster '%s' is in '%s' state. Operator roles can be deleted only for the "+
+				"uninstalled clusters", c.ID(), c.State())
+			os.Exit(1)
+		}
+
+		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
+		os.Exit(1)
+	}
+	mode := args.mode
+	if interactive.Enabled() {
+		mode, err = interactive.GetOption(interactive.Input{
+			Question: "Operator roles deletion mode",
+			Help:     cmd.Flags().Lookup("mode").Usage,
+			Default:  mode,
+			Options:  modes,
+			Required: true,
+		})
+		if err != nil {
+			reporter.Errorf("Expected a valid operator role deletion mode: %s", err)
+			os.Exit(1)
+		}
+	}
+
+	rolesList := []string{}
+	for _, cluster := range clusters {
+		roleNames := getRoleNames(cluster.AWS().STS().OperatorIAMRoles())
+		roles, err := awsClient.GetOperatorRolesFromAccount(roleNames)
+		if err != nil {
+			reporter.Errorf("Error when fetching the roles from aws account: %v", err)
+			os.Exit(1)
+		}
+		rolesList = append(rolesList, roles...)
+	}
+
+	if len(rolesList) == 0 {
+		reporter.Errorf("There are no operator roles to delete from aws account")
+		os.Exit(1)
+	}
+
+	switch mode {
+	case "auto":
+		ocmClient.LogEvent("ROSADeleteOperatorroleModeAuto")
+		for _, role := range rolesList {
+			if !confirm.Prompt(true, "Delete the operator roles  '%s'?", role) {
+				continue
+			}
+			err = awsClient.DeleteOperatorRole(role)
+			if err != nil {
+				reporter.Errorf("There was an error deleting the Operator Roles: %s", err)
+				continue
+			}
+		}
+	case "manual":
+		ocmClient.LogEvent("ROSADeleteOperatorroleModeManual")
+		policyMap, err := awsClient.GetPolicyForOperatorRole(rolesList)
+		if err != nil {
+			reporter.Errorf("There was an error getting the policy: %v", err)
+			os.Exit(1)
+		}
+		commands := buildCommand(rolesList, policyMap)
+		if reporter.IsTerminal() {
+			reporter.Infof("Run the following commands to delete the Operator roles:\n")
+		}
+		fmt.Println(commands)
+	default:
+		reporter.Errorf("Invalid mode. Allowed values are %s", modes)
+		os.Exit(1)
+	}
+}
+
+func buildCommand(roleNames []string, policyMap map[string][]string) string {
+	commands := []string{}
+	for _, roleName := range roleNames {
+		policyARN := policyMap[roleName]
+		detachPolicy := ""
+		if len(policyARN) > 0 {
+			detachPolicy = fmt.Sprintf("aws iam detach-role-policy \\\n"+
+				"\t--role-name  %s  --policy-arn  %s  \n\n",
+				roleName, policyARN[0])
+		}
+		deleteRole := fmt.Sprintf("aws iam delete-role \\\n"+
+			"\t--role-name  %s \n\n",
+			roleName)
+		commands = append(commands, detachPolicy, deleteRole)
+	}
+	return strings.Join(commands, "\n\n")
+}
+
+func getRoleNames(operatorIAMRoles []*cmv1.OperatorIAMRole) []string {
+	roleNames := []string{}
+	for _, role := range operatorIAMRoles {
+		s := strings.Split(role.RoleARN(), "/")[1]
+		roleNames = append(roleNames, s)
+	}
+	return roleNames
+}

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -83,12 +83,16 @@ type Client interface {
 	EnsurePolicy(policyArn string, document string, version string, tagList map[string]string) (string, error)
 	AttachRolePolicy(roleName string, policyARN string) error
 	CreateOpenIDConnectProvider(issuerURL string, thumbprint string) (string, error)
+	DeleteOpenIDConnectProvider(providerURL string) error
 	HasOpenIDConnectProvider(issuerURL string, accountID string) (bool, error)
 	FindRoleARNs(roleType string, version string) ([]string, error)
 	FindPolicyARN(operator Operator, version string) (string, error)
 	ListAccountRoles(version string) ([]Role, error)
 	GetRoleByARN(roleARN string) (*iam.Role, error)
 	HasCompatibleVersionTags(iamTags []*iam.Tag, version string) (bool, error)
+	DeleteOperatorRole(roles string) error
+	GetOperatorRolesFromAccount(roles []string) ([]string, error)
+	GetPolicyForOperatorRole(roles []string) (map[string][]string, error)
 }
 
 // ClientBuilder contains the information and logic needed to build a new AWS client.

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -82,7 +82,7 @@ type Client interface {
 	PutRolePolicy(roleName string, policyName string, policy string) error
 	EnsurePolicy(policyArn string, document string, version string, tagList map[string]string) (string, error)
 	AttachRolePolicy(roleName string, policyARN string) error
-	CreateOpenIDConnectProvider(issuerURL string, thumbprint string) (string, error)
+	CreateOpenIDConnectProvider(issuerURL string, thumbprint string, clusterID string) (string, error)
 	DeleteOpenIDConnectProvider(providerURL string) error
 	HasOpenIDConnectProvider(issuerURL string, accountID string) (bool, error)
 	FindRoleARNs(roleType string, version string) ([]string, error)
@@ -91,12 +91,14 @@ type Client interface {
 	GetRoleByARN(roleARN string) (*iam.Role, error)
 	HasCompatibleVersionTags(iamTags []*iam.Tag, version string) (bool, error)
 	DeleteOperatorRole(roles string) error
-	GetOperatorRolesFromAccount(roles []string) ([]string, error)
+	GetOperatorRolesFromAccount(clusterID string) ([]string, error)
 	GetPolicies(roles []string) (map[string][]string, error)
 	GetAccountRolesForCurrentEnv(env string, accountID string) ([]Role, error)
-	GetAccountRoleForCurrentEnv(env string, roleName string) (string, error)
+	GetAccountRoleForCurrentEnv(env string, roleName string) (Role, error)
+	GetAccountRoleForCurrentEnvWithPrefix(env string, rolePrefix string) ([]Role, error)
 	DeleteAccountRole(roles string) error
 	GetAccountRolePolicies(roles []string) (map[string]string, error)
+	GetOpenIDConnectProvider(clusterID string) (string, error)
 }
 
 // ClientBuilder contains the information and logic needed to build a new AWS client.

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -92,7 +92,11 @@ type Client interface {
 	HasCompatibleVersionTags(iamTags []*iam.Tag, version string) (bool, error)
 	DeleteOperatorRole(roles string) error
 	GetOperatorRolesFromAccount(roles []string) ([]string, error)
-	GetPolicyForOperatorRole(roles []string) (map[string][]string, error)
+	GetPolicies(roles []string) (map[string][]string, error)
+	GetAccountRolesForCurrentEnv(env string, accountID string) ([]Role, error)
+	GetAccountRoleForCurrentEnv(env string, roleName string) (string, error)
+	DeleteAccountRole(roles string) error
+	GetAccountRolePolicies(roles []string) (map[string]string, error)
 }
 
 // ClientBuilder contains the information and logic needed to build a new AWS client.

--- a/pkg/aws/idps.go
+++ b/pkg/aws/idps.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/openshift/rosa/pkg/aws/tags"
 )
 
 const (
@@ -30,7 +31,8 @@ const (
 	OIDCClientIDSTSAWS    = "sts.amazonaws.com"
 )
 
-func (c *awsClient) CreateOpenIDConnectProvider(providerURL string, thumbprint string) (string, error) {
+func (c *awsClient) CreateOpenIDConnectProvider(providerURL string, thumbprint string, clusterID string) (
+	string, error) {
 	output, err := c.iamClient.CreateOpenIDConnectProvider(&iam.CreateOpenIDConnectProviderInput{
 		ClientIDList: []*string{
 			aws.String(OIDCClientIDOpenShift),
@@ -38,6 +40,12 @@ func (c *awsClient) CreateOpenIDConnectProvider(providerURL string, thumbprint s
 		},
 		ThumbprintList: []*string{aws.String(thumbprint)},
 		Url:            aws.String(providerURL),
+		Tags: []*iam.Tag{
+			{
+				Key:   aws.String(tags.ClusterID),
+				Value: aws.String(clusterID),
+			},
+		},
 	})
 	if err != nil {
 		return "", err

--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -17,10 +17,8 @@ limitations under the License.
 package ocm
 
 import (
-	"errors"
 	"fmt"
 	"net"
-	"net/http"
 	"os"
 	"time"
 
@@ -31,6 +29,7 @@ import (
 	"github.com/openshift/rosa/pkg/logging"
 	"github.com/openshift/rosa/pkg/properties"
 	rprtr "github.com/openshift/rosa/pkg/reporter"
+	errors "github.com/zgalor/weberr"
 )
 
 // Spec is the configuration for a cluster spec.
@@ -163,19 +162,27 @@ func (c *Client) CreateCluster(config Spec) (*cmv1.Cluster, error) {
 	return clusterObject, nil
 }
 
+/**
+pass 0 to get all clusters
+*/
 func (c *Client) GetClusters(creator *aws.Creator, count int) (clusters []*cmv1.Cluster, err error) {
-	if count < 1 {
-		err = errors.New("Cannot fetch fewer than 1 cluster")
+	if count < 0 {
+		err = errors.Errorf("Invalid Cluster count")
 		return
 	}
 	query := getClusterFilter(creator)
 	request := c.ocm.ClustersMgmt().V1().Clusters().List().Search(query)
 	page := 1
 	for {
-		response, err := request.Page(page).Size(count).Send()
+		clusterRequestList := request.Page(page)
+		if count > 0 {
+			clusterRequestList = clusterRequestList.Size(count)
+		}
+		response, err := clusterRequestList.Send()
 		if err != nil {
 			return clusters, err
 		}
+
 		response.Items().Each(func(cluster *cmv1.Cluster) bool {
 			clusters = append(clusters, cluster)
 			return true
@@ -186,6 +193,10 @@ func (c *Client) GetClusters(creator *aws.Creator, count int) (clusters []*cmv1.
 		page++
 	}
 	return clusters, nil
+}
+
+func (c *Client) GetAllClusters(creator *aws.Creator) (clusters []*cmv1.Cluster, err error) {
+	return c.GetClusters(creator, 0)
 }
 
 func (c *Client) GetCluster(clusterKey string, creator *aws.Creator) (*cmv1.Cluster, error) {
@@ -204,11 +215,35 @@ func (c *Client) GetCluster(clusterKey string, creator *aws.Creator) (*cmv1.Clus
 
 	switch response.Total() {
 	case 0:
-		return nil, fmt.Errorf("There is no cluster with identifier or name '%s'", clusterKey)
+		return nil, errors.NotFound.Errorf("There is no cluster with identifier or name '%s'", clusterKey)
 	case 1:
 		return response.Items().Slice()[0], nil
 	default:
 		return nil, fmt.Errorf("There are %d clusters with identifier or name '%s'", response.Total(), clusterKey)
+	}
+}
+
+func (c *Client) GetClusterByID(clusterKey string, creator *aws.Creator) (*cmv1.Cluster, error) {
+	query := fmt.Sprintf("%s AND id = '%s'",
+		getClusterFilter(creator),
+		clusterKey,
+	)
+	response, err := c.ocm.ClustersMgmt().V1().Clusters().List().
+		Search(query).
+		Page(1).
+		Size(1).
+		Send()
+	if err != nil {
+		return nil, handleErr(response.Error(), err)
+	}
+
+	switch response.Total() {
+	case 0:
+		return nil, errors.NotFound.Errorf("There is no cluster with identifier '%s'", clusterKey)
+	case 1:
+		return response.Items().Slice()[0], nil
+	default:
+		return nil, fmt.Errorf("There are %d clusters with identifier '%s'", response.Total(), clusterKey)
 	}
 }
 
@@ -226,6 +261,37 @@ func (c *Client) GetPendingClusterForARN(creator *aws.Creator) (cluster *cmv1.Cl
 		return cluster, err
 	}
 	return response.Items().Get(0), nil
+}
+
+func (c *Client) IsSTSClusterExists(creator *aws.Creator, count int, roleARN string) (exists bool, err error) {
+	if count < 1 {
+		err = errors.Errorf("Cannot fetch fewer than 1 cluster")
+		return
+	}
+	query := fmt.Sprintf(
+		"product.id = 'rosa' AND ("+
+			"properties.%s LIKE '%%:%s:%%' OR "+
+			"aws.sts.role_arn = '%s' OR "+
+			"aws.sts.support_role_arn = '%s' OR "+
+			"aws.sts.instance_iam_roles.master_role_arn = '%s' OR "+
+			"aws.sts.instance_iam_roles.worker_role_arn = '%s')",
+		properties.CreatorARN,
+		creator.AccountID,
+		roleARN,
+		roleARN,
+		roleARN,
+		roleARN,
+	)
+	request := c.ocm.ClustersMgmt().V1().Clusters().List().Search(query)
+	page := 1
+	response, err := request.Page(page).Size(count).Send()
+	if err != nil {
+		return false, err
+	}
+	if response.Total() > 0 {
+		return true, nil
+	}
+	return false, nil
 }
 
 func (c *Client) GetClusterStatus(clusterID string) (*cmv1.ClusterStatus, error) {
@@ -604,27 +670,4 @@ func (c *Client) ResumeCluster(clusterID string) error {
 	}
 
 	return nil
-}
-
-//Get all the archived ROSA STS clusters
-func (c *Client) GetArchivedCluster(clusterKey string, creator *aws.Creator) (clusters []*cmv1.Cluster, err error) {
-	query := fmt.Sprintf("%s AND (id = '%s' OR name = '%s' OR external_id = '%s')",
-		getClusterFilter(creator),
-		clusterKey, clusterKey, clusterKey,
-	)
-	request := c.ocm.ClustersMgmt().V1().ArchivedClusters().List().Search(query)
-	response, err := request.Send()
-
-	if err != nil {
-		if response.Status() == http.StatusNotFound {
-			return clusters, handleErr(response.Error(), err)
-		}
-		return clusters, err
-	}
-	response.Items().Each(func(cluster *cmv1.Cluster) bool {
-		clusters = append(clusters, cluster)
-		return true
-	})
-
-	return clusters, nil
 }


### PR DESCRIPTION
rosa delete operator-roles -c <clusterID>
rosa delete oidc-provider -c   <clusterID>
rosa delete account-roles --role-name  
rosa delete account-roles --role-name 
rosa delete account-roles --role-name 


 ./rosa delete cluster -c test
```
? Are you sure you want to delete cluster test? Yes
I: Cluster 'test' will start uninstalling now
I: Your cluster 'ttt' will be deleted but the following object may remain
I: Operator IAM Roles:
 - arn:aws:iam::765374464689:role/ttt-e1n6-openshift-ingress-operator-cloud-credentials
 - arn:aws:iam::765374464689:role/ttt-e1n6-openshift-cluster-csi-drivers-ebs-cloud-credentials
 - arn:aws:iam::765374464689:role/ttt-e1n6-openshift-machine-api-aws-cloud-credentials
 - arn:aws:iam::765374464689:role/ttt-e1n6-openshift-cloud-credential-operator-cloud-credential-op
 - arn:aws:iam::765374464689:role/ttt-e1n6-openshift-image-registry-installer-cloud-credentials

I: OIDC Provider : https://rh-oidc-staging.s3.us-east-1.amazonaws.com/1nti3unvq0p717v4ie34ncdr95itajh6

I: Once the cluster is uninstalled use the following commands to remove the above aws resource.
        rosa delete operator-roles -c 1nti3unvq0p717v4ie34ncdr95itajh6
        rosa delete oidc-provider -c 1nti3unvq0p717v4ie34ncdr95itajh6
I: To watch your cluster uninstallation logs, run 'rosa logs uninstall -c ttt --watch'
```
