### PR TITLE
Revert "Verify chosen machine pool type is available"

### DIFF
--- a/pkg/ocm/machines.go
+++ b/pkg/ocm/machines.go
@@ -62,9 +62,6 @@ func ValidateMachineType(machineType string, machineTypes []*MachineType, multiA
 		// Check and set the cluster machineType
 		hasMachineType := false
 		for _, v := range machineTypes {
-			if !v.Available {
-				continue
-			}
 			machineTypeList = append(machineTypeList, v.MachineType.ID())
 			if v.MachineType.ID() == machineType {
 				if v.MachineType.Category() == AcceleratedComputing && v.AvailableQuota < getDefaultNodes(multiAZ) {


### PR DESCRIPTION
Reverts openshift/rosa#578

Looks like `MachineType.available` doesn't actually indicate if a type is available in a specific zone, but rather if the user has appropriate quota to use it. We'll probably need to handle the logic of checking for availability in a specified zone on the server side.