### PR TITLE
List roles - display a spinner while fetching the roles

### DIFF
--- a/cmd/list/accountroles/cmd.go
+++ b/cmd/list/accountroles/cmd.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"os"
 	"text/tabwriter"
+	"time"
 
+	"github.com/briandowns/spinner"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/pkg/aws"
@@ -96,7 +98,20 @@ func run(_ *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
+	var spin *spinner.Spinner
+	if reporter.IsTerminal() {
+		spin = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+	}
+	if spin != nil {
+		reporter.Infof("Fetching account roles")
+		spin.Start()
+	}
+
 	accountRoles, err := awsClient.ListAccountRoles(args.version)
+
+	if spin != nil {
+		spin.Stop()
+	}
 
 	if err != nil {
 		reporter.Errorf("Failed to get account roles: %v", err)

--- a/cmd/list/ocmroles/cmd.go
+++ b/cmd/list/ocmroles/cmd.go
@@ -20,6 +20,9 @@ import (
 	"fmt"
 	"os"
 	"text/tabwriter"
+	"time"
+
+	"github.com/briandowns/spinner"
 
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/helper"
@@ -73,7 +76,21 @@ func run(_ *cobra.Command, _ []string) {
 		}
 	}()
 
+	var spin *spinner.Spinner
+	if reporter.IsTerminal() {
+		spin = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+	}
+	if spin != nil {
+		reporter.Infof("Fetching ocm roles")
+		spin.Start()
+	}
+
 	ocmRoles, err := listOCMRoles(awsClient, ocmClient)
+
+	if spin != nil {
+		spin.Stop()
+	}
+
 	if err != nil {
 		reporter.Errorf("Failed to get ocm roles: %v", err)
 		os.Exit(1)

--- a/cmd/list/userroles/cmd.go
+++ b/cmd/list/userroles/cmd.go
@@ -17,6 +17,9 @@ import (
 	"fmt"
 	"os"
 	"text/tabwriter"
+	"time"
+
+	"github.com/briandowns/spinner"
 
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/helper"
@@ -54,7 +57,21 @@ func run(_ *cobra.Command, _ []string) {
 		}
 	}()
 
+	var spin *spinner.Spinner
+	if reporter.IsTerminal() {
+		spin = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+	}
+	if spin != nil {
+		reporter.Infof("Fetching user roles")
+		spin.Start()
+	}
+
 	userRoles, err := listUserRoles(awsClient, ocmClient)
+
+	if spin != nil {
+		spin.Stop()
+	}
+
 	if err != nil {
 		reporter.Errorf("Failed to get user roles: %v", err)
 		os.Exit(1)


### PR DESCRIPTION
The command of fetching the roles with the AWS client can take some time when
there are a lot of roles in an account.
A spinner was added to `list ocm-roles`, `list user-roles`, and `list account-roles`
to improve the user experience.

https://user-images.githubusercontent.com/57869309/155566837-cc94abab-804f-4984-b826-bce2e1c00392.mp4


