### PR TITLE
create-cluster: Respect disable-uwm flag default

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1459,7 +1459,7 @@ func run(cmd *cobra.Command, _ []string) {
 		disableWorkloadMonitoring, err = interactive.GetBool(interactive.Input{
 			Question: "Disable Workload monitoring",
 			Help:     cmd.Flags().Lookup("disable-workload-monitoring").Usage,
-			Default:  false,
+			Default:  disableWorkloadMonitoring,
 		})
 		if err != nil {
 			reporter.Errorf("Expected a valid disable-workload-monitoring value: %v", err)


### PR DESCRIPTION
If the user sets the --disable-workload-monitoring flag, the interactive
mode should respect it and mark it as the default value.