### PR TITLE
Only prompt for HTPasswd IDP name when actually creating a new IDP

### DIFF
--- a/cmd/create/idp/cmd.go
+++ b/cmd/create/idp/cmd.go
@@ -392,17 +392,8 @@ func run(cmd *cobra.Command, _ []string) {
 			os.Exit(1)
 		}
 	}
-	if interactive.Enabled() {
-		idpName, err = interactive.GetString(interactive.Input{
-			Question: "Identity provider name",
-			Help:     cmd.Flags().Lookup("name").Usage,
-			Default:  idpName,
-			Required: true,
-		})
-		if err != nil {
-			reporter.Errorf("Expected a valid name for the identity provider: %s", err)
-			os.Exit(1)
-		}
+	if interactive.Enabled() && idpType != "htpasswd" {
+		idpName = getIDPName(cmd, idpName)
 	}
 	idpName = strings.Trim(idpName, " \t")
 
@@ -428,6 +419,20 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	doCreateIDP(idpName, idpBuilder, cluster, clusterKey, ocmClient)
+}
+
+func getIDPName(cmd *cobra.Command, idpName string) string {
+	idpName, err := interactive.GetString(interactive.Input{
+		Question: "Identity provider name",
+		Help:     cmd.Flags().Lookup("name").Usage,
+		Default:  idpName,
+		Required: true,
+	})
+	if err != nil {
+		reporter.Errorf("Expected a valid name for the identity provider: %s", err)
+		os.Exit(1)
+	}
+	return strings.Trim(idpName, " \t")
 }
 
 func doCreateIDP(


### PR DESCRIPTION
Addresses [SDA-5645](https://issues.redhat.com/browse/SDA-5645)

This MR introduces some UX improvements for the HTPasswd IDP flow in the ROSA CLI based on the different configurations it may have. 

- User will only be prompted for a name for their HTPasswd IDP if a new IDP is actually created
- User will not be prompted for a name for their HTPasswd IDP if we will be adding users to an existing IDP serving as an admin container
- User will not be prompted for a name for their HTPasswd IDP if there's already an HTPasswd IDP on the cluster.

[See a detailed flow here](https://docs.google.com/document/d/1fyJL9sE74bSGHN7_dhwNo6WKDT9FcxucXgE-FOqt8EA/edit?usp=sharing)

PTAL @pvasant 