### PR TITLE
fix sts mode validation

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -589,7 +589,7 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	// validate mode passed is allowed value
-	if isSTS {
+	if isSTS && mode != "" {
 		modeIsValid := false
 		for _, m := range modes {
 			if m == mode {


### PR DESCRIPTION
Closes : https://issues.redhat.com/browse/SDA-4926

Issues - if mode was not passed explicitly the validation would fail, this change only validates mode if a value is passed 