### PR TITLE
HTPasswd bug fixes corresponding with some CS changes

### DIFF
--- a/cmd/create/admin/cmd.go
+++ b/cmd/create/admin/cmd.go
@@ -115,8 +115,8 @@ func run(cmd *cobra.Command, _ []string) {
 
 	// Try to find an existing htpasswd identity provider and
 	// check if cluster-admin user already exists
-	existingHTPasswdIDP := idp.FindExistingHTPasswdIDP(cluster, ocmClient)
-	if idp.HasClusterAdmin(existingHTPasswdIDP) {
+	existingHTPasswdIDP, existingUserList := idp.FindExistingHTPasswdIDP(cluster, ocmClient)
+	if idp.HasClusterAdmin(existingUserList) {
 		reporter.Errorf("Cluster '%s' already has an admin", clusterKey)
 		os.Exit(1)
 	}

--- a/cmd/dlt/admin/cmd.go
+++ b/cmd/dlt/admin/cmd.go
@@ -124,16 +124,6 @@ func run(cmd *cobra.Command, _ []string) {
 				idp.ClusterAdminUsername, clusterKey, err)
 			os.Exit(1)
 		}
-
-		// Delete admin user from the cluster-admins group:
-		reporter.Debugf("Deleting '%s' user from cluster-admins group on cluster '%s'", idp.ClusterAdminUsername, clusterKey)
-		err = ocmClient.DeleteUser(cluster.ID(), "cluster-admins", idp.ClusterAdminUsername)
-		if err != nil {
-			reporter.Errorf("Failed to delete '%s' user from cluster '%s': %s",
-				idp.ClusterAdminUsername, clusterKey, err)
-			os.Exit(1)
-		}
-
 		reporter.Infof("Admin user '%s' has been deleted from cluster '%s'", idp.ClusterAdminUsername, clusterKey)
 	}
 }

--- a/pkg/ocm/idps.go
+++ b/pkg/ocm/idps.go
@@ -47,6 +47,15 @@ func (c *Client) CreateIdentityProvider(clusterID string, idp *cmv1.IdentityProv
 	return response.Body(), nil
 }
 
+func (c *Client) GetHTPasswdUserList(clusterID, htpasswdIDPId string) (*cmv1.HTPasswdUserList, error) {
+	listResponse, err := c.ocm.ClustersMgmt().V1().Clusters().Cluster(clusterID).
+		IdentityProviders().IdentityProvider(htpasswdIDPId).HtpasswdUsers().List().Send()
+	if err != nil {
+		return nil, handleErr(listResponse.Error(), err)
+	}
+	return listResponse.Items(), nil
+}
+
 func (c *Client) AddHTPasswdUser(username, password, clusterID, idpID string) error {
 	htpasswdUser, _ := cmv1.NewHTPasswdUser().Username(username).Password(password).Build()
 	response, err := c.ocm.ClustersMgmt().V1().Clusters().Cluster(clusterID).


### PR DESCRIPTION
In this MR:

- Correctly fetch the HTPasswd user list to if idp indeed `HasClusterAdmin`
- Don't dispatch the request to delete the `cluster-admin` user from the `cluster-admins` group, since this is now done on the CS side. 