### PR TITLE
fix early exit in cluster creation(json+mode=auto)

### DIFF
--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -117,7 +117,7 @@ func run(cmd *cobra.Command, argv []string) {
 			reporter.Errorf("%s", err)
 			os.Exit(1)
 		}
-		os.Exit(0)
+		return
 	}
 
 	creatorARN, err := arn.Parse(cluster.Properties()[properties.CreatorARN])


### PR DESCRIPTION
When running the below command, `rosa describe cluster ...` is called
causing an early exit before `--mode=auto`+STS is evaluated.

`rosa create cluster --cluster-name=testing-124 --sts --mode=auto --yes --output=json`

Rather than exiting early, return to the caller to finish and exit.

Signed-off-by: Brady Pratt <bpratt@redhat.com>

mentioned in #659

culprit
https://github.com/openshift/rosa/blob/b5af865e3f78ac8cf7ffc9d26540b89a3be893bf/cmd/create/cluster/cmd.go#L1799