### PR TITLE
Upgrade cluster bug fixes

### DIFF
--- a/cmd/upgrade/cluster/cmd.go
+++ b/cmd/upgrade/cluster/cmd.go
@@ -268,10 +268,14 @@ func run(cmd *cobra.Command, _ []string) {
 
 		if isAccountRoleUpgradeNeeded || isOperatorRoleUpgradeNeeded {
 			if mode != "" {
-				reporter.Infof("Preparing to upgrade account roles.")
-				accountroles.Cmd.Run(accountroles.Cmd, []string{prefix, mode})
-				reporter.Infof("Preparing to upgrade operator roles.")
-				operatorroles.Cmd.Run(operatorroles.Cmd, []string{clusterKey, mode})
+				if isAccountRoleUpgradeNeeded {
+					reporter.Infof("Preparing to upgrade account roles.")
+					accountroles.Cmd.Run(accountroles.Cmd, []string{prefix, mode})
+				}
+				if isOperatorRoleUpgradeNeeded {
+					reporter.Infof("Preparing to upgrade operator roles.")
+					operatorroles.Cmd.Run(operatorroles.Cmd, []string{clusterKey, mode})
+				}
 			} else {
 				reporter.Infof("Cluster Roles are not valid with upgrade version %s. "+
 					"Run the following command(s) to upgrade Cluster Roles:\n\n"+

--- a/cmd/upgrade/cluster/cmd.go
+++ b/cmd/upgrade/cluster/cmd.go
@@ -276,6 +276,12 @@ func run(cmd *cobra.Command, _ []string) {
 					reporter.Infof("Preparing to upgrade operator roles.")
 					operatorroles.Cmd.Run(operatorroles.Cmd, []string{clusterKey, mode})
 				}
+				if mode == aws.ModeManual {
+					reporter.Infof("Run the following command to continue scheduling cluster upgrade"+
+						" once cluster roles have been upgraded : \n\n"+
+						"\trosa upgrade cluster --cluster %s\n", clusterKey)
+					os.Exit(0)
+				}
 			} else {
 				reporter.Infof("Cluster Roles are not valid with upgrade version %s. "+
 					"Run the following command(s) to upgrade Cluster Roles:\n\n"+


### PR DESCRIPTION
Closes : 
- https://issues.redhat.com/browse/SDA-5017
- https://issues.redhat.com/browse/SDA-5018
- https://issues.redhat.com/browse/SDA-5022

#### Manual upgrade needing both account and operator role upgrades
```
$ rosa upgrade cluster --cluster croche-upgrade --mode manual           
? Version: 4.7.36
I: Ensuring cluster roles and policies are compatible with upgrade.
I: Preparing to upgrade account roles.
I: All policy files saved to the current directory
I: Run the following commands to upgrade the account role policies:

aws iam create-policy-version \
        --policy-arn arn:aws:iam::765374464689:policy/croche-test-Installer-Role-Policy \
        --policy-document file://sts_installer_permission_policy.json \
        --set-as-default

aws iam tag-policy \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --policy-arn arn:aws:iam::765374464689:policy/croche-test-Installer-Role-Policy

aws iam tag-role \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --role-name croche-test-Installer-Role

aws iam create-policy-version \
        --policy-arn arn:aws:iam::765374464689:policy/croche-test-ControlPlane-Role-Policy \
        --policy-document file://sts_instance_controlplane_permission_policy.json \
        --set-as-default

aws iam tag-policy \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --policy-arn arn:aws:iam::765374464689:policy/croche-test-ControlPlane-Role-Policy

aws iam tag-role \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --role-name croche-test-ControlPlane-Role

aws iam create-policy-version \
        --policy-arn arn:aws:iam::765374464689:policy/croche-test-Worker-Role-Policy \
        --policy-document file://sts_instance_worker_permission_policy.json \
        --set-as-default

aws iam tag-policy \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --policy-arn arn:aws:iam::765374464689:policy/croche-test-Worker-Role-Policy

aws iam tag-role \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --role-name croche-test-Worker-Role

aws iam create-policy-version \
        --policy-arn arn:aws:iam::765374464689:policy/croche-test-Support-Role-Policy \
        --policy-document file://sts_support_permission_policy.json \
        --set-as-default

aws iam tag-policy \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --policy-arn arn:aws:iam::765374464689:policy/croche-test-Support-Role-Policy

aws iam tag-role \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --role-name croche-test-Support-Role

aws iam create-policy-version \
        --policy-arn arn:aws:iam::765374464689:policy/croche-test-openshift-image-registry-installer-cloud-credentials \
        --policy-document file://openshift_image_registry_installer_cloud_credentials_policy.json \
        --set-as-default

aws iam tag-policy \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --policy-arn arn:aws:iam::765374464689:policy/croche-test-openshift-image-registry-installer-cloud-credentials

aws iam create-policy-version \
        --policy-arn arn:aws:iam::765374464689:policy/croche-test-openshift-ingress-operator-cloud-credentials \
        --policy-document file://openshift_ingress_operator_cloud_credentials_policy.json \
        --set-as-default

aws iam tag-policy \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --policy-arn arn:aws:iam::765374464689:policy/croche-test-openshift-ingress-operator-cloud-credentials

aws iam create-policy-version \
        --policy-arn arn:aws:iam::765374464689:policy/croche-test-openshift-cluster-csi-drivers-ebs-cloud-credentials \
        --policy-document file://openshift_cluster_csi_drivers_ebs_cloud_credentials_policy.json \
        --set-as-default

aws iam tag-policy \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --policy-arn arn:aws:iam::765374464689:policy/croche-test-openshift-cluster-csi-drivers-ebs-cloud-credentials

aws iam create-policy-version \
        --policy-arn arn:aws:iam::765374464689:policy/croche-test-openshift-machine-api-aws-cloud-credentials \
        --policy-document file://openshift_machine_api_aws_cloud_credentials_policy.json \
        --set-as-default

aws iam tag-policy \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --policy-arn arn:aws:iam::765374464689:policy/croche-test-openshift-machine-api-aws-cloud-credentials

aws iam create-policy-version \
        --policy-arn arn:aws:iam::765374464689:policy/croche-test-openshift-cloud-credential-operator-cloud-credential \
        --policy-document file://openshift_cloud_credential_operator_cloud_credential_operator_iam_ro_creds_policy.json \
        --set-as-default

aws iam tag-policy \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --policy-arn arn:aws:iam::765374464689:policy/croche-test-openshift-cloud-credential-operator-cloud-credential
I: Preparing to upgrade operator roles.
I: Starting to upgrade the policies
I: All policy files saved to the current directory
I: Run the following commands to upgrade the operator IAM policies:

W: Operator roles MUST only be upgraded after Account Roles upgrade has completed.

aws iam tag-role \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --role-name croche-upgrade-x5t2-openshift-image-registry-installer-cloud-cre

aws iam tag-role \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --role-name croche-upgrade-x5t2-openshift-ingress-operator-cloud-credentials

aws iam tag-role \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --role-name croche-upgrade-x5t2-openshift-cluster-csi-drivers-ebs-cloud-cred

aws iam tag-role \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --role-name croche-upgrade-x5t2-openshift-machine-api-aws-cloud-credentials

aws iam tag-role \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --role-name croche-upgrade-x5t2-openshift-cloud-credential-operator-cloud-cr
I: Run the following command to continue scheduling cluster upgrade once cluster roles have been upgraded : 

        rosa upgrade cluster --cluster croche-upgrade

```
#### Manual upgrade needing operator role upgrades only
```
rosa upgrade cluster --cluster croche-upgrade --mode manual                                                        
? Version: 4.7.36
I: Ensuring cluster roles and policies are compatible with upgrade.
I: Preparing to upgrade operator roles.
I: Starting to upgrade the policies
I: All policy files saved to the current directory
I: Run the following commands to upgrade the operator IAM policies:

aws iam tag-role \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --role-name croche-upgrade-x5t2-openshift-image-registry-installer-cloud-cre

aws iam tag-role \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --role-name croche-upgrade-x5t2-openshift-ingress-operator-cloud-credentials

aws iam tag-role \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --role-name croche-upgrade-x5t2-openshift-cluster-csi-drivers-ebs-cloud-cred

aws iam tag-role \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --role-name croche-upgrade-x5t2-openshift-machine-api-aws-cloud-credentials

aws iam tag-role \
        --tags Key=rosa_openshift_version,Value=4.9 \
        --role-name croche-upgrade-x5t2-openshift-cloud-credential-operator-cloud-cr
I: Run the following command to continue scheduling cluster upgrade once cluster roles have been upgraded : 

        rosa upgrade cluster --cluster croche-upgrade
```
#### Auto upgrade needing operator role upgrades only
```
$ rosa upgrade cluster --cluster croche-upgrade --mode auto  
? Version: 4.7.36
I: Ensuring cluster roles and policies are compatible with upgrade.
I: Preparing to upgrade operator roles.
I: Starting to upgrade the policies
? Upgrade the 'croche-upgrade-x5t2-openshift-machine-api-aws-cloud-credentials' operator role policy to version 4.9? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-test-openshift-machine-api-aws-cloud-credentials' to version '4.9'
? Upgrade the 'croche-upgrade-x5t2-openshift-cloud-credential-operator-cloud-cr' operator role policy to version 4.9? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-test-openshift-cloud-credential-operator-cloud-credential' to version '4.9'
? Upgrade the 'croche-upgrade-x5t2-openshift-image-registry-installer-cloud-cre' operator role policy to version 4.9? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-test-openshift-image-registry-installer-cloud-credentials' to version '4.9'
? Upgrade the 'croche-upgrade-x5t2-openshift-ingress-operator-cloud-credentials' operator role policy to version 4.9? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-test-openshift-ingress-operator-cloud-credentials' to version '4.9'
? Upgrade the 'croche-upgrade-x5t2-openshift-cluster-csi-drivers-ebs-cloud-cred' operator role policy to version 4.9? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-test-openshift-cluster-csi-drivers-ebs-cloud-credentials' to version '4.9'
? Please input desired date in format yyyy-mm-dd: [? for help] (2021-11-09) 

```
#### Auto upgrade needing both account and operator role upgrades
```
$ rosa upgrade cluster --cluster croche-upgrade --mode auto                                                                                               
? Version: 4.7.36
I: Ensuring cluster roles and policies are compatible with upgrade.
I: Preparing to upgrade account roles.
I: Starting to upgrade the policies
? Upgrade the 'croche-test-Installer-Role' role polices to version 4.9? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-test-Installer-Role-Policy' to version '4.9'
? Upgrade the 'croche-test-ControlPlane-Role' role polices to version 4.9? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-test-ControlPlane-Role-Policy' to version '4.9'
? Upgrade the 'croche-test-Worker-Role' role polices to version 4.9? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-test-Worker-Role-Policy' to version '4.9'
? Upgrade the 'croche-test-Support-Role' role polices to version 4.9? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-test-Support-Role-Policy' to version '4.9'
? Upgrade the operator role policies to version 4.9? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-test-openshift-image-registry-installer-cloud-credentials' to version '4.9'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-test-openshift-ingress-operator-cloud-credentials' to version '4.9'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-test-openshift-cluster-csi-drivers-ebs-cloud-credentials' to version '4.9'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-test-openshift-machine-api-aws-cloud-credentials' to version '4.9'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-test-openshift-cloud-credential-operator-cloud-credential' to version '4.9'
I: Preparing to upgrade operator roles.
I: Starting to upgrade the policies
? Upgrade the 'croche-upgrade-x5t2-openshift-cluster-csi-drivers-ebs-cloud-cred' operator role policy to version 4.9? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-test-openshift-cluster-csi-drivers-ebs-cloud-credentials' to version '4.9'
? Upgrade the 'croche-upgrade-x5t2-openshift-machine-api-aws-cloud-credentials' operator role policy to version 4.9? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-test-openshift-machine-api-aws-cloud-credentials' to version '4.9'
? Upgrade the 'croche-upgrade-x5t2-openshift-cloud-credential-operator-cloud-cr' operator role policy to version 4.9? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-test-openshift-cloud-credential-operator-cloud-credential' to version '4.9'
? Upgrade the 'croche-upgrade-x5t2-openshift-image-registry-installer-cloud-cre' operator role policy to version 4.9? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-test-openshift-image-registry-installer-cloud-credentials' to version '4.9'
? Upgrade the 'croche-upgrade-x5t2-openshift-ingress-operator-cloud-credentials' operator role policy to version 4.9? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/croche-test-openshift-ingress-operator-cloud-credentials' to version '4.9'
? Please input desired date in format yyyy-mm-dd: [? for help] (2021-11-09) 
E: Expected a valid date: interrupt
```

