### PR TITLE
Fix help for --compute-nodes

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -350,7 +350,7 @@ func init() {
 		&args.computeNodes,
 		"compute-nodes",
 		2,
-		"Number of worker nodes to provision per zone. Single zone clusters need at least 2 nodes, "+
+		"Number of worker nodes to provision. Single zone clusters need at least 2 nodes, "+
 			"multizone clusters need at least 3 nodes.",
 	)
 


### PR DESCRIPTION
The flag --compute-nodes is used to pass total number
of compute nodes, not compute nodes per zone.

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>