### PR TITLE
Create command 'rosa unlink ocm-role'

### DIFF
--- a/cmd/rosa/main.go
+++ b/cmd/rosa/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/openshift/rosa/cmd/resume"
 	"github.com/openshift/rosa/cmd/revoke"
 	"github.com/openshift/rosa/cmd/uninstall"
+	"github.com/openshift/rosa/cmd/unlink"
 	"github.com/openshift/rosa/cmd/upgrade"
 	"github.com/openshift/rosa/cmd/verify"
 	"github.com/openshift/rosa/cmd/version"
@@ -83,6 +84,7 @@ func init() {
 	root.AddCommand(hibernate.Cmd)
 	root.AddCommand(resume.Cmd)
 	root.AddCommand(link.Cmd)
+	root.AddCommand(unlink.Cmd)
 }
 
 func main() {

--- a/cmd/unlink/cmd.go
+++ b/cmd/unlink/cmd.go
@@ -1,0 +1,38 @@
+/*
+Copyright (c) 2022 Red Hat, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unlink
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/cmd/unlink/ocmrole"
+	"github.com/openshift/rosa/pkg/arguments"
+	"github.com/openshift/rosa/pkg/interactive/confirm"
+)
+
+var Cmd = &cobra.Command{
+	Use:     "unlink",
+	Aliases: []string{"unlink"},
+	Short:   "Unlink a resource from stdin",
+	Long:    "Unlink a resource from stdin",
+	Hidden:  true,
+}
+
+func init() {
+	Cmd.AddCommand(ocmrole.Cmd)
+
+	flags := Cmd.PersistentFlags()
+	arguments.AddProfileFlag(flags)
+	confirm.AddFlag(flags)
+}

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -19,3 +19,14 @@ func SliceToMap(s []string) map[string]bool {
 
 	return m
 }
+
+// RemoveStrFromSlice removes one occurrence of 'str' from the 's' slice if exists.
+func RemoveStrFromSlice(s []string, str string) []string {
+	for i, v := range s {
+		if v == str {
+			return append(s[:i], s[i+1:]...)
+		}
+	}
+
+	return s
+}


### PR DESCRIPTION
The new command modifies the `sts_ocm_role` label's value.
If the role is the last one linked to the organization,
the 'sts_ocm_role' will be removed.
Otherwise, only the label's value will be updated.

Related: [SDA-5410](https://issues.redhat.com/browse/SDA-5410)