### PR TITLE
Add 'rosa delete ocm-role' command

### DIFF
--- a/cmd/dlt/cmd.go
+++ b/cmd/dlt/cmd.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openshift/rosa/cmd/dlt/idp"
 	"github.com/openshift/rosa/cmd/dlt/ingress"
 	"github.com/openshift/rosa/cmd/dlt/machinepool"
+	"github.com/openshift/rosa/cmd/dlt/ocmrole"
 	"github.com/openshift/rosa/cmd/dlt/oidcprovider"
 	"github.com/openshift/rosa/cmd/dlt/operatorrole"
 	"github.com/openshift/rosa/cmd/dlt/upgrade"
@@ -49,6 +50,7 @@ func init() {
 	Cmd.AddCommand(oidcprovider.Cmd)
 	Cmd.AddCommand(operatorrole.Cmd)
 	Cmd.AddCommand(accountroles.Cmd)
+	Cmd.AddCommand(ocmrole.Cmd)
 
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)

--- a/cmd/dlt/ocmrole/cmd.go
+++ b/cmd/dlt/ocmrole/cmd.go
@@ -1,0 +1,239 @@
+/*
+  Copyright (c) 2022 Red Hat, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+*/
+
+package ocmrole
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/spf13/cobra"
+
+	unlinkocmrole "github.com/openshift/rosa/cmd/unlink/ocmrole"
+	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/helper"
+	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/interactive/confirm"
+	"github.com/openshift/rosa/pkg/logging"
+	"github.com/openshift/rosa/pkg/ocm"
+	rprtr "github.com/openshift/rosa/pkg/reporter"
+)
+
+var args struct {
+	roleARN string
+}
+
+var Cmd = &cobra.Command{
+	Use:     "ocm-role",
+	Aliases: []string{"ocmrole"},
+	Short:   "Delete ocm role",
+	Long:    "Delete ocm role from the current AWS account",
+	Example: ` # Delete ocm role
+rosa delete ocm-role --role-arn arn:aws:iam::123456789012:role/xxx-OCM-Role-1223456778`,
+	RunE: run,
+}
+
+func init() {
+	flags := Cmd.Flags()
+
+	flags.StringVar(
+		&args.roleARN,
+		"role-arn",
+		"",
+		"Role ARN to delete from the OCM organization account")
+
+	aws.AddModeFlag(Cmd)
+
+	confirm.AddFlag(flags)
+	interactive.AddFlag(flags)
+}
+
+func run(cmd *cobra.Command, argv []string) error {
+	reporter := rprtr.CreateReporterOrExit()
+	logger := logging.CreateLoggerOrExit(reporter)
+	awsClient := aws.CreateNewClientOrExit(logger, reporter)
+	ocmClient := ocm.CreateNewClientOrExit(logger, reporter)
+	defer func() {
+		err := ocmClient.Close()
+		if err != nil {
+			reporter.Errorf("Failed to close OCM connection: %v", err)
+		}
+	}()
+
+	mode, err := aws.GetMode()
+	if err != nil {
+		reporter.Errorf("%s", err)
+		os.Exit(1)
+	}
+
+	orgID, _, err := ocmClient.GetCurrentOrganization()
+	if err != nil {
+		reporter.Errorf("Error getting organization account: %v", err)
+		return err
+	}
+
+	if len(argv) > 0 {
+		args.roleARN = argv[0]
+	}
+
+	// Determine if interactive mode is needed
+	if !interactive.Enabled() && (!cmd.Flags().Changed("mode")) {
+		interactive.Enable()
+	}
+
+	if reporter.IsTerminal() {
+		reporter.Infof("Deleting OCM role")
+	}
+
+	roleARN := args.roleARN
+
+	if !interactive.Enabled() && roleARN == "" {
+		interactive.Enable()
+	}
+
+	if interactive.Enabled() {
+		roleARN, err = interactive.GetString(interactive.Input{
+			Question: "OCM Role ARN",
+			Help:     cmd.Flags().Lookup("role-arn").Usage,
+			Default:  roleARN,
+			Required: true,
+			Validators: []interactive.Validator{
+				aws.ARNValidator,
+			},
+		})
+		if err != nil {
+			reporter.Errorf("Expected a valid ocm role ARN to delete from the current organization: %s", err)
+			os.Exit(1)
+		}
+	}
+	if roleARN != "" {
+		_, err := arn.Parse(roleARN)
+		if err != nil {
+			reporter.Errorf("Expected a valid ocm role ARN to delete from the current organization: %s", err)
+			os.Exit(1)
+		}
+	}
+	if !confirm.Prompt(true, "Delete '%s' ocm role?", roleARN) {
+		os.Exit(0)
+	}
+
+	linkedRoles, err := ocmClient.GetOrganizationLinkedOCMRoles(orgID)
+	if err != nil {
+		reporter.Errorf("An error occurred while trying to get the organization linked roles: %s", err)
+		os.Exit(1)
+	}
+	isLinked := helper.Contains(linkedRoles, roleARN)
+
+	if interactive.Enabled() {
+		mode, err = interactive.GetOption(interactive.Input{
+			Question: "OCM role deletion mode",
+			Help:     cmd.Flags().Lookup("mode").Usage,
+			Default:  aws.ModeAuto,
+			Options:  aws.Modes,
+			Required: true,
+		})
+		if err != nil {
+			reporter.Errorf("Expected a valid OCM role deletion mode: %s", err)
+			os.Exit(1)
+		}
+	}
+
+	roleName, err := aws.RoleARNToRoleName(roleARN)
+	if err != nil {
+		reporter.Errorf("%s", err)
+		os.Exit(1)
+	}
+	switch mode {
+	case aws.ModeAuto:
+		ocmClient.LogEvent("ROSADeleteOCMRoleModeAuto", nil)
+		if isLinked {
+			reporter.Warnf("Role ARN '%s' is linked to organization '%s'", roleARN, orgID)
+			err = unlinkocmrole.Cmd.RunE(unlinkocmrole.Cmd, []string{roleARN})
+			if err != nil {
+				reporter.Errorf("Unable to unlink role ARN '%s' from organization : '%s' : %v",
+					roleARN, orgID, err)
+			}
+		}
+		err := awsClient.DeleteOCMRole(roleName)
+		if err != nil {
+			reporter.Errorf("There was an error deleting the OCM role: %s", err)
+			os.Exit(1)
+		}
+		reporter.Infof("Successfully deleted the OCM role")
+	case aws.ModeManual:
+		ocmClient.LogEvent("ROSADeleteOCMRoleModeManual", nil)
+		commands, err := buildCommands(roleName, roleARN, isLinked, awsClient)
+		if err != nil {
+			reporter.Errorf("%s", err)
+			os.Exit(1)
+		}
+		if reporter.IsTerminal() {
+			reporter.Infof("Run the following commands to delete the OCM role:\n")
+		}
+		fmt.Println(commands)
+	default:
+		reporter.Errorf("Invalid mode. Allowed values are %s", aws.Modes)
+		os.Exit(1)
+	}
+
+	return nil
+}
+
+func buildCommands(roleName string, roleARN string, isLinked bool, awsClient aws.Client) (string, error) {
+	var commands []string
+
+	if isLinked {
+		unlinkRole := fmt.Sprintf("rosa unlink ocm-role \\\n"+
+			"\t--role-arn %s", roleARN)
+		commands = append(commands, unlinkRole)
+	}
+
+	policies, err := awsClient.GetAttachedPolicy(&roleName)
+	if err != nil {
+		return "", err
+	}
+	for _, policy := range policies {
+		detachPolicy := fmt.Sprintf("aws iam detach-role-policy \\\n"+
+			"\t--role-name %s \\\n"+
+			"\t--policy-arn %s",
+			roleName, policy.PolicyArn)
+		commands = append(commands, detachPolicy)
+		deletePolicy := fmt.Sprintf("aws iam delete-policy \\\n"+
+			"\t--policy-arn %s",
+			policy.PolicyArn)
+		commands = append(commands, deletePolicy)
+	}
+
+	hasPermissionBoundary, err := awsClient.HasPermissionsBoundary(roleName)
+	if err != nil {
+		return "", err
+	}
+	if hasPermissionBoundary {
+		deletePermissionBoundary := fmt.Sprintf("aws iam delete-role-permissions-boundary \\\n"+
+			"\t--role-name %s",
+			roleName)
+		commands = append(commands, deletePermissionBoundary)
+	}
+
+	deleteRole := fmt.Sprintf("aws iam delete-role \\\n"+
+		"\t--role-name %s", roleName)
+	commands = append(commands, deleteRole)
+
+	return strings.Join(commands, "\n"), nil
+}

--- a/cmd/unlink/ocmrole/cmd.go
+++ b/cmd/unlink/ocmrole/cmd.go
@@ -101,7 +101,7 @@ func run(cmd *cobra.Command, argv []string) (err error) {
 		interactive.Enable()
 	}
 
-	if interactive.Enabled() {
+	if interactive.Enabled() && roleArn == "" {
 		roleArn, err = interactive.GetString(interactive.Input{
 			Question: "OCM Role ARN",
 			Help:     cmd.Flags().Lookup("role-arn").Usage,

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -114,7 +114,10 @@ type Client interface {
 	GetAccountRoleForCurrentEnv(env string, roleName string) (Role, error)
 	GetAccountRoleForCurrentEnvWithPrefix(env string, rolePrefix string) ([]Role, error)
 	DeleteAccountRole(roles string) error
+	DeleteOCMRole(roleARN string) error
 	GetAccountRolePolicies(roles []string) (map[string][]PolicyDetail, error)
+	GetAttachedPolicy(role *string) ([]PolicyDetail, error)
+	HasPermissionsBoundary(roleName string) (bool, error)
 	GetOpenIDConnectProvider(clusterID string) (string, error)
 	GetInstanceProfilesForRole(role string) ([]string, error)
 	IsUpgradedNeededForAccountRolePolicies(rolePrefix string, version string) (bool, error)

--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -993,7 +993,7 @@ func (c *awsClient) deleteAccountRolePolicies(role *string) error {
 	}
 	return nil
 }
-func (c *awsClient) getAttachedPolicy(role *string) ([]PolicyDetail, error) {
+func (c *awsClient) GetAttachedPolicy(role *string) ([]PolicyDetail, error) {
 	policies := []PolicyDetail{}
 	attachedPoliciesOutput, err := c.iamClient.ListAttachedRolePolicies(&iam.ListAttachedRolePoliciesInput{RoleName: role})
 	if err != nil {
@@ -1301,7 +1301,7 @@ func getAWSPrincipals(awsPrincipal interface{}) []string {
 func (c *awsClient) GetAccountRolePolicies(roles []string) (map[string][]PolicyDetail, error) {
 	roleMap := make(map[string][]PolicyDetail)
 	for _, role := range roles {
-		policies, err := c.getAttachedPolicy(aws.String(role))
+		policies, err := c.GetAttachedPolicy(aws.String(role))
 		if err != nil {
 			if aerr, ok := err.(awserr.Error); ok {
 				switch aerr.Code() {
@@ -1448,7 +1448,7 @@ func (c *awsClient) IsUpgradedNeededForOperatorRolePoliciesUsingPrefix(prefix st
 
 func (c *awsClient) validateRoleUpgradeVersionCompatibility(roleName string,
 	version string) (bool, error) {
-	attachedPolicies, err := c.getAttachedPolicy(aws.String(roleName))
+	attachedPolicies, err := c.GetAttachedPolicy(aws.String(roleName))
 	if err != nil {
 		return false, err
 	}

--- a/pkg/aws/sts.go
+++ b/pkg/aws/sts.go
@@ -1,0 +1,118 @@
+/*
+Copyright (c) 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/pkg/errors"
+)
+
+func (c *awsClient) DeleteOCMRole(roleName string) error {
+	err := c.deleteOCMRolePolicies(roleName)
+	if err != nil {
+		return err
+	}
+
+	err = c.deletePermissionsBoundary(roleName)
+	if err != nil {
+		return err
+	}
+
+	return c.DeleteRole(roleName, aws.String(roleName))
+}
+
+func RoleARNToRoleName(roleARN string) (string, error) {
+	parsedARN, err := arn.Parse(roleARN)
+	if err != nil {
+		return "", err
+	}
+
+	// ARN = arn:aws:iam::123456789123:role/prefix-OCM-Role-12345678 --> ARN.Resource = role/prefix-OCM-Role-12541229
+	ARNResourceSubStr := strings.SplitN(parsedARN.Resource, "/", 2)
+	if len(ARNResourceSubStr) > 1 {
+		return ARNResourceSubStr[1], nil
+	}
+
+	return "", errors.Errorf("Couldn't extract the role name from role ARN")
+}
+
+func (c *awsClient) HasPermissionsBoundary(roleName string) (bool, error) {
+	output, err := c.iamClient.GetRole(&iam.GetRoleInput{
+		RoleName: aws.String(roleName),
+	})
+	if err != nil {
+		return false, err
+	}
+
+	return output.Role.PermissionsBoundary != nil, nil
+}
+
+func (c *awsClient) deletePermissionsBoundary(roleName string) error {
+	output, err := c.iamClient.GetRole(&iam.GetRoleInput{
+		RoleName: aws.String(roleName),
+	})
+	if err != nil {
+		return err
+	}
+
+	if output.Role.PermissionsBoundary != nil {
+		_, err := c.iamClient.DeleteRolePermissionsBoundary(&iam.DeleteRolePermissionsBoundaryInput{
+			RoleName: aws.String(roleName),
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *awsClient) deleteOCMRolePolicies(roleName string) error {
+	policiesOutput, err := c.iamClient.ListAttachedRolePolicies(&iam.ListAttachedRolePoliciesInput{
+		RoleName: aws.String(roleName),
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, policy := range policiesOutput.AttachedPolicies {
+		_, err := c.iamClient.DetachRolePolicy(&iam.DetachRolePolicyInput{
+			PolicyArn: policy.PolicyArn,
+			RoleName:  aws.String(roleName),
+		})
+		if err != nil {
+			return err
+		}
+
+		_, err = c.iamClient.DeletePolicy(&iam.DeletePolicyInput{PolicyArn: policy.PolicyArn})
+		if err != nil {
+			if awsErr, ok := err.(awserr.Error); ok {
+				if awsErr.Code() == iam.ErrCodeDeleteConflictException { // policy is attached to another entity
+					continue
+				}
+			}
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
The new command follows these steps:
1. Unlink role if needed.
2. Detach Attached role policies.
3. Delete the policies from step 2.
4. Delete permissions boundary (doesn't delete the policy).
5. Delete role.

![image](https://user-images.githubusercontent.com/57869309/154045644-7c435f29-1255-4cd3-8e67-15948991ccf8.png)

Related: [SDA-5202](https://issues.redhat.com/browse/SDA-5202)