### PR TITLE
idp: Enable interactive mode when missing required flags

### DIFF
--- a/cmd/create/idp/cmd.go
+++ b/cmd/create/idp/cmd.go
@@ -314,14 +314,18 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
+	// Grab all the IDP information interactively if necessary
+	idpType := args.idpType
+	if idpType == "" {
+		interactive.Enable()
+	}
+
 	if interactive.Enabled() {
 		reporter.Infof("Interactive mode enabled.\n" +
 			"Any optional fields can be left empty and a default will be selected.")
 	}
 
-	// Grab all the IDP information interactively if necessary
-	idpType := args.idpType
-	if idpType == "" {
+	if interactive.Enabled() {
 		if idpType == "" {
 			idpType = validIdps[0]
 		}

--- a/cmd/create/idp/gitlab.go
+++ b/cmd/create/idp/gitlab.go
@@ -36,7 +36,11 @@ func buildGitlabIdp(cmd *cobra.Command,
 	clientSecret := args.clientSecret
 	gitlabURL := args.gitlabURL
 
-	if !cmd.Flags().Changed("host-url") {
+	if clientID == "" || clientSecret == "" {
+		interactive.Enable()
+	}
+
+	if interactive.Enabled() {
 		gitlabURL, err = interactive.GetString(interactive.Input{
 			Question: "URL",
 			Help:     cmd.Flags().Lookup("host-url").Usage,
@@ -56,7 +60,7 @@ func buildGitlabIdp(cmd *cobra.Command,
 		return idpBuilder, err
 	}
 
-	if clientID == "" || clientSecret == "" {
+	if interactive.Enabled() {
 		instructionsURL := fmt.Sprintf("%s/profile/applications", gitlabURL)
 		consoleURL := cluster.Console().URL()
 		oauthURL := strings.Replace(consoleURL, "console-openshift-console", "oauth-openshift", 1)
@@ -102,7 +106,7 @@ func buildGitlabIdp(cmd *cobra.Command,
 	}
 
 	caPath := args.caPath
-	if interactive.Enabled() && cmd.Flags().Changed("host-url") {
+	if interactive.Enabled() && gitlabURL != cmd.Flags().Lookup("host-url").DefValue {
 		caPath, err = interactive.GetCert(interactive.Input{
 			Question: "CA file path",
 			Help:     cmd.Flags().Lookup("ca").Usage,

--- a/cmd/create/idp/ldap.go
+++ b/cmd/create/idp/ldap.go
@@ -36,6 +36,10 @@ func buildLdapIdp(cmd *cobra.Command,
 	ldapIDs := args.ldapIDs
 
 	if ldapURL == "" || ldapIDs == "" {
+		interactive.Enable()
+	}
+
+	if interactive.Enabled() {
 		instructionsURL := "https://docs.openshift.com/dedicated/identity_providers/" +
 			"config-identity-providers.html#config-ldap-idp_config-identity-providers"
 		err = interactive.PrintHelp(interactive.Help{
@@ -51,7 +55,7 @@ func buildLdapIdp(cmd *cobra.Command,
 		}
 	}
 
-	if ldapURL == "" {
+	if interactive.Enabled() {
 		ldapURL, err = interactive.GetString(interactive.Input{
 			Question: "LDAP URL",
 			Help:     cmd.Flags().Lookup("url").Usage,
@@ -150,7 +154,7 @@ func buildLdapIdp(cmd *cobra.Command,
 		}
 	}
 
-	if ldapIDs == "" {
+	if interactive.Enabled() {
 		ldapIDs, err = interactive.GetString(interactive.Input{
 			Question: "ID",
 			Help:     cmd.Flags().Lookup("id-attributes").Usage,
@@ -160,6 +164,9 @@ func buildLdapIdp(cmd *cobra.Command,
 		if err != nil {
 			return idpBuilder, fmt.Errorf("Expected a valid comma-separated list of attributes: %s", err)
 		}
+	}
+	if ldapIDs == "" {
+		return idpBuilder, fmt.Errorf("LDAP ID is required")
 	}
 
 	ldapUsernames := args.ldapUsernames

--- a/cmd/create/idp/openid.go
+++ b/cmd/create/idp/openid.go
@@ -39,10 +39,11 @@ func buildOpenidIdp(cmd *cobra.Command,
 	name := args.openidName
 	username := args.openidUsername
 
-	isInteractive := clientID == "" || clientSecret == "" || issuerURL == "" ||
-		(email == "" && name == "" && username == "")
+	if clientID == "" || clientSecret == "" || issuerURL == "" || (email == "" && name == "" && username == "") {
+		interactive.Enable()
+	}
 
-	if isInteractive {
+	if interactive.Enabled() {
 		instructionsURL := "https://docs.openshift.com/dedicated/identity_providers/" +
 			"config-identity-providers.html#config-openid-idp_config-identity-providers"
 		oauthURL := strings.Replace(cluster.Console().URL(), "console-openshift-console", "oauth-openshift", 1)
@@ -61,7 +62,7 @@ func buildOpenidIdp(cmd *cobra.Command,
 		}
 	}
 
-	if isInteractive {
+	if interactive.Enabled() {
 		clientID, err = interactive.GetString(interactive.Input{
 			Question: "Client ID",
 			Help:     "Paste the Client ID provided by the OpenID provider when registering your application.",
@@ -73,7 +74,7 @@ func buildOpenidIdp(cmd *cobra.Command,
 		}
 	}
 
-	if isInteractive && clientSecret == "" {
+	if interactive.Enabled() && clientSecret == "" {
 		clientSecret, err = interactive.GetPassword(interactive.Input{
 			Question: "Client Secret",
 			Help:     "Paste the Client Secret provided by the OpenID provider when registering your application.",
@@ -84,7 +85,7 @@ func buildOpenidIdp(cmd *cobra.Command,
 		}
 	}
 
-	if isInteractive {
+	if interactive.Enabled() {
 		issuerURL, err = interactive.GetString(interactive.Input{
 			Question: "Issuer URL",
 			Help:     cmd.Flags().Lookup("issuer-url").Usage,
@@ -131,7 +132,7 @@ func buildOpenidIdp(cmd *cobra.Command,
 		return idpBuilder, err
 	}
 
-	if isInteractive {
+	if interactive.Enabled() {
 		err = interactive.PrintHelp(interactive.Help{
 			Message: `You can indicate which claims to use as the user’s preferred user name, display name, and email address.
   At least one claim must be configured to use as the user’s identity. Enter multiple values separated by commas.`,


### PR DESCRIPTION
To ensure a consistent experience in interactive mode, instead of
prompting the user for only the required fields, we verify if the flags
are missing and enable interactive mode globally. This ensures that when
dropped into interactive mode no options are skipped.

https://issues.redhat.com/browse/SDA-5229