### PR TITLE
Sort roles to display linked ones first

### DIFF
--- a/cmd/list/ocmroles/cmd.go
+++ b/cmd/list/ocmroles/cmd.go
@@ -142,5 +142,7 @@ func listOCMRoles(awsClient aws.Client, ocmClient *ocm.Client) ([]aws.Role, erro
 		}
 	}
 
+	aws.SortRolesByLinkedRole(ocmRoles)
+
 	return ocmRoles, nil
 }

--- a/cmd/list/userroles/cmd.go
+++ b/cmd/list/userroles/cmd.go
@@ -125,5 +125,7 @@ func listUserRoles(awsClient aws.Client, ocmClient *ocm.Client) ([]aws.Role, err
 		}
 	}
 
+	aws.SortRolesByLinkedRole(userRoles)
+
 	return userRoles, nil
 }

--- a/pkg/aws/sts.go
+++ b/pkg/aws/sts.go
@@ -17,6 +17,7 @@ limitations under the License.
 package aws
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -147,4 +148,10 @@ func (c *awsClient) deleteOCMRolePolicies(roleName string) error {
 	}
 
 	return nil
+}
+
+func SortRolesByLinkedRole(roles []Role) {
+	sort.SliceStable(roles, func(i, j int) bool {
+		return roles[i].Linked == "Yes" && roles[j].Linked == "No"
+	})
 }


### PR DESCRIPTION
For the commands `list user-roles` and `list ocm-roles` linked roles
will be displayed first.

The order between the unlinked roles stays the same.
The same applied to the linked roles.

Related: [SDA-5574](https://issues.redhat.com/browse/SDA-5574)

![image](https://user-images.githubusercontent.com/57869309/156914982-76d707b1-58e0-497a-967b-6652a544281f.png)
