### PR TITLE
Reduce extra call to OCM when manipulating addons

### DIFF
--- a/cmd/edit/addon/cmd.go
+++ b/cmd/edit/addon/cmd.go
@@ -125,7 +125,7 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
-	addOnInstallation, err := ocmClient.GetAddOnInstallation(clusterKey, awsCreator, addOnID)
+	addOnInstallation, err := ocmClient.GetAddOnInstallation(cluster.ID(), addOnID)
 	if err != nil {
 		reporter.Errorf("Failed to get add-on '%s' installation: %v", addOnID, err)
 		os.Exit(1)
@@ -251,7 +251,7 @@ func run(cmd *cobra.Command, argv []string) {
 	})
 
 	reporter.Debugf("Updating add-on parameters for '%s' on cluster '%s'", addOnID, clusterKey)
-	err = ocmClient.UpdateAddOnInstallation(clusterKey, awsCreator, addOnID, params)
+	err = ocmClient.UpdateAddOnInstallation(cluster.ID(), addOnID, params)
 	if err != nil {
 		reporter.Errorf("Failed to update add-on installation '%s' for cluster '%s': %v", addOnID, clusterKey, err)
 		os.Exit(1)

--- a/cmd/install/addon/cmd.go
+++ b/cmd/install/addon/cmd.go
@@ -111,7 +111,7 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
-	addOn, err := ocmClient.GetAddOnInstallation(clusterKey, awsCreator, addOnID)
+	addOn, err := ocmClient.GetAddOnInstallation(cluster.ID(), addOnID)
 	if err != nil && errors.GetType(err) != errors.NotFound {
 		reporter.Errorf("An error occurred while trying to get addon installation : %v", err)
 		os.Exit(1)
@@ -225,7 +225,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	reporter.Debugf("Installing add-on '%s' on cluster '%s'", addOnID, clusterKey)
-	err = ocmClient.InstallAddOn(clusterKey, awsCreator, addOnID, params)
+	err = ocmClient.InstallAddOn(cluster.ID(), addOnID, params)
 	if err != nil {
 		reporter.Errorf("Failed to add add-on installation '%s' for cluster '%s': %v", addOnID, clusterKey, err)
 		os.Exit(1)

--- a/cmd/uninstall/addon/cmd.go
+++ b/cmd/uninstall/addon/cmd.go
@@ -107,7 +107,7 @@ func run(_ *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
-	addOn, err := ocmClient.GetAddOnInstallation(clusterKey, awsCreator, addOnID)
+	addOn, err := ocmClient.GetAddOnInstallation(cluster.ID(), addOnID)
 	if addOn == nil {
 		reporter.Warnf("Addon '%s' is not installed on cluster '%s'", addOnID, clusterKey)
 		os.Exit(0)
@@ -118,7 +118,7 @@ func run(_ *cobra.Command, argv []string) {
 	}
 
 	reporter.Debugf("Uninstalling add-on '%s' from cluster '%s'", addOnID, clusterKey)
-	err = ocmClient.UninstallAddOn(clusterKey, awsCreator, addOnID)
+	err = ocmClient.UninstallAddOn(cluster.ID(), addOnID)
 	if err != nil {
 		reporter.Errorf("Failed to remove add-on installation '%s' from cluster '%s': %s", addOnID, clusterKey, err)
 		os.Exit(1)

--- a/pkg/ocm/addons.go
+++ b/pkg/ocm/addons.go
@@ -19,8 +19,6 @@ package ocm
 import (
 	amsv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-
-	"github.com/openshift/rosa/pkg/aws"
 )
 
 type AddOnParam struct {
@@ -40,13 +38,7 @@ type ClusterAddOn struct {
 	State string
 }
 
-func (c *Client) InstallAddOn(clusterKey string, creator *aws.Creator, addOnID string,
-	params []AddOnParam) error {
-	cluster, err := c.GetCluster(clusterKey, creator)
-	if err != nil {
-		return err
-	}
-
+func (c *Client) InstallAddOn(clusterID, addOnID string, params []AddOnParam) error {
 	addOnInstallationBuilder := cmv1.NewAddOnInstallation().
 		Addon(cmv1.NewAddOn().ID(addOnID))
 
@@ -66,7 +58,7 @@ func (c *Client) InstallAddOn(clusterKey string, creator *aws.Creator, addOnID s
 
 	response, err := c.ocm.ClustersMgmt().V1().
 		Clusters().
-		Cluster(cluster.ID()).
+		Cluster(clusterID).
 		Addons().
 		Add().
 		Body(addOnInstallation).
@@ -78,15 +70,10 @@ func (c *Client) InstallAddOn(clusterKey string, creator *aws.Creator, addOnID s
 	return nil
 }
 
-func (c *Client) UninstallAddOn(clusterKey string, creator *aws.Creator, addOnID string) error {
-	cluster, err := c.GetCluster(clusterKey, creator)
-	if err != nil {
-		return err
-	}
-
+func (c *Client) UninstallAddOn(clusterID, addOnID string) error {
 	response, err := c.ocm.ClustersMgmt().V1().
 		Clusters().
-		Cluster(cluster.ID()).
+		Cluster(clusterID).
 		Addons().
 		Addoninstallation(addOnID).
 		Delete().
@@ -98,16 +85,10 @@ func (c *Client) UninstallAddOn(clusterKey string, creator *aws.Creator, addOnID
 	return nil
 }
 
-func (c *Client) GetAddOnInstallation(clusterKey string, creator *aws.Creator,
-	addOnID string) (*cmv1.AddOnInstallation, error) {
-	cluster, err := c.GetCluster(clusterKey, creator)
-	if err != nil {
-		return nil, err
-	}
-
+func (c *Client) GetAddOnInstallation(clusterID, addOnID string) (*cmv1.AddOnInstallation, error) {
 	response, err := c.ocm.ClustersMgmt().V1().
 		Clusters().
-		Cluster(cluster.ID()).
+		Cluster(clusterID).
 		Addons().
 		Addoninstallation(addOnID).
 		Get().
@@ -119,13 +100,7 @@ func (c *Client) GetAddOnInstallation(clusterKey string, creator *aws.Creator,
 	return response.Body(), nil
 }
 
-func (c *Client) UpdateAddOnInstallation(clusterKey string, creator *aws.Creator, addOnID string,
-	params []AddOnParam) error {
-	cluster, err := c.GetCluster(clusterKey, creator)
-	if err != nil {
-		return err
-	}
-
+func (c *Client) UpdateAddOnInstallation(clusterID, addOnID string, params []AddOnParam) error {
 	addOnInstallationBuilder := cmv1.NewAddOnInstallation().
 		Addon(cmv1.NewAddOn().ID(addOnID))
 
@@ -143,7 +118,7 @@ func (c *Client) UpdateAddOnInstallation(clusterKey string, creator *aws.Creator
 		return err
 	}
 
-	response, err := c.ocm.ClustersMgmt().V1().Clusters().Cluster(cluster.ID()).
+	response, err := c.ocm.ClustersMgmt().V1().Clusters().Cluster(clusterID).
 		Addons().Addoninstallation(addOnID).
 		Update().Body(addOnInstallation).Send()
 	if err != nil {
@@ -153,7 +128,7 @@ func (c *Client) UpdateAddOnInstallation(clusterKey string, creator *aws.Creator
 	return nil
 }
 
-func (c *Client) GetAddOnParameters(clusterID string, addOnID string) (*cmv1.AddOnParameterList, error) {
+func (c *Client) GetAddOnParameters(clusterID, addOnID string) (*cmv1.AddOnParameterList, error) {
 	response, err := c.ocm.ClustersMgmt().V1().Clusters().
 		Cluster(clusterID).AddonInquiries().AddonInquiry(addOnID).Get().Send()
 	if err != nil {


### PR DESCRIPTION
Looking up an addon installation triggers another call to OCM just to
get the cluster ID, but we already have it every time we fetch the
installation.