### PR TITLE
Fix crash when calling link cmd internally

### DIFF
--- a/cmd/create/ocmrole/cmd.go
+++ b/cmd/create/ocmrole/cmd.go
@@ -216,7 +216,7 @@ func run(cmd *cobra.Command, argv []string) {
 		ocmClient.LogEvent("ROSACreateOCMRoleModeAuto", map[string]string{
 			ocm.Response: ocm.Success,
 		})
-		err = linkocmrole.Cmd.RunE(cmd, []string{roleARN})
+		err = linkocmrole.Cmd.RunE(linkocmrole.Cmd, []string{roleARN})
 		if err != nil {
 			reporter.Errorf("Unable to link role arn '%s' with the organization account id : '%s' : %v",
 				roleARN, orgID, err)

--- a/cmd/create/userrole/cmd.go
+++ b/cmd/create/userrole/cmd.go
@@ -211,7 +211,7 @@ func run(cmd *cobra.Command, argv []string) {
 			ocm.Response: ocm.Success,
 		})
 
-		err = linkuser.Cmd.RunE(cmd, []string{roleARN})
+		err = linkuser.Cmd.RunE(linkuser.Cmd, []string{roleARN})
 		if err != nil {
 			reporter.Errorf("Unable to link role arn '%s' with the account id : '%s' : %v",
 				roleARN, currentAccount.ID(), err)

--- a/cmd/link/ocmrole/cmd.go
+++ b/cmd/link/ocmrole/cmd.go
@@ -84,12 +84,13 @@ func run(cmd *cobra.Command, argv []string) (err error) {
 		reporter.Infof("Linking OCM role")
 	}
 
+	roleArn := args.roleArn
+
 	// Determine if interactive mode is needed
-	if !interactive.Enabled() && !cmd.Flags().Changed("role-arn") {
+	if !interactive.Enabled() && roleArn == "" {
 		interactive.Enable()
 	}
 
-	roleArn := args.roleArn
 	if interactive.Enabled() {
 		roleArn, err = interactive.GetString(interactive.Input{
 			Question: "OCM Role ARN",

--- a/cmd/link/userrole/cmd.go
+++ b/cmd/link/userrole/cmd.go
@@ -88,12 +88,13 @@ func run(cmd *cobra.Command, argv []string) (err error) {
 		reporter.Infof("Linking User role")
 	}
 
+	roleArn := args.roleArn
+
 	// Determine if interactive mode is needed
-	if !interactive.Enabled() && !cmd.Flags().Changed("role-arn") {
+	if !interactive.Enabled() && roleArn == "" {
 		interactive.Enable()
 	}
 
-	roleArn := args.roleArn
 	if interactive.Enabled() {
 		roleArn, err = interactive.GetString(interactive.Input{
 			Question: "User Role ARN",


### PR DESCRIPTION
When calling link cmd internally we set the roleArn, but not via flags,
so `Flags().Changed()` returns false.

I changed the test to determine if interactive mode is required to check if
roleArn has a value instead of using `Changed()`



Before the fix:
```
$ rosa create ocm-role --prefix zg --mode auto
I: Creating ocm role
I: Creating role using 'arn:aws:iam::765374464689:user/zgalor'
? Create the 'zg-OCM-Role' role? Yes
I: Created role 'zg-OCM-Role' with ARN 'arn:aws:iam::765374464689:role/zg-OCM-Role'
I: Linking OCM role
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x12575f4]

goroutine 1 [running]:
github.com/openshift/rosa/cmd/link/ocmrole.run(0x2436420, 0xc001488c20, 0x1, 0x1, 0x0, 0x0)
	/home/zgalor/go/src/github.com/openshift/rosa/cmd/link/ocmrole/cmd.go:96 +0x814
github.com/openshift/rosa/cmd/create/ocmrole.run(0x2436420, 0xc0003a1180, 0x0, 0x4)
	/home/zgalor/go/src/github.com/openshift/rosa/cmd/create/ocmrole/cmd.go:219 +0xbb4
github.com/spf13/cobra.(*Command).execute(0x2436420, 0xc0003a1140, 0x4, 0x4, 0x2436420, 0xc0003a1140)
	/home/zgalor/go/src/github.com/openshift/rosa/vendor/github.com/spf13/cobra/command.go:856 +0x2c2
github.com/spf13/cobra.(*Command).ExecuteC(0x24410a0, 0x244cbc0, 0x0, 0xc000070778)
	/home/zgalor/go/src/github.com/openshift/rosa/vendor/github.com/spf13/cobra/command.go:960 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	/home/zgalor/go/src/github.com/openshift/rosa/vendor/github.com/spf13/cobra/command.go:897
main.main()
	/home/zgalor/go/src/github.com/openshift/rosa/cmd/rosa/main.go:91 +0x9d
```