### PR TITLE
removed --enable_proxy argument

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -262,12 +262,6 @@ func init() {
 			"This option configures etcd encryption on top of existing storage encryption.",
 	)
 
-	flags.BoolVar(
-		&args.enableProxy,
-		"enable-proxy",
-		false,
-		"whether cluster-wide proxy is enabled or not.")
-
 	flags.StringVar(
 		&args.httpProxy,
 		"http-proxy",
@@ -1130,6 +1124,17 @@ func run(cmd *cobra.Command, _ []string) {
 		useExistingVPC = true
 	}
 
+	// cluster-wide proxy values set here as we need to know whather to skip the "Install
+	// into an existing VPC" question
+	enableProxy := false
+	httpProxy := args.httpProxy
+	httpsProxy := args.httpsProxy
+	additionalTrustBundleFile := args.additionalTrustBundleFile
+	if httpProxy != "" || httpsProxy != "" || additionalTrustBundleFile != "" {
+		useExistingVPC = true
+		enableProxy = true
+	}
+
 	// Subnet IDs
 	subnetIDs := args.subnetIDs
 	subnetsProvided := len(subnetIDs) > 0
@@ -1140,6 +1145,7 @@ func run(cmd *cobra.Command, _ []string) {
 		if privateLink {
 			existingVPCHelp += "For PrivateLink, only a private subnet per availability zone is needed."
 		}
+
 		useExistingVPC, err = interactive.GetBool(interactive.Input{
 			Question: "Install into an existing VPC",
 			Help:     existingVPCHelp,
@@ -1502,18 +1508,12 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	// Cluster-wide proxy configuration
-	enableProxy := args.enableProxy
-	httpProxy := args.httpProxy
-	httpsProxy := args.httpsProxy
-	additionalTrustBundleFile := args.additionalTrustBundleFile
-	if httpProxy != "" || httpsProxy != "" || additionalTrustBundleFile != "" {
-		enableProxy = true
-	}
-	if useExistingVPC && interactive.Enabled() {
+	if useExistingVPC && !enableProxy && interactive.Enabled() {
 		enableProxy, err = interactive.GetBool(interactive.Input{
 			Question: "Use cluster-wide proxy",
-			Help:     cmd.Flags().Lookup("enable-proxy").Usage,
-			Default:  enableProxy,
+			Help: "To install cluster-wide proxy, you need to set one of the following attributes: 'http-proxy', " +
+				"'https-proxy', additional-trust-bundle",
+			Default: enableProxy,
 		})
 		if err != nil {
 			reporter.Errorf("Expected a valid proxy-enabled value: %s", err)
@@ -1580,6 +1580,7 @@ func run(cmd *cobra.Command, _ []string) {
 		reporter.Errorf("%s", err)
 		os.Exit(1)
 	}
+
 	// Get certificate contents
 	additionalTrustBundle := ""
 	if additionalTrustBundleFile != "" {
@@ -1591,6 +1592,11 @@ func run(cmd *cobra.Command, _ []string) {
 		additionalTrustBundle = string(cert)
 	}
 
+	if enableProxy && httpProxy == "" && httpsProxy == "" && additionalTrustBundleFile == "" {
+		reporter.Errorf("Expected at least one of the following: http-proxy, https-proxy, additional-trust-bundle")
+		os.Exit(1)
+	}
+
 	clusterConfig := ocm.Spec{
 		Name:                      clusterName,
 		Region:                    region,
@@ -1599,7 +1605,7 @@ func run(cmd *cobra.Command, _ []string) {
 		ChannelGroup:              channelGroup,
 		Flavour:                   args.flavour,
 		EtcdEncryption:            args.etcdEncryption,
-		ProxyEnabled:              enableProxy,
+		EnableProxy:               enableProxy,
 		HTTPProxy:                 httpProxy,
 		HTTPSProxy:                httpsProxy,
 		AdditionalTrustBundle:     additionalTrustBundle,
@@ -1979,7 +1985,7 @@ func buildCommand(spec ocm.Spec, operatorRolesPrefix string) string {
 		command += " --etcd-encryption"
 	}
 
-	if spec.ProxyEnabled {
+	if spec.EnableProxy {
 		if spec.HTTPProxy != "" {
 			command += fmt.Sprintf(" --http-proxy %s", spec.HTTPProxy)
 		}

--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -92,7 +92,7 @@ type Spec struct {
 
 	NodeDrainGracePeriodInMinutes float64
 
-	ProxyEnabled              bool
+	EnableProxy               bool
 	HTTPProxy                 string
 	HTTPSProxy                string
 	AdditionalTrustBundleFile string


### PR DESCRIPTION
Signed-off-by: Tzvika Avni <tavni@redhat.com>

https://issues.redhat.com/browse/SDA-4981
https://issues.redhat.com/browse/SDA-4982

Removed the '--enable-proxy' argument. Made it behaving the same as 'Use existing VPC', where we don't use any other flag when we set subnets.