### PR TITLE
sts: Automatically select default account roles

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -663,16 +663,21 @@ func run(cmd *cobra.Command, _ []string) {
 				}
 			}
 			reporter.Warnf("More than one %s role found", role.Name)
-			roleARN, err = interactive.GetOption(interactive.Input{
-				Question: fmt.Sprintf("%s role ARN", role.Name),
-				Help:     cmd.Flags().Lookup(role.Flag).Usage,
-				Options:  roleARNs,
-				Default:  defaultRoleARN,
-				Required: true,
-			})
-			if err != nil {
-				reporter.Errorf("Expected a valid role ARN: %s", err)
-				os.Exit(1)
+			if !interactive.Enabled() && confirm.Yes() {
+				reporter.Infof("Using %s for the %s role", defaultRoleARN, role.Name)
+				roleARN = defaultRoleARN
+			} else {
+				roleARN, err = interactive.GetOption(interactive.Input{
+					Question: fmt.Sprintf("%s role ARN", role.Name),
+					Help:     cmd.Flags().Lookup(role.Flag).Usage,
+					Options:  roleARNs,
+					Default:  defaultRoleARN,
+					Required: true,
+				})
+				if err != nil {
+					reporter.Errorf("Expected a valid role ARN: %s", err)
+					os.Exit(1)
+				}
 			}
 		} else if len(roleARNs) == 1 {
 			if !output.HasFlag() || reporter.IsTerminal() {

--- a/pkg/interactive/confirm/confirm.go
+++ b/pkg/interactive/confirm/confirm.go
@@ -36,6 +36,10 @@ func AddFlag(flags *pflag.FlagSet) {
 	)
 }
 
+func Yes() bool {
+	return yes
+}
+
 func Confirm(q string, v ...interface{}) bool {
 	msg := fmt.Sprintf("Are you sure you want to %s?", fmt.Sprintf(q, v...))
 	return Prompt(false, msg)


### PR DESCRIPTION
When using the '--yes' flag in non-interactive mode, we should
automatically select the default set of account roles. This ensures that
automation processes can be run without having to manually feed flags.