### PR TITLE
Modify function `handleErr` to include the error type in the new error

### DIFF
--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -153,7 +153,8 @@ func handleErr(res *ocmerrors.Error, err error) error {
 			"Go to https://www.redhat.com/wapps/tnc/ackrequired?site=ocm&event=register\n" +
 			"Once you accept the terms, you will need to retry the action that was blocked."
 	}
-	return errors.Errorf("%s", msg)
+	errType := errors.ErrorType(res.Status())
+	return errType.Set(errors.Errorf("%s", msg))
 }
 
 func (c *Client) GetDefaultClusterFlavors(flavour string) (dMachinecidr *net.IPNet, dPodcidr *net.IPNet,


### PR DESCRIPTION
In some places in our code, we display an error message to the user depending
on the error type.
Function `handleErr` omits the error type in the new error it generates.
This function is called in many places in our code, and this change might affect the
error message returned to the user.

These are some occurrences that I found that can be affected by this change:
`dlt/oidcprovider/cmd.go 101`
`dlt/oidcprovider/cmd.go 126`
`link/userrole/cmg.go 140`
`ocm/logs.go 40`
`logs/install/cmd.go 164`
`logs/uninstall/cmd.go 150`