### PR TITLE
Create command 'rosa list ocm-roles'

### DIFF
--- a/cmd/list/cmd.go
+++ b/cmd/list/cmd.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openshift/rosa/cmd/list/ingress"
 	"github.com/openshift/rosa/cmd/list/instancetypes"
 	"github.com/openshift/rosa/cmd/list/machinepool"
+	"github.com/openshift/rosa/cmd/list/ocmroles"
 	"github.com/openshift/rosa/cmd/list/region"
 	"github.com/openshift/rosa/cmd/list/upgrade"
 	"github.com/openshift/rosa/cmd/list/user"
@@ -53,6 +54,7 @@ func init() {
 	Cmd.AddCommand(version.Cmd)
 	Cmd.AddCommand(instancetypes.Cmd)
 	Cmd.AddCommand(accountroles.Cmd)
+	Cmd.AddCommand(ocmroles.Cmd)
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)
 	arguments.AddRegionFlag(flags)

--- a/cmd/list/ocmroles/cmd.go
+++ b/cmd/list/ocmroles/cmd.go
@@ -1,0 +1,129 @@
+/*
+Copyright (c) 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ocmroles
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/helper"
+	"github.com/openshift/rosa/pkg/logging"
+	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/output"
+	rprtr "github.com/openshift/rosa/pkg/reporter"
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &cobra.Command{
+	Use:     "ocm-roles",
+	Aliases: []string{"ocmrole", "ocm-role", "ocmroles", "ocm-roles"},
+	Short:   "List ocm roles",
+	Long:    "List ocm roles for the current AWS account.",
+	Example: ` # List all ocm roles
+rosa list ocm-roles`,
+	Run:    run,
+	Hidden: true,
+}
+
+func init() {
+	output.AddFlag(Cmd)
+}
+
+func run(_ *cobra.Command, _ []string) {
+	reporter := rprtr.CreateReporterOrExit()
+	logger := logging.CreateLoggerOrExit(reporter)
+
+	// Create the AWS client:
+	awsClient, err := aws.NewClient().
+		Logger(logger).
+		Build()
+	if err != nil {
+		reporter.Errorf("Failed to create AWS client: %v", err)
+		os.Exit(1)
+	}
+
+	// Create the client for the OCM API:
+	ocmClient, err := ocm.NewClient().
+		Logger(logger).
+		Build()
+	if err != nil {
+		reporter.Errorf("Failed to create OCM connection: %v", err)
+		os.Exit(1)
+	}
+	defer func() {
+		err = ocmClient.Close()
+		if err != nil {
+			reporter.Errorf("Failed to close OCM connection: %v", err)
+		}
+	}()
+
+	ocmRoles, err := listOCMRoles(awsClient, ocmClient)
+	if err != nil {
+		reporter.Errorf("Failed to get ocm roles: %v", err)
+		os.Exit(1)
+	}
+
+	if len(ocmRoles) == 0 {
+		reporter.Infof("No ocm roles available")
+		os.Exit(0)
+	}
+	if output.HasFlag() {
+		err = output.Print(ocmRoles)
+		if err != nil {
+			reporter.Errorf("%s", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
+	// Create the writer that will be used to print the tabulated results:
+	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprint(writer, "ROLE NAME\tROLE ARN\tLINKED\tADMIN\n")
+	for _, ocmRole := range ocmRoles {
+		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\n", ocmRole.RoleName, ocmRole.RoleARN, ocmRole.Linked, ocmRole.Admin)
+	}
+	writer.Flush()
+}
+
+func listOCMRoles(awsClient aws.Client, ocmClient *ocm.Client) ([]aws.Role, error) {
+	ocmRoles, err := awsClient.ListOCMRoles()
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if roles are linked to organization
+	orgID, _, err := ocmClient.GetCurrentOrganization()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get organization account: %v", err)
+	}
+	linkedRoles, err := ocmClient.GetLinkedRoles(orgID)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range ocmRoles {
+		if helper.Contains(linkedRoles, ocmRoles[i].RoleARN) {
+			ocmRoles[i].Linked = "Yes"
+		} else {
+			ocmRoles[i].Linked = "No"
+		}
+	}
+
+	return ocmRoles, nil
+}

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -100,6 +100,7 @@ type Client interface {
 	HasOpenIDConnectProvider(issuerURL string, accountID string) (bool, error)
 	FindRoleARNs(roleType string, version string) ([]string, error)
 	FindPolicyARN(operator Operator, version string) (string, error)
+	ListOCMRoles() ([]Role, error)
 	ListAccountRoles(version string) ([]Role, error)
 	GetRoleByARN(roleARN string) (*iam.Role, error)
 	HasCompatibleVersionTags(iamTags []*iam.Tag, version string) (bool, error)

--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -248,15 +248,6 @@ func GetTagValues(tagsValue []*iam.Tag) (roleType string, version string) {
 	return
 }
 
-func IsAdminTag(tagsValue []*iam.Tag) bool {
-	for _, tag := range tagsValue {
-		if aws.StringValue(tag.Key) == tags.AdminRole && aws.StringValue(tag.Value) == "true" {
-			return true
-		}
-	}
-	return false
-}
-
 func MarshalRoles(role []Role, b *bytes.Buffer) error {
 	reqBodyBytes := new(bytes.Buffer)
 	json.NewEncoder(reqBodyBytes).Encode(role)

--- a/pkg/helper/helper.go
+++ b/pkg/helper/helper.go
@@ -1,0 +1,11 @@
+package helper
+
+func Contains(s []string, str string) bool {
+	for _, v := range s {
+		if v == str {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
The new command is implemented similarly to the `rosa list account-roles` command.
The code checks if a `role name` contains the `OCM-Role` infix to identify an ocm-role.

![image](https://user-images.githubusercontent.com/57869309/152809960-30fe80ba-d5e5-43b3-abcf-78970af7227c.png)

Related: [SDA-5405](https://issues.redhat.com/browse/SDA-5405)