### PR TITLE
Add global color flag

### DIFF
--- a/cmd/rosa/main.go
+++ b/cmd/rosa/main.go
@@ -47,6 +47,7 @@ import (
 	"github.com/openshift/rosa/cmd/version"
 	"github.com/openshift/rosa/cmd/whoami"
 	"github.com/openshift/rosa/pkg/arguments"
+	"github.com/openshift/rosa/pkg/color"
 )
 
 var root = &cobra.Command{
@@ -60,6 +61,7 @@ var root = &cobra.Command{
 func init() {
 	// Add the command line flags:
 	fs := root.PersistentFlags()
+	color.AddFlag(root)
 	arguments.AddDebugFlag(fs)
 
 	// Register the subcommands:

--- a/pkg/color/flag.go
+++ b/pkg/color/flag.go
@@ -1,0 +1,69 @@
+/*
+Copyright (c) 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains functions used to implement the '--color' command line option.
+
+package color
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+
+	"github.com/spf13/cobra"
+)
+
+var color string
+
+var options = []string{"auto", "never", "always"}
+
+// AddFlag adds the interactive flag to the given set of command line flags.
+func AddFlag(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringVar(
+		&color,
+		"color",
+		"auto",
+		fmt.Sprintf("Surround certain characters with escape sequences to display them in color "+
+			"on the terminal. Allowed options are %s", options),
+	)
+
+	cmd.RegisterFlagCompletionFunc("color", completion)
+}
+
+func completion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return options, cobra.ShellCompDirectiveDefault
+}
+
+// UseColor returns a bool that indicates whether the color is enabled
+func UseColor() bool {
+	switch color {
+	case "never":
+		return false
+	case "always":
+		return true
+	case "auto":
+		fallthrough
+	default:
+		if runtime.GOOS == "windows" {
+			return false
+		}
+		stdout, err := os.Stdout.Stat()
+		if err != nil {
+			return true
+		}
+		return (stdout.Mode()&os.ModeDevice != 0) && (stdout.Mode()&os.ModeNamedPipe == 0)
+	}
+}

--- a/pkg/interactive/interactive.go
+++ b/pkg/interactive/interactive.go
@@ -25,6 +25,8 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/core"
 	"github.com/AlecAivazis/survey/v2/terminal"
+
+	"github.com/openshift/rosa/pkg/color"
 )
 
 type Input struct {
@@ -38,6 +40,7 @@ type Input struct {
 
 // Gets string input from the command line
 func GetString(input Input) (a string, err error) {
+	core.DisableColor = !color.UseColor()
 	dflt, ok := input.Default.(string)
 	if !ok {
 		dflt = ""
@@ -60,6 +63,7 @@ func GetString(input Input) (a string, err error) {
 
 // Gets int number input from the command line
 func GetInt(input Input) (a int, err error) {
+	core.DisableColor = !color.UseColor()
 	dflt, ok := input.Default.(int)
 	if !ok {
 		dflt = 0
@@ -97,6 +101,7 @@ func parseInt(str string) (num int, err error) {
 
 // Gets float number input from the command line
 func GetFloat(input Input) (a float64, err error) {
+	core.DisableColor = !color.UseColor()
 	dflt, ok := input.Default.(float64)
 	if !ok {
 		dflt = 0
@@ -136,6 +141,7 @@ func parseFloat(str string) (num float64, err error) {
 
 // Asks for multiple options selection
 func GetMultipleOptions(input Input) ([]string, error) {
+	core.DisableColor = !color.UseColor()
 	var err error
 	res := make([]string, 0)
 	dflt, ok := input.Default.([]string)
@@ -161,6 +167,7 @@ func GetMultipleOptions(input Input) ([]string, error) {
 
 // Asks for option selection in the command line
 func GetOption(input Input) (a string, err error) {
+	core.DisableColor = !color.UseColor()
 	dflt, ok := input.Default.(string)
 	if !ok {
 		dflt = ""
@@ -184,6 +191,7 @@ func GetOption(input Input) (a string, err error) {
 
 // Asks for true/false value in the command line
 func GetBool(input Input) (a bool, err error) {
+	core.DisableColor = !color.UseColor()
 	dflt, ok := input.Default.(bool)
 	if !ok {
 		dflt = false
@@ -206,6 +214,7 @@ func GetBool(input Input) (a bool, err error) {
 
 // Asks for CIDR value in the command line
 func GetIPNet(input Input) (a net.IPNet, err error) {
+	core.DisableColor = !color.UseColor()
 	dflt, ok := input.Default.(net.IPNet)
 	if !ok {
 		dflt = net.IPNet{}
@@ -246,6 +255,7 @@ func GetIPNet(input Input) (a net.IPNet, err error) {
 
 // Gets password input from the command line
 func GetPassword(input Input) (a string, err error) {
+	core.DisableColor = !color.UseColor()
 	question := input.Question
 	if !input.Required {
 		question = fmt.Sprintf("%s (optional)", question)
@@ -263,6 +273,7 @@ func GetPassword(input Input) (a string, err error) {
 
 // Gets path to certificate file from the command line
 func GetCert(input Input) (a string, err error) {
+	core.DisableColor = !color.UseColor()
 	dflt, ok := input.Default.(string)
 	if !ok {
 		dflt = ""
@@ -292,6 +303,7 @@ type Help struct {
 }
 
 func PrintHelp(help Help) error {
+	core.DisableColor = !color.UseColor()
 	out, _, err := core.RunTemplate(helpTemplate, help)
 	if err != nil {
 		return err

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -20,8 +20,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"runtime"
 
+	"github.com/openshift/rosa/pkg/color"
 	"github.com/openshift/rosa/pkg/debug"
 )
 
@@ -60,7 +60,7 @@ func (r *Object) Debugf(format string, args ...interface{}) {
 // Infof prints an informative message with the given format and arguments.
 func (r *Object) Infof(format string, args ...interface{}) {
 	message := fmt.Sprintf(format, args...)
-	if r.useColors() {
+	if color.UseColor() {
 		_, _ = fmt.Fprintf(os.Stdout, "%s%s\n", infoPrefix, message)
 	} else {
 		_, _ = fmt.Fprintf(os.Stdout, "%s%s\n", "INFO: ", message)
@@ -70,7 +70,7 @@ func (r *Object) Infof(format string, args ...interface{}) {
 // Warnf prints an warning message with the given format and arguments.
 func (r *Object) Warnf(format string, args ...interface{}) {
 	message := fmt.Sprintf(format, args...)
-	if r.useColors() {
+	if color.UseColor() {
 		_, _ = fmt.Fprintf(os.Stderr, "%s%s\n", warnPrefix, message)
 	} else {
 		_, _ = fmt.Fprintf(os.Stderr, "%s%s\n", "WARN: ", message)
@@ -82,7 +82,7 @@ func (r *Object) Warnf(format string, args ...interface{}) {
 // report the error and also return it.
 func (r *Object) Errorf(format string, args ...interface{}) error {
 	message := fmt.Sprintf(format, args...)
-	if r.useColors() {
+	if color.UseColor() {
 		_, _ = fmt.Fprintf(os.Stderr, "%s%s\n", errorPrefix, message)
 	} else {
 		_, _ = fmt.Fprintf(os.Stderr, "%s%s\n", "ERR: ", message)
@@ -102,10 +102,6 @@ const (
 	warnPrefix  = "\033[0;33mW:\033[m "
 	errorPrefix = "\033[0;31mE:\033[m "
 )
-
-func (r *Object) useColors() bool {
-	return runtime.GOOS != "windows"
-}
 
 // Determine whether the reporter output is meant for the terminal
 // or whether it's piped or redirected to a file.


### PR DESCRIPTION
To allow for automation that cannot handle ANSI escape sequences, we
provide a '--color' with options for 'auto', 'always', 'never'.