### PR TITLE
Create command 'rosa list user-roles'

### DIFF
--- a/cmd/list/cmd.go
+++ b/cmd/list/cmd.go
@@ -31,6 +31,7 @@ import (
 	"github.com/openshift/rosa/cmd/list/region"
 	"github.com/openshift/rosa/cmd/list/upgrade"
 	"github.com/openshift/rosa/cmd/list/user"
+	"github.com/openshift/rosa/cmd/list/userroles"
 	"github.com/openshift/rosa/cmd/list/version"
 	"github.com/openshift/rosa/pkg/arguments"
 )
@@ -55,6 +56,7 @@ func init() {
 	Cmd.AddCommand(instancetypes.Cmd)
 	Cmd.AddCommand(accountroles.Cmd)
 	Cmd.AddCommand(ocmroles.Cmd)
+	Cmd.AddCommand(userroles.Cmd)
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)
 	arguments.AddRegionFlag(flags)

--- a/cmd/list/userroles/cmd.go
+++ b/cmd/list/userroles/cmd.go
@@ -1,12 +1,9 @@
 /*
 Copyright (c) 2022 Red Hat, Inc.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
   http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package ocmroles
+package userroles
 
 import (
 	"fmt"
@@ -31,12 +28,12 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:     "ocm-roles",
-	Aliases: []string{"ocmrole", "ocm-role", "ocmroles", "ocm-roles"},
-	Short:   "List ocm roles",
-	Long:    "List ocm roles for the current AWS account.",
-	Example: ` # List all ocm roles
-rosa list ocm-roles`,
+	Use:     "user-roles",
+	Aliases: []string{"userrole", "user-role", "userroles", "user-roles"},
+	Short:   "List user roles",
+	Long:    "List user roles for current AWS account",
+	Example: `# List all user roles
+rosa list user-roles`,
 	Run:    run,
 	Hidden: true,
 }
@@ -48,43 +45,27 @@ func init() {
 func run(_ *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
 	logger := logging.CreateLoggerOrExit(reporter)
-
-	// Create the AWS client:
-	awsClient, err := aws.NewClient().
-		Logger(logger).
-		Build()
-	if err != nil {
-		reporter.Errorf("Failed to create AWS client: %v", err)
-		os.Exit(1)
-	}
-
-	// Create the client for the OCM API:
-	ocmClient, err := ocm.NewClient().
-		Logger(logger).
-		Build()
-	if err != nil {
-		reporter.Errorf("Failed to create OCM connection: %v", err)
-		os.Exit(1)
-	}
+	awsClient := aws.CreateNewClientOrExit(logger, reporter)
+	ocmClient := ocm.CreateNewClientOrExit(logger, reporter)
 	defer func() {
-		err = ocmClient.Close()
+		err := ocmClient.Close()
 		if err != nil {
 			reporter.Errorf("Failed to close OCM connection: %v", err)
 		}
 	}()
 
-	ocmRoles, err := listOCMRoles(awsClient, ocmClient)
+	userRoles, err := listUserRoles(awsClient, ocmClient)
 	if err != nil {
-		reporter.Errorf("Failed to get ocm roles: %v", err)
+		reporter.Errorf("Failed to get user roles: %v", err)
 		os.Exit(1)
 	}
 
-	if len(ocmRoles) == 0 {
-		reporter.Infof("No ocm roles available")
+	if len(userRoles) == 0 {
+		reporter.Infof("No user roles available")
 		os.Exit(0)
 	}
 	if output.HasFlag() {
-		err = output.Print(ocmRoles)
+		err = output.Print(userRoles)
 		if err != nil {
 			reporter.Errorf("%s", err)
 			os.Exit(1)
@@ -94,36 +75,38 @@ func run(_ *cobra.Command, _ []string) {
 
 	// Create the writer that will be used to print the tabulated results:
 	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprint(writer, "ROLE NAME\tROLE ARN\tLINKED\tADMIN\n")
-	for _, ocmRole := range ocmRoles {
-		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\n", ocmRole.RoleName, ocmRole.RoleARN, ocmRole.Linked, ocmRole.Admin)
+	fmt.Fprint(writer, "ROLE NAME\tROLE ARN\tLINKED\n")
+	for _, userRole := range userRoles {
+		fmt.Fprintf(writer, "%s\t%s\t%s\n", userRole.RoleName, userRole.RoleARN, userRole.Linked)
 	}
 	writer.Flush()
 }
 
-func listOCMRoles(awsClient aws.Client, ocmClient *ocm.Client) ([]aws.Role, error) {
-	ocmRoles, err := awsClient.ListOCMRoles()
+func listUserRoles(awsClient aws.Client, ocmClient *ocm.Client) ([]aws.Role, error) {
+	userRoles, err := awsClient.ListUserRoles()
 	if err != nil {
 		return nil, err
 	}
 
-	// Check if roles are linked to organization
-	orgID, _, err := ocmClient.GetCurrentOrganization()
+	// Check if roles are linked to account
+	account, err := ocmClient.GetCurrentAccount()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get organization account: %v", err)
+		return nil, fmt.Errorf("Failed to get Redhat User Account: %v", err)
 	}
-	linkedRoles, err := ocmClient.GetOrganizationLinkedOCMRoles(orgID)
+	linkedRoles, err := ocmClient.GetAccountLinkedUserRoles(account.ID())
 	if err != nil {
 		return nil, err
 	}
 
-	for i := range ocmRoles {
-		if helper.Contains(linkedRoles, ocmRoles[i].RoleARN) {
-			ocmRoles[i].Linked = "Yes"
+	linkedRolesMap := helper.SliceToMap(linkedRoles)
+	for i := range userRoles {
+		_, exist := linkedRolesMap[userRoles[i].RoleARN]
+		if exist {
+			userRoles[i].Linked = "Yes"
 		} else {
-			ocmRoles[i].Linked = "No"
+			userRoles[i].Linked = "No"
 		}
 	}
 
-	return ocmRoles, nil
+	return userRoles, nil
 }

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -9,3 +9,13 @@ func Contains(s []string, str string) bool {
 
 	return false
 }
+
+func SliceToMap(s []string) map[string]bool {
+	m := make(map[string]bool)
+
+	for _, v := range s {
+		m[v] = true
+	}
+
+	return m
+}

--- a/pkg/ocm/client.go
+++ b/pkg/ocm/client.go
@@ -18,6 +18,7 @@ package ocm
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -26,6 +27,7 @@ import (
 
 	"github.com/openshift/rosa/pkg/info"
 	"github.com/openshift/rosa/pkg/logging"
+	"github.com/openshift/rosa/pkg/reporter"
 )
 
 type Client struct {
@@ -42,6 +44,18 @@ type ClientBuilder struct {
 // NewClient creates a builder that can then be used to configure and build an OCM connection.
 func NewClient() *ClientBuilder {
 	return &ClientBuilder{}
+}
+
+func CreateNewClientOrExit(logger *logrus.Logger, reporter *reporter.Object) *Client {
+	client, err := NewClient().
+		Logger(logger).
+		Build()
+	if err != nil {
+		reporter.Errorf("Failed to create OCM connection: %v", err)
+		os.Exit(1)
+	}
+
+	return client
 }
 
 // Logger sets the logger that the connection will use to send messages to the log. This is

--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -52,7 +52,8 @@ const (
 	Username  = "Username"
 	URL       = "URL"
 
-	OCMRoleLabel = "sts_ocm_role"
+	OCMRoleLabel  = "sts_ocm_role"
+	USERRoleLabel = "sts_user_role"
 )
 
 // Regular expression to used to make sure that the identifier or name given by the user is
@@ -357,7 +358,17 @@ func (c *Client) LinkOrgToRole(orgID string, roleARN string) (bool, error) {
 	return true, nil
 }
 
-func (c *Client) GetLinkedRoles(orgID string) ([]string, error) {
+func (c *Client) GetAccountLinkedUserRoles(accountID string) ([]string, error) {
+	resp, err := c.ocm.AccountsMgmt().V1().Accounts().Account(accountID).
+		Labels().Labels(USERRoleLabel).Get().Send()
+	if err != nil && resp.Status() != http.StatusNotFound {
+		return nil, handleErr(resp.Error(), err)
+	}
+
+	return strings.Split(resp.Body().Value(), ","), nil
+}
+
+func (c *Client) GetOrganizationLinkedOCMRoles(orgID string) ([]string, error) {
 	resp, err := c.ocm.AccountsMgmt().V1().Organizations().Organization(orgID).
 		Labels().Labels(OCMRoleLabel).Get().Send()
 	if err != nil && resp.Status() != http.StatusNotFound {


### PR DESCRIPTION
The new command is implemented similarly to the `rosa list ocm-roles` command.
The code checks if a `role name` contains the `User` infix and in addition,
checks if the role has the tag `rosa_role_type: User`, because 'user' is a common word.

![image](https://user-images.githubusercontent.com/57869309/153199329-dd9fbdaa-a2b3-49d4-985f-bf918c229688.png)

Related: [SDA-5412](https://issues.redhat.com/browse/SDA-5412)