### PR TITLE
SDA-4911 : Fix creating operator roles prefix

### DIFF
--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -99,11 +99,18 @@ type Policy struct {
 	PolicyDocument PolicyDocument `json:"PolicyDocument,omitempty"`
 }
 
+const (
+	InstallerAccountRole    = "installer"
+	ControlPlaneAccountRole = "instance_controlplane"
+	WorkerAccountRole       = "instance_worker"
+	SupportAccountRole      = "support"
+)
+
 var AccountRoles map[string]AccountRole = map[string]AccountRole{
-	"installer":             {Name: "Installer", Flag: "role-arn"},
-	"instance_controlplane": {Name: "ControlPlane", Flag: "controlplane-iam-role"},
-	"instance_worker":       {Name: "Worker", Flag: "worker-iam-role"},
-	"support":               {Name: "Support", Flag: "support-role-arn"},
+	InstallerAccountRole:    {Name: "Installer", Flag: "role-arn"},
+	ControlPlaneAccountRole: {Name: "ControlPlane", Flag: "controlplane-iam-role"},
+	WorkerAccountRole:       {Name: "Worker", Flag: "worker-iam-role"},
+	SupportAccountRole:      {Name: "Support", Flag: "support-role-arn"},
 }
 
 var roleTypeMap = map[string]string{


### PR DESCRIPTION
### Successful Run Non Interactive
```
 rosa create cluster --cluster-name croche-test --role-arn arn:aws:iam::765374464689:role/croche-test-Installer-Role --support-role-arn arn:aws:iam::765374464689:role/croche-test-Support-Role --controlplane-iam-role arn:aws:iam::765374464689:role/croche-test-ControlPlane-Role --worker-iam-role arn:aws:iam::765374464689:role/croche-test-Worker-Role --region eu-west-1 --version 4.8.13 --compute-nodes 2 --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23 --mode manual
I: Creating cluster 'croche-test'
I: To view a list of clusters and their status, run 'rosa list clusters'
I: Cluster 'croche-test' has been created.
I: Once the cluster is installed you will need to add an Identity Provider before you can login into the cluster. See 'rosa create idp --help' for more information.
I: To determine when your cluster is Ready, run 'rosa describe cluster -c croche-test'.
I: To watch your cluster installation logs, run 'rosa logs install -c croche-test --watch'.
Name:                       croche-test
ID:                         1nr0c8pdm0m1h8tsbggaa73bo7ea4mjf
External ID:                
OpenShift Version:          
Channel Group:              stable
DNS:                        croche-test.ckat.s1.devshift.org
AWS Account:                765374464689
API URL:                    
Console URL:                
Region:                     eu-west-1
Multi-AZ:                   false
Nodes:
 - Control plane:           3
 - Infra:                   2
 - Compute:                 2
Network:
 - Service CIDR:            172.30.0.0/16
 - Machine CIDR:            10.0.0.0/16
 - Pod CIDR:                10.128.0.0/14
 - Host Prefix:             /23
STS Role ARN:               arn:aws:iam::765374464689:role/croche-test-Installer-Role
Support Role ARN:           arn:aws:iam::765374464689:role/croche-test-Support-Role
Instance IAM Roles:
 - Control plane:           arn:aws:iam::765374464689:role/croche-test-ControlPlane-Role
 - Worker:                  arn:aws:iam::765374464689:role/croche-test-Worker-Role
Operator IAM Roles:
 - arn:aws:iam::765374464689:role/croche-test-k8j9-openshift-ingress-operator-cloud-credentials
 - arn:aws:iam::765374464689:role/croche-test-k8j9-openshift-cluster-csi-drivers-ebs-cloud-credent
 - arn:aws:iam::765374464689:role/croche-test-k8j9-openshift-machine-api-aws-cloud-credentials
 - arn:aws:iam::765374464689:role/croche-test-k8j9-openshift-cloud-credential-operator-cloud-crede
 - arn:aws:iam::765374464689:role/croche-test-k8j9-openshift-image-registry-installer-cloud-creden
State:                      waiting (Waiting for OIDC configuration)
Private:                    No
Created:                    Oct 14 2021 16:00:38 UTC
Details Page:               https://qaprodauth.cloud.redhat.com/openshift/details/s/1zVJI6yS3Xf9xVMqTmIjzn2xdgV
OIDC Endpoint URL:          https://rh-oidc-staging.s3.us-east-1.amazonaws.com/1nr0c8pdm0m1h8tsbggaa73bo7ea4mjf

I: Preparing to create operator roles.
I: Run the following commands to create the operator roles:

aws iam create-role \
        --role-name croche-test-k8j9-openshift-cluster-csi-drivers-ebs-cloud-credent \
        --assume-role-policy-document file://operator_cluster_csi_drivers_ebs_cloud_credentials_policy.json \
        --tags Key=rosa_cluster_id,Value=1nr0c8pdm0m1h8tsbggaa73bo7ea4mjf Key=rosa_openshift_version,Value=4.8 Key=rosa_role_prefix,Value=croche-test Key=operator_namespace,Value=openshift-cluster-csi-drivers Key=operator_name,Value=ebs-cloud-credentials

aws iam attach-role-policy \
        --role-name croche-test-k8j9-openshift-cluster-csi-drivers-ebs-cloud-credent \
        --policy-arn arn:aws:iam::765374464689:policy/croche-test-openshift-cluster-csi-drivers-ebs-cloud-credentials

aws iam create-role \
        --role-name croche-test-k8j9-openshift-machine-api-aws-cloud-credentials \
        --assume-role-policy-document file://operator_machine_api_aws_cloud_credentials_policy.json \
        --tags Key=rosa_cluster_id,Value=1nr0c8pdm0m1h8tsbggaa73bo7ea4mjf Key=rosa_openshift_version,Value=4.8 Key=rosa_role_prefix,Value=croche-test Key=operator_namespace,Value=openshift-machine-api Key=operator_name,Value=aws-cloud-credentials

aws iam attach-role-policy \
        --role-name croche-test-k8j9-openshift-machine-api-aws-cloud-credentials \
        --policy-arn arn:aws:iam::765374464689:policy/croche-test-openshift-machine-api-aws-cloud-credentials

aws iam create-role \
        --role-name croche-test-k8j9-openshift-cloud-credential-operator-cloud-crede \
        --assume-role-policy-document file://operator_cloud_credential_operator_cloud_credential_operator_iam_ro_creds_policy.json \
        --tags Key=rosa_cluster_id,Value=1nr0c8pdm0m1h8tsbggaa73bo7ea4mjf Key=rosa_openshift_version,Value=4.8 Key=rosa_role_prefix,Value=croche-test Key=operator_namespace,Value=openshift-cloud-credential-operator Key=operator_name,Value=cloud-credential-operator-iam-ro-creds

aws iam attach-role-policy \
        --role-name croche-test-k8j9-openshift-cloud-credential-operator-cloud-crede \
        --policy-arn arn:aws:iam::765374464689:policy/croche-test-openshift-cloud-credential-operator-cloud-credential

aws iam create-role \
        --role-name croche-test-k8j9-openshift-image-registry-installer-cloud-creden \
        --assume-role-policy-document file://operator_image_registry_installer_cloud_credentials_policy.json \
        --tags Key=rosa_cluster_id,Value=1nr0c8pdm0m1h8tsbggaa73bo7ea4mjf Key=rosa_openshift_version,Value=4.8 Key=rosa_role_prefix,Value=croche-test Key=operator_namespace,Value=openshift-image-registry Key=operator_name,Value=installer-cloud-credentials

aws iam attach-role-policy \
        --role-name croche-test-k8j9-openshift-image-registry-installer-cloud-creden \
        --policy-arn arn:aws:iam::765374464689:policy/croche-test-openshift-image-registry-installer-cloud-credentials

aws iam create-role \
        --role-name croche-test-k8j9-openshift-ingress-operator-cloud-credentials \
        --assume-role-policy-document file://operator_ingress_operator_cloud_credentials_policy.json \
        --tags Key=rosa_cluster_id,Value=1nr0c8pdm0m1h8tsbggaa73bo7ea4mjf Key=rosa_openshift_version,Value=4.8 Key=rosa_role_prefix,Value=croche-test Key=operator_namespace,Value=openshift-ingress-operator Key=operator_name,Value=cloud-credentials

aws iam attach-role-policy \
        --role-name croche-test-k8j9-openshift-ingress-operator-cloud-credentials \
        --policy-arn arn:aws:iam::765374464689:policy/croche-test-openshift-ingress-operator-cloud-credentials
I: Preparing to create OIDC Provider.
I: Run the following commands to create the OIDC provider:

aws iam create-open-id-connect-provider \
        --url https://rh-oidc-staging.s3.us-east-1.amazonaws.com/1nr0c8pdm0m1h8tsbggaa73bo7ea4mjf \
        --client-id-list openshift sts.amazonaws.com \
        --thumbprint-list a9d53002e97e00e043244f3d170d6f4c414104fd
```
### Successful Run Interactive 
```
rosa create cluster --cluster-name croche-test --sts --mode manual
W: More than one Installer role found
? Installer role ARN: arn:aws:iam::765374464689:role/croche-test-Installer-Role
I: Creating cluster 'croche-test'
I: To view a list of clusters and their status, run 'rosa list clusters'
I: Cluster 'croche-test' has been created.
I: Once the cluster is installed you will need to add an Identity Provider before you can login into the cluster. See 'rosa create idp --help' for more information.
I: To determine when your cluster is Ready, run 'rosa describe cluster -c croche-test'.
I: To watch your cluster installation logs, run 'rosa logs install -c croche-test --watch'.
Name:                       croche-test
ID:                         1nr0cmte1u6elev409qe2krbj7e6t9nu
External ID:                
OpenShift Version:          
Channel Group:              stable
DNS:                        croche-test.0b53.s1.devshift.org
AWS Account:                765374464689
API URL:                    
Console URL:                
Region:                     eu-west-1
Multi-AZ:                   false
Nodes:
 - Control plane:           3
 - Infra:                   2
 - Compute:                 2
Network:
 - Service CIDR:            172.30.0.0/16
 - Machine CIDR:            10.0.0.0/16
 - Pod CIDR:                10.128.0.0/14
 - Host Prefix:             /23
STS Role ARN:               arn:aws:iam::765374464689:role/croche-test-Installer-Role
Support Role ARN:           arn:aws:iam::765374464689:role/croche-test-Support-Role
Instance IAM Roles:
 - Control plane:           arn:aws:iam::765374464689:role/croche-test-ControlPlane-Role
 - Worker:                  arn:aws:iam::765374464689:role/croche-test-Worker-Role
Operator IAM Roles:
 - arn:aws:iam::765374464689:role/croche-test-j3h1-openshift-machine-api-aws-cloud-credentials
 - arn:aws:iam::765374464689:role/croche-test-j3h1-openshift-cloud-credential-operator-cloud-crede
 - arn:aws:iam::765374464689:role/croche-test-j3h1-openshift-image-registry-installer-cloud-creden
 - arn:aws:iam::765374464689:role/croche-test-j3h1-openshift-ingress-operator-cloud-credentials
 - arn:aws:iam::765374464689:role/croche-test-j3h1-openshift-cluster-csi-drivers-ebs-cloud-credent
State:                      waiting (Waiting for OIDC configuration)
Private:                    No
Created:                    Oct 14 2021 16:01:34 UTC
Details Page:               https://qaprodauth.cloud.redhat.com/openshift/details/s/1zVJP6LGWkNLcpaygMxIH3igxuM
OIDC Endpoint URL:          https://rh-oidc-staging.s3.us-east-1.amazonaws.com/1nr0cmte1u6elev409qe2krbj7e6t9nu

I: Preparing to create operator roles.
I: Run the following commands to create the operator roles:

aws iam create-role \
        --role-name croche-test-j3h1-openshift-machine-api-aws-cloud-credentials \
        --assume-role-policy-document file://operator_machine_api_aws_cloud_credentials_policy.json \
        --tags Key=rosa_cluster_id,Value=1nr0cmte1u6elev409qe2krbj7e6t9nu Key=rosa_openshift_version,Value=4.8 Key=rosa_role_prefix,Value=croche-test Key=operator_namespace,Value=openshift-machine-api Key=operator_name,Value=aws-cloud-credentials

aws iam attach-role-policy \
        --role-name croche-test-j3h1-openshift-machine-api-aws-cloud-credentials \
        --policy-arn arn:aws:iam::765374464689:policy/croche-test-openshift-machine-api-aws-cloud-credentials

aws iam create-role \
        --role-name croche-test-j3h1-openshift-cloud-credential-operator-cloud-crede \
        --assume-role-policy-document file://operator_cloud_credential_operator_cloud_credential_operator_iam_ro_creds_policy.json \
        --tags Key=rosa_cluster_id,Value=1nr0cmte1u6elev409qe2krbj7e6t9nu Key=rosa_openshift_version,Value=4.8 Key=rosa_role_prefix,Value=croche-test Key=operator_namespace,Value=openshift-cloud-credential-operator Key=operator_name,Value=cloud-credential-operator-iam-ro-creds

aws iam attach-role-policy \
        --role-name croche-test-j3h1-openshift-cloud-credential-operator-cloud-crede \
        --policy-arn arn:aws:iam::765374464689:policy/croche-test-openshift-cloud-credential-operator-cloud-credential

aws iam create-role \
        --role-name croche-test-j3h1-openshift-image-registry-installer-cloud-creden \
        --assume-role-policy-document file://operator_image_registry_installer_cloud_credentials_policy.json \
        --tags Key=rosa_cluster_id,Value=1nr0cmte1u6elev409qe2krbj7e6t9nu Key=rosa_openshift_version,Value=4.8 Key=rosa_role_prefix,Value=croche-test Key=operator_namespace,Value=openshift-image-registry Key=operator_name,Value=installer-cloud-credentials

aws iam attach-role-policy \
        --role-name croche-test-j3h1-openshift-image-registry-installer-cloud-creden \
        --policy-arn arn:aws:iam::765374464689:policy/croche-test-openshift-image-registry-installer-cloud-credentials

aws iam create-role \
        --role-name croche-test-j3h1-openshift-ingress-operator-cloud-credentials \
        --assume-role-policy-document file://operator_ingress_operator_cloud_credentials_policy.json \
        --tags Key=rosa_cluster_id,Value=1nr0cmte1u6elev409qe2krbj7e6t9nu Key=rosa_openshift_version,Value=4.8 Key=rosa_role_prefix,Value=croche-test Key=operator_namespace,Value=openshift-ingress-operator Key=operator_name,Value=cloud-credentials

aws iam attach-role-policy \
        --role-name croche-test-j3h1-openshift-ingress-operator-cloud-credentials \
        --policy-arn arn:aws:iam::765374464689:policy/croche-test-openshift-ingress-operator-cloud-credentials

aws iam create-role \
        --role-name croche-test-j3h1-openshift-cluster-csi-drivers-ebs-cloud-credent \
        --assume-role-policy-document file://operator_cluster_csi_drivers_ebs_cloud_credentials_policy.json \
        --tags Key=rosa_cluster_id,Value=1nr0cmte1u6elev409qe2krbj7e6t9nu Key=rosa_openshift_version,Value=4.8 Key=rosa_role_prefix,Value=croche-test Key=operator_namespace,Value=openshift-cluster-csi-drivers Key=operator_name,Value=ebs-cloud-credentials

aws iam attach-role-policy \
        --role-name croche-test-j3h1-openshift-cluster-csi-drivers-ebs-cloud-credent \
        --policy-arn arn:aws:iam::765374464689:policy/croche-test-openshift-cluster-csi-drivers-ebs-cloud-credentials
I: Preparing to create OIDC Provider.
I: Run the following commands to create the OIDC provider:

aws iam create-open-id-connect-provider \
        --url https://rh-oidc-staging.s3.us-east-1.amazonaws.com/1nr0cmte1u6elev409qe2krbj7e6t9nu \
        --client-id-list openshift sts.amazonaws.com \
        --thumbprint-list a9d53002e97e00e043244f3d170d6f4c414104fd
```
### Unsuccessful run interactive 
```
 rosa create cluster --cluster-name croche-test --sts --mode manual
W: More than one Installer role found
? Installer role ARN: arn:aws:iam::765374464689:role/croche-Installer-Role
E: Expected account role 'ControlPlane' to have prefix 'croche'
run 'rosa create account-roles --prefix croche to create account roles with the same prefix.
```
### Unsuccessful run non interactive 
```
rosa create cluster --cluster-name croche-test --role-arn arn:aws:iam::765374464689:role/croche-test-Installer-Role --support-role-arn arn:aws:iam::765374464689:role/croche-test-Support-Role --controlplane-iam-role arn:aws:iam:
:765374464689:role/croche-test-ControlPlane-Role --worker-iam-role arn:aws:iam::765374464689:role/ManagedOpenShift-Worker-Role --region eu-west-1 --version 4.8.13 --compute-nodes 2 --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23 --mode manual
E: Expected 'instance_worker' Role to have prefix 'croche-test'

```