### PR TITLE
aws: Remove hard dependency on default region

### DIFF
--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -485,7 +485,6 @@ func (c *awsClient) ValidateAccessKeys(AccessKey *AccessKey) error {
 		// Create the AWS client
 		_, err := NewClient().
 			Logger(logger).
-			Region(DefaultRegion).
 			AccessKeys(AccessKey).
 			Build()
 

--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -142,7 +142,6 @@ func (c *Client) CreateCluster(config Spec) (*cmv1.Cluster, error) {
 	// Create the AWS client:
 	awsClient, err := aws.NewClient().
 		Logger(logger).
-		Region(aws.DefaultRegion).
 		Build()
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create AWS client: %v", err)

--- a/pkg/ocm/regions.go
+++ b/pkg/ocm/regions.go
@@ -48,7 +48,6 @@ func (c *Client) GetRegions(roleARN string, externalID string) (regions []*cmv1.
 	} else {
 		awsClient, err := aws.NewClient().
 			Logger(logger).
-			Region(aws.DefaultRegion).
 			Build()
 		if err != nil {
 			return nil, fmt.Errorf("Error creating AWS client: %v", err)


### PR DESCRIPTION
This forces a fall back on the region configured in the current AWS
session and allows the user to override the region with the use of the
'profile' and 'region' flags.

https://issues.redhat.com/browse/OSD-9245