### PR TITLE
cluster: Allow using local AWS credentials

### DIFF
--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -87,6 +87,7 @@ type Client interface {
 	EnsureOsdCcsAdminUser(stackName string, adminUserName string, awsRegion string) (bool, error)
 	DeleteOsdCcsAdminUser(stackName string) error
 	GetAWSAccessKeys() (*AccessKey, error)
+	GetLocalAWSAccessKeys() (*AccessKey, error)
 	GetCreator() (*Creator, error)
 	ValidateSCP(*string, map[string]string) (bool, error)
 	GetSubnetIDs() ([]*ec2.Subnet, error)
@@ -634,6 +635,18 @@ func (c *awsClient) GetAWSAccessKeys() (*AccessKey, error) {
 
 	c.awsAccessKeys = accessKey
 
+	return c.awsAccessKeys, nil
+}
+
+func (c *awsClient) GetLocalAWSAccessKeys() (*AccessKey, error) {
+	creds, err := c.awsSession.Config.Credentials.Get()
+	if err != nil {
+		return nil, err
+	}
+	c.awsAccessKeys = &AccessKey{
+		AccessKeyID:     creds.AccessKeyID,
+		SecretAccessKey: creds.SecretAccessKey,
+	}
 	return c.awsAccessKeys, nil
 }
 

--- a/pkg/properties/properties.go
+++ b/pkg/properties/properties.go
@@ -29,3 +29,6 @@ const CreatorARN = prefix + "creator_arn"
 const CLIVersion = prefix + "cli_version"
 
 const FakeCluster = "fake_cluster"
+
+// nolint:gosec // Linter thinks there are hardcoded credentials here...
+const UseLocalCredentials = "use_local_credentials"


### PR DESCRIPTION
This is an experimental internal feature where we allow local
credentials to be used for creating legacy IAM clusters.

https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/4148