### PR TITLE
Add 'rosa delete user-role' command

### DIFF
--- a/cmd/dlt/cmd.go
+++ b/cmd/dlt/cmd.go
@@ -29,6 +29,7 @@ import (
 	"github.com/openshift/rosa/cmd/dlt/oidcprovider"
 	"github.com/openshift/rosa/cmd/dlt/operatorrole"
 	"github.com/openshift/rosa/cmd/dlt/upgrade"
+	"github.com/openshift/rosa/cmd/dlt/userrole"
 	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 )
@@ -51,6 +52,7 @@ func init() {
 	Cmd.AddCommand(operatorrole.Cmd)
 	Cmd.AddCommand(accountroles.Cmd)
 	Cmd.AddCommand(ocmrole.Cmd)
+	Cmd.AddCommand(userrole.Cmd)
 
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)

--- a/cmd/unlink/userrole/cmd.go
+++ b/cmd/unlink/userrole/cmd.go
@@ -84,7 +84,7 @@ func run(cmd *cobra.Command, argv []string) (err error) {
 		currentAccount, err := ocmClient.GetCurrentAccount()
 		if err != nil {
 			reporter.Errorf("Error getting current account: %v", err)
-			return err
+			os.Exit(1)
 		}
 		accountID = currentAccount.ID()
 	}
@@ -100,7 +100,7 @@ func run(cmd *cobra.Command, argv []string) (err error) {
 		interactive.Enable()
 	}
 
-	if interactive.Enabled() {
+	if interactive.Enabled() && roleArn == "" {
 		roleArn, err = interactive.GetString(interactive.Input{
 			Question: "User Role ARN",
 			Help:     cmd.Flags().Lookup("role-arn").Usage,
@@ -132,11 +132,11 @@ func run(cmd *cobra.Command, argv []string) (err error) {
 			reporter.Errorf("Only organization admin can run this command. "+
 				"Please ask someone with the organization admin role to run the following command \n\n"+
 				"\t rosa unlink user-role --role-arn %s --account-id %s", roleArn, accountID)
-			return err
+			os.Exit(1)
 		}
 		reporter.Errorf("Unable to unlink role ARN '%s' from the account id : '%s' : %v",
 			args.roleArn, accountID, err)
-		return err
+		os.Exit(1)
 	}
 	reporter.Infof("Successfully unlinked role ARN '%s' from account '%s'", roleArn, accountID)
 	return nil

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -115,6 +115,7 @@ type Client interface {
 	GetAccountRoleForCurrentEnvWithPrefix(env string, rolePrefix string) ([]Role, error)
 	DeleteAccountRole(roles string) error
 	DeleteOCMRole(roleARN string) error
+	DeleteUserRole(roleName string) error
 	GetAccountRolePolicies(roles []string) (map[string][]PolicyDetail, error)
 	GetAttachedPolicy(role *string) ([]PolicyDetail, error)
 	HasPermissionsBoundary(roleName string) (bool, error)

--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -950,7 +950,7 @@ func (c *awsClient) DeleteAccountRole(roleName string) error {
 	return c.DeleteRole(roleName, role)
 }
 
-func (c *awsClient) deleteAccountRolePolicies(role *string) error {
+func (c *awsClient) detachAttachedRolePolicies(role *string) error {
 	attachedPoliciesOutput, err := c.iamClient.ListAttachedRolePolicies(&iam.ListAttachedRolePoliciesInput{
 		RoleName: role,
 	})
@@ -972,6 +972,11 @@ func (c *awsClient) deleteAccountRolePolicies(role *string) error {
 			return err
 		}
 	}
+
+	return nil
+}
+
+func (c *awsClient) deleteInlineRolePolicies(role *string) error {
 	listRolePolicyOutput, err := c.iamClient.ListRolePolicies(&iam.ListRolePoliciesInput{RoleName: role})
 	if err != nil {
 		return err
@@ -991,6 +996,20 @@ func (c *awsClient) deleteAccountRolePolicies(role *string) error {
 			return err
 		}
 	}
+
+	return nil
+}
+
+func (c *awsClient) deleteAccountRolePolicies(role *string) error {
+	err := c.detachAttachedRolePolicies(role)
+	if err != nil {
+		return err
+	}
+	err = c.deleteInlineRolePolicies(role)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 func (c *awsClient) GetAttachedPolicy(role *string) ([]PolicyDetail, error) {

--- a/pkg/aws/sts.go
+++ b/pkg/aws/sts.go
@@ -26,6 +26,20 @@ import (
 	"github.com/pkg/errors"
 )
 
+func (c *awsClient) DeleteUserRole(roleName string) error {
+	err := c.detachAttachedRolePolicies(aws.String(roleName))
+	if err != nil {
+		return err
+	}
+
+	err = c.deletePermissionsBoundary(roleName)
+	if err != nil {
+		return err
+	}
+
+	return c.DeleteRole(roleName, aws.String(roleName))
+}
+
 func (c *awsClient) DeleteOCMRole(roleName string) error {
 	err := c.deleteOCMRolePolicies(roleName)
 	if err != nil {


### PR DESCRIPTION
The new command is implemented similarly to `rosa delete ocm-role`.
1. Unlink user role if needed.
2. Detach attached role policies.
3. Delete permission boundary (doesn't delete the policy).
4. Delete role.

![image](https://user-images.githubusercontent.com/57869309/154234290-b10607d8-a972-433e-a944-6162d7a1e22e.png)

Related: [SDA-5437](https://issues.redhat.com/browse/SDA-5437)