### PR TITLE
Display HTPasswd IDP when listing a cluster's IDPs

### DIFF
--- a/cmd/list/idp/cmd.go
+++ b/cmd/list/idp/cmd.go
@@ -127,9 +127,6 @@ func run(_ *cobra.Command, _ []string) {
 	fmt.Fprintf(writer, "NAME\t\tTYPE\t\tAUTH URL\n")
 	for _, idp := range idps {
 		idpType := ocm.IdentityProviderType(idp)
-		if idpType == "htpasswd" {
-			continue
-		}
 		fmt.Fprintf(writer, "%s\t\t%s\t\t%s\n", idp.Name(), idpType, getAuthURL(cluster, idp.Name()))
 	}
 	writer.Flush()


### PR DESCRIPTION
Now that the HTPasswd IDP has been [introduced to ROSA](https://github.com/openshift/rosa/pull/608), we can stop hiding it when listing the IDPs.