### PR TITLE
SDA-4829 update getThumbprints to use http package instead of tls

### DIFF
--- a/cmd/create/oidcprovider/cmd.go
+++ b/cmd/create/oidcprovider/cmd.go
@@ -19,9 +19,9 @@ package oidcprovider
 import (
 	// nolint:gosec
 	"crypto/sha1"
-	"crypto/tls"
 	"encoding/hex"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -271,13 +271,12 @@ func getThumbprint(oidcEndpointURL string) (string, error) {
 		return "", err
 	}
 
-	conn, err := tls.Dial("tcp", fmt.Sprintf("%s:443", connect.Host), nil)
+	response, err := http.Get(fmt.Sprintf("https://%s:443", connect.Host))
 	if err != nil {
 		return "", err
 	}
-	defer conn.Close()
 
-	certChain := conn.ConnectionState().PeerCertificates
+	certChain := response.TLS.PeerCertificates
 
 	// Grab the CA in the chain
 	for _, cert := range certChain {


### PR DESCRIPTION
Closes : https://issues.redhat.com/browse/SDA-4829

Copied thumbprints from http to tls to show no differences in the peer certificates returned : https://gist.github.com/ciaranRoche/3c0054a28c4d7a608a7d8ebc4e06ffa0