### PR TITLE
ocm-role: Add permission to describe VPCs

### DIFF
--- a/assets/bindata.go
+++ b/assets/bindata.go
@@ -937,6 +937,7 @@ var _templatesPoliciesSts_ocm_permission_policyJson = []byte(`{
         "iam:ListRoleTags",
         "iam:GetOpenIDConnectProvider",
         "ec2:DescribeSubnets",
+        "ec2:DescribeVpcs",
         "sts:AssumeRole",
         "sts:AssumeRoleWithWebIdentity"
       ],

--- a/templates/policies/sts_ocm_permission_policy.json
+++ b/templates/policies/sts_ocm_permission_policy.json
@@ -9,6 +9,7 @@
         "iam:ListRoleTags",
         "iam:GetOpenIDConnectProvider",
         "ec2:DescribeSubnets",
+        "ec2:DescribeVpcs",
         "sts:AssumeRole",
         "sts:AssumeRoleWithWebIdentity"
       ],


### PR DESCRIPTION
This will allow OCM to fetch a list of available VPCs for adding
new clusters to.

https://issues.redhat.com/browse/SDA-5080