### PR TITLE
fix cluster creation hanging with auto+watch flags

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1783,19 +1783,6 @@ func run(cmd *cobra.Command, _ []string) {
 				"for more information.")
 	}
 
-	if args.watch {
-		installLogs.Cmd.Run(installLogs.Cmd, []string{clusterName})
-	} else if !output.HasFlag() || reporter.IsTerminal() {
-		reporter.Infof(
-			"To determine when your cluster is Ready, run 'rosa describe cluster -c %s'.",
-			clusterName,
-		)
-		reporter.Infof(
-			"To watch your cluster installation logs, run 'rosa logs install -c %s --watch'.",
-			clusterName,
-		)
-	}
-
 	clusterdescribe.Cmd.Run(clusterdescribe.Cmd, []string{clusterName})
 
 	if isSTS {
@@ -1817,6 +1804,19 @@ func run(cmd *cobra.Command, _ []string) {
 				"\t%s\n",
 				rolesCMD, oidcCMD)
 		}
+	}
+
+	if args.watch {
+		installLogs.Cmd.Run(installLogs.Cmd, []string{clusterName})
+	} else if !output.HasFlag() || reporter.IsTerminal() {
+		reporter.Infof(
+			"To determine when your cluster is Ready, run 'rosa describe cluster -c %s'.",
+			clusterName,
+		)
+		reporter.Infof(
+			"To watch your cluster installation logs, run 'rosa logs install -c %s --watch'.",
+			clusterName,
+		)
 	}
 }
 


### PR DESCRIPTION
Having the install logs command run before the creation of operator
roles and the OIDC provider (`--mode auto`) causes the cluster creation
to hang waiting for these to be created. Moving watch to be after the
STS block executes the creation of the operator roles and OIDC provider
before blocking on cluster install logs

fixes #659

Signed-off-by: Brady Pratt <bpratt@redhat.com>

validation:
```
❯ ./rosa create cluster --cluster-name=testing-123 --sts --mode=auto --yes --watch
I: Using arn:aws:iam::x:role/ManagedOpenShift-Installer-Role for the Installer role
I: Using arn:aws:iam::x:role/ManagedOpenShift-ControlPlane-Role for the ControlPlane role
I: Using arn:aws:iam::x:role/ManagedOpenShift-Worker-Role for the Worker role
I: Using arn:aws:iam::x:role/ManagedOpenShift-Support-Role for the Support role
I: Creating cluster 'testing-123'
I: To view a list of clusters and their status, run 'rosa list clusters'
I: Cluster 'testing-123' has been created.
I: Once the cluster is installed you will need to add an Identity Provider before you can login into the cluster. See 'rosa create idp --help' for more information.
Name:                       testing-123
ID:                        x 
External ID:
OpenShift Version:
Channel Group:              stable
DNS:                        testing-123.71qn.p1.openshiftapps.com
AWS Account:               x 
API URL:
Console URL:
Region:                     us-east-1
Multi-AZ:                   false
Nodes:
 - Control plane:           3
 - Infra:                   2
 - Compute:                 2
Network:
 - Service CIDR:            172.30.0.0/16
 - Machine CIDR:            10.0.0.0/16
 - Pod CIDR:                10.128.0.0/14
 - Host Prefix:             /23
STS Role ARN:               arn:aws:iam::x:role/ManagedOpenShift-Installer-Role
Support Role ARN:           arn:aws:iam::x:role/ManagedOpenShift-Support-Role
Instance IAM Roles:
 - Control plane:           arn:aws:iam::x:role/ManagedOpenShift-ControlPlane-Role
 - Worker:                  arn:aws:iam::x:role/ManagedOpenShift-Worker-Role
Operator IAM Roles:
 - arn:aws:iam::x:role/testing-123-x1r9-openshift-machine-api-aws-cloud-credentials
 - arn:aws:iam::x:role/testing-123-x1r9-openshift-cloud-credential-operator-cloud-crede
 - arn:aws:iam::x:role/testing-123-x1r9-openshift-image-registry-installer-cloud-creden
 - arn:aws:iam::x:role/testing-123-x1r9-openshift-ingress-operator-cloud-credentials
 - arn:aws:iam::x:role/testing-123-x1r9-openshift-cluster-csi-drivers-ebs-cloud-credent
 - arn:aws:iam::x:role/testing-123-x1r9-openshift-cloud-network-config-controller-cloud
State:                      waiting (Waiting for OIDC configuration)
Private:                    No
Created:                    Mar 31 2022 21:34:37 UTC
Details Page:               https://console.redhat.com/openshift/details/s/x
OIDC Endpoint URL:          https://rh-oidc.s3.us-east-1.amazonaws.com/x

I: Preparing to create operator roles.
I: Creating roles using 'arn:aws:iam::x:user/osdCcsAdmin'
I: Created role 'testing-123-x1r9-openshift-cloud-credential-operator-cloud-crede' with ARN 'arn:aws:iam::x:role/testing-123-x1r9-openshift-cloud-credential-operator-cloud-crede'
I: Created role 'testing-123-x1r9-openshift-image-registry-installer-cloud-creden' with ARN 'arn:aws:iam::x:role/testing-123-x1r9-openshift-image-registry-installer-cloud-creden'
time="2022-03-31T16:34:50-05:00" level=error msg="Throttling Rate exceeded. Retrying"
time="2022-03-31T16:35:07-05:00" level=error msg="Throttling Rate exceeded. Retrying"
I: Created role 'testing-123-x1r9-openshift-ingress-operator-cloud-credentials' with ARN 'arn:aws:iam::x:role/testing-123-x1r9-openshift-ingress-operator-cloud-credentials'
I: Created role 'testing-123-x1r9-openshift-cluster-csi-drivers-ebs-cloud-credent' with ARN 'arn:aws:iam::x:role/testing-123-x1r9-openshift-cluster-csi-drivers-ebs-cloud-credent'
I: Created role 'testing-123-x1r9-openshift-cloud-network-config-controller-cloud' with ARN 'arn:aws:iam::x:role/testing-123-x1r9-openshift-cloud-network-config-controller-cloud'
I: Created role 'testing-123-x1r9-openshift-machine-api-aws-cloud-credentials' with ARN 'arn:aws:iam::x:role/testing-123-x1r9-openshift-machine-api-aws-cloud-credentials'
I: Preparing to create OIDC Provider.
I: Creating OIDC provider using 'arn:aws:iam::x:user/osdCcsAdmin'
I: Created OIDC provider with ARN 'arn:aws:iam::x:oidc-provider/rh-oidc.s3.us-east-1.amazonaws.com/x'
I: Cluster 'testing-123' is in waiting state waiting for installation to begin. Logs will show up within 5 minutes
| ^C
```

One thing of slight concern was the throttling issue

```
time="2022-03-31T16:34:50-05:00" level=error msg="Throttling Rate exceeded. Retrying"
time="2022-03-31T16:35:07-05:00" level=error msg="Throttling Rate exceeded. Retrying"
```