### PR TITLE
Initial implementation of runtime

### DIFF
--- a/pkg/rosa/runtime.go
+++ b/pkg/rosa/runtime.go
@@ -1,0 +1,57 @@
+package rosa
+
+import (
+	"os"
+
+	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/logging"
+	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/reporter"
+	"github.com/sirupsen/logrus"
+)
+
+type Runtime struct {
+	Reporter  *reporter.Object
+	Logger    *logrus.Logger
+	OCMClient *ocm.Client
+	AWSClient aws.Client
+	Creator   *aws.Creator
+}
+
+func NewRuntime() *Runtime {
+	reporter := reporter.CreateReporterOrExit()
+	logger := logging.NewLogger()
+	return &Runtime{Reporter: reporter, Logger: logger}
+}
+
+// Adds an OCM client to the runtime. Requires a deferred call to `.Cleanup()` to close connections.
+func (r *Runtime) WithOCM() *Runtime {
+	if r.OCMClient == nil {
+		r.OCMClient = ocm.CreateNewClientOrExit(r.Logger, r.Reporter)
+	}
+	return r
+}
+
+// Adds an AWS client to the runtime
+func (r *Runtime) WithAWS() *Runtime {
+	if r.AWSClient == nil {
+		r.AWSClient = aws.CreateNewClientOrExit(r.Logger, r.Reporter)
+	}
+	if r.Creator == nil {
+		var err error
+		r.Creator, err = r.AWSClient.GetCreator()
+		if err != nil {
+			r.Reporter.Errorf("Failed to get AWS creator: %v", err)
+			os.Exit(1)
+		}
+	}
+	return r
+}
+
+func (r *Runtime) Cleanup() {
+	if r.OCMClient != nil {
+		if err := r.OCMClient.Close(); err != nil {
+			r.Reporter.Errorf("Failed to close OCM connection: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
The runtime provides command run() methods with common tools such as
logger, reporter and various clients. This change will allow removing a
lot of boilerplate from the various commands and make refactoring them
simpler as extracting methods will require fewer parameters.

@vkareh @pvasant @oriAdler @zvikorn WDYT?
 I'd be happy for any suggestions on better naming, if we want this level of flexibility or if we should initialize all the clients for all commands anyways, and if you think this approach makes sense. If we agree on this direction i'll follow up with a cleanup of all the other commands (right now added just a couple to show the impact).
 
 [SDA-6207](https://issues.redhat.com//browse/SDA-6207)