### PR TITLE
Adding message to update rosa CLI if incompatible roles are found

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -896,7 +896,7 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 		if !validVersion {
 			reporter.Errorf("Account role '%s' is not compatible with version %s. "+
-				"Verify you are using the latest 'rosa' client and then run 'rosa create account-roles' to create compatible roles and try again.",
+				"Use latest 'rosa' client and run 'rosa create account-roles' to create compatible roles and try again.",
 				ARN, version)
 			os.Exit(1)
 		}

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -896,7 +896,7 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 		if !validVersion {
 			reporter.Errorf("Account role '%s' is not compatible with version %s. "+
-				"Run 'rosa create account-roles' to create compatible roles and try again.",
+				"Verify you are using the latest 'rosa' client and then run 'rosa create account-roles' to create compatible roles and try again.",
 				ARN, version)
 			os.Exit(1)
 		}


### PR DESCRIPTION
Based on feedback by end user, updating the message to suggest updating `rosa` CLI to latest version and try again if incompatible roles are found. Not sure if this would work and be valid for all versions and latest `rosa` CLI yet but I think its worth adding if its supported.