### PR TITLE
Refactor function for more general use

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1249,10 +1249,10 @@ func run(cmd *cobra.Command, _ []string) {
 			availabilityZone := awssdk.StringValue(subnet.AvailabilityZone)
 
 			// Create the options to prompt the user.
-			options[i] = setSubnetOption(subnetID, availabilityZone)
+			options[i] = aws.SetSubnetOption(subnetID, availabilityZone)
 			if subnetsProvided {
 				for _, subnetArg := range subnetIDs {
-					defaultOptions = append(defaultOptions, setSubnetOption(subnetArg, availabilityZone))
+					defaultOptions = append(defaultOptions, aws.SetSubnetOption(subnetArg, availabilityZone))
 				}
 			}
 			mapSubnetToAZ[subnetID] = availabilityZone
@@ -1272,7 +1272,7 @@ func run(cmd *cobra.Command, _ []string) {
 				os.Exit(1)
 			}
 			for i, subnet := range subnetIDs {
-				subnetIDs[i] = parseSubnet(subnet)
+				subnetIDs[i] = aws.ParseSubnet(subnet)
 			}
 		}
 
@@ -2125,18 +2125,6 @@ func parseRFC3339(s string) (time.Time, error) {
 		return t, nil
 	}
 	return time.Parse(time.RFC3339, s)
-}
-
-const subnetTemplate = "%s (%s)"
-
-// Creates a subnet options using a predefined template.
-func setSubnetOption(subnet, zone string) string {
-	return fmt.Sprintf(subnetTemplate, subnet, zone)
-}
-
-// Parses the subnet from the option chosen by the user.
-func parseSubnet(subnetOption string) string {
-	return strings.Split(subnetOption, " ")[0]
 }
 
 func buildCommand(spec ocm.Spec, operatorRolesPrefix string, userSelectedAvailabilityZones bool) string {

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -349,9 +349,14 @@ func (c *awsClient) GetRegion() string {
 	return aws.StringValue(c.awsSession.Config.Region)
 }
 
-// GetSubnetIDs will return the list of subnetsIDs supported for the region picked.
 func (c *awsClient) GetSubnetIDs() ([]*ec2.Subnet, error) {
-	res, err := c.ec2Client.DescribeSubnets(&ec2.DescribeSubnetsInput{})
+	return c.getSubnetIDs(&ec2.DescribeSubnetsInput{})
+}
+
+// getSubnetIDs will return the list of subnetsIDs supported for the region picked.
+// It is possible to pass non-empty `describeSubnetsInput` to filter results.
+func (c *awsClient) getSubnetIDs(describeSubnetsInput *ec2.DescribeSubnetsInput) ([]*ec2.Subnet, error) {
+	res, err := c.ec2Client.DescribeSubnets(describeSubnetsInput)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -525,3 +525,15 @@ func UpggradeOperatorRolePolicies(reporter *rprtr.Object, awsClient Client, acco
 	}
 	return nil
 }
+
+const subnetTemplate = "%s (%s)"
+
+// SetSubnetOption Creates a subnet options using a predefined template.
+func SetSubnetOption(subnet, zone string) string {
+	return fmt.Sprintf(subnetTemplate, subnet, zone)
+}
+
+// ParseSubnet Parses the subnet from the option chosen by the user.
+func ParseSubnet(subnetOption string) string {
+	return strings.Split(subnetOption, " ")[0]
+}


### PR DESCRIPTION
1. Modify `GetSubnetsIDs` to recieve `DescribeSubnetsInput` for re-use.
2. Move `setSubnetOption` and `ParseSubnet` to `pkg/aws/helpers.go` for re-use.

Related: https://github.com/openshift/rosa/pull/765