### PR TITLE
Refactor `list ocm-role` to use a map of linked roles

### DIFF
--- a/cmd/list/ocmroles/cmd.go
+++ b/cmd/list/ocmroles/cmd.go
@@ -134,8 +134,10 @@ func listOCMRoles(awsClient aws.Client, ocmClient *ocm.Client) ([]aws.Role, erro
 		return nil, err
 	}
 
+	linkedRolesMap := helper.SliceToMap(linkedRoles)
 	for i := range ocmRoles {
-		if helper.Contains(linkedRoles, ocmRoles[i].RoleARN) {
+		_, exist := linkedRolesMap[ocmRoles[i].RoleARN]
+		if exist {
 			ocmRoles[i].Linked = "Yes"
 		} else {
 			ocmRoles[i].Linked = "No"


### PR DESCRIPTION
Implementation is similar to the command `list user-roles`.
This change improves the time complexity of marking the linked roles.