### PR TITLE
Fix issue with Auto mode during upgrade cluster

### DIFF
--- a/cmd/upgrade/cluster/cmd.go
+++ b/cmd/upgrade/cluster/cmd.go
@@ -277,7 +277,14 @@ func run(cmd *cobra.Command, _ []string) {
 					os.Exit(1)
 				}
 			}
-			accountroles.Cmd.Run(accountroles.Cmd, []string{prefix, mode})
+			err := accountroles.Cmd.RunE(accountroles.Cmd, []string{prefix, mode})
+			if err != nil {
+				reporter.Infof("Account and/Or Operator Role policies are not valid with upgrade version %s. "+
+					"Run the following command(s) to upgrade the roles:\n\n"+
+					"\t%s\n",
+					version, fmt.Sprintf("rosa upgrade account-roles --prefix %s", prefix))
+				mode = aws.ModeManual
+			}
 			if mode == aws.ModeManual {
 				reporter.Infof("Run the following command to continue scheduling cluster upgrade"+
 					" once account and operator roles have been upgraded : \n\n"+


### PR DESCRIPTION
https://issues.redhat.com/browse/SDA-5343 


```
 ./rosa upgrade cluster -c 1pq7u8m8grp32kob42qu1cqbv0hhbp4n
? Version: 4.9.13
I: Ensuring account and operator role policies for cluster '1pq7u8m8grp32kob42qu1cqbv0hhbp4n' are compatible with upgrade.
I: Account and/or operator roles needed upgrade
? Upgrade mode: auto
I: Starting to upgrade the policies
? Upgrade the 'ManagedOpenShift-Installer-Role' role polices to version 4.9? No
E: Account roles need to be upgraded to proceed
I: Account and/Or Operator Role policies are not valid with upgrade version 4.9.13. Run the following command(s) to upgrade the roles:

	rosa upgrade account-roles --prefix ManagedOpenShift

I: Run the following command to continue scheduling cluster upgrade once account and operator roles have been upgraded : 

	rosa upgrade cluster --cluster 1pq7u8m8grp32kob42qu1cqbv0hhbp4n
```
