### PR TITLE
Add quota service permissions to the `installer policy`

### DIFF
--- a/assets/bindata.go
+++ b/assets/bindata.go
@@ -739,6 +739,8 @@ var _templatesPoliciesSts_installer_permission_policyJson = []byte(`{
                 "s3:PutObject",
                 "s3:PutObjectAcl",
                 "s3:PutObjectTagging",
+                "servicequotas:GetServiceQuota",
+                "servicequotas:ListAWSDefaultServiceQuotas",
                 "sts:AssumeRole",
                 "sts:AssumeRoleWithWebIdentity",
                 "sts:GetCallerIdentity",

--- a/templates/policies/sts_installer_permission_policy.json
+++ b/templates/policies/sts_installer_permission_policy.json
@@ -169,6 +169,8 @@
                 "s3:PutObject",
                 "s3:PutObjectAcl",
                 "s3:PutObjectTagging",
+                "servicequotas:GetServiceQuota",
+                "servicequotas:ListAWSDefaultServiceQuotas",
                 "sts:AssumeRole",
                 "sts:AssumeRoleWithWebIdentity",
                 "sts:GetCallerIdentity",


### PR DESCRIPTION
This MR will enable CS to run preflight quota checks.

Related: [SDA-5429](https://issues.redhat.com/browse/SDA-5429)