### PR TITLE
Permit overriding confirmation prompt for cluster upgrades

### DIFF
--- a/cmd/upgrade/cluster/cmd.go
+++ b/cmd/upgrade/cluster/cmd.go
@@ -102,6 +102,8 @@ func init() {
 			"Budgets that have not been successfully drained from a node will be forcibly evicted.\nValid "+
 			"options are ['%s']", strings.Join(nodeDrainOptions, "','")),
 	)
+
+	confirm.AddFlag(flags)
 }
 
 func run(cmd *cobra.Command, _ []string) {


### PR DESCRIPTION
- Add `--yes` arg to `rosa upgrade cluster`, matching usage of `rosa upgrade account-roles` and `rosa upgrade operator-roles`