### PR TITLE
add --mode to create command output

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1498,6 +1498,7 @@ func run(cmd *cobra.Command, _ []string) {
 		OperatorIAMRoles:          operatorIAMRoleList,
 		ControlPlaneRoleARN:       controlPlaneRoleARN,
 		WorkerRoleARN:             workerRoleARN,
+		Mode:                      mode,
 		Tags:                      tagsList,
 		KMSKeyArn:                 kmsKeyARN,
 		DisableWorkloadMonitoring: disableWorkloadMonitoring,
@@ -1764,6 +1765,9 @@ func buildCommand(spec ocm.Spec, operatorRolesPrefix string) string {
 	command += fmt.Sprintf(" --cluster-name %s", spec.Name)
 	if spec.IsSTS {
 		command += " --sts"
+		if spec.Mode != "" {
+			command += fmt.Sprintf(" --mode %s", spec.Mode)
+		}
 	}
 	if spec.RoleARN != "" {
 		command += fmt.Sprintf(" --role-arn %s", spec.RoleARN)

--- a/cmd/dlt/oidcprovider/cmd.go
+++ b/cmd/dlt/oidcprovider/cmd.go
@@ -141,8 +141,8 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 	if providerARN == "" {
-		reporter.Errorf("Cluster '%s' doesn't have OIDC provider associated with it.", clusterKey)
-		os.Exit(1)
+		reporter.Infof("Cluster '%s' doesn't have OIDC provider associated with it.", clusterKey)
+		return
 	}
 
 	// Determine if interactive mode is needed

--- a/cmd/dlt/operatorrole/cmd.go
+++ b/cmd/dlt/operatorrole/cmd.go
@@ -180,8 +180,11 @@ func run(cmd *cobra.Command, argv []string) {
 
 	roles, err := awsClient.GetOperatorRolesFromAccount(clusterKey)
 	if len(roles) == 0 {
-		reporter.Errorf("There are no operator roles to delete for the cluster '%s'", clusterKey)
-		os.Exit(1)
+		if spin != nil {
+			spin.Stop()
+		}
+		reporter.Infof("There are no operator roles to delete for the cluster '%s'", clusterKey)
+		return
 	}
 	if spin != nil {
 		spin.Stop()

--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -87,6 +87,7 @@ type Spec struct {
 	OperatorIAMRoles    []OperatorIAMRole
 	ControlPlaneRoleARN string
 	WorkerRoleARN       string
+	Mode                string
 
 	NodeDrainGracePeriodInMinutes float64
 }


### PR DESCRIPTION
This change : 

- Adds --mode to create command output
- Reduces message from error to info on delete operator roles if no roles are found
- Reduces message from error to info on delete oidc provider if no provider is found

[Verification](https://gist.github.com/ciaranRoche/a21d33a4e4d303fa268a508cb3f8df46)