### PR TITLE
Fix bug - validate role type before deletion

### DIFF
--- a/cmd/dlt/ocmrole/cmd.go
+++ b/cmd/dlt/ocmrole/cmd.go
@@ -167,6 +167,12 @@ func run(cmd *cobra.Command, argv []string) error {
 		reporter.Errorf("%s", err)
 		os.Exit(1)
 	}
+
+	if !aws.IsOCMRole(&roleName) {
+		reporter.Errorf("Role '%s' is not an OCM role", roleName)
+		os.Exit(1)
+	}
+
 	switch mode {
 	case aws.ModeAuto:
 		ocmClient.LogEvent("ROSADeleteOCMRoleModeAuto", nil)

--- a/cmd/dlt/userrole/cmd.go
+++ b/cmd/dlt/userrole/cmd.go
@@ -161,6 +161,17 @@ func run(cmd *cobra.Command, argv []string) {
 		reporter.Errorf("%s", err)
 		os.Exit(1)
 	}
+
+	isUserRole, err := awsClient.IsUserRole(&roleName)
+	if err != nil {
+		reporter.Errorf("%s", err)
+		os.Exit(1)
+	}
+	if !isUserRole {
+		reporter.Errorf("Role '%s' is not a user role", roleName)
+		os.Exit(1)
+	}
+
 	switch mode {
 	case aws.ModeAuto:
 		ocmClient.LogEvent("ROSADeleteUserMRoleModeAuto", nil)

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -131,6 +131,7 @@ type Client interface {
 	GetAccountRoleVersion(roleName string) (string, error)
 	IsPolicyExists(policyARN string) (*iam.GetPolicyOutput, error)
 	IsAdminRole(roleName string) (bool, error)
+	IsUserRole(roleName *string) (bool, error)
 }
 
 // ClientBuilder contains the information and logic needed to build a new AWS client.

--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -686,12 +686,12 @@ func roleHasTag(roleTags []*iam.Tag, tagKey string, tagValue string) bool {
 	return false
 }
 
-func isOCMRole(roleName *string) bool {
+func IsOCMRole(roleName *string) bool {
 	return strings.Contains(aws.StringValue(roleName), fmt.Sprintf("%s-Role", OCMRole))
 }
 
-// isUserRole checks the role tags in addition to the role name, because the word 'user' is common
-func (c *awsClient) isUserRole(roleName *string) (bool, error) {
+// IsUserRole checks the role tags in addition to the role name, because the word 'user' is common
+func (c *awsClient) IsUserRole(roleName *string) (bool, error) {
 	if strings.Contains(aws.StringValue(roleName), OCMUserRole) {
 		roleTags, err := c.iamClient.ListRoleTags(&iam.ListRoleTagsInput{
 			RoleName: roleName,
@@ -714,7 +714,7 @@ func (c *awsClient) ListUserRoles() ([]Role, error) {
 	}
 
 	for _, role := range roles {
-		isUserRole, err := c.isUserRole(role.RoleName)
+		isUserRole, err := c.IsUserRole(role.RoleName)
 		if err != nil {
 			return nil, err
 		}
@@ -739,7 +739,7 @@ func (c *awsClient) ListOCMRoles() ([]Role, error) {
 	}
 
 	for _, role := range roles {
-		if isOCMRole(role.RoleName) {
+		if IsOCMRole(role.RoleName) {
 			var ocmRole Role
 			ocmRole.RoleName = aws.StringValue(role.RoleName)
 			ocmRole.RoleARN = aws.StringValue(role.Arn)


### PR DESCRIPTION
To delete a role using the AWS client, a role name is sufficient.

This PR adds the following validations:
- `delete ocm-role`: check that the provided role is an **ocm role**.
- `delete user-role`: check that the provided role is a **user role**.

Related: [SDA-5564](https://issues.redhat.com/browse/SDA-5564)

![image](https://user-images.githubusercontent.com/57869309/156330985-836c3148-cdae-419f-8db9-2e15abfee0f2.png)
