### PR TITLE
added Version gates acks

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -250,7 +250,7 @@ func run(cmd *cobra.Command, argv []string) {
 			ocm.Version:  aws.DefaultPolicyVersion,
 		})
 	case aws.ModeManual:
-		err = aws.GeneratePolicyFiles(reporter, env)
+		err = aws.GeneratePolicyFiles(reporter, env, true, true)
 		if err != nil {
 			reporter.Errorf("There was an error generating the policy files: %s", err)
 			ocmClient.LogEvent("ROSACreateAccountRolesModeManual", map[string]string{

--- a/cmd/upgrade/cluster/cmd.go
+++ b/cmd/upgrade/cluster/cmd.go
@@ -23,15 +23,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/openshift/rosa/pkg/interactive/confirm"
-
 	"github.com/briandowns/spinner"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/cmd/upgrade/accountroles"
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/logging"
 	"github.com/openshift/rosa/pkg/ocm"
 	rprtr "github.com/openshift/rosa/pkg/reporter"
@@ -227,7 +227,6 @@ func run(cmd *cobra.Command, _ []string) {
 		reporter.Errorf("Expected a valid version to upgrade to")
 		os.Exit(1)
 	}
-
 	if scheduleDate == "" || scheduleTime == "" {
 		interactive.Enable()
 	}
@@ -238,18 +237,16 @@ func run(cmd *cobra.Command, _ []string) {
 		if reporter.IsTerminal() {
 			spin = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
 		}
-
-		reporter.Infof("Ensuring cluster roles and policies are compatible with upgrade.")
+		reporter.Infof("Ensuring account and operator role policies for cluster '%s'"+
+			" are compatible with upgrade.", cluster.ID())
 		if spin != nil {
 			spin.Start()
 		}
-
 		prefix, err := aws.GetPrefixFromAccountRole(cluster)
 		if err != nil {
 			reporter.Errorf("Could not get role prefix for cluster '%s' : %v", clusterKey, err)
 			os.Exit(1)
 		}
-
 		isAccountRoleUpgradeNeeded, err := awsClient.IsUpgradedNeededForAccountRolePolicies(prefix, version)
 		if err != nil {
 			reporter.Errorf("Could not validate '%s' clusters account roles : %v", clusterKey, err)
@@ -262,13 +259,11 @@ func run(cmd *cobra.Command, _ []string) {
 			reporter.Errorf("Could not validate '%s' clusters operator roles : %v", clusterKey, err)
 			os.Exit(1)
 		}
-
 		if spin != nil {
 			spin.Stop()
 		}
-
 		if isAccountRoleUpgradeNeeded || isOperatorRoleUpgradeNeeded {
-			reporter.Infof("Account and operator roles needed upgrade")
+			reporter.Infof("Account and/or operator roles needed upgrade")
 			if interactive.Enabled() || mode == "" {
 				mode, err = interactive.GetOption(interactive.Input{
 					Question: "Upgrade mode",
@@ -282,7 +277,6 @@ func run(cmd *cobra.Command, _ []string) {
 					os.Exit(1)
 				}
 			}
-			reporter.Infof("Preparing to upgrade role policies")
 			accountroles.Cmd.Run(accountroles.Cmd, []string{prefix, mode})
 			if mode == aws.ModeManual {
 				reporter.Infof("Run the following command to continue scheduling cluster upgrade"+
@@ -290,9 +284,25 @@ func run(cmd *cobra.Command, _ []string) {
 					"\trosa upgrade cluster --cluster %s\n", clusterKey)
 				os.Exit(0)
 			}
+		} else {
+			reporter.Infof("Account and operator roles are up-to-date")
 		}
 	}
 
+	upgradePolicyBuilder := cmv1.NewUpgradePolicy().
+		ScheduleType("manual").
+		Version(version)
+
+	upgradePolicy, err := upgradePolicyBuilder.Build()
+	if err != nil {
+		reporter.Errorf("Failed to schedule upgrade for cluster '%s': %v", clusterKey, err)
+		os.Exit(1)
+	}
+	err = checkAndAckMissingAgreements(ocmClient, cluster, upgradePolicy, reporter, clusterKey)
+	if err != nil {
+		reporter.Errorf("%v", err)
+		os.Exit(1)
+	}
 	// Set the default next run within the next 10 minutes
 	now := time.Now().UTC().Add(time.Minute * 10)
 	if scheduleDate == "" {
@@ -357,10 +367,7 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
-	upgradePolicyBuilder := cmv1.NewUpgradePolicy().
-		ScheduleType("manual").
-		Version(version).
-		NextRun(nextRun)
+	upgradePolicyBuilder = upgradePolicyBuilder.NextRun(nextRun)
 
 	nodeDrainGracePeriod := ""
 	// Determine if the cluster already has a node drain grace period set and use that as the default
@@ -422,35 +429,10 @@ func run(cmd *cobra.Command, _ []string) {
 		NodeDrainGracePeriodInMinutes: nodeDrainValue,
 	}
 
-	upgradePolicy, err := upgradePolicyBuilder.Build()
+	upgradePolicy, err = upgradePolicyBuilder.Build()
 	if err != nil {
 		reporter.Errorf("Failed to schedule upgrade for cluster '%s': %v", clusterKey, err)
 		os.Exit(1)
-	}
-
-	// check if the cluster upgrade requires gate agreements
-	gates, err := ocmClient.GetMissingGateAgreements(cluster.ID(), upgradePolicy)
-	if err != nil {
-		reporter.Errorf("Failed to check for missing gate agreements upgrade for cluster '%s': %v", clusterKey, err)
-		os.Exit(1)
-	}
-
-	for _, gate := range gates {
-		reporter.Infof("Gate: %v", gate)
-		if !gate.STSOnly() {
-			// for non sts gates we require user agreement
-			if !confirm.Prompt(true,
-				"I acknowledge that my workloads are no longer using removed APIs. (Background:'%s)",
-				gate.Description()) {
-				os.Exit(0)
-			}
-		}
-		err = ocmClient.AckVersionGate(cluster.ID(), gate.ID())
-		if err != nil {
-			reporter.Errorf("Failed to acknowledge version gate '%s' for cluster '%s': %v",
-				gate.ID(), clusterKey, err)
-			os.Exit(1)
-		}
 	}
 
 	err = ocmClient.ScheduleUpgrade(cluster.ID(), upgradePolicy)
@@ -466,4 +448,44 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	reporter.Infof("Upgrade successfully scheduled for cluster '%s'", clusterKey)
+}
+
+func checkAndAckMissingAgreements(ocmClient *ocm.Client, cluster *cmv1.Cluster, upgradePolicy *cmv1.UpgradePolicy,
+	reporter *rprtr.Object, clusterKey string) error {
+	// check if the cluster upgrade requires gate agreements
+	gates, err := ocmClient.GetMissingGateAgreements(cluster.ID(), upgradePolicy)
+	if err != nil {
+		return errors.Errorf("Failed to check for missing gate agreements upgrade for "+
+			"cluster '%s': %v", clusterKey, err)
+	}
+	isWarningDisplayed := false
+	for _, gate := range gates {
+		if !gate.STSOnly() {
+			if !isWarningDisplayed {
+				reporter.Warnf("Missing required acknowledgements to schedule upgrade. \n")
+				isWarningDisplayed = true
+			}
+			err = interactive.PrintHelp(interactive.Help{
+				Message: "Read the below description and acknowledge to proceed with upgrade",
+				Steps: []string{
+					fmt.Sprintf("Description: %s\n"+
+						"    URL:         %s\n", gate.Description(), gate.DocumentationURL()),
+				},
+			})
+			if err != nil {
+				return errors.Errorf("Failed to get version gate '%s' for cluster '%s': %v",
+					gate.ID(), clusterKey, err)
+			}
+			// for non sts gates we require user agreement
+			if !confirm.Prompt(true, "I acknowledge") {
+				os.Exit(0)
+			}
+		}
+		err = ocmClient.AckVersionGate(cluster.ID(), gate.ID())
+		if err != nil {
+			return errors.Errorf("Failed to acknowledge version gate '%s' for cluster '%s': %v",
+				gate.ID(), clusterKey, err)
+		}
+	}
+	return err
 }

--- a/cmd/upgrade/cluster/cmd.go
+++ b/cmd/upgrade/cluster/cmd.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openshift/rosa/pkg/interactive/confirm"
+
 	"github.com/briandowns/spinner"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
@@ -424,6 +426,31 @@ func run(cmd *cobra.Command, _ []string) {
 	if err != nil {
 		reporter.Errorf("Failed to schedule upgrade for cluster '%s': %v", clusterKey, err)
 		os.Exit(1)
+	}
+
+	// check if the cluster upgrade requires gate agreements
+	gates, err := ocmClient.GetMissingGateAgreements(cluster.ID(), upgradePolicy)
+	if err != nil {
+		reporter.Errorf("Failed to check for missing gate agreements upgrade for cluster '%s': %v", clusterKey, err)
+		os.Exit(1)
+	}
+
+	for _, gate := range gates {
+		reporter.Infof("Gate: %v", gate)
+		if !gate.STSOnly() {
+			// for non sts gates we require user agreement
+			if !confirm.Prompt(true,
+				"I acknowledge that my workloads are no longer using removed APIs. (Background:'%s)",
+				gate.Description()) {
+				os.Exit(0)
+			}
+		}
+		err = ocmClient.AckVersionGate(cluster.ID(), gate.ID())
+		if err != nil {
+			reporter.Errorf("Failed to acknowledge version gate '%s' for cluster '%s': %v",
+				gate.ID(), clusterKey, err)
+			os.Exit(1)
+		}
 	}
 
 	err = ocmClient.ScheduleUpgrade(cluster.ID(), upgradePolicy)

--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -343,55 +343,51 @@ func GetAccountRoleName(cluster *cmv1.Cluster) (string, error) {
 	return roleName, nil
 }
 
-func GeneratePolicyFiles(reporter *rprtr.Object, env string) error {
-	for file := range AccountRoles {
-		filename := fmt.Sprintf("sts_%s_trust_policy.json", file)
-		path := fmt.Sprintf("templates/policies/%s", filename)
-
-		policy, err := ReadPolicyDocument(path, map[string]string{
-			"aws_account_id": JumpAccounts[env],
-		})
-		if err != nil {
-			return err
-		}
-
-		reporter.Debugf("Saving '%s' to the current directory", filename)
-		err = SaveDocument(policy, filename)
-		if err != nil {
-			return err
-		}
-
-		filename = fmt.Sprintf("sts_%s_permission_policy.json", file)
-		path = fmt.Sprintf("templates/policies/%s", filename)
-
-		policy, err = ReadPolicyDocument(path)
-		if err != nil {
-			return err
-		}
-
-		reporter.Debugf("Saving '%s' to the current directory", filename)
-		err = SaveDocument(policy, filename)
-		if err != nil {
-			return err
+func GeneratePolicyFiles(reporter *rprtr.Object, env string, generateAccountRolePolicies bool,
+	generateOperatorRolePolicies bool) error {
+	if generateAccountRolePolicies {
+		for file := range AccountRoles {
+			filename := fmt.Sprintf("sts_%s_trust_policy.json", file)
+			path := fmt.Sprintf("templates/policies/%s", filename)
+			policy, err := ReadPolicyDocument(path, map[string]string{
+				"aws_account_id": JumpAccounts[env],
+			})
+			if err != nil {
+				return err
+			}
+			reporter.Debugf("Saving '%s' to the current directory", filename)
+			err = SaveDocument(policy, filename)
+			if err != nil {
+				return err
+			}
+			filename = fmt.Sprintf("sts_%s_permission_policy.json", file)
+			path = fmt.Sprintf("templates/policies/%s", filename)
+			policy, err = ReadPolicyDocument(path)
+			if err != nil {
+				return err
+			}
+			reporter.Debugf("Saving '%s' to the current directory", filename)
+			err = SaveDocument(policy, filename)
+			if err != nil {
+				return err
+			}
 		}
 	}
-
-	for credrequest := range CredentialRequests {
-		filename := fmt.Sprintf("openshift_%s_policy.json", credrequest)
-		path := fmt.Sprintf("templates/policies/%s", filename)
-
-		policy, err := ReadPolicyDocument(path)
-		if err != nil {
-			return err
-		}
-
-		reporter.Debugf("Saving '%s' to the current directory", filename)
-		err = SaveDocument(policy, filename)
-		if err != nil {
-			return err
+	if generateOperatorRolePolicies {
+		for credrequest := range CredentialRequests {
+			filename := fmt.Sprintf("openshift_%s_policy.json", credrequest)
+			path := fmt.Sprintf("templates/policies/%s", filename)
+			policy, err := ReadPolicyDocument(path)
+			if err != nil {
+				return err
+			}
+			reporter.Debugf("Saving '%s' to the current directory", filename)
+			err = SaveDocument(policy, filename)
+			if err != nil {
+				return err
+			}
 		}
 	}
-
 	return nil
 }
 

--- a/pkg/ocm/upgrades.go
+++ b/pkg/ocm/upgrades.go
@@ -17,8 +17,7 @@ limitations under the License.
 package ocm
 
 import (
-	"fmt"
-
+	"encoding/json"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
@@ -51,7 +50,6 @@ func (c *Client) GetScheduledUpgrade(clusterID string) (*cmv1.UpgradePolicy, *cm
 	if err != nil {
 		return nil, nil, err
 	}
-
 	for _, upgradePolicy := range upgradePolicies {
 		if upgradePolicy.ScheduleType() == "manual" && upgradePolicy.UpgradeType() == "OSD" {
 			state, err := c.ocm.ClustersMgmt().V1().
@@ -102,49 +100,33 @@ func (c *Client) CancelUpgrade(clusterID string) (bool, error) {
 func (c *Client) GetMissingGateAgreements(
 	clusterID string,
 	upgradePolicy *cmv1.UpgradePolicy) ([]*cmv1.VersionGate, error) {
-	response, err := c.ocm.ClustersMgmt().V1().
-		Clusters().Cluster(clusterID).
-		UpgradePolicies().
-		Add().
-		Parameter("dryRun", true).
-		Body(upgradePolicy).
-		Send()
-	if err == nil {
-		return []*cmv1.VersionGate{}, nil
-	}
+	response, err := c.ocm.ClustersMgmt().V1().Clusters().
+		Cluster(clusterID).UpgradePolicies().Add().Parameter("dryRun", true).Body(upgradePolicy).Send()
 
-	// parse gates list
-	details, ok := response.Error().GetDetails()
-	if !ok {
-		return []*cmv1.VersionGate{}, handleErr(response.Error(), err)
-	}
-
-	listOfMaps, ok := details.([]interface{})
-	if !ok {
-		return []*cmv1.VersionGate{}, fmt.Errorf("Failed to parse gates")
-	}
-
-	gates := make([]*cmv1.VersionGate, 0)
-	for _, object := range listOfMaps {
-		gateAsMap, ok := object.(map[string]interface{})
-		if !ok {
-			return []*cmv1.VersionGate{}, handleErr(response.Error(), err)
+	if err != nil {
+		if response.Error() != nil {
+			// parse gates list
+			errorDetails, ok := response.Error().GetDetails()
+			if !ok {
+				return []*cmv1.VersionGate{}, handleErr(response.Error(), err)
+			}
+			data, err := json.Marshal(errorDetails)
+			if err != nil {
+				return []*cmv1.VersionGate{}, handleErr(response.Error(), err)
+			}
+			gates, err := cmv1.UnmarshalVersionGateList(data)
+			if err != nil {
+				return []*cmv1.VersionGate{}, handleErr(response.Error(), err)
+			}
+			return gates, nil
 		}
-
-		gate, err := gateFromMap(gateAsMap)
-		if err != nil {
-			return []*cmv1.VersionGate{}, fmt.Errorf("failed to read gate")
-		}
-		gates = append(gates, gate)
 	}
-
-	return gates, nil
+	return []*cmv1.VersionGate{}, nil
 }
 
 func (c *Client) AckVersionGate(
 	clusterID string,
 	gateID string) error {
-
 	agreement, err := cmv1.NewVersionGateAgreement().
 		VersionGate(cmv1.NewVersionGate().ID(gateID)).
 		Build()
@@ -161,16 +143,4 @@ func (c *Client) AckVersionGate(
 		return handleErr(response.Error(), err)
 	}
 	return nil
-}
-
-func gateFromMap(gateMap map[string]interface{}) (*cmv1.VersionGate, error) {
-	id := gateMap["id"].(string)
-	desc := gateMap["description"].(string)
-	stsOnly := gateMap["sts_only"].(bool)
-
-	gate, err := cmv1.NewVersionGate().ID(id).Description(desc).STSOnly(stsOnly).Build()
-	if err != nil {
-		return nil, err
-	}
-	return gate, nil
 }


### PR DESCRIPTION
**Upgrade with ack** 
```
./rosa upgrade cluster -c 1pq7u8m8grp32kob42qu1cqbv0hhbp4n
? Version: 4.9.13
W: Missing required acknowledgements to schedule upgrade. 

? Read the below description and acknowledge to proceed with upgrade
  - Description: OpenShift removes several Kubernetes APIs in OpenShift 4.9. To help prevent issues with workloads and tools after upgrading, an administrator is required to provide manual acknowledgement before the cluster can be upgraded from OpenShift 4.8 to 4.9.
    URL:         https://access.redhat.com/articles/6329921

? I acknowledge Yes
? Please input desired date in format yyyy-mm-dd: 2022-01-21
? Please input desired UTC time in format HH:mm: [? for help] (16:50) 
 
```
 

**Upgrade with auto mode update** 
```
./rosa upgrade cluster -c 1pq7u8m8grp32kob42qu1cqbv0hhbp4n
? Version: 4.9.13
I: Ensuring account and operator role policies for cluster '1pq7u8m8grp32kob42qu1cqbv0hhbp4n' are compatible with upgrade.
I: Account and/or operator roles needed upgrade
? Upgrade mode: auto
I: Preparing to upgrade role policies
I: Starting to upgrade the policies
? Upgrade the 'ManagedOpenShift-Installer-Role' role polices to version 4.9? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/ManagedOpenShift-Installer-Role-Policy' to version '4.9'
? Upgrade the 'ManagedOpenShift-ControlPlane-Role' role polices to version 4.9? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/ManagedOpenShift-ControlPlane-Role-Policy' to version '4.9'
? Upgrade the 'ManagedOpenShift-Worker-Role' role polices to version 4.9? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/ManagedOpenShift-Worker-Role-Policy' to version '4.9'
? Upgrade the 'ManagedOpenShift-Support-Role' role polices to version 4.9? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/ManagedOpenShift-Support-Role-Policy' to version '4.9'
? Upgrade the operator role policies to version 4.9? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/ManagedOpenShift-openshift-machine-api-aws-cloud-credentials' to version '4.9'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/ManagedOpenShift-openshift-cloud-credential-operator-cloud-crede' to version '4.9'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/ManagedOpenShift-openshift-image-registry-installer-cloud-creden' to version '4.9'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/ManagedOpenShift-openshift-ingress-operator-cloud-credentials' to version '4.9'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/ManagedOpenShift-openshift-cluster-csi-drivers-ebs-cloud-credent' to version '4.9'
? Please input desired date in format yyyy-mm-dd: 2022-01-20
? Please input desired UTC time in format HH:mm: [? for help] (22:47) 
```


**Upgrade with manual mode update** 
```
./rosa upgrade cluster -c 1pq7u8m8grp32kob42qu1cqbv0hhbp4n
? Version: 4.9.13
I: Ensuring account and operator role policies for cluster '1pq7u8m8grp32kob42qu1cqbv0hhbp4n' are compatible with upgrade.
I: Account and/or operator roles needed upgrade
? Upgrade mode: manual
I: Preparing to upgrade role policies
I: All policy files saved to the current directory
I: Run the following commands to upgrade the account role policies:

aws iam create-policy-version \
	--policy-arn arn:aws:iam::765374464689:policy/ManagedOpenShift-Installer-Role-Policy \
	--policy-document file://sts_installer_permission_policy.json \
	--set-as-default

contd... 
....
```

**Upgrade with acks and compatible policies** 
```
./rosa upgrade cluster -c 1pq7u8m8grp32kob42qu1cqbv0hhbp4n
? Version: 4.9.13
I: Ensuring account and operator role policies for cluster '1pq7u8m8grp32kob42qu1cqbv0hhbp4n' are compatible with upgrade.
? Please input desired date in format yyyy-mm-dd: 2022-01-20
? Please input desired UTC time in format HH:mm: 22:52

```





