### PR TITLE
Avoid nil pointer dereference in cluster create

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1451,10 +1451,11 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 	}
 
-	var dMachinecidr *net.IPNet
-	var dPodcidr *net.IPNet
-	var dServicecidr *net.IPNet
 	dMachinecidr, dPodcidr, dServicecidr, dhostPrefix := ocmClient.GetDefaultClusterFlavors(args.flavour)
+	if dMachinecidr == nil || dPodcidr == nil || dServicecidr == nil {
+		reporter.Errorf("Error retrieving default cluster flavors")
+		os.Exit(1)
+	}
 
 	// Machine CIDR:
 	machineCIDR := args.machineCIDR


### PR DESCRIPTION
If the call to ocmClient.GetDefaultClusterFlavors fails, it returns a
`nil` pointer which then causes the process to panic when it is
dereferenced. If that occurs, we should exit early with an informative
message.