### PR TITLE
fix json output for cluster creation (sts+mode=auto)

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1787,9 +1787,13 @@ func run(cmd *cobra.Command, _ []string) {
 
 	if isSTS {
 		if mode != "" {
-			reporter.Infof("Preparing to create operator roles.")
+			if !output.HasFlag() || reporter.IsTerminal() {
+				reporter.Infof("Preparing to create operator roles.")
+			}
 			operatorroles.Cmd.Run(operatorroles.Cmd, []string{clusterName, mode, permissionsBoundary})
-			reporter.Infof("Preparing to create OIDC Provider.")
+			if !output.HasFlag() || reporter.IsTerminal() {
+				reporter.Infof("Preparing to create OIDC Provider.")
+			}
 			oidcprovider.Cmd.Run(oidcprovider.Cmd, []string{clusterName, mode})
 		} else {
 			rolesCMD := fmt.Sprintf("rosa create operator-roles --cluster %s", clusterName)

--- a/cmd/create/oidcprovider/cmd.go
+++ b/cmd/create/oidcprovider/cmd.go
@@ -35,6 +35,7 @@ import (
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/logging"
 	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/output"
 	rprtr "github.com/openshift/rosa/pkg/reporter"
 )
 
@@ -169,7 +170,9 @@ func run(cmd *cobra.Command, argv []string) {
 				"Verify that the cluster operator roles exist and are configured correctly.", clusterKey)
 			os.Exit(1)
 		}
-		reporter.Infof("Creating OIDC provider using '%s'", creator.ARN)
+		if !output.HasFlag() || reporter.IsTerminal() {
+			reporter.Infof("Creating OIDC provider using '%s'", creator.ARN)
+		}
 		if !confirm.Prompt(true, "Create the OIDC provider for cluster '%s'?", clusterKey) {
 			os.Exit(0)
 		}
@@ -223,7 +226,9 @@ func createProvider(reporter *rprtr.Object, awsClient aws.Client, cluster *cmv1.
 	if err != nil {
 		return err
 	}
-	reporter.Infof("Created OIDC provider with ARN '%s'", oidcProviderARN)
+	if !output.HasFlag() || reporter.IsTerminal() {
+		reporter.Infof("Created OIDC provider with ARN '%s'", oidcProviderARN)
+	}
 
 	return nil
 }

--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -31,6 +31,7 @@ import (
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/logging"
 	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/output"
 	rprtr "github.com/openshift/rosa/pkg/reporter"
 )
 
@@ -227,7 +228,9 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 	switch mode {
 	case aws.ModeAuto:
-		reporter.Infof("Creating roles using '%s'", creator.ARN)
+		if !output.HasFlag() || reporter.IsTerminal() {
+			reporter.Infof("Creating roles using '%s'", creator.ARN)
+		}
 		err = createRoles(reporter, awsClient, prefix, permissionsBoundary, cluster, creator.AccountID,
 			accountRoleVersion)
 		if err != nil {
@@ -325,7 +328,9 @@ func createRoles(reporter *rprtr.Object, awsClient aws.Client,
 		if err != nil {
 			return err
 		}
-		reporter.Infof("Created role '%s' with ARN '%s'", roleName, roleARN)
+		if !output.HasFlag() || reporter.IsTerminal() {
+			reporter.Infof("Created role '%s' with ARN '%s'", roleName, roleARN)
+		}
 
 		reporter.Debugf("Attaching permission policy '%s' to role '%s'", policyARN, roleName)
 		err = awsClient.AttachRolePolicy(roleName, policyARN)


### PR DESCRIPTION
When executing with `--output=json` and `--mode=auto`, plain info logs
are printed from the create commands of `oidc-provider` and
`operator-roles` causing the output to no longer parse as JSON. Bug was
surfaced in #661 and mentioned in #662.

Simply add the output flag/terminal check conditional to offending log
statements. This does not include support for the commands themselves,
the `output` flag variable is set when calling from the cluster creation
command and prevents plain text logs. 

Test command:

```
rosa create cluster -c <cluster-name> --mode=auto --output=json --sts --yes | jq .
```

Signed-off-by: Brady Pratt <bpratt@redhat.com>