### PR TITLE
creating htpassword idp still prompts for username even if provided

### DIFF
--- a/cmd/create/idp/htpasswd.go
+++ b/cmd/create/idp/htpasswd.go
@@ -69,7 +69,6 @@ func createHTPasswdIDP(cmd *cobra.Command,
 		reporter.Infof("User '%s' added", username)
 	} else {
 		// HTPasswd IDP does not exist - create it
-		idpName := getIDPName(cmd, idpName)
 		if username == "" || password == "" {
 			reporter.Infof("At least one user is required to create the IDP.")
 			username, password = getUserDetails(cmd)


### PR DESCRIPTION
Signed-off-by: Tzvika Avni <tavni@redhat.com>

[SDA-6160](https://issues.redhat.com//browse/SDA-6160)

@pvasant @zgalor @oriAdler  PTAL