### PR TITLE
add rosa upgrade account/operator role

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -260,7 +260,7 @@ func run(cmd *cobra.Command, argv []string) {
 			ocm.Response: ocm.Success,
 		})
 	case "manual":
-		err = generatePolicyFiles(reporter, env)
+		err = aws.GeneratePolicyFiles(reporter, env)
 		if err != nil {
 			reporter.Errorf("There was an error generating the policy files: %s", err)
 			ocmClient.LogEvent("ROSACreateAccountRolesModeManual", map[string]string{
@@ -280,78 +280,11 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 }
 
-func generatePolicyFiles(reporter *rprtr.Object, env string) error {
-	for file := range aws.AccountRoles {
-		filename := fmt.Sprintf("sts_%s_trust_policy.json", file)
-		path := fmt.Sprintf("templates/policies/%s", filename)
-
-		policy, err := aws.ReadPolicyDocument(path, map[string]string{
-			"aws_account_id": aws.JumpAccounts[env],
-		})
-		if err != nil {
-			return err
-		}
-
-		reporter.Debugf("Saving '%s' to the current directory", filename)
-		err = saveDocument(policy, filename)
-		if err != nil {
-			return err
-		}
-
-		filename = fmt.Sprintf("sts_%s_permission_policy.json", file)
-		path = fmt.Sprintf("templates/policies/%s", filename)
-
-		policy, err = aws.ReadPolicyDocument(path)
-		if err != nil {
-			return err
-		}
-
-		reporter.Debugf("Saving '%s' to the current directory", filename)
-		err = saveDocument(policy, filename)
-		if err != nil {
-			return err
-		}
-	}
-
-	for credrequest := range aws.CredentialRequests {
-		filename := fmt.Sprintf("openshift_%s_policy.json", credrequest)
-		path := fmt.Sprintf("templates/policies/%s", filename)
-
-		policy, err := aws.ReadPolicyDocument(path)
-		if err != nil {
-			return err
-		}
-
-		reporter.Debugf("Saving '%s' to the current directory", filename)
-		err = saveDocument(policy, filename)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func saveDocument(doc []byte, filename string) error {
-	file, err := os.Create(filename)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	_, err = file.Write(doc)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func buildCommands(prefix string, permissionsBoundary string, accountID string) string {
 	commands := []string{}
 
 	for file, role := range aws.AccountRoles {
-		name := getRoleName(prefix, role.Name)
+		name := aws.GetRoleName(prefix, role.Name)
 		policyName := fmt.Sprintf("%s-Policy", name)
 		iamTags := fmt.Sprintf(
 			"Key=%s,Value=%s Key=%s,Value=%s Key=%s,Value=%s",
@@ -377,12 +310,12 @@ func buildCommands(prefix string, permissionsBoundary string, accountID string) 
 		attachRolePolicy := fmt.Sprintf("aws iam attach-role-policy \\\n"+
 			"\t--role-name %s \\\n"+
 			"\t--policy-arn %s",
-			name, getPolicyARN(accountID, policyName))
+			name, aws.GetPolicyARN(accountID, policyName))
 		commands = append(commands, createRole, createPolicy, attachRolePolicy)
 	}
 
 	for credrequest, operator := range aws.CredentialRequests {
-		name := getPolicyName(prefix, operator.Namespace, operator.Name)
+		name := aws.GetPolicyName(prefix, operator.Namespace, operator.Name)
 		iamTags := fmt.Sprintf(
 			"Key=%s,Value=%s Key=%s,Value=%s Key=%s,Value=%s Key=%s,Value=%s",
 			tags.OpenShiftVersion, aws.DefaultPolicyVersion,
@@ -405,8 +338,8 @@ func createRoles(reporter *rprtr.Object, awsClient aws.Client,
 	prefix string, permissionsBoundary string,
 	accountID string, env string) error {
 	for file, role := range aws.AccountRoles {
-		name := getRoleName(prefix, role.Name)
-		policyARN := getPolicyARN(accountID, fmt.Sprintf("%s-Policy", name))
+		name := aws.GetRoleName(prefix, role.Name)
+		policyARN := aws.GetPolicyARN(accountID, fmt.Sprintf("%s-Policy", name))
 
 		if !confirm.Prompt(true, "Create the '%s' role?", name) {
 			continue
@@ -462,7 +395,7 @@ func createRoles(reporter *rprtr.Object, awsClient aws.Client,
 
 	if confirm.Prompt(true, "Create the operator policies?") {
 		for credrequest, operator := range aws.CredentialRequests {
-			policyARN := getOperatorPolicyARN(accountID, prefix, operator.Namespace, operator.Name)
+			policyARN := aws.GetOperatorPolicyARN(accountID, prefix, operator.Namespace, operator.Name)
 
 			filename := fmt.Sprintf("openshift_%s_policy.json", credrequest)
 			path := fmt.Sprintf("templates/policies/%s", filename)
@@ -487,28 +420,4 @@ func createRoles(reporter *rprtr.Object, awsClient aws.Client,
 	}
 
 	return nil
-}
-
-func getRoleName(prefix string, role string) string {
-	name := fmt.Sprintf("%s-%s-Role", prefix, role)
-	if len(name) > 64 {
-		name = name[0:64]
-	}
-	return name
-}
-
-func getPolicyName(prefix string, namespace string, name string) string {
-	policy := fmt.Sprintf("%s-%s-%s", prefix, namespace, name)
-	if len(policy) > 64 {
-		policy = policy[0:64]
-	}
-	return policy
-}
-
-func getOperatorPolicyARN(accountID string, prefix string, namespace string, name string) string {
-	return getPolicyARN(accountID, getPolicyName(prefix, namespace, name))
-}
-
-func getPolicyARN(accountID string, name string) string {
-	return fmt.Sprintf("arn:aws:iam::%s:policy/%s", accountID, name)
 }

--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -174,7 +174,7 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(0)
 	}
 
-	prefix, err := getPrefixFromAccountRole(cluster)
+	prefix, err := aws.GetPrefixFromAccountRole(cluster)
 	if err != nil {
 		reporter.Errorf("Failed to find prefix from %s account role", aws.InstallerAccountRole)
 		os.Exit(1)
@@ -463,15 +463,4 @@ func validateOperatorRoles(awsClient aws.Client, cluster *cmv1.Cluster) ([]strin
 	}
 
 	return missingRoles, nil
-}
-
-func getPrefixFromAccountRole(cluster *cmv1.Cluster) (string, error) {
-	role := aws.AccountRoles[aws.InstallerAccountRole]
-	parsedARN, err := arn.Parse(cluster.AWS().STS().RoleARN())
-	if err != nil {
-		return "", err
-	}
-	roleName := strings.SplitN(parsedARN.Resource, "/", 2)[1]
-	rolePrefix := strings.TrimSuffix(roleName, fmt.Sprintf("-%s-Role", role.Name))
-	return rolePrefix, nil
 }

--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -1,0 +1,294 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package accountroles
+
+import (
+	"fmt"
+
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/arguments"
+	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/aws/tags"
+	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/interactive/confirm"
+	"github.com/openshift/rosa/pkg/logging"
+	"github.com/openshift/rosa/pkg/ocm"
+	rprtr "github.com/openshift/rosa/pkg/reporter"
+)
+
+var modes []string = []string{"auto", "manual"}
+
+var args struct {
+	prefix string
+	mode   string
+}
+
+var Cmd = &cobra.Command{
+	Use:     "account-roles",
+	Aliases: []string{"accountroles", "roles", "policies"},
+	Short:   "Upgrade account-wide IAM roles to the latest version.",
+	Long:    "Upgrade account-wide IAM roles to the latest version before upgrading your cluster.",
+	Example: `  # Upgrade account roles for ROSA STS clusters
+  rosa upgrade account-roles`,
+	Run: run,
+}
+
+func init() {
+	flags := Cmd.Flags()
+
+	flags.StringVar(
+		&args.mode,
+		"mode",
+		modes[0],
+		"How to perform the operation. Valid options are:\n"+
+			"auto: Account roles will be upgraded automatically to the latest version\n"+
+			"manual: Command to upgrade the account roles will be output which can be used to upgrade manually",
+	)
+	Cmd.RegisterFlagCompletionFunc("mode", modeCompletion)
+
+	flags.StringVarP(
+		&args.prefix,
+		"prefix",
+		"p",
+		"",
+		"User-defined prefix for all generated AWS resources",
+	)
+	Cmd.MarkFlagRequired("prefix")
+	confirm.AddFlag(flags)
+	interactive.AddFlag(flags)
+}
+
+func modeCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return modes, cobra.ShellCompDirectiveDefault
+}
+
+func run(cmd *cobra.Command, argv []string) {
+	reporter := rprtr.CreateReporterOrExit()
+	logger := logging.CreateLoggerOrExit(reporter)
+
+	if !arguments.IsValidMode(modes, args.mode) {
+		reporter.Errorf("Invalid mode. Allowed values are %s", modes)
+		os.Exit(1)
+	}
+	prefix := args.prefix
+
+	// Create the AWS client:
+	awsClient, err := aws.NewClient().
+		Logger(logger).
+		Build()
+	if err != nil {
+		reporter.Errorf("Failed to create AWS client: %v", err)
+		os.Exit(1)
+	}
+
+	// Create the client for the OCM API:
+	ocmClient, err := ocm.NewClient().
+		Logger(logger).
+		Build()
+	if err != nil {
+		reporter.Errorf("Failed to create OCM connection: %v", err)
+		os.Exit(1)
+	}
+	defer func() {
+		err = ocmClient.Close()
+		if err != nil {
+			reporter.Errorf("Failed to close OCM connection: %v", err)
+		}
+	}()
+
+	env, err := ocm.GetEnv()
+	if err != nil {
+		reporter.Errorf("Failed to determine OCM environment: %v", err)
+		os.Exit(1)
+	}
+
+	creator, err := awsClient.GetCreator()
+	if err != nil {
+		reporter.Errorf("Failed to get IAM credentials: %s", err)
+		os.Exit(1)
+	}
+
+	isUpgradeNeed, err := awsClient.IsUpgradedNeededForRole(prefix, creator.AccountID)
+	if err != nil {
+		reporter.Errorf("%s", err)
+		os.Exit(1)
+	}
+	if !isUpgradeNeed {
+		reporter.Infof("Account role with the prefix '%s' is already up-to-date.", prefix)
+		os.Exit(0)
+	}
+
+	// Determine if interactive mode is needed
+	if !interactive.Enabled() && !cmd.Flags().Changed("mode") {
+		interactive.Enable()
+	}
+	mode := args.mode
+	if interactive.Enabled() {
+		mode, err = interactive.GetOption(interactive.Input{
+			Question: "Account role upgrade mode",
+			Help:     cmd.Flags().Lookup("mode").Usage,
+			Default:  mode,
+			Options:  modes,
+			Required: true,
+		})
+		if err != nil {
+			reporter.Errorf("Expected a valid Account role upgrade mode: %s", err)
+			os.Exit(1)
+		}
+	}
+	switch mode {
+	case "auto":
+		reporter.Infof("Starting to upgrade the policies")
+		err = upgradeAccountRolePolicies(reporter, awsClient, prefix, creator.AccountID)
+		if err != nil {
+			reporter.Errorf("Error upgrading the role polices: %s", err)
+			os.Exit(1)
+		}
+		err = upgradeOperatorRolePolicies(reporter, awsClient, creator.AccountID, prefix)
+		if err != nil {
+			reporter.Errorf("Error upgrading the operator role polices: %s", err)
+			os.Exit(1)
+		}
+	case "manual":
+		err = aws.GeneratePolicyFiles(reporter, env)
+		if err != nil {
+			reporter.Errorf("There was an error generating the policy files: %s", err)
+			os.Exit(1)
+		}
+		if reporter.IsTerminal() {
+			reporter.Infof("All policy files saved to the current directory")
+			reporter.Infof("Run the following commands to upgrade the account role policies:\n")
+		}
+		commands := buildCommands(prefix, creator.AccountID)
+		fmt.Println(commands)
+	default:
+		reporter.Errorf("Invalid mode. Allowed values are %s", modes)
+		os.Exit(1)
+	}
+}
+
+func upgradeAccountRolePolicies(reporter *rprtr.Object, awsClient aws.Client, prefix string, accountID string) error {
+	for file, role := range aws.AccountRoles {
+		name := aws.GetRoleName(prefix, role.Name)
+		if !confirm.Prompt(true, "Upgrade the '%s' role polices to version %s?", name,
+			aws.DefaultPolicyVersion) {
+			continue
+		}
+		filename := fmt.Sprintf("sts_%s_permission_policy.json", file)
+		path := fmt.Sprintf("templates/policies/%s", filename)
+		policyARN := aws.GetPolicyARN(accountID, fmt.Sprintf("%s-Policy", name))
+
+		policy, err := aws.ReadPolicyDocument(path)
+		if err != nil {
+			return err
+		}
+		policyARN, err = awsClient.EnsurePolicy(policyARN, string(policy),
+			aws.DefaultPolicyVersion, map[string]string{
+				tags.OpenShiftVersion: aws.DefaultPolicyVersion,
+				tags.RolePrefix:       prefix,
+				tags.RoleType:         file,
+			})
+		if err != nil {
+			return err
+		}
+		reporter.Infof("Upgraded policy with ARN '%s' to version '%s'", policyARN, aws.DefaultPolicyVersion)
+		err = awsClient.UpdateTag(name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func upgradeOperatorRolePolicies(reporter *rprtr.Object, awsClient aws.Client, accountID string, prefix string) error {
+	if !confirm.Prompt(true, "Upgrade the operator role policies to version %s?", aws.DefaultPolicyVersion) {
+		return nil
+	}
+	for credrequest, operator := range aws.CredentialRequests {
+		policyARN := aws.GetOperatorPolicyARN(accountID, prefix, operator.Namespace, operator.Name)
+		filename := fmt.Sprintf("openshift_%s_policy.json", credrequest)
+		path := fmt.Sprintf("templates/policies/%s", filename)
+
+		policy, err := aws.ReadPolicyDocument(path)
+		if err != nil {
+			return err
+		}
+		policyARN, err = awsClient.EnsurePolicy(policyARN, string(policy),
+			aws.DefaultPolicyVersion, map[string]string{
+				tags.OpenShiftVersion: aws.DefaultPolicyVersion,
+				tags.RolePrefix:       prefix,
+				"operator_namespace":  operator.Namespace,
+				"operator_name":       operator.Name,
+			})
+		if err != nil {
+			return err
+		}
+		reporter.Infof("Upgraded policy with ARN '%s' to version '%s'", policyARN, aws.DefaultPolicyVersion)
+	}
+	return nil
+}
+
+func buildCommands(prefix string, accountID string) string {
+	commands := []string{}
+	for file, role := range aws.AccountRoles {
+		name := aws.GetRoleName(prefix, role.Name)
+		policyARN := aws.GetPolicyARN(accountID, fmt.Sprintf("%s-Policy", name))
+		policyTags := fmt.Sprintf(
+			"Key=%s,Value=%s",
+			tags.OpenShiftVersion, aws.DefaultPolicyVersion,
+		)
+		createPolicyVersion := fmt.Sprintf("aws iam create-policy-version \\\n"+
+			"\t--policy-arn %s \\\n"+
+			"\t--policy-document file://sts_%s_permission_policy.json \\\n"+
+			"\t--set-as-default",
+			policyARN, file)
+		tagPolicies := fmt.Sprintf("aws iam tag-policy \\\n"+
+			"\t--tags %s \\\n"+
+			"\t--policy-arn %s",
+			policyTags, policyARN)
+		iamRoleTags := fmt.Sprintf(
+			"Key=%s,Value=%s",
+			tags.OpenShiftVersion, aws.DefaultPolicyVersion)
+		tagRole := fmt.Sprintf("aws iam tag-role \\\n"+
+			"\t--tags %s \\\n"+
+			"\t--role-name %s",
+			iamRoleTags, name)
+		commands = append(commands, createPolicyVersion, tagPolicies, tagRole)
+	}
+	for credrequest, operator := range aws.CredentialRequests {
+		policyARN := aws.GetOperatorPolicyARN(accountID, prefix, operator.Namespace, operator.Name)
+		policTags := fmt.Sprintf(
+			"Key=%s,Value=%s",
+			tags.OpenShiftVersion, aws.DefaultPolicyVersion,
+		)
+		createPolicy := fmt.Sprintf("aws iam create-policy-version \\\n"+
+			"\t--policy-arn %s \\\n"+
+			"\t--policy-document file://openshift_%s_policy.json \\\n"+
+			"\t--set-as-default",
+			policyARN, credrequest)
+		tagPolicy := fmt.Sprintf("aws iam tag-policy \\\n"+
+			"\t--tags %s \\\n"+
+			"\t--policy-arn %s",
+			policTags, policyARN)
+		commands = append(commands, createPolicy, tagPolicy)
+	}
+	return strings.Join(commands, "\n\n")
+}

--- a/cmd/upgrade/cmd.go
+++ b/cmd/upgrade/cmd.go
@@ -19,7 +19,9 @@ package upgrade
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/rosa/cmd/upgrade/accountroles"
 	"github.com/openshift/rosa/cmd/upgrade/cluster"
+	"github.com/openshift/rosa/cmd/upgrade/operatorroles"
 	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/interactive"
 )
@@ -32,6 +34,8 @@ var Cmd = &cobra.Command{
 
 func init() {
 	Cmd.AddCommand(cluster.Cmd)
+	Cmd.AddCommand(accountroles.Cmd)
+	Cmd.AddCommand(operatorroles.Cmd)
 
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)

--- a/cmd/upgrade/operatorroles/cmd.go
+++ b/cmd/upgrade/operatorroles/cmd.go
@@ -1,0 +1,281 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operatorroles
+
+import (
+	"fmt"
+
+	"os"
+	"strings"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/arguments"
+	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/aws/tags"
+	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/interactive/confirm"
+	"github.com/openshift/rosa/pkg/logging"
+	"github.com/openshift/rosa/pkg/ocm"
+	rprtr "github.com/openshift/rosa/pkg/reporter"
+)
+
+var modes []string = []string{"auto", "manual"}
+
+var args struct {
+	mode string
+}
+
+var Cmd = &cobra.Command{
+	Use:     "operator-roles",
+	Aliases: []string{"operator-role", "operatorroles"},
+	Short:   "Upgrade operator IAM roles for a cluster.",
+	Long:    "Upgrade cluster-specific operator IAM roles to latest version.",
+	Example: `  # Upgrade cluster-specific operator IAM roles
+  rosa upgrade operators-roles`,
+	Run: run,
+}
+
+func init() {
+	flags := Cmd.Flags()
+
+	flags.StringVar(
+		&args.mode,
+		"mode",
+		modes[0],
+		"How to perform the operation. Valid options are:\n"+
+			"auto: Operator IAM roles will be upgraded automatically to the latest version\n"+
+			"manual: Command to upgrade the operator IAM roles will be output which can be used to upgrade manually",
+	)
+	Cmd.RegisterFlagCompletionFunc("mode", modeCompletion)
+
+	ocm.AddClusterFlag(Cmd)
+	confirm.AddFlag(flags)
+	interactive.AddFlag(flags)
+}
+
+func modeCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return modes, cobra.ShellCompDirectiveDefault
+}
+
+func run(cmd *cobra.Command, argv []string) {
+	reporter := rprtr.CreateReporterOrExit()
+	logger := logging.CreateLoggerOrExit(reporter)
+
+	if !arguments.IsValidMode(modes, args.mode) {
+		reporter.Errorf("Invalid mode. Allowed values are %s", modes)
+		os.Exit(1)
+	}
+
+	clusterKey, err := ocm.GetClusterKey()
+	if err != nil {
+		reporter.Errorf("%s", err)
+		os.Exit(1)
+	}
+	// Create the client for the OCM API:
+	ocmClient, err := ocm.NewClient().
+		Logger(logger).
+		Build()
+	if err != nil {
+		reporter.Errorf("Failed to create OCM connection: %v", err)
+		os.Exit(1)
+	}
+	defer func() {
+		err = ocmClient.Close()
+		if err != nil {
+			reporter.Errorf("Failed to close OCM connection: %v", err)
+		}
+	}()
+	// Create the AWS client:
+	awsClient, err := aws.NewClient().
+		Logger(logger).
+		Build()
+	if err != nil {
+		reporter.Errorf("Failed to create AWS client: %v", err)
+		os.Exit(1)
+	}
+
+	creator, err := awsClient.GetCreator()
+	if err != nil {
+		reporter.Errorf("Failed to get IAM credentials: %s", err)
+		os.Exit(1)
+	}
+	// Try to find the cluster:
+	reporter.Debugf("Loading cluster '%s'", clusterKey)
+	cluster, err := ocmClient.GetCluster(clusterKey, creator)
+	if err != nil {
+		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
+		os.Exit(1)
+	}
+
+	operatorRoles, hasOperatorRoles := cluster.AWS().STS().GetOperatorIAMRoles()
+	if !hasOperatorRoles || len(operatorRoles) < 0 {
+		reporter.Errorf("Cluster '%s' doesnt have any operator roles associated with it",
+			clusterKey)
+	}
+	prefix, err := aws.GetPrefixFromAccountRole(cluster)
+	if err != nil {
+		reporter.Errorf("Error getting account role prefix for the cluster '%s'",
+			clusterKey)
+	}
+	//Check if account roles are up-to-date
+	isAccountRoleUpgradeNeed, err := awsClient.IsUpgradedNeededForRole(prefix, creator.AccountID)
+	if err != nil {
+		reporter.Errorf("%s", err)
+		os.Exit(1)
+	}
+	if isAccountRoleUpgradeNeed {
+		reporter.Infof("Account roles with prefix '%s' need to be upgraded before operator roles. "+
+			"Use rosa upgrade account-roles --prefix %s", prefix, prefix)
+		os.Exit(1)
+	}
+
+	isUpgradeNeeded, err := awsClient.IsUpgradedNeededForOperatorRole(cluster, aws.DefaultPolicyVersion,
+		creator.AccountID)
+	if err != nil {
+		reporter.Errorf("%s", err)
+		os.Exit(1)
+	}
+	if !isUpgradeNeeded {
+		reporter.Infof("Operator roles associated with the cluster '%s' is already up-to-date.", cluster.ID())
+		os.Exit(1)
+	}
+	reporter.Infof("Starting to upgrade the policies")
+
+	// Determine if interactive mode is needed
+	if !interactive.Enabled() && !cmd.Flags().Changed("mode") {
+		interactive.Enable()
+	}
+	mode := args.mode
+	if interactive.Enabled() {
+		mode, err = interactive.GetOption(interactive.Input{
+			Question: "Operator IAM role upgrade mode",
+			Help:     cmd.Flags().Lookup("mode").Usage,
+			Default:  mode,
+			Options:  modes,
+			Required: true,
+		})
+		if err != nil {
+			reporter.Errorf("Expected a valid operator IAM role upgrade mode: %s", err)
+			os.Exit(1)
+		}
+	}
+	switch mode {
+	case "auto":
+		err = upgradeOperatorRolePolicies(reporter, awsClient, creator.AccountID, cluster, prefix)
+		if err != nil {
+			reporter.Errorf("Error upgrading the role polices: %s", err)
+			os.Exit(1)
+		}
+	case "manual":
+		err = aws.GenerateOperatorPolicyFiles(reporter)
+		if err != nil {
+			reporter.Errorf("There was an error generating the policy files: %s", err)
+			os.Exit(1)
+		}
+		if reporter.IsTerminal() {
+			reporter.Infof("All policy files saved to the current directory")
+			reporter.Infof("Run the following commands to upgrade the operator IAM policies:\n")
+		}
+		commands, err := buildCommands(prefix, creator.AccountID, cluster, awsClient)
+		if err != nil {
+			reporter.Errorf("There was an error building the commands %s", err)
+			os.Exit(1)
+		}
+		fmt.Println(commands)
+	default:
+		reporter.Errorf("Invalid mode. Allowed values are %s", modes)
+		os.Exit(1)
+	}
+}
+
+func upgradeOperatorRolePolicies(reporter *rprtr.Object, awsClient aws.Client, accountID string,
+	cluster *cmv1.Cluster, prefix string) error {
+	for credrequest, operator := range aws.CredentialRequests {
+		roleName := aws.GetOperatorRoleName(cluster, operator)
+		if !confirm.Prompt(true, "Upgrade the '%s' operator role policy to version %s?", roleName,
+			aws.DefaultPolicyVersion) {
+			continue
+		}
+		policyARN := aws.GetOperatorPolicyARN(accountID, prefix, operator.Namespace, operator.Name)
+		filename := fmt.Sprintf("openshift_%s_policy.json", credrequest)
+		path := fmt.Sprintf("templates/policies/%s", filename)
+
+		policy, err := aws.ReadPolicyDocument(path)
+		if err != nil {
+			return err
+		}
+		policyARN, err = awsClient.EnsurePolicy(policyARN, string(policy),
+			aws.DefaultPolicyVersion, map[string]string{
+				tags.OpenShiftVersion: aws.DefaultPolicyVersion,
+				tags.RolePrefix:       prefix,
+				"operator_namespace":  operator.Namespace,
+				"operator_name":       operator.Name,
+			})
+		if err != nil {
+			return err
+		}
+		reporter.Infof("Upgraded policy with ARN '%s' to version '%s'", policyARN, aws.DefaultPolicyVersion)
+		err = awsClient.UpdateTag(roleName)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func buildCommands(prefix string, accountID string, cluster *cmv1.Cluster, awsClient aws.Client) (string, error) {
+	commands := []string{}
+	for credrequest, operator := range aws.CredentialRequests {
+		roleName := aws.GetOperatorRoleName(cluster, operator)
+		iamRoleTags := fmt.Sprintf(
+			"Key=%s,Value=%s",
+			tags.OpenShiftVersion, aws.DefaultPolicyVersion)
+		tagRole := fmt.Sprintf("aws iam tag-role \\\n"+
+			"\t--tags %s \\\n"+
+			"\t--role-name %s",
+			iamRoleTags, roleName)
+		commands = append(commands, tagRole)
+
+		policyARN := aws.GetOperatorPolicyARN(accountID, prefix, operator.Namespace, operator.Name)
+		policyTags := fmt.Sprintf(
+			"Key=%s,Value=%s",
+			tags.OpenShiftVersion, aws.DefaultPolicyVersion,
+		)
+		isCompatible, err := awsClient.IsPolicyCompatible(policyARN, aws.DefaultPolicyVersion)
+		if err != nil {
+			return "", err
+		}
+		//We need because users might run it mutiple times and we dont want to create unnecessary versions
+		if isCompatible {
+			continue
+		}
+		createPolicy := fmt.Sprintf("aws iam create-policy-version \\\n"+
+			"\t--policy-arn %s \\\n"+
+			"\t--policy-document file://openshift_%s_policy.json \\\n"+
+			"\t --set-as-default",
+			policyARN, credrequest)
+		tagPolicy := fmt.Sprintf("aws iam tag-policy \\\n"+
+			"\t--tags %s \\\n"+
+			"\t--policy-arn %s",
+			policyTags, policyARN)
+
+		commands = append(commands, createPolicy, tagPolicy, tagRole)
+	}
+	return strings.Join(commands, "\n\n"), nil
+}

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -42,6 +42,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/servicequotas/servicequotasiface"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/rosa/pkg/aws/profile"
@@ -104,6 +105,10 @@ type Client interface {
 	GetAccountRolePolicies(roles []string) (map[string][]PolicyDetail, error)
 	GetOpenIDConnectProvider(clusterID string) (string, error)
 	GetInstanceProfilesForRole(role string) ([]string, error)
+	IsUpgradedNeededForRole(rolePrefix string, accountID string) (bool, error)
+	UpdateTag(roleName string) error
+	IsUpgradedNeededForOperatorRole(cluster *cmv1.Cluster, version string, accountID string) (bool, error)
+	IsPolicyCompatible(policyArn string, version string) (bool, error)
 }
 
 // ClientBuilder contains the information and logic needed to build a new AWS client.


### PR DESCRIPTION
```
? Account role upgrade mode: manual
I: All policy files saved to the current directory
I: Run the following commands to upgrade the account role policies:

aws iam create-policy-version \
	--policy-arn arn:aws:iam::765374464689:policy/nov4-Support-Role-Policy \
	--policy-document file://sts_support_permission_policy.json \
	--set-as-default

aws iam tag-policy \
	--tags Key=rosa_openshift_version,Value=4.9 \
	--policy-arn arn:aws:iam::765374464689:policy/nov4-Support-Role-Policy

aws iam tag-role \
	--tags Key=rosa_openshift_version,Value=4.9 \
	--role-name nov4-Support-Role

aws iam create-policy-version \
	--policy-arn arn:aws:iam::765374464689:policy/nov4-Installer-Role-Policy \
	--policy-document file://sts_installer_permission_policy.json \
	--set-as-default

aws iam tag-policy \
	--tags Key=rosa_openshift_version,Value=4.9 \
	--policy-arn arn:aws:iam::765374464689:policy/nov4-Installer-Role-Policy

aws iam tag-role \
	--tags Key=rosa_openshift_version,Value=4.9 \
	--role-name nov4-Installer-Role

aws iam create-policy-version \
	--policy-arn arn:aws:iam::765374464689:policy/nov4-ControlPlane-Role-Policy \
	--policy-document file://sts_instance_controlplane_permission_policy.json \
	--set-as-default

aws iam tag-policy \
	--tags Key=rosa_openshift_version,Value=4.9 \
	--policy-arn arn:aws:iam::765374464689:policy/nov4-ControlPlane-Role-Policy

aws iam tag-role \
	--tags Key=rosa_openshift_version,Value=4.9 \
	--role-name nov4-ControlPlane-Role

aws iam create-policy-version \
	--policy-arn arn:aws:iam::765374464689:policy/nov4-Worker-Role-Policy \
	--policy-document file://sts_instance_worker_permission_policy.json \
	--set-as-default

aws iam tag-policy \
	--tags Key=rosa_openshift_version,Value=4.9 \
	--policy-arn arn:aws:iam::765374464689:policy/nov4-Worker-Role-Policy

aws iam tag-role \
	--tags Key=rosa_openshift_version,Value=4.9 \
	--role-name nov4-Worker-Role

aws iam create-policy-version \
	--policy-arn arn:aws:iam::765374464689:policy/nov4-openshift-machine-api-aws-cloud-credentials \
	--policy-document file://openshift_machine_api_aws_cloud_credentials_policy.json \
	--set-as-default

aws iam tag-policy \
	--tags Key=rosa_openshift_version,Value=4.9 \
	--policy-arn arn:aws:iam::765374464689:policy/nov4-openshift-machine-api-aws-cloud-credentials

aws iam create-policy-version \
	--policy-arn arn:aws:iam::765374464689:policy/nov4-openshift-cloud-credential-operator-cloud-credential-operat \
	--policy-document file://openshift_cloud_credential_operator_cloud_credential_operator_iam_ro_creds_policy.json \
	--set-as-default

aws iam tag-policy \
	--tags Key=rosa_openshift_version,Value=4.9 \
	--policy-arn arn:aws:iam::765374464689:policy/nov4-openshift-cloud-credential-operator-cloud-credential-operat

aws iam create-policy-version \
	--policy-arn arn:aws:iam::765374464689:policy/nov4-openshift-image-registry-installer-cloud-credentials \
	--policy-document file://openshift_image_registry_installer_cloud_credentials_policy.json \
	--set-as-default

aws iam tag-policy \
	--tags Key=rosa_openshift_version,Value=4.9 \
	--policy-arn arn:aws:iam::765374464689:policy/nov4-openshift-image-registry-installer-cloud-credentials

aws iam create-policy-version \
	--policy-arn arn:aws:iam::765374464689:policy/nov4-openshift-ingress-operator-cloud-credentials \
	--policy-document file://openshift_ingress_operator_cloud_credentials_policy.json \
	--set-as-default

aws iam tag-policy \
	--tags Key=rosa_openshift_version,Value=4.9 \
	--policy-arn arn:aws:iam::765374464689:policy/nov4-openshift-ingress-operator-cloud-credentials

aws iam create-policy-version \
	--policy-arn arn:aws:iam::765374464689:policy/nov4-openshift-cluster-csi-drivers-ebs-cloud-credentials \
	--policy-document file://openshift_cluster_csi_drivers_ebs_cloud_credentials_policy.json \
	--set-as-default

aws iam tag-policy \
	--tags Key=rosa_openshift_version,Value=4.9 \
	--policy-arn arn:aws:iam::765374464689:policy/nov4-openshift-cluster-csi-drivers-ebs-cloud-credentials


```

----------------------------------------------------------------------------------------------------------------------------------------------------------
```

./rosa upgrade operator-roles --cluster test56
I: Starting to upgrade the policies
? Operator IAM role upgrade mode: manual
I: All policy files saved to the current directory
I: Run the following commands to upgrade the operator IAM policies:

aws iam create-policy-version \
	--policy-arn arn:aws:iam::765374464689:policy/nov4-openshift-machine-api-aws-cloud-credentials \
	--policy-document file://openshift_machine_api_aws_cloud_credentials_policy.json \
	 --set-as-default

aws iam tag-policy \
	--tags Key=rosa_openshift_version,Value=4.9 \
	--policy-arn arn:aws:iam::765374464689:policy/nov4-openshift-machine-api-aws-cloud-credentials

aws iam tag-role \
	--tags Key=rosa_openshift_version,Value=4.9 \
	--role-name test56-j7n3-openshift-machine-api-aws-cloud-credentials

aws iam create-policy-version \
	--policy-arn arn:aws:iam::765374464689:policy/nov4-openshift-cloud-credential-operator-cloud-credential-operat \
	--policy-document file://openshift_cloud_credential_operator_cloud_credential_operator_iam_ro_creds_policy.json \
	 --set-as-default

aws iam tag-policy \
	--tags Key=rosa_openshift_version,Value=4.9 \
	--policy-arn arn:aws:iam::765374464689:policy/nov4-openshift-cloud-credential-operator-cloud-credential-operat

aws iam tag-role \
	--tags Key=rosa_openshift_version,Value=4.9 \
	--role-name test56-j7n3-openshift-cloud-credential-operator-cloud-credential

aws iam create-policy-version \
	--policy-arn arn:aws:iam::765374464689:policy/nov4-openshift-image-registry-installer-cloud-credentials \
	--policy-document file://openshift_image_registry_installer_cloud_credentials_policy.json \
	 --set-as-default

aws iam tag-policy \
	--tags Key=rosa_openshift_version,Value=4.9 \
	--policy-arn arn:aws:iam::765374464689:policy/nov4-openshift-image-registry-installer-cloud-credentials

aws iam tag-role \
	--tags Key=rosa_openshift_version,Value=4.9 \
	--role-name test56-j7n3-openshift-image-registry-installer-cloud-credentials

aws iam create-policy-version \
	--policy-arn arn:aws:iam::765374464689:policy/nov4-openshift-ingress-operator-cloud-credentials \
	--policy-document file://openshift_ingress_operator_cloud_credentials_policy.json \
	 --set-as-default

aws iam tag-policy \
	--tags Key=rosa_openshift_version,Value=4.9 \
	--policy-arn arn:aws:iam::765374464689:policy/nov4-openshift-ingress-operator-cloud-credentials

aws iam tag-role \
	--tags Key=rosa_openshift_version,Value=4.9 \
	--role-name test56-j7n3-openshift-ingress-operator-cloud-credentials

aws iam create-policy-version \
	--policy-arn arn:aws:iam::765374464689:policy/nov4-openshift-cluster-csi-drivers-ebs-cloud-credentials \
	--policy-document file://openshift_cluster_csi_drivers_ebs_cloud_credentials_policy.json \
	 --set-as-default

aws iam tag-policy \
	--tags Key=rosa_openshift_version,Value=4.9 \
	--policy-arn arn:aws:iam::765374464689:policy/nov4-openshift-cluster-csi-drivers-ebs-cloud-credentials

aws iam tag-role \
	--tags Key=rosa_openshift_version,Value=4.9 \
	--role-name test56-j7n3-openshift-cluster-csi-drivers-ebs-cloud-credentials

```

----------------------------------------------------------------------------------------------------
Output if the users ran the account role first and then operator role

./rosa upgrade operator-roles --cluster test56
I: Starting to upgrade the policies
? Operator IAM role upgrade mode: manual
I: All policy files saved to the current directory
I: Run the following commands to upgrade the operator IAM policies:

aws iam tag-role \
	--tags Key=rosa_openshift_version,Value=4.9 \
	--role-name test56-j7n3-openshift-image-registry-installer-cloud-credentials

aws iam tag-role \
	--tags Key=rosa_openshift_version,Value=4.9 \
	--role-name test56-j7n3-openshift-ingress-operator-cloud-credentials

aws iam tag-role \
	--tags Key=rosa_openshift_version,Value=4.9 \
	--role-name test56-j7n3-openshift-cluster-csi-drivers-ebs-cloud-credentials
 

aws iam tag-role \
	--tags Key=rosa_openshift_version,Value=4.9 \
	--role-name test56-j7n3-openshift-cluster-csi-drivers-ebs-cloud-credentials

aws iam tag-role \
	--tags Key=rosa_openshift_version,Value=4.9 \
	--role-name test56-j7n3-openshift-machine-api-aws-cloud-credentials

aws iam tag-role \
	--tags Key=rosa_openshift_version,Value=4.9 \
	--role-name test56-j7n3-openshift-cloud-credential-operator-cloud-credential




