### PR TITLE
Restrict iam:PassRole to account wide instance IAM Roles

### DIFF
--- a/assets/bindata.go
+++ b/assets/bindata.go
@@ -299,6 +299,13 @@ var _templatesPoliciesOpenshift_machine_api_aws_cloud_credentials_policyJson = [
     {
       "Effect": "Allow",
       "Action": [
+        "iam:PassRole"
+      ],
+      "Resource": "arn:aws:iam::%{aws_account_id}:role/%{worker_arn}"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
         "ec2:CreateTags",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeDhcpOptions",
@@ -316,7 +323,6 @@ var _templatesPoliciesOpenshift_machine_api_aws_cloud_credentials_policyJson = [
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:DeregisterTargets",
-        "iam:PassRole",
         "iam:CreateServiceLinkedRole"
       ],
       "Resource": "*"
@@ -574,6 +580,16 @@ var _templatesPoliciesSts_installer_permission_policyJson = []byte(`{
         {
             "Effect": "Allow",
             "Action": [
+                "iam:PassRole"
+            ],
+            "Resource": [
+                "arn:aws:iam::%{aws_account_id}:role/%{controlplane_arn}",
+                "arn:aws:iam::%{aws_account_id}:role/%{worker_arn}"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
                 "autoscaling:DescribeAutoScalingGroups",
                 "ec2:AllocateAddress",
                 "ec2:AssociateAddress",
@@ -680,9 +696,6 @@ var _templatesPoliciesSts_installer_permission_policyJson = []byte(`{
                 "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
                 "elasticloadbalancing:RegisterTargets",
                 "elasticloadbalancing:SetLoadBalancerPoliciesOfListener",
-                "iam:AddRoleToInstanceProfile",
-                "iam:CreateInstanceProfile",
-                "iam:DeleteInstanceProfile",
                 "iam:GetInstanceProfile",
                 "iam:GetRole",
                 "iam:GetRolePolicy",
@@ -694,11 +707,13 @@ var _templatesPoliciesSts_installer_permission_policyJson = []byte(`{
                 "iam:ListRoles",
                 "iam:ListUserPolicies",
                 "iam:ListUsers",
-                "iam:PassRole",
-                "iam:RemoveRoleFromInstanceProfile",
                 "iam:SimulatePrincipalPolicy",
                 "iam:TagRole",
                 "iam:UntagRole",
+                "iam:CreateInstanceProfile",
+                "iam:DeleteInstanceProfile",
+                "iam:AddRoleToInstanceProfile",
+                "iam:RemoveRoleFromInstanceProfile",
                 "route53:ChangeResourceRecordSets",
                 "route53:ChangeTagsForResource",
                 "route53:CreateHostedZone",

--- a/assets/bindata.go
+++ b/assets/bindata.go
@@ -583,8 +583,7 @@ var _templatesPoliciesSts_installer_permission_policyJson = []byte(`{
                 "iam:PassRole"
             ],
             "Resource": [
-                "arn:aws:iam::%{aws_account_id}:role/%{controlplane_arn}",
-                "arn:aws:iam::%{aws_account_id}:role/%{worker_arn}"
+                "arn:aws:iam::%{aws_account_id}:role/%{controlplane_arn}"
             ]
         },
         {

--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -364,15 +364,14 @@ func createRoles(reporter *rprtr.Object, awsClient aws.Client,
 		path = fmt.Sprintf("templates/policies/%s", filename)
 
 		// For the installer permission policy scope the iam:PassRole permission
-		// to the worker and controlplane ARNs roles only
+		// to the controlplane ARN role only.
+		// The cluster itslef will provision worker nodes see machine-api-operator
+		// permission.
 		if strings.ToLower(role.Name) == aws.InstallerAccountRole {
 			policy, err = aws.ReadPolicyDocument(path, map[string]string{
 				"aws_account_id":   accountID,
 				"controlplane_arn": aws.GetRoleName(prefix, aws.AccountRoles[aws.ControlPlaneAccountRole].Name),
-				"worker_arn":       aws.GetRoleName(prefix, aws.AccountRoles[aws.WorkerAccountRole].Name),
 			})
-		} else {
-			policy, err = aws.ReadPolicyDocument(path)
 		}
 		if err != nil {
 			return err
@@ -414,8 +413,6 @@ func createRoles(reporter *rprtr.Object, awsClient aws.Client,
 					"aws_account_id": accountID,
 					"worker_arn":     aws.GetRoleName(prefix, aws.AccountRoles[aws.WorkerAccountRole].Name),
 				})
-			} else {
-				policy, err = aws.ReadPolicyDocument(path)
 			}
 
 			if err != nil {

--- a/templates/policies/openshift_machine_api_aws_cloud_credentials_policy.json
+++ b/templates/policies/openshift_machine_api_aws_cloud_credentials_policy.json
@@ -4,6 +4,13 @@
     {
       "Effect": "Allow",
       "Action": [
+        "iam:PassRole"
+      ],
+      "Resource": "arn:aws:iam::%{aws_account_id}:role/%{worker_arn}"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
         "ec2:CreateTags",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeDhcpOptions",
@@ -21,7 +28,6 @@
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:DeregisterTargets",
-        "iam:PassRole",
         "iam:CreateServiceLinkedRole"
       ],
       "Resource": "*"

--- a/templates/policies/sts_installer_permission_policy.json
+++ b/templates/policies/sts_installer_permission_policy.json
@@ -4,6 +4,16 @@
         {
             "Effect": "Allow",
             "Action": [
+                "iam:PassRole"
+            ],
+            "Resource": [
+                "arn:aws:iam::%{aws_account_id}:role/%{controlplane_arn}",
+                "arn:aws:iam::%{aws_account_id}:role/%{worker_arn}"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
                 "autoscaling:DescribeAutoScalingGroups",
                 "ec2:AllocateAddress",
                 "ec2:AssociateAddress",
@@ -110,9 +120,6 @@
                 "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
                 "elasticloadbalancing:RegisterTargets",
                 "elasticloadbalancing:SetLoadBalancerPoliciesOfListener",
-                "iam:AddRoleToInstanceProfile",
-                "iam:CreateInstanceProfile",
-                "iam:DeleteInstanceProfile",
                 "iam:GetInstanceProfile",
                 "iam:GetRole",
                 "iam:GetRolePolicy",
@@ -124,11 +131,13 @@
                 "iam:ListRoles",
                 "iam:ListUserPolicies",
                 "iam:ListUsers",
-                "iam:PassRole",
-                "iam:RemoveRoleFromInstanceProfile",
                 "iam:SimulatePrincipalPolicy",
                 "iam:TagRole",
                 "iam:UntagRole",
+                "iam:CreateInstanceProfile",
+                "iam:DeleteInstanceProfile",
+                "iam:AddRoleToInstanceProfile",
+                "iam:RemoveRoleFromInstanceProfile",
                 "route53:ChangeResourceRecordSets",
                 "route53:ChangeTagsForResource",
                 "route53:CreateHostedZone",

--- a/templates/policies/sts_installer_permission_policy.json
+++ b/templates/policies/sts_installer_permission_policy.json
@@ -7,8 +7,7 @@
                 "iam:PassRole"
             ],
             "Resource": [
-                "arn:aws:iam::%{aws_account_id}:role/%{controlplane_arn}",
-                "arn:aws:iam::%{aws_account_id}:role/%{worker_arn}"
+                "arn:aws:iam::%{aws_account_id}:role/%{controlplane_arn}"
             ]
         },
         {


### PR DESCRIPTION
Restrict the `iam:PassRole` permission to the specific roles created for the controlplane and worker nodes.

We cannot remove the specific `iam:PassRole` action because the installer is creating the controlplane IAM instance profiles and needs to assign the controlplane IAM role when the controlplane node is created. The cluster it self will create the worker nodes and needs to assign the IAM instance profile and the worker IAM roles when they are created.

https://issues.redhat.com/browse/OSD-10327