### PR TITLE
fix issue with delete operatorrole/oidcprovider role

### DIFF
--- a/cmd/dlt/oidcprovider/cmd.go
+++ b/cmd/dlt/oidcprovider/cmd.go
@@ -108,7 +108,12 @@ func run(cmd *cobra.Command, argv []string) {
 		reporter.Errorf("Error validating cluster '%s': %v", clusterKey, err)
 		os.Exit(1)
 	}
-	c, err := ocmClient.GetClusterByID(sub.ClusterID(), creator)
+
+	clusterID := clusterKey
+	if sub != nil {
+		clusterID = sub.ClusterID()
+	}
+	c, err := ocmClient.GetClusterByID(clusterID, creator)
 	if err != nil {
 		if errors.GetType(err) != errors.NotFound {
 			reporter.Errorf("Error validating cluster '%s': %v", clusterKey, err)

--- a/cmd/dlt/operatorrole/cmd.go
+++ b/cmd/dlt/operatorrole/cmd.go
@@ -133,8 +133,11 @@ func run(cmd *cobra.Command, argv []string) {
 		reporter.Errorf("Error validating cluster '%s': %v", clusterKey, err)
 		os.Exit(1)
 	}
-
-	c, err := ocmClient.GetClusterByID(sub.ClusterID(), creator)
+	clusterID := clusterKey
+	if sub != nil {
+		clusterID = sub.ClusterID()
+	}
+	c, err := ocmClient.GetClusterByID(clusterID, creator)
 	if err != nil {
 		if errors.GetType(err) != errors.NotFound {
 			reporter.Errorf("Error validating cluster '%s': %v", clusterKey, err)

--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -278,7 +278,7 @@ func (c *Client) GetClusterUsingSubscription(clusterKey string, creator *aws.Cre
 
 	switch response.Total() {
 	case 0:
-		return nil, errors.NotFound.Errorf("There is no cluster with identifier '%s'", clusterKey)
+		return nil, nil
 	case 1:
 		return response.Items().Slice()[0], nil
 	default:


### PR DESCRIPTION
Subscription takes time to move to deprovisioned status when the cluster is uninstalled. So if the user immediately tries the rosa delete operatorrole/oidc provider we get the error that the cluster is not present which is not correct.