### PR TITLE
Missing permissions added to installer IAM role when using STS mode and private link

### DIFF
--- a/templates/policies/sts_installer_permission_policy.json
+++ b/templates/policies/sts_installer_permission_policy.json
@@ -128,6 +128,7 @@
                 "iam:SimulatePrincipalPolicy",
                 "iam:TagRole",
                 "iam:UntagRole",
+                "iam:CreateServiceLinkedRole",
                 "route53:ChangeResourceRecordSets",
                 "route53:ChangeTagsForResource",
                 "route53:CreateHostedZone",
@@ -177,7 +178,12 @@
                 "ec2:DescribeVpcEndpointServiceConfigurations",
                 "ec2:DescribeVpcEndpointServicePermissions",
                 "ec2:DescribeVpcEndpointServices",
-                "ec2:ModifyVpcEndpointServicePermissions"
+                "ec2:ModifyVpcEndpointServicePermissions",
+                "servicequotas:ListServices",
+                "servicequotas:GetRequestedServiceQuotaChange",
+                "servicequotas:GetServiceQuota",
+                "servicequotas:RequestServiceQuotaIncrease",
+                "servicequotas:ListServiceQuotas"
             ],
             "Resource": "*"
         }


### PR DESCRIPTION
Hi,

I tested latest version of rosa with STS installation mode in private link architecture on an existing VPC. Without adding the missing IAM permission added in this PR I was not able to install.

I am using the following commands for the installation:

````shell
rosa create account-roles --mode auto 

rosa create cluster --cluster-name dummy --sts --multi-az --region eu-central-1 --enable-autoscaling --min-replicas 3 --max-replicas 3 --machine-cidr 10.10.10.0/24 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23 --private-link --subnet-ids subnet-0...,subnet-0...,subnet-0... --version --yes
````
This results in the following warning:
````shell

# warning
level=warning msg=Missing permissions to fetch Quotas and therefore will skip checking them: failed to load limits for servicequotas: failed to list default serviceqquotas for ec2: AccessDeniedException: User: arn:aws:sts::<<aws-account-id>>:assumed-role/ManagedOpenShift-Installer-Role/1636060964779712355 is not authorized to perform: servicequotas:ListAWSDefaultServiceQuotas because no identity-based policy allows the servicequotas:ListAWSDefaultServiceQuotas action, make sure you have `servicequotas:ListAWSDefaultServiceQuotas` permission available to the user.\n
````
The installation fails with the message that the installer role does not have the permission to set `iam:CreateServiceLinkedRole` on the NLB.

After adding those permissions to the installation role the installation went fine without warnings and errors.
