### PR TITLE
SDA-4916 add validation to sts cluster create mode flag

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -522,7 +522,6 @@ func run(cmd *cobra.Command, _ []string) {
 		isIAM = !isSTS
 	}
 
-	mode := args.mode
 	permissionsBoundary := args.operatorRolesPermissionsBoundary
 	if permissionsBoundary != "" {
 		_, err := arn.Parse(permissionsBoundary)
@@ -583,8 +582,28 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
-	hasRoles := false
+	mode := args.mode
+	// warn if mode is used for non sts cluster
+	if !isSTS && mode != "" {
+		reporter.Warnf("--mode is only valid for STS clusters")
+	}
 
+	// validate mode passed is allowed value
+	if isSTS {
+		modeIsValid := false
+		for _, m := range modes {
+			if m == mode {
+				modeIsValid = true
+				break
+			}
+		}
+		if !modeIsValid {
+			reporter.Errorf("Invalid --mode '%s'. Allowed values are %s", mode, modes)
+			os.Exit(1)
+		}
+	}
+
+	hasRoles := false
 	if isSTS && roleARN == "" {
 		minor := getVersionMinor(version)
 		// Attempt to find account roles using AWS resource tags
@@ -1521,8 +1540,6 @@ func run(cmd *cobra.Command, _ []string) {
 				"\t%s\n",
 				rolesCMD, oidcCMD)
 		}
-	} else if mode != "" {
-		reporter.Warnf("--mode is only valid for STS clusters")
 	}
 }
 


### PR DESCRIPTION
Currently mode is not validated until the operator roles func is called. This leads to a confusing error, and breaks the mode flow. This change validates mode value before the cluster is created 

Closes : https://issues.redhat.com/browse/SDA-4916