### PR TITLE
Having the option to remove or add a new cluster-admin in rosa cli

### DIFF
--- a/cmd/create/idp/cmd.go
+++ b/cmd/create/idp/cmd.go
@@ -31,6 +31,8 @@ import (
 	"github.com/openshift/rosa/pkg/rosa"
 )
 
+const HTPasswdIDPName = "htpasswd"
+
 type IdentityProvider interface {
 	Name() string
 }
@@ -454,7 +456,11 @@ func GenerateIdpName(idpType string, idps []IdentityProvider) string {
 			}
 		}
 	}
-	return fmt.Sprintf("%s-%d", idpType, nextSuffix+1)
+
+	if idpType != HTPasswdIDPName {
+		return fmt.Sprintf("%s-%d", idpType, nextSuffix+1)
+	}
+	return idpType
 }
 
 func getMappingMethod(cmd *cobra.Command, mappingMethod string) (string, error) {

--- a/cmd/dlt/admin/cmd.go
+++ b/cmd/dlt/admin/cmd.go
@@ -81,6 +81,23 @@ func run(cmd *cobra.Command, _ []string) {
 				idp.ClusterAdminUsername, clusterKey, err)
 			os.Exit(1)
 		}
+		//if no users remained in htpasswd idp, delete the idp
+		userList, err := r.OCMClient.GetHTPasswdUserList(cluster.ID(), htpasswdIDP.ID())
+		if err != nil {
+			r.Reporter.Errorf("Failed to get htpasswd idp user list of cluster '%s': %s",
+				clusterKey, err)
+			os.Exit(1)
+		}
+
+		if userList.Len() == 0 {
+			//delete the htpasswd IDP
+			err = r.OCMClient.DeleteIdentityProvider(cluster.ID(), htpasswdIDP.ID())
+			if err != nil {
+				r.Reporter.Errorf("Failed to delete htpasswd IDP of cluster '%s': %s",
+					clusterKey, err)
+				os.Exit(1)
+			}
+		}
 		r.Reporter.Infof("Admin user '%s' has been deleted from cluster '%s'", idp.ClusterAdminUsername, clusterKey)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Tzvika Avni <tavni@redhat.com>

[SDA-6170](https://issues.redhat.com//browse/SDA-6170)

@pvasant 
1) rosa create admin: 'cluster-admin' user is added to group 'cluster-admins'. htpasswd idp with the name 'htpasswd' is created and 'cluster-admin' user is added to this idp. If the htpasswd idp already exists, we just add the 'cluster-admin' user to this idp

2) rosa delete admin: 'cluster-admin' user is deleted from group 'cluster-admins'. user 'cluster-admin' is deleted from htpasswd idp. If htpasswd idp user list is empty, we delete the htpasswd idp as well.

3) rosa create (htpasswd) idp: if htpasswd idp does not exist, we create the idp and add users to it. 'cluster-admin' user is NOT allowed. if htpasswd exists,  we allow adding users.

4) on rosa create admin -> if htpasswd idp creation fails, we rollback and delete the 'cluster-admin' user from group 'cluster-admins'

 this MR includes also a fix for [SDA-6106](https://issues.redhat.com/browse/SDA-6106)



