### PR TITLE
Upgrade cluster to 4.10.* - add delay after roles creation

### DIFF
--- a/cmd/upgrade/operatorroles/cmd.go
+++ b/cmd/upgrade/operatorroles/cmd.go
@@ -20,8 +20,10 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/rosa/pkg/helper"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/pkg/aws"
@@ -347,6 +349,7 @@ func createOperatorRole(mode string, reporter *rprtr.Object, awsClient aws.Clien
 		if err != nil {
 			return err
 		}
+		helper.DisplaySpinnerWithDelay(reporter, "Waiting for operator roles to reconcile", 5*time.Second)
 	case aws.ModeManual:
 		commands, err := buildMissingOperatorRoleCommand(missingRoles, cluster, accountID, prefix, reporter, policies)
 		if err != nil {

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -1,5 +1,12 @@
 package helper
 
+import (
+	"time"
+
+	"github.com/briandowns/spinner"
+	"github.com/openshift/rosa/pkg/reporter"
+)
+
 func Contains(s []string, str string) bool {
 	for _, v := range s {
 		if v == str {
@@ -29,4 +36,16 @@ func RemoveStrFromSlice(s []string, str string) []string {
 	}
 
 	return s
+}
+
+func DisplaySpinnerWithDelay(reporter *reporter.Object, infoMessage string, delay time.Duration) {
+	if reporter.IsTerminal() {
+		spin := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+		reporter.Infof(infoMessage)
+		spin.Start()
+		time.Sleep(delay)
+		spin.Stop()
+	} else {
+		time.Sleep(delay)
+	}
 }


### PR DESCRIPTION
CS first attempts to validate the new roles right after the creation fails.
Add 5 seconds delay with a spinner to reduce the number of retries on conflict in CS.
It's better to wait in the CLI, instead of blocking both CLI and CS.

![image](https://user-images.githubusercontent.com/57869309/163424697-6387e0be-feae-4d24-b077-36c0eb2948ed.png)
![image](https://user-images.githubusercontent.com/57869309/163424740-e60b2e13-6ce8-47bd-b4b1-9e4162f3d1f7.png)


Related: [SDA-5753](https://issues.redhat.com/browse/SDA-5753)