### PR TITLE
Fix bug - `delete ocm-role` should be hidden in rosa cli

### DIFF
--- a/cmd/dlt/ocmrole/cmd.go
+++ b/cmd/dlt/ocmrole/cmd.go
@@ -46,7 +46,8 @@ var Cmd = &cobra.Command{
 	Long:    "Delete ocm role from the current AWS account",
 	Example: ` # Delete ocm role
 rosa delete ocm-role --role-arn arn:aws:iam::123456789012:role/xxx-OCM-Role-1223456778`,
-	RunE: run,
+	RunE:   run,
+	Hidden: true,
 }
 
 func init() {


### PR DESCRIPTION
Related: [SDA-5558](https://issues.redhat.com/browse/SDA-5558)