### PR TITLE
Set minimum retry delay for AWS API calls

### DIFF
--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -690,6 +690,7 @@ func buildCustomRetryer() CustomRetryer {
 	return CustomRetryer{
 		DefaultRetryer: client.DefaultRetryer{
 			NumMaxRetries:    6,
+			MinRetryDelay:    1 * time.Second,
 			MinThrottleDelay: 10 * time.Second,
 		},
 	}


### PR DESCRIPTION
MinRetryDelay is the minimum retry delay after which retry will be performed. If not set, the value is 0ns.

https://docs.aws.amazon.com/sdk-for-go/api/aws/client/