### PR TITLE
fix interactive setting of `mode` option

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -223,7 +223,7 @@ func run(cmd *cobra.Command, argv []string) {
 		mode, err = interactive.GetOption(interactive.Input{
 			Question: "Role creation mode",
 			Help:     cmd.Flags().Lookup("mode").Usage,
-			Default:  mode,
+			Default:  aws.ModeAuto,
 			Options:  aws.Modes,
 			Required: true,
 		})
@@ -232,7 +232,6 @@ func run(cmd *cobra.Command, argv []string) {
 			os.Exit(1)
 		}
 	}
-
 	switch mode {
 	case aws.ModeAuto:
 		reporter.Infof("Creating roles using '%s'", creator.ARN)

--- a/cmd/create/oidcprovider/cmd.go
+++ b/cmd/create/oidcprovider/cmd.go
@@ -137,7 +137,7 @@ func run(cmd *cobra.Command, argv []string) {
 		mode, err = interactive.GetOption(interactive.Input{
 			Question: "OIDC provider creation mode",
 			Help:     cmd.Flags().Lookup("mode").Usage,
-			Default:  mode,
+			Default:  aws.ModeAuto,
 			Options:  aws.Modes,
 			Required: true,
 		})

--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -198,7 +198,7 @@ func run(cmd *cobra.Command, argv []string) {
 		mode, err = interactive.GetOption(interactive.Input{
 			Question: "Role creation mode",
 			Help:     cmd.Flags().Lookup("mode").Usage,
-			Default:  mode,
+			Default:  aws.ModeAuto,
 			Options:  aws.Modes,
 			Required: true,
 		})

--- a/cmd/dlt/accountroles/cmd.go
+++ b/cmd/dlt/accountroles/cmd.go
@@ -159,7 +159,7 @@ func run(cmd *cobra.Command, _ []string) {
 		mode, err = interactive.GetOption(interactive.Input{
 			Question: "Account role deletion mode",
 			Help:     cmd.Flags().Lookup("mode").Usage,
-			Default:  mode,
+			Default:  aws.ModeAuto,
 			Options:  aws.Modes,
 			Required: true,
 		})

--- a/cmd/dlt/oidcprovider/cmd.go
+++ b/cmd/dlt/oidcprovider/cmd.go
@@ -140,7 +140,7 @@ func run(cmd *cobra.Command, argv []string) {
 		mode, err = interactive.GetOption(interactive.Input{
 			Question: "OIDC provider deletion mode",
 			Help:     cmd.Flags().Lookup("mode").Usage,
-			Default:  mode,
+			Default:  aws.ModeAuto,
 			Options:  aws.Modes,
 			Required: true,
 		})

--- a/cmd/dlt/operatorrole/cmd.go
+++ b/cmd/dlt/operatorrole/cmd.go
@@ -164,7 +164,7 @@ func run(cmd *cobra.Command, argv []string) {
 		mode, err = interactive.GetOption(interactive.Input{
 			Question: "Operator roles deletion mode",
 			Help:     cmd.Flags().Lookup("mode").Usage,
-			Default:  mode,
+			Default:  aws.ModeAuto,
 			Options:  aws.Modes,
 			Required: true,
 		})

--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -141,7 +141,7 @@ func run(cmd *cobra.Command, argv []string) {
 		mode, err = interactive.GetOption(interactive.Input{
 			Question: "Account role upgrade mode",
 			Help:     cmd.Flags().Lookup("mode").Usage,
-			Default:  mode,
+			Default:  aws.ModeAuto,
 			Options:  aws.Modes,
 			Required: true,
 		})

--- a/cmd/upgrade/operatorroles/cmd.go
+++ b/cmd/upgrade/operatorroles/cmd.go
@@ -160,7 +160,7 @@ func run(cmd *cobra.Command, argv []string) {
 		mode, err = interactive.GetOption(interactive.Input{
 			Question: "Operator IAM role upgrade mode",
 			Help:     cmd.Flags().Lookup("mode").Usage,
-			Default:  mode,
+			Default:  aws.ModeAuto,
 			Options:  aws.Modes,
 			Required: true,
 		})


### PR DESCRIPTION
Fixes issue of setting `mode` option in interactive mode.

```
$ rosa create account-roles
I: Logged in as 'croche_openshift' on 'https://api.stage.openshift.com'
I: Validating AWS credentials...
I: AWS credentials are valid!
I: Validating AWS quota...
I: AWS quota ok. If cluster installation fails, validate actual AWS resource usage against https://docs.openshift.com/rosa/rosa_getting_started/rosa-required-aws-service-quotas.html
I: Verifying whether OpenShift command-line tool is available...
I: Current OpenShift Client Version: 4.5.8
I: Creating account roles
? Role prefix: delete
the prefix  delete
? Permissions boundary ARN (optional): 
? Role creation mode: manual
I: All policy files saved to the current directory
I: Run the following commands to create the account roles and policies:

aws iam create-role \
        --role-name delete-Installer-Role \
        --assume-role-policy-document file://sts_installer_trust_policy.json \
        --tags Key=rosa_openshift_version,Value=4.9 Key=rosa_role_prefix,Value=delete Key=rosa_role_type,Value=installer

aws iam create-policy \
        --policy-name delete-Installer-Role-Policy \
        --policy-document file://sts_installer_permission_policy.json   --tags Key=rosa_openshift_version,Value=4.9 Key=rosa_role_prefix,Value=delete Key=rosa_role_type,Value=installer

aws iam attach-role-policy \
        --role-name delete-Installer-Role \
        --policy-arn arn:aws:iam::765374464689:policy/delete-Installer-Role-Policy

aws iam create-role \
        --role-name delete-ControlPlane-Role \
        --assume-role-policy-document file://sts_instance_controlplane_trust_policy.json \
        --tags Key=rosa_openshift_version,Value=4.9 Key=rosa_role_prefix,Value=delete Key=rosa_role_type,Value=instance_controlplane

aws iam create-policy \
        --policy-name delete-ControlPlane-Role-Policy \
        --policy-document file://sts_instance_controlplane_permission_policy.json       --tags Key=rosa_openshift_version,Value=4.9 Key=rosa_role_prefix,Value=delete Key=rosa_role_type,Value=instance_controlplane

aws iam attach-role-policy \
        --role-name delete-ControlPlane-Role \
        --policy-arn arn:aws:iam::765374464689:policy/delete-ControlPlane-Role-Policy

aws iam create-role \
        --role-name delete-Worker-Role \
        --assume-role-policy-document file://sts_instance_worker_trust_policy.json \
        --tags Key=rosa_openshift_version,Value=4.9 Key=rosa_role_prefix,Value=delete Key=rosa_role_type,Value=instance_worker

aws iam create-policy \
        --policy-name delete-Worker-Role-Policy \
        --policy-document file://sts_instance_worker_permission_policy.json     --tags Key=rosa_openshift_version,Value=4.9 Key=rosa_role_prefix,Value=delete Key=rosa_role_type,Value=instance_worker

aws iam attach-role-policy \
        --role-name delete-Worker-Role \
        --policy-arn arn:aws:iam::765374464689:policy/delete-Worker-Role-Policy

aws iam create-role \
        --role-name delete-Support-Role \
        --assume-role-policy-document file://sts_support_trust_policy.json \
        --tags Key=rosa_openshift_version,Value=4.9 Key=rosa_role_prefix,Value=delete Key=rosa_role_type,Value=support

aws iam create-policy \
        --policy-name delete-Support-Role-Policy \
        --policy-document file://sts_support_permission_policy.json     --tags Key=rosa_openshift_version,Value=4.9 Key=rosa_role_prefix,Value=delete Key=rosa_role_type,Value=support

aws iam attach-role-policy \
        --role-name delete-Support-Role \
        --policy-arn arn:aws:iam::765374464689:policy/delete-Support-Role-Policy

aws iam create-policy \
        --policy-name delete-openshift-machine-api-aws-cloud-credentials \
        --policy-document file://openshift_machine_api_aws_cloud_credentials_policy.json \
        --tags Key=rosa_openshift_version,Value=4.9 Key=rosa_role_prefix,Value=delete Key=operator_namespace,Value=openshift-machine-api Key=operator_name,Value=aws-cloud-credentials

aws iam create-policy \
        --policy-name delete-openshift-cloud-credential-operator-cloud-credential-oper \
        --policy-document file://openshift_cloud_credential_operator_cloud_credential_operator_iam_ro_creds_policy.json \
        --tags Key=rosa_openshift_version,Value=4.9 Key=rosa_role_prefix,Value=delete Key=operator_namespace,Value=openshift-cloud-credential-operator Key=operator_name,Value=cloud-credential-operator-iam-ro-creds

aws iam create-policy \
        --policy-name delete-openshift-image-registry-installer-cloud-credentials \
        --policy-document file://openshift_image_registry_installer_cloud_credentials_policy.json \
        --tags Key=rosa_openshift_version,Value=4.9 Key=rosa_role_prefix,Value=delete Key=operator_namespace,Value=openshift-image-registry Key=operator_name,Value=installer-cloud-credentials

aws iam create-policy \
        --policy-name delete-openshift-ingress-operator-cloud-credentials \
        --policy-document file://openshift_ingress_operator_cloud_credentials_policy.json \
        --tags Key=rosa_openshift_version,Value=4.9 Key=rosa_role_prefix,Value=delete Key=operator_namespace,Value=openshift-ingress-operator Key=operator_name,Value=cloud-credentials

aws iam create-policy \
        --policy-name delete-openshift-cluster-csi-drivers-ebs-cloud-credentials \
        --policy-document file://openshift_cluster_csi_drivers_ebs_cloud_credentials_policy.json \
        --tags Key=rosa_openshift_version,Value=4.9 Key=rosa_role_prefix,Value=delete Key=operator_namespace,Value=openshift-cluster-csi-drivers Key=operator_name,Value=ebs-cloud-credentials


╭─croche@localhost ~/Projects/sda/rosa ‹fix-interactive-mode› 
╰─$ rosa create account-roles
I: Logged in as 'croche_openshift' on 'https://api.stage.openshift.com'
I: Validating AWS credentials...
I: AWS credentials are valid!
I: Validating AWS quota...
I: AWS quota ok. If cluster installation fails, validate actual AWS resource usage against https://docs.openshift.com/rosa/rosa_getting_started/rosa-required-aws-service-quotas.html
I: Verifying whether OpenShift command-line tool is available...
I: Current OpenShift Client Version: 4.5.8
I: Creating account roles
? Role prefix: delete
the prefix  delete
? Permissions boundary ARN (optional): 
? Role creation mode: auto
I: Creating roles using 'arn:aws:iam::765374464689:user/croche'
? Create the 'delete-Support-Role' role? (Y/n) 

```

