### PR TITLE
Create cluster - detect multi-AZ cluster

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -518,6 +518,10 @@ func run(cmd *cobra.Command, _ []string) {
 		r.Reporter.Errorf("Setting availability zones is not supported for BYO VPC. " +
 			"ROSA autodetects availability zones from subnet IDs provided")
 	}
+	// Select a multi-AZ cluster implicitly by providing three availability zones
+	if len(args.availabilityZones) == multiAZCount {
+		args.multiAZ = true
+	}
 
 	if interactive.Enabled() {
 		r.Reporter.Infof("Interactive mode enabled.\n" +


### PR DESCRIPTION
If the user provided three availability zones using the flags, set the multi-AZ
to true.

Related: [SDA-6330](https://issues.redhat.com/browse/SDA-6330)

![image](https://user-images.githubusercontent.com/57869309/177037364-014dd236-adae-4a13-bb83-a367fc5d1780.png)
