### PR TITLE
aws: Add ROSACLI/version to User-Agent string

### DIFF
--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -48,6 +48,7 @@ import (
 	"github.com/openshift/rosa/pkg/aws/profile"
 	regionflag "github.com/openshift/rosa/pkg/aws/region"
 	"github.com/openshift/rosa/pkg/aws/tags"
+	"github.com/openshift/rosa/pkg/info"
 	"github.com/openshift/rosa/pkg/logging"
 )
 
@@ -62,6 +63,13 @@ const (
 	Inline        = "inline"
 	Attached      = "attached"
 )
+
+// addROSAVersionToUserAgent is a named handler that will add ROSA CLI
+// version information to requests made by the AWS SDK.
+var addROSAVersionToUserAgent = request.NamedHandler{
+	Name: "rosa.ROSAVersionUserAgentHandler",
+	Fn:   request.MakeAddToUserAgentHandler(info.UserAgent, info.Version),
+}
 
 // Client defines a client interface
 type Client interface {
@@ -233,6 +241,9 @@ func (b *ClientBuilder) Build() (Client, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Add ROSACLI as user-agent
+	sess.Handlers.Build.PushFrontNamed(addROSAVersionToUserAgent)
 
 	if profile.Profile() != "" {
 		b.logger.Debugf("Using AWS profile: %s", profile.Profile())

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -19,3 +19,5 @@ limitations under the License.
 package info
 
 const Version = "1.1.5"
+
+const UserAgent = "ROSACLI"


### PR DESCRIPTION
```
$ rosa list clusters --debug 2>&1 | grep -i user.agent | head -n1
time="2021-11-05T08:12:59-04:00" level=debug msg="Request header 'User-Agent' is 'ROSACLI/1.1.5 aws-sdk-go/1.39.3 (go1.16.8; linux; amd64)'"
```