### PR TITLE
Create a single AZ machine pool - availability zone flag

### DIFF
--- a/cmd/create/machinepool/cmd.go
+++ b/cmd/create/machinepool/cmd.go
@@ -295,7 +295,7 @@ func run(cmd *cobra.Command, _ []string) {
 					reporter.Errorf("Expected a valid AWS availability zone: %s", err)
 					os.Exit(1)
 				}
-			} else {
+			} else if isAvailabilityZoneSet {
 				availabilityZone = args.availabilityZone
 			}
 


### PR DESCRIPTION
Use the `availability-zone` flag's value only if provided by the user,
otherwise, choose az arbitrarily.

Before the `make` command - the state before this MR changes.
![image](https://user-images.githubusercontent.com/57869309/174019934-5b2131a4-6fdf-4ac1-b3e8-21563e11c515.png)
