### PR TITLE
validate sts roles on sts cluster upgrade

### DIFF
--- a/cmd/upgrade/cluster/cmd.go
+++ b/cmd/upgrade/cluster/cmd.go
@@ -23,9 +23,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/briandowns/spinner"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/rosa/cmd/upgrade/accountroles"
+	"github.com/openshift/rosa/cmd/upgrade/operatorroles"
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/logging"
@@ -67,6 +70,7 @@ func init() {
 	flags.SortFlags = false
 
 	ocm.AddClusterFlag(Cmd)
+	aws.AddModeFlag(Cmd)
 
 	flags.StringVar(
 		&args.version,
@@ -105,6 +109,12 @@ func run(cmd *cobra.Command, _ []string) {
 	logger := logging.CreateLoggerOrExit(reporter)
 
 	clusterKey, err := ocm.GetClusterKey()
+	if err != nil {
+		reporter.Errorf("%s", err)
+		os.Exit(1)
+	}
+
+	mode, err := aws.GetMode()
 	if err != nil {
 		reporter.Errorf("%s", err)
 		os.Exit(1)
@@ -150,6 +160,12 @@ func run(cmd *cobra.Command, _ []string) {
 
 	if cluster.State() != cmv1.ClusterStateReady {
 		reporter.Errorf("Cluster '%s' is not yet ready", clusterKey)
+		os.Exit(1)
+	}
+
+	_, isSTS := cluster.AWS().STS().GetRoleARN()
+	if !isSTS && mode != "" {
+		reporter.Errorf("The 'mode' option is only supported for STS clusters")
 		os.Exit(1)
 	}
 
@@ -213,6 +229,58 @@ func run(cmd *cobra.Command, _ []string) {
 
 	if scheduleDate == "" || scheduleTime == "" {
 		interactive.Enable()
+	}
+
+	// if cluster is sts validate roles are compatible with upgrade version
+	if isSTS {
+		var spin *spinner.Spinner
+		if reporter.IsTerminal() {
+			spin = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+		}
+
+		reporter.Infof("Ensuring cluster roles and policies are compatible with upgrade.")
+		if spin != nil {
+			spin.Start()
+		}
+
+		prefix, err := aws.GetPrefixFromAccountRole(cluster)
+		if err != nil {
+			reporter.Errorf("Could not get role prefix for cluster '%s' : %v", clusterKey, err)
+			os.Exit(1)
+		}
+
+		isAccountRoleUpgradeNeeded, err := awsClient.IsUpgradedNeededForRole(prefix, awsCreator.AccountID, version)
+		if err != nil {
+			reporter.Errorf("Could not validate '%s' clusters account roles : %v", clusterKey, err)
+			os.Exit(1)
+		}
+
+		isOperatorRoleUpgradeNeeded, err := awsClient.IsUpgradedNeededForOperatorRole(cluster,
+			awsCreator.AccountID, version)
+		if err != nil {
+			reporter.Errorf("Could not validate '%s' clusters operator roles : %v", clusterKey, err)
+			os.Exit(1)
+		}
+
+		if spin != nil {
+			spin.Stop()
+		}
+
+		if isAccountRoleUpgradeNeeded || isOperatorRoleUpgradeNeeded {
+			if mode != "" {
+				reporter.Infof("Preparing to upgrade account roles.")
+				accountroles.Cmd.Run(accountroles.Cmd, []string{prefix, mode})
+				reporter.Infof("Preparing to upgrade operator roles.")
+				operatorroles.Cmd.Run(operatorroles.Cmd, []string{clusterKey, mode})
+			} else {
+				reporter.Infof("Cluster Roles are not valid with upgrade version %s. "+
+					"Run the following command(s) to upgrade Cluster Roles:\n\n"+
+					"\t%s\n",
+					version,
+					buildRoleUpgradeCommand(isAccountRoleUpgradeNeeded, isOperatorRoleUpgradeNeeded, clusterKey, prefix))
+				os.Exit(0)
+			}
+		}
 	}
 
 	// Set the default next run within the next 10 minutes
@@ -363,4 +431,18 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	reporter.Infof("Upgrade successfully scheduled for cluster '%s'", clusterKey)
+}
+
+func buildRoleUpgradeCommand(isAccountRoleUpgradeNeeded bool, isOperatorRoleUpgradeNeeded bool,
+	clusterKey string, prefix string) string {
+	accountRoleCmd := fmt.Sprintf("rosa upgrade account-roles --prefix %s", prefix)
+	operatorRoleCmd := fmt.Sprintf("rosa upgrade operator-roles --cluster %s", clusterKey)
+
+	if isAccountRoleUpgradeNeeded && isOperatorRoleUpgradeNeeded {
+		return fmt.Sprintf("%s\n\t%s", accountRoleCmd, operatorRoleCmd)
+	}
+	if isAccountRoleUpgradeNeeded {
+		return accountRoleCmd
+	}
+	return operatorRoleCmd
 }

--- a/cmd/upgrade/operatorroles/cmd.go
+++ b/cmd/upgrade/operatorroles/cmd.go
@@ -25,7 +25,6 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
-	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/aws/tags"
 	"github.com/openshift/rosa/pkg/interactive"
@@ -34,12 +33,6 @@ import (
 	"github.com/openshift/rosa/pkg/ocm"
 	rprtr "github.com/openshift/rosa/pkg/reporter"
 )
-
-var modes []string = []string{"auto", "manual"}
-
-var args struct {
-	mode string
-}
 
 var Cmd = &cobra.Command{
 	Use:     "operator-roles",
@@ -54,31 +47,30 @@ var Cmd = &cobra.Command{
 func init() {
 	flags := Cmd.Flags()
 
-	flags.StringVar(
-		&args.mode,
-		"mode",
-		modes[0],
-		"How to perform the operation. Valid options are:\n"+
-			"auto: Operator IAM roles will be upgraded automatically to the latest version\n"+
-			"manual: Command to upgrade the operator IAM roles will be output which can be used to upgrade manually",
-	)
-	Cmd.RegisterFlagCompletionFunc("mode", modeCompletion)
-
+	aws.AddModeFlag(Cmd)
 	ocm.AddClusterFlag(Cmd)
 	confirm.AddFlag(flags)
 	interactive.AddFlag(flags)
-}
-
-func modeCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	return modes, cobra.ShellCompDirectiveDefault
 }
 
 func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
 	logger := logging.CreateLoggerOrExit(reporter)
 
-	if !arguments.IsValidMode(modes, args.mode) {
-		reporter.Errorf("Invalid mode. Allowed values are %s", modes)
+	// Allow the command to be called programmatically
+	skipInteractive := false
+	if len(argv) == 2 && !cmd.Flag("cluster").Changed {
+		ocm.SetClusterKey(argv[0])
+		aws.SetModeKey(argv[1])
+
+		if argv[1] != "" {
+			skipInteractive = true
+		}
+	}
+
+	mode, err := aws.GetMode()
+	if err != nil {
+		reporter.Errorf("%s", err)
 		os.Exit(1)
 	}
 
@@ -134,19 +126,21 @@ func run(cmd *cobra.Command, argv []string) {
 			clusterKey)
 	}
 	//Check if account roles are up-to-date
-	isAccountRoleUpgradeNeed, err := awsClient.IsUpgradedNeededForRole(prefix, creator.AccountID)
+	isAccountRoleUpgradeNeed, err := awsClient.IsUpgradedNeededForRole(
+		prefix, creator.AccountID, aws.DefaultPolicyVersion)
 	if err != nil {
 		reporter.Errorf("%s", err)
 		os.Exit(1)
 	}
 	if isAccountRoleUpgradeNeed {
 		reporter.Infof("Account roles with prefix '%s' need to be upgraded before operator roles. "+
-			"Use rosa upgrade account-roles --prefix %s", prefix, prefix)
+			"Roles can be upgraded with the following command :"+
+			"\n\n\trosa upgrade account-roles --prefix %s\n", prefix, prefix)
 		os.Exit(1)
 	}
 
-	isUpgradeNeeded, err := awsClient.IsUpgradedNeededForOperatorRole(cluster, aws.DefaultPolicyVersion,
-		creator.AccountID)
+	isUpgradeNeeded, err := awsClient.IsUpgradedNeededForOperatorRole(cluster,
+		creator.AccountID, aws.DefaultPolicyVersion)
 	if err != nil {
 		reporter.Errorf("%s", err)
 		os.Exit(1)
@@ -161,13 +155,13 @@ func run(cmd *cobra.Command, argv []string) {
 	if !interactive.Enabled() && !cmd.Flags().Changed("mode") {
 		interactive.Enable()
 	}
-	mode := args.mode
-	if interactive.Enabled() {
+
+	if interactive.Enabled() && !skipInteractive {
 		mode, err = interactive.GetOption(interactive.Input{
 			Question: "Operator IAM role upgrade mode",
 			Help:     cmd.Flags().Lookup("mode").Usage,
 			Default:  mode,
-			Options:  modes,
+			Options:  aws.Modes,
 			Required: true,
 		})
 		if err != nil {
@@ -176,13 +170,13 @@ func run(cmd *cobra.Command, argv []string) {
 		}
 	}
 	switch mode {
-	case "auto":
+	case aws.ModeAuto:
 		err = upgradeOperatorRolePolicies(reporter, awsClient, creator.AccountID, cluster, prefix)
 		if err != nil {
 			reporter.Errorf("Error upgrading the role polices: %s", err)
 			os.Exit(1)
 		}
-	case "manual":
+	case aws.ModeManual:
 		err = aws.GenerateOperatorPolicyFiles(reporter)
 		if err != nil {
 			reporter.Errorf("There was an error generating the policy files: %s", err)
@@ -199,7 +193,7 @@ func run(cmd *cobra.Command, argv []string) {
 		}
 		fmt.Println(commands)
 	default:
-		reporter.Errorf("Invalid mode. Allowed values are %s", modes)
+		reporter.Errorf("Invalid mode. Allowed values are %s", aws.Modes)
 		os.Exit(1)
 	}
 }

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -105,9 +105,9 @@ type Client interface {
 	GetAccountRolePolicies(roles []string) (map[string][]PolicyDetail, error)
 	GetOpenIDConnectProvider(clusterID string) (string, error)
 	GetInstanceProfilesForRole(role string) ([]string, error)
-	IsUpgradedNeededForRole(rolePrefix string, accountID string) (bool, error)
+	IsUpgradedNeededForRole(rolePrefix string, accountID string, version string) (bool, error)
+	IsUpgradedNeededForOperatorRole(cluster *cmv1.Cluster, accountID string, version string) (bool, error)
 	UpdateTag(roleName string) error
-	IsUpgradedNeededForOperatorRole(cluster *cmv1.Cluster, version string, accountID string) (bool, error)
 	IsPolicyCompatible(policyArn string, version string) (bool, error)
 }
 

--- a/pkg/aws/flag.go
+++ b/pkg/aws/flag.go
@@ -1,0 +1,63 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"fmt"
+	"github.com/openshift/rosa/pkg/arguments"
+	"github.com/spf13/cobra"
+)
+
+var mode string
+
+const (
+	ModeAuto   = "auto"
+	ModeManual = "manual"
+)
+
+var Modes = []string{ModeAuto, ModeManual}
+
+func AddModeFlag(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(
+		&mode,
+		"mode",
+		"m",
+		"",
+		"How to perform the operation. Valid options are:\n"+
+			"auto: Resource changes will be automatic applied using the current AWS account\n\n"+
+			"manual: Commands necessary to modify AWS resources will be output to be run manually",
+	)
+	cmd.RegisterFlagCompletionFunc("mode", modeCompletion)
+}
+
+func SetModeKey(key string) {
+	mode = key
+}
+
+func GetMode() (string, error) {
+	if mode == "" {
+		return "", nil
+	}
+	if !arguments.IsValidMode(Modes, mode) {
+		return "", fmt.Errorf("Invalid mode. Allowed values are %s", Modes)
+	}
+	return mode, nil
+}
+
+func modeCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return Modes, cobra.ShellCompDirectiveDefault
+}


### PR DESCRIPTION
Closes : https://issues.redhat.com/browse/SDA-4818

### Upgrade cluster mode manual 
```
 rosa upgrade cluster --cluster croche-upgrade --mode manual                                                                                              
? Version: 4.7.36
I: Ensuring cluster roles and policies are compatible with upgrade.
I: Preparing to upgrade account roles.
I: All policy files saved to the current directory
I: Run the following commands to upgrade the account role policies:

aws iam create-policy-version \
        --policy-arn arn:aws:iam::765374464689:policy/croche-upgrade-ControlPlane-Role-Policy \
        --policy-document file://sts_instance_controlplane_permission_policy.json \
        --set-as-default

aws iam tag-policy \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --policy-arn arn:aws:iam::765374464689:policy/croche-upgrade-ControlPlane-Role-Policy

aws iam tag-role \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --role-name croche-upgrade-ControlPlane-Role

aws iam create-policy-version \
        --policy-arn arn:aws:iam::765374464689:policy/croche-upgrade-Worker-Role-Policy \
        --policy-document file://sts_instance_worker_permission_policy.json \
        --set-as-default

aws iam tag-policy \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --policy-arn arn:aws:iam::765374464689:policy/croche-upgrade-Worker-Role-Policy

aws iam tag-role \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --role-name croche-upgrade-Worker-Role

aws iam create-policy-version \
        --policy-arn arn:aws:iam::765374464689:policy/croche-upgrade-Support-Role-Policy \
        --policy-document file://sts_support_permission_policy.json \
        --set-as-default

aws iam tag-policy \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --policy-arn arn:aws:iam::765374464689:policy/croche-upgrade-Support-Role-Policy

aws iam tag-role \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --role-name croche-upgrade-Support-Role

aws iam create-policy-version \
        --policy-arn arn:aws:iam::765374464689:policy/croche-upgrade-Installer-Role-Policy \
        --policy-document file://sts_installer_permission_policy.json \
        --set-as-default

aws iam tag-policy \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --policy-arn arn:aws:iam::765374464689:policy/croche-upgrade-Installer-Role-Policy

aws iam tag-role \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --role-name croche-upgrade-Installer-Role

aws iam create-policy-version \
        --policy-arn arn:aws:iam::765374464689:policy/croche-upgrade-openshift-machine-api-aws-cloud-credentials \
        --policy-document file://openshift_machine_api_aws_cloud_credentials_policy.json \
        --set-as-default

aws iam tag-policy \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --policy-arn arn:aws:iam::765374464689:policy/croche-upgrade-openshift-machine-api-aws-cloud-credentials

aws iam create-policy-version \
        --policy-arn arn:aws:iam::765374464689:policy/croche-upgrade-openshift-cloud-credential-operator-cloud-credent \
        --policy-document file://openshift_cloud_credential_operator_cloud_credential_operator_iam_ro_creds_policy.json \
        --set-as-default

aws iam tag-policy \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --policy-arn arn:aws:iam::765374464689:policy/croche-upgrade-openshift-cloud-credential-operator-cloud-credent

aws iam create-policy-version \
        --policy-arn arn:aws:iam::765374464689:policy/croche-upgrade-openshift-image-registry-installer-cloud-credenti \
        --policy-document file://openshift_image_registry_installer_cloud_credentials_policy.json \
        --set-as-default

aws iam tag-policy \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --policy-arn arn:aws:iam::765374464689:policy/croche-upgrade-openshift-image-registry-installer-cloud-credenti

aws iam create-policy-version \
        --policy-arn arn:aws:iam::765374464689:policy/croche-upgrade-openshift-ingress-operator-cloud-credentials \
        --policy-document file://openshift_ingress_operator_cloud_credentials_policy.json \
        --set-as-default

aws iam tag-policy \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --policy-arn arn:aws:iam::765374464689:policy/croche-upgrade-openshift-ingress-operator-cloud-credentials

aws iam create-policy-version \
        --policy-arn arn:aws:iam::765374464689:policy/croche-upgrade-openshift-cluster-csi-drivers-ebs-cloud-credentia \
        --policy-document file://openshift_cluster_csi_drivers_ebs_cloud_credentials_policy.json \
        --set-as-default

aws iam tag-policy \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --policy-arn arn:aws:iam::765374464689:policy/croche-upgrade-openshift-cluster-csi-drivers-ebs-cloud-credentia
I: Preparing to upgrade operator roles.
I: Account roles with prefix 'croche-upgrade' need to be upgraded before operator roles. Roles can be upgraded with the following command :

        rosa upgrade account-roles --prefix croche-upgrade

```

### Upgrade cluster mode auto
```
rosa upgrade cluster --cluster croche-upgrade --mode auto                                                                                                                                                                      1 ↵
? Version: 4.7.36
I: Ensuring cluster roles and policies are compatible with upgrade.
I: Preparing to upgrade account roles.
I: Starting to upgrade the policies
? Upgrade the 'croche-upgrade-Installer-Role' role polices to version 4.9? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-upgrade-Installer-Role-Policy' to version '4.9'
? Upgrade the 'croche-upgrade-ControlPlane-Role' role polices to version 4.9? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-upgrade-ControlPlane-Role-Policy' to version '4.9'
? Upgrade the 'croche-upgrade-Worker-Role' role polices to version 4.9? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-upgrade-Worker-Role-Policy' to version '4.9'
? Upgrade the 'croche-upgrade-Support-Role' role polices to version 4.9? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-upgrade-Support-Role-Policy' to version '4.9'
? Upgrade the operator role policies to version 4.9? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-upgrade-openshift-cloud-credential-operator-cloud-credent' to version '4.9'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-upgrade-openshift-image-registry-installer-cloud-credenti' to version '4.9'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-upgrade-openshift-ingress-operator-cloud-credentials' to version '4.9'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-upgrade-openshift-cluster-csi-drivers-ebs-cloud-credentia' to version '4.9'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-upgrade-openshift-machine-api-aws-cloud-credentials' to version '4.9'
I: Preparing to upgrade operator roles.
I: Starting to upgrade the policies
? Upgrade the 'croche-upgrade-u3b5-openshift-image-registry-installer-cloud-cre' operator role policy to version 4.9? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-upgrade-openshift-image-registry-installer-cloud-credenti' to version '4.9'
? Upgrade the 'croche-upgrade-u3b5-openshift-ingress-operator-cloud-credentials' operator role policy to version 4.9? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-upgrade-openshift-ingress-operator-cloud-credentials' to version '4.9'
? Upgrade the 'croche-upgrade-u3b5-openshift-cluster-csi-drivers-ebs-cloud-cred' operator role policy to version 4.9? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-upgrade-openshift-cluster-csi-drivers-ebs-cloud-credentia' to version '4.9'
? Upgrade the 'croche-upgrade-u3b5-openshift-machine-api-aws-cloud-credentials' operator role policy to version 4.9? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-upgrade-openshift-machine-api-aws-cloud-credentials' to version '4.9'
? Upgrade the 'croche-upgrade-u3b5-openshift-cloud-credential-operator-cloud-cr' operator role policy to version 4.9? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-upgrade-openshift-cloud-credential-operator-cloud-credent' to version '4.9'
? Please input desired date in format yyyy-mm-dd: 2021-11-05
? Please input desired UTC time in format HH:mm: 13:50
? Node draining: 1 hour
I: Upgrade successfully scheduled for cluster 'croche-upgrade'

```

### Upgrade cluster no mode 
```
rosa upgrade cluster --cluster croche-upgrade 
? Version: 4.7.36
I: Ensuring cluster roles and policies are compatible with upgrade.
I: Cluster Roles are not valid with upgrade version 4.7.36. Run the following command(s) to upgrade Cluster Roles:

        rosa upgrade account-roles --prefix croche-upgrade
        rosa upgrade operator-roles --cluster croche-upgrade

```