### PR TITLE
Addon install -	fix bug - do not print not-set parameters

### DIFF
--- a/cmd/install/addon/cmd.go
+++ b/cmd/install/addon/cmd.go
@@ -241,7 +241,9 @@ func buildCommand(clusterName string, addonName string, params []ocm.AddOnParam)
 	command := fmt.Sprintf("rosa install addon --cluster %s %s -y", clusterName, addonName)
 
 	for _, param := range params {
-		command += fmt.Sprintf(" --%s %s", param.Key, param.Val)
+		if param.Val != "" {
+			command += fmt.Sprintf(" --%s %s", param.Key, param.Val)
+		}
 	}
 
 	return command


### PR DESCRIPTION
Related: [SDA-6022](https://issues.redhat.com/browse/SDA-6022)

![image](https://user-images.githubusercontent.com/57869309/168582022-8bead287-ea04-449a-b93c-f6b7c1014e4d.png)
