### PR TITLE
The additional-trust-bundle-file can't be set via interactive mode if the cluster is not set proxy fields

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1704,7 +1704,7 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
-	if enableProxy && interactive.Enabled() {
+	if useExistingVPC && interactive.Enabled() {
 		additionalTrustBundleFile, err = interactive.GetCert(interactive.Input{
 			Question: "Additional trust bundle file path",
 			Help:     cmd.Flags().Lookup("additional-trust-bundle-file").Usage,

--- a/cmd/edit/cluster/cmd.go
+++ b/cmd/edit/cluster/cmd.go
@@ -457,7 +457,7 @@ func run(cmd *cobra.Command, _ []string) {
 	if additionalTrustBundleFile != nil {
 		updateAdditionalTrustBundle = true
 	}
-	if useExistingVPC && enableProxy && !updateAdditionalTrustBundle && additionalTrustBundleFile == nil &&
+	if useExistingVPC && !updateAdditionalTrustBundle && additionalTrustBundleFile == nil &&
 		interactive.Enabled() {
 		updateAdditionalTrustBundleValue, err := interactive.GetBool(interactive.Input{
 			Question: "Update additional trust bundle",
@@ -469,7 +469,7 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 		updateAdditionalTrustBundle = updateAdditionalTrustBundleValue
 	}
-	if enableProxy && updateAdditionalTrustBundle && interactive.Enabled() {
+	if updateAdditionalTrustBundle && interactive.Enabled() {
 		var def string
 		if cluster.AdditionalTrustBundle() == "REDACTED" {
 			def = "REDACTED"


### PR DESCRIPTION

Signed-off-by: Tzvika Avni <tavni@redhat.com>

[SDA-6111](https://issues.redhat.com//browse/SDA-6111)