### PR TITLE
Fix bug - deletion of a role with the wrong account ID in role ARN

### DIFF
--- a/cmd/dlt/ocmrole/cmd.go
+++ b/cmd/dlt/ocmrole/cmd.go
@@ -130,6 +130,12 @@ func run(cmd *cobra.Command, argv []string) error {
 		}
 	}
 
+	err = awsClient.ValidateRoleARNAccountIDMatchCallerAccountID(roleARN)
+	if err != nil {
+		reporter.Errorf("%s", err)
+		os.Exit(1)
+	}
+
 	if !confirm.Prompt(true, "Delete '%s' ocm role?", roleARN) {
 		os.Exit(0)
 	}

--- a/cmd/dlt/userrole/cmd.go
+++ b/cmd/dlt/userrole/cmd.go
@@ -118,6 +118,13 @@ func run(cmd *cobra.Command, argv []string) {
 			os.Exit(1)
 		}
 	}
+
+	err = awsClient.ValidateRoleARNAccountIDMatchCallerAccountID(roleARN)
+	if err != nil {
+		reporter.Errorf("%s", err)
+		os.Exit(1)
+	}
+
 	if !confirm.Prompt(true, "Delete the '%s' role from the AWS account?", roleARN) {
 		os.Exit(0)
 	}

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -79,6 +79,7 @@ type Client interface {
 	CheckAdminUserExists(userName string) (err error)
 	CheckStackReadyOrNotExisting(stackName string) (stackReady bool, stackStatus *string, err error)
 	CheckRoleExists(roleName string) (bool, string, error)
+	ValidateRoleARNAccountIDMatchCallerAccountID(roleARN string) error
 	GetIAMCredentials() (credentials.Value, error)
 	GetRegion() string
 	ValidateCredentials() (isValid bool, err error)


### PR DESCRIPTION
To delete a role using the AWS client the role name is sufficient.

For `delete ocm-role` and `delete user-role`, we ask the user to enter the whole role ARN,
in order to unlink the role in case it's linked, and to be consistent with other ROSA commands.

This PR adds validation to check if the user account ID match the role ARN account ID,
if not, an error message will be displayed and the program will terminate.

Related: [SDA-5544](https://issues.redhat.com/browse/SDA-5544)

![image](https://user-images.githubusercontent.com/57869309/155877915-ae4b66b1-567c-4afd-8619-05ebd9fc7452.png)
