### PR TITLE
policies: Allow compatible policies to create clusters

### DIFF
--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -471,7 +471,17 @@ func (c *awsClient) FindRoleARNs(roleType string, version string) ([]string, err
 				}
 			case tags.OpenShiftVersion:
 				isTagged = true
-				if tagValue != version {
+				clusterVersion, err := semver.NewVersion(version)
+				if err != nil {
+					skip = true
+					break
+				}
+				policyVersion, err := semver.NewVersion(tagValue)
+				if err != nil {
+					skip = true
+					break
+				}
+				if policyVersion.LessThan(clusterVersion) {
 					skip = true
 					break
 				}


### PR DESCRIPTION
Since OpenShift policy permissions are incremental across versions, When
creating a cluster, the policy auto-finder should ensure that it can use
current and newer policies, instead of restricting to only the current
version.