### PR TITLE
Better messages to improve HTPasswd UX

### DIFF
--- a/cmd/create/idp/cmd.go
+++ b/cmd/create/idp/cmd.go
@@ -271,13 +271,17 @@ func init() {
 		&args.htpasswdUsername,
 		"username",
 		"",
-		"HTPasswd: Username to log into the cluster's console with.\n",
+		"HTPasswd: Username to log into the cluster's console with.\n"+
+			"Username must not contain /, :, or %%",
 	)
 	flags.StringVar(
 		&args.htpasswdPassword,
 		"password",
 		"",
-		"HTPasswd: Password for provided username, to log into the cluster's console with.\n",
+		"HTPasswd: Password for provided username, to log into the cluster's console with.\n"+
+			"The password must\n"+
+			"- Be at least 14 characters (ASCII-standard) without whitespaces\n"+
+			"- Include uppercase letters, lowercase letters, and numbers or symbols (ASCII-standard characters only)",
 	)
 
 	interactive.AddFlag(flags)


### PR DESCRIPTION
- added help strings to the `username` and `password` flags, detailing the requirements for them.
- added a warning on `rosa delete idp` where the IDP is an HTPasswd IDP that contains an admin user, informing the user that the admin user will be deleted upon deleting the IDP. For example:
```
./rosa delete idp htpasswd-1 -c 1ri5vbcoqcvfais6guuafrtld29tp2fk
W: The cluster-admin user is contained in the HTPasswd IDP. Deleting the IDP willalso delete the admin user.
? Are you sure you want to delete identity provider htpasswd-1 on cluster 1ri5vbcoqcvfais6guuafrtld29tp2fk? Yes
I: Successfully deleted identity provider 'htpasswd-1' from cluster '1ri5vbcoqcvfais6guuafrtld29tp2fk'
```

PTAL @pvasant 