### PR TITLE
Add max throttle delay to avoid exponential backoff

### DIFF
--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -692,6 +692,7 @@ func buildCustomRetryer() CustomRetryer {
 			NumMaxRetries:    12,
 			MinRetryDelay:    1 * time.Second,
 			MinThrottleDelay: 5 * time.Second,
+			MaxThrottleDelay: 5 * time.Second,
 		},
 	}
 }


### PR DESCRIPTION
AWS SDK uses exponential backoff to wait longer between retries for consecutive error responses.
Because exponential backoff grows quickly, we are adding a maximum delay interval.

Reference: [https://aws.amazon.com/blogs/mt/managing-monitoring-api-throttling-in-workloads/](https://aws.amazon.com/blogs/mt/managing-monitoring-api-throttling-in-workloads/)