### PR TITLE
Simplify logger package

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -80,7 +80,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	mode, err := aws.GetMode()
 	if err != nil {

--- a/cmd/create/admin/cmd.go
+++ b/cmd/create/admin/cmd.go
@@ -62,7 +62,7 @@ func init() {
 
 func run(cmd *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	clusterKey, err := ocm.GetClusterKey()
 	if err != nil {

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -489,7 +489,7 @@ func networkTypeCompletion(cmd *cobra.Command, args []string, toComplete string)
 
 func run(cmd *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 	var err error
 
 	// Create the client for the OCM API:

--- a/cmd/create/idp/cmd.go
+++ b/cmd/create/idp/cmd.go
@@ -293,7 +293,7 @@ func init() {
 
 	interactive.AddFlag(flags)
 	reporter = rprtr.CreateReporterOrExit()
-	logger = logging.CreateLoggerOrExit(reporter)
+	logger = logging.NewLogger()
 }
 
 func run(cmd *cobra.Command, _ []string) {

--- a/cmd/create/ingress/cmd.go
+++ b/cmd/create/ingress/cmd.go
@@ -77,7 +77,7 @@ func init() {
 
 func run(cmd *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	clusterKey, err := ocm.GetClusterKey()
 	if err != nil {

--- a/cmd/create/machinepool/cmd.go
+++ b/cmd/create/machinepool/cmd.go
@@ -156,7 +156,7 @@ func init() {
 
 func run(cmd *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	clusterKey, err := ocm.GetClusterKey()
 	if err != nil {

--- a/cmd/create/ocmrole/cmd.go
+++ b/cmd/create/ocmrole/cmd.go
@@ -85,7 +85,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	mode, err := aws.GetMode()
 	if err != nil {

--- a/cmd/create/oidcprovider/cmd.go
+++ b/cmd/create/oidcprovider/cmd.go
@@ -61,7 +61,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	// Allow the command to be called programmatically
 	skipInteractive := false

--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -81,7 +81,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	// Allow the command to be called programmatically
 	skipInteractive := false

--- a/cmd/create/service/cmd.go
+++ b/cmd/create/service/cmd.go
@@ -123,7 +123,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	if args.ServiceType == "" {
 		reporter.Errorf("Service type not specified.")

--- a/cmd/create/userrole/cmd.go
+++ b/cmd/create/userrole/cmd.go
@@ -77,7 +77,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	mode, err := aws.GetMode()
 	if err != nil {

--- a/cmd/describe/addon/cmd.go
+++ b/cmd/describe/addon/cmd.go
@@ -49,7 +49,7 @@ var Cmd = &cobra.Command{
 
 func run(_ *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	// Create the client for the OCM API:
 	ocmClient, err := ocm.NewClient().

--- a/cmd/describe/admin/cmd.go
+++ b/cmd/describe/admin/cmd.go
@@ -44,7 +44,7 @@ func init() {
 
 func run(cmd *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	clusterKey, err := ocm.GetClusterKey()
 	if err != nil {

--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -55,7 +55,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	var clusterKey string
 	var err error

--- a/cmd/describe/installation/cmd.go
+++ b/cmd/describe/installation/cmd.go
@@ -65,7 +65,7 @@ func init() {
 
 func run(_ *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	if args.clusterKey == "" {
 		reporter.Errorf(

--- a/cmd/describe/service/cmd.go
+++ b/cmd/describe/service/cmd.go
@@ -53,7 +53,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	if args.ID == "" {
 		reporter.Errorf("id not specified.")

--- a/cmd/dlt/accountroles/cmd.go
+++ b/cmd/dlt/accountroles/cmd.go
@@ -63,7 +63,7 @@ func init() {
 
 func run(cmd *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	// Determine if interactive mode is needed (if a prefix is not provided, fallback to interactive mode)
 	if !interactive.Enabled() && !cmd.Flags().Changed("mode") || args.prefix == "" {

--- a/cmd/dlt/admin/cmd.go
+++ b/cmd/dlt/admin/cmd.go
@@ -45,7 +45,7 @@ func init() {
 
 func run(cmd *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	clusterKey, err := ocm.GetClusterKey()
 	if err != nil {

--- a/cmd/dlt/cluster/cmd.go
+++ b/cmd/dlt/cluster/cmd.go
@@ -63,7 +63,7 @@ func init() {
 
 func run(cmd *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	clusterKey, err := ocm.GetClusterKey()
 	if err != nil {

--- a/cmd/dlt/idp/cmd.go
+++ b/cmd/dlt/idp/cmd.go
@@ -55,7 +55,7 @@ func init() {
 
 func run(_ *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	idpName := argv[0]
 

--- a/cmd/dlt/ingress/cmd.go
+++ b/cmd/dlt/ingress/cmd.go
@@ -62,7 +62,7 @@ func init() {
 
 func run(_ *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	ingressID := argv[0]
 	if !ingressKeyRE.MatchString(ingressID) {

--- a/cmd/dlt/machinepool/cmd.go
+++ b/cmd/dlt/machinepool/cmd.go
@@ -59,7 +59,7 @@ func init() {
 
 func run(_ *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	machinePoolID := argv[0]
 	if machinePoolID != "Default" && !machinePoolKeyRE.MatchString(machinePoolID) {

--- a/cmd/dlt/ocmrole/cmd.go
+++ b/cmd/dlt/ocmrole/cmd.go
@@ -66,7 +66,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) error {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 	awsClient := aws.CreateNewClientOrExit(logger, reporter)
 	ocmClient := ocm.CreateNewClientOrExit(logger, reporter)
 	defer func() {

--- a/cmd/dlt/oidcprovider/cmd.go
+++ b/cmd/dlt/oidcprovider/cmd.go
@@ -19,6 +19,8 @@ package oidcprovider
 import (
 	"fmt"
 
+	"os"
+
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
@@ -27,7 +29,6 @@ import (
 	rprtr "github.com/openshift/rosa/pkg/reporter"
 	"github.com/spf13/cobra"
 	errors "github.com/zgalor/weberr"
-	"os"
 )
 
 var Cmd = &cobra.Command{
@@ -50,7 +51,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 	if len(argv) == 1 && !cmd.Flag("cluster").Changed {
 		ocm.SetClusterKey(argv[0])
 	}

--- a/cmd/dlt/operatorrole/cmd.go
+++ b/cmd/dlt/operatorrole/cmd.go
@@ -65,7 +65,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	if len(argv) == 1 && !cmd.Flag("cluster").Changed {
 		args.clusterKey = argv[0]

--- a/cmd/dlt/service/cmd.go
+++ b/cmd/dlt/service/cmd.go
@@ -57,7 +57,7 @@ func init() {
 
 func run(cmd *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	if args.ID == "" {
 		reporter.Errorf("id not specified.")

--- a/cmd/dlt/upgrade/cmd.go
+++ b/cmd/dlt/upgrade/cmd.go
@@ -43,7 +43,7 @@ func init() {
 
 func run(cmd *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	clusterKey, err := ocm.GetClusterKey()
 	if err != nil {

--- a/cmd/dlt/userrole/cmd.go
+++ b/cmd/dlt/userrole/cmd.go
@@ -65,7 +65,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 	awsClient := aws.CreateNewClientOrExit(logger, reporter)
 	ocmClient := ocm.CreateNewClientOrExit(logger, reporter)
 	defer func() {

--- a/cmd/edit/addon/cmd.go
+++ b/cmd/edit/addon/cmd.go
@@ -63,7 +63,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	// Parse out CLI flags, then override positional arguments
 	_ = cmd.Flags().Parse(argv)

--- a/cmd/edit/cluster/cmd.go
+++ b/cmd/edit/cluster/cmd.go
@@ -152,7 +152,7 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 	}
 
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	// Create the client for the OCM API:
 	ocmClient, err := ocm.NewClient().

--- a/cmd/edit/ingress/cmd.go
+++ b/cmd/edit/ingress/cmd.go
@@ -88,7 +88,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	ingressID := argv[0]
 	if !ingressKeyRE.MatchString(ingressID) {

--- a/cmd/edit/machinepool/cmd.go
+++ b/cmd/edit/machinepool/cmd.go
@@ -117,7 +117,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	machinePoolID := argv[0]
 	if machinePoolID != "Default" && !machinePoolKeyRE.MatchString(machinePoolID) {

--- a/cmd/edit/service/cmd.go
+++ b/cmd/edit/service/cmd.go
@@ -66,7 +66,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	if args.ID == "" {
 		reporter.Errorf("Service id not specified.")

--- a/cmd/grant/user/cmd.go
+++ b/cmd/grant/user/cmd.go
@@ -75,7 +75,7 @@ func init() {
 
 func run(_ *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	clusterKey, err := ocm.GetClusterKey()
 	if err != nil {

--- a/cmd/hibernate/cluster/cmd.go
+++ b/cmd/hibernate/cluster/cmd.go
@@ -44,7 +44,7 @@ func init() {
 
 func run(cmd *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	clusterKey, err := ocm.GetClusterKey()
 	if err != nil {

--- a/cmd/initialize/cmd.go
+++ b/cmd/initialize/cmd.go
@@ -94,7 +94,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	// If necessary, call `login` as part of `init`. We do this before
 	// other validations to get the prompt out of the way before performing

--- a/cmd/install/addon/cmd.go
+++ b/cmd/install/addon/cmd.go
@@ -67,7 +67,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	// Parse out CLI flags, then override positional arguments
 	_ = cmd.Flags().Parse(argv)

--- a/cmd/link/ocmrole/cmd.go
+++ b/cmd/link/ocmrole/cmd.go
@@ -66,7 +66,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) (err error) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	if len(argv) > 0 {
 		args.roleArn = argv[0]

--- a/cmd/link/userrole/cmd.go
+++ b/cmd/link/userrole/cmd.go
@@ -43,7 +43,7 @@ var Cmd = &cobra.Command{
 	Aliases: []string{"userrole"},
 	Short:   "link user role to specific OCM account.",
 	Long:    "link user role to specific OCM account before create your cluster.",
-	Example: ` # Link user roles 
+	Example: ` # Link user roles
   rosa link user-role --role-arn arn:aws:iam::{accountid}:role/{prefix}-User-{username}-Role`,
 	RunE: run,
 }
@@ -70,7 +70,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) (err error) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	if len(argv) > 0 {
 		args.roleArn = argv[0]

--- a/cmd/list/accountroles/cmd.go
+++ b/cmd/list/accountroles/cmd.go
@@ -60,7 +60,7 @@ func init() {
 
 func run(_ *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	// Create the AWS client:
 	awsClient, err := aws.NewClient().

--- a/cmd/list/addon/cmd.go
+++ b/cmd/list/addon/cmd.go
@@ -58,7 +58,7 @@ func init() {
 
 func run(_ *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	// Check that the cluster key (name, identifier or external identifier) given by the user
 	// is reasonably safe so that there is no risk of SQL injection:

--- a/cmd/list/cluster/cmd.go
+++ b/cmd/list/cluster/cmd.go
@@ -50,7 +50,7 @@ func init() {
 
 func run(_ *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	// Create the AWS client:
 	awsClient, err := aws.NewClient().

--- a/cmd/list/gates/cmd.go
+++ b/cmd/list/gates/cmd.go
@@ -101,7 +101,7 @@ var (
 
 func run(cmd *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	// Create the AWS client:
 	awsClient, err := aws.NewClient().

--- a/cmd/list/idp/cmd.go
+++ b/cmd/list/idp/cmd.go
@@ -49,7 +49,7 @@ func init() {
 
 func run(_ *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	clusterKey, err := ocm.GetClusterKey()
 	if err != nil {

--- a/cmd/list/ingress/cmd.go
+++ b/cmd/list/ingress/cmd.go
@@ -49,7 +49,7 @@ func init() {
 
 func run(_ *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	clusterKey, err := ocm.GetClusterKey()
 	if err != nil {

--- a/cmd/list/instancetypes/cmd.go
+++ b/cmd/list/instancetypes/cmd.go
@@ -46,7 +46,7 @@ func init() {
 
 func run(cmd *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	// Create the client for the OCM API:
 	ocmClient, err := ocm.NewClient().

--- a/cmd/list/machinepool/cmd.go
+++ b/cmd/list/machinepool/cmd.go
@@ -49,7 +49,7 @@ func init() {
 
 func run(_ *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	clusterKey, err := ocm.GetClusterKey()
 	if err != nil {

--- a/cmd/list/ocmroles/cmd.go
+++ b/cmd/list/ocmroles/cmd.go
@@ -49,7 +49,7 @@ func init() {
 
 func run(_ *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	// Create the AWS client:
 	awsClient, err := aws.NewClient().

--- a/cmd/list/region/cmd.go
+++ b/cmd/list/region/cmd.go
@@ -72,7 +72,7 @@ func init() {
 
 func run(cmd *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	// Create the client for the OCM API:
 	ocmClient, err := ocm.NewClient().

--- a/cmd/list/service/cmd.go
+++ b/cmd/list/service/cmd.go
@@ -52,7 +52,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	// Parse out CLI flags, then override positional arguments
 	// This allows for arbitrary flags used for addon parameters

--- a/cmd/list/upgrade/cmd.go
+++ b/cmd/list/upgrade/cmd.go
@@ -46,7 +46,7 @@ func init() {
 
 func run(_ *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	clusterKey, err := ocm.GetClusterKey()
 	if err != nil {

--- a/cmd/list/user/cmd.go
+++ b/cmd/list/user/cmd.go
@@ -47,7 +47,7 @@ func init() {
 
 func run(_ *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	clusterKey, err := ocm.GetClusterKey()
 	if err != nil {

--- a/cmd/list/userroles/cmd.go
+++ b/cmd/list/userroles/cmd.go
@@ -46,7 +46,7 @@ func init() {
 
 func run(_ *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 	awsClient := aws.CreateNewClientOrExit(logger, reporter)
 	ocmClient := ocm.CreateNewClientOrExit(logger, reporter)
 	defer func() {

--- a/cmd/list/version/cmd.go
+++ b/cmd/list/version/cmd.go
@@ -58,7 +58,7 @@ func init() {
 
 func run(cmd *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	// Create the client for the OCM API:
 	ocmClient, err := ocm.NewClient().

--- a/cmd/login/cmd.go
+++ b/cmd/login/cmd.go
@@ -122,7 +122,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	// Check mandatory options:
 	if args.env == "" {

--- a/cmd/logs/install/cmd.go
+++ b/cmd/logs/install/cmd.go
@@ -73,7 +73,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	// Determine whether the user wants to watch logs streaming.
 	// We check the flag value this way to allow other commands to watch logs

--- a/cmd/logs/uninstall/cmd.go
+++ b/cmd/logs/uninstall/cmd.go
@@ -73,7 +73,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	// Determine whether the user wants to watch logs streaming.
 	// We check the flag value this way to allow other commands to watch logs

--- a/cmd/resume/cluster/cmd.go
+++ b/cmd/resume/cluster/cmd.go
@@ -51,7 +51,7 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 	// Create the AWS client:
 	awsClient, err := aws.NewClient().
 		Logger(logger).

--- a/cmd/revoke/user/cmd.go
+++ b/cmd/revoke/user/cmd.go
@@ -75,7 +75,7 @@ func init() {
 
 func run(_ *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	clusterKey, err := ocm.GetClusterKey()
 	if err != nil {

--- a/cmd/uninstall/addon/cmd.go
+++ b/cmd/uninstall/addon/cmd.go
@@ -54,7 +54,7 @@ func init() {
 
 func run(_ *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	addOnID := argv[0]
 

--- a/cmd/unlink/ocmrole/cmd.go
+++ b/cmd/unlink/ocmrole/cmd.go
@@ -66,7 +66,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) (err error) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 	ocmClient := ocm.CreateNewClientOrExit(logger, reporter)
 	defer func() {
 		err = ocmClient.Close()

--- a/cmd/unlink/userrole/cmd.go
+++ b/cmd/unlink/userrole/cmd.go
@@ -66,7 +66,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) (err error) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 	ocmClient := ocm.CreateNewClientOrExit(logger, reporter)
 	defer func() {
 		err = ocmClient.Close()

--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -71,7 +71,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) error {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	isInvokedFromClusterUpgrade := false
 	skipInteractive := false

--- a/cmd/upgrade/cluster/cmd.go
+++ b/cmd/upgrade/cluster/cmd.go
@@ -109,7 +109,7 @@ func init() {
 
 func run(cmd *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	clusterKey, err := ocm.GetClusterKey()
 	if err != nil {

--- a/cmd/upgrade/operatorroles/cmd.go
+++ b/cmd/upgrade/operatorroles/cmd.go
@@ -68,7 +68,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) error {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	// Allow the command to be called programmatically
 	skipInteractive := false

--- a/cmd/verify/permissions/cmd.go
+++ b/cmd/verify/permissions/cmd.go
@@ -52,7 +52,7 @@ func init() {
 
 func run(cmd *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	// Get AWS region
 	region, err := aws.GetRegion(arguments.GetRegion())

--- a/cmd/verify/quota/cmd.go
+++ b/cmd/verify/quota/cmd.go
@@ -50,7 +50,7 @@ func init() {
 
 func run(cmd *cobra.Command, _ []string) (err error) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	// Get AWS region
 	region, err := aws.GetRegion(arguments.GetRegion())

--- a/cmd/whoami/cmd.go
+++ b/cmd/whoami/cmd.go
@@ -47,7 +47,7 @@ func init() {
 
 func run(_ *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	// Create the AWS client:
 	awsClient, err := aws.NewClient().

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -497,11 +497,7 @@ func (c *awsClient) GetAWSAccessKeys() (*AccessKey, error) {
 // ValidateAccessKeys deals with AWS' eventual consistency, its attempts to call
 // GetCallerIdentity and will try again if the error is access denied.
 func (c *awsClient) ValidateAccessKeys(AccessKey *AccessKey) error {
-	logger, err := logging.NewLogger().
-		Build()
-	if err != nil {
-		return fmt.Errorf("Unable to create AWS logger: %v", err)
-	}
+	logger := logging.NewLogger()
 
 	start := time.Now()
 	maxAttempts := 15
@@ -675,11 +671,7 @@ func (r CustomRetryer) ShouldRetry(req *request.Request) bool {
 	if req.HTTPResponse.StatusCode >= 500 {
 		return false
 	}
-	logger, err := logging.NewLogger().
-		Build()
-	if err != nil {
-		logger.Errorf("Unable to create AWS logger: %v", err)
-	}
+	logger := logging.NewLogger()
 	if strings.Contains(req.Error.Error(), "Throttling") {
 		logger.Warn("Throttling Rate limit exceeded. Retrying the request again")
 	}

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -19,27 +19,13 @@ limitations under the License.
 package logging
 
 import (
-	"os"
-
 	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/rosa/pkg/debug"
-	rprtr "github.com/openshift/rosa/pkg/reporter"
 )
 
-// LoggerBuilder contains the information and logic needed to create the default loggers used by
-// the project. Don't create instances of this type directly; use the NewLogger function instead.
-type LoggerBuilder struct {
-}
-
-// NewLogger creates new builder that can then be used to configure and build an OCM logger that
-// uses the logging framework of the project.
-func NewLogger() *LoggerBuilder {
-	return &LoggerBuilder{}
-}
-
-// Build uses the information stored in the builder to create a new logger.
-func (b *LoggerBuilder) Build() (result *logrus.Logger, err error) {
+// NewLogger creates a new logger with the default config for the project
+func NewLogger() (result *logrus.Logger) {
 	// Create the logger:
 	result = logrus.New()
 	result.SetFormatter(&logrus.TextFormatter{
@@ -53,16 +39,4 @@ func (b *LoggerBuilder) Build() (result *logrus.Logger, err error) {
 	}
 
 	return
-}
-
-// CreateLoggerOrExit creates the logger instance or exits to the console
-// noting the error on failure.
-func CreateLoggerOrExit(reporter *rprtr.Object) *logrus.Logger {
-	// Create the logger:
-	logger, err := NewLogger().Build()
-	if err != nil {
-		reporter.Errorf("Failed to create logger: %v", err)
-		os.Exit(1)
-	}
-	return logger
 }

--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -137,12 +137,7 @@ func (c *Client) HasClusters(creator *aws.Creator) (bool, error) {
 }
 
 func (c *Client) CreateCluster(config Spec) (*cmv1.Cluster, error) {
-	logger, err := logging.NewLogger().
-		Build()
-	if err != nil {
-		return nil, fmt.Errorf("Unable to create AWS logger: %v", err)
-	}
-
+	logger := logging.NewLogger()
 	// Create the AWS client:
 	awsClient, err := aws.NewClient().
 		Logger(logger).

--- a/pkg/ocm/flag.go
+++ b/pkg/ocm/flag.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/logging"
-	rprtr "github.com/openshift/rosa/pkg/reporter"
 )
 
 var clusterKey string
@@ -58,8 +57,7 @@ func GetClusterKey() (string, error) {
 }
 
 func clusterCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	ocmClient, err := NewClient().Logger(logger).Build()
 	if err != nil {

--- a/pkg/ocm/regions.go
+++ b/pkg/ocm/regions.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/logging"
-	rprtr "github.com/openshift/rosa/pkg/reporter"
 )
 
 func (c *Client) GetRegions(roleARN string, externalID string) (regions []*cmv1.CloudRegion, err error) {
@@ -35,8 +34,7 @@ func (c *Client) GetRegions(roleARN string, externalID string) (regions []*cmv1.
 	// Build AWS client and retrieve credentials
 	// This ensures we use the profile flag if passed to rosa
 	// Create the AWS client:
-	reporter := rprtr.CreateReporterOrExit()
-	logger := logging.CreateLoggerOrExit(reporter)
+	logger := logging.NewLogger()
 
 	awsBuilder := cmv1.NewAWS()
 	if roleARN != "" {


### PR DESCRIPTION
The logger creation never actually errors. There is no point in a
builder object that is only used to call .Build() right away and
contains no data.

Refs: [SDA-6206](https://issues.redhat.com//browse/SDA-6206)