### PR TITLE
Fix error message - create non-BYOVPC - select availability zone

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2112,7 +2112,7 @@ func validateAvailabilityZones(multiAZ bool, availabilityZones []string, awsClie
 	for _, az := range availabilityZones {
 		if !helper.Contains(regionAvailabilityZones, az) {
 			return fmt.Errorf("Expected a valid availability zone, "+
-				"'%s' doesn't belong to the region's availability zones", az)
+				"'%s' doesn't belong to region '%s' availability zones", az, awsClient.GetRegion())
 		}
 	}
 


### PR DESCRIPTION
Mention region name in the error message when the availability zone
doesn't belong to the region's availability zones.

Related: [SDA-6327](https://issues.redhat.com/browse/SDA-6327)