### PR TITLE
Check for pre-existing operator roles and error if they exist

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -965,6 +965,15 @@ func run(cmd *cobra.Command, _ []string) {
 				})
 			}
 		}
+		// Validate the role names are available on AWS
+		for _, role := range operatorIAMRoleList {
+			name := strings.SplitN(role.RoleARN, "/", 2)[1]
+			err := awsClient.ValidateRoleNameAvailable(name)
+			if err != nil {
+				reporter.Errorf("Error validating role: %v", err)
+				os.Exit(1)
+			}
+		}
 	}
 
 	// Custom tags for AWS resources

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -82,6 +82,7 @@ type Client interface {
 	GetClusterRegionTagForUser(username string) (string, error)
 	EnsureRole(name string, policy string, permissionsBoundary string,
 		version string, tagList map[string]string) (string, error)
+	ValidateRoleNameAvailable(name string) (err error)
 	PutRolePolicy(roleName string, policyName string, policy string) error
 	EnsurePolicy(policyArn string, document string, version string, tagList map[string]string) (string, error)
 	AttachRolePolicy(roleName string, policyARN string) error


### PR DESCRIPTION
Related: [SDA-4624](https://issues.redhat.com/browse/SDA-4624)

```
$ ./rosa create cluster --sts --operator-roles-prefix zg-oct-14-u8z3 -c zg-nov-3
W: More than one Installer role found
? Installer role ARN: arn:aws:iam::765374464689:role/ManagedOpenShift-Installer-Role
I: Using arn:aws:iam::765374464689:role/ManagedOpenShift-ControlPlane-Role for the ControlPlane role
I: Using arn:aws:iam::765374464689:role/ManagedOpenShift-Worker-Role for the Worker role
I: Using arn:aws:iam::765374464689:role/ManagedOpenShift-Support-Role for the Support role
E: Error validating role: A role named 'zg-oct-14-u8z3-openshift-machine-api-aws-cloud-credentials' already exists. Please delete the existing role, or provide a different prefix
```