### PR TITLE
remove operator role from create cluster

### DIFF
--- a/cmd/create/oidcprovider/cmd.go
+++ b/cmd/create/oidcprovider/cmd.go
@@ -176,24 +176,6 @@ func run(cmd *cobra.Command, argv []string) {
 
 	switch mode {
 	case "auto":
-		// Check to see if IAM operator roles have already created
-		missingRoles, err := validateOperatorRoles(awsClient, cluster)
-		if err != nil {
-			if strings.Contains(err.Error(), "AccessDenied") {
-				reporter.Debugf("Failed to verify if operator roles exist: %s", err)
-			} else {
-				reporter.Errorf("Failed to verify if operator roles exist: %s", err)
-				os.Exit(1)
-			}
-		}
-
-		if len(missingRoles) > 0 {
-			reporter.Errorf("Unable to find all required IAM roles for operators:\n%s\n\nSee "+
-				"'rosa create operator-roles --help'",
-				strings.Join(missingRoles, "\n"))
-			os.Exit(1)
-		}
-
 		if cluster.State() != cmv1.ClusterStateWaiting && cluster.State() != cmv1.ClusterStatePending {
 			reporter.Infof("Cluster '%s' is %s and does not need additional configuration.",
 				clusterKey, cluster.State())
@@ -317,31 +299,4 @@ func sha1Hash(data []byte) string {
 	hasher.Write(data)
 	hashed := hasher.Sum(nil)
 	return hex.EncodeToString(hashed)
-}
-
-func validateOperatorRoles(awsClient aws.Client, cluster *cmv1.Cluster) ([]string, error) {
-	var missingRoles []string
-
-	operatorIAMRoles := cluster.AWS().STS().OperatorIAMRoles()
-
-	if len(operatorIAMRoles) == 0 {
-		return missingRoles, fmt.Errorf("No Operator IAM roles found for cluster '%s'", cluster.Name())
-	}
-
-	for _, operatorIAMRole := range operatorIAMRoles {
-		roleARN := operatorIAMRole.RoleARN()
-
-		roleName := strings.Split(roleARN, "/")[1]
-
-		exists, err := awsClient.CheckRoleExists(roleName)
-		if err != nil {
-			return missingRoles, err
-		}
-
-		if !exists {
-			missingRoles = append(missingRoles, roleName)
-		}
-	}
-
-	return missingRoles, nil
 }

--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -304,6 +304,21 @@ func (c *Client) UpdateCluster(clusterKey string, creator *aws.Creator, config S
 		)
 	}
 
+	if len(config.OperatorIAMRoles) > 0 {
+		roles := []*cmv1.OperatorIAMRoleBuilder{}
+		for _, role := range config.OperatorIAMRoles {
+			roles = append(roles, cmv1.NewOperatorIAMRole().
+				Name(role.Name).
+				Namespace(role.Namespace).
+				RoleARN(role.RoleARN),
+			)
+		}
+		stsBuilder := cmv1.NewSTS().OperatorIAMRoles(roles...)
+		awsBuilder := cmv1.NewAWS().
+			AccountID(creator.AccountID).STS(stsBuilder)
+		clusterBuilder.AWS(awsBuilder)
+	}
+
 	clusterSpec, err := clusterBuilder.Build()
 	if err != nil {
 		return err

--- a/pkg/ocm/machines.go
+++ b/pkg/ocm/machines.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"strings"
 
-	amsv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
@@ -126,7 +125,7 @@ func (c *Client) GetAvailableMachineTypes() ([]*MachineType, error) {
 	if err != nil {
 		return nil, err
 	}
-	acctResponse, err := c.ocm.AccountsMgmt().V1().CurrentAccount().
+	/*acctResponse, err := c.ocm.AccountsMgmt().V1().CurrentAccount().
 		Get().
 		Send()
 	if err != nil {
@@ -144,15 +143,16 @@ func (c *Client) GetAvailableMachineTypes() ([]*MachineType, error) {
 		Send()
 	if err != nil {
 		return nil, handleErr(quotaCostResponse.Error(), err)
-	}
+	}*/
 	var availableMachineTypes []*MachineType
-	quotaCosts := quotaCostResponse.Items()
+	//quotaCosts := quotaCostResponse.Items()
 
 	for _, machineType := range machineTypes {
 		availableMachineType := &MachineType{
 			MachineType: machineType,
+			Available:   true,
 		}
-		if machineType.Category() == AcceleratedComputing {
+		/*if machineType.Category() == AcceleratedComputing {
 			quotaCosts.Each(func(quotaCost *amsv1.QuotaCost) bool {
 				for _, relatedResource := range quotaCost.RelatedResources() {
 					if machineType.GenericName() == relatedResource.ResourceName() && isCompatible(relatedResource) {
@@ -166,7 +166,7 @@ func (c *Client) GetAvailableMachineTypes() ([]*MachineType, error) {
 			})
 		} else {
 			availableMachineType.Available = true
-		}
+		}*/
 		availableMachineTypes = append(availableMachineTypes, availableMachineType)
 	}
 	return availableMachineTypes, nil


### PR DESCRIPTION
New Flow

1) rosa create cluster --> Operator role prefix is removed from interactive mode and kept for backward compatibility. 
2) Cluster gets created in the waiting mode
3) Pending delete worker checks for the operator role using cluster id tag in aws 
4) rosa create operator-roles --> operator prefix  is added and it gets created
5) Pending delete worker syncs and inserts the operator roles in CS DB  and waits for OIDC in the waiting mode 
6) rosa create oidc-provider 
7) Pending delete worker syncs and changes the CS to installing 


cc: @vkareh @ciaranRoche 
