### PR TITLE
Create a single AZ machine pool implicitly by providing a subnet

### DIFF
--- a/cmd/create/machinepool/cmd.go
+++ b/cmd/create/machinepool/cmd.go
@@ -261,8 +261,8 @@ func run(cmd *cobra.Command, _ []string) {
 	var multiAZMachinePool bool
 	var availabilityZone string
 	if cluster.MultiAZ() {
-		// Choosing a single AZ machine pool implicitly
-		if isAvailabilityZoneSet {
+		// Choosing a single AZ machine pool implicitly (providing availability zone or subnet)
+		if isAvailabilityZoneSet || isSubnetSet {
 			isMultiAvailabilityZoneSet = true
 			args.multiAvailabilityZone = false
 		}


### PR DESCRIPTION
In this case, the user wants to create a single AZ machine pool for
a multi-AZ cluster.
If the user provided a subnet, consider	it as choosing a single	AZ
machine pool.

**Note:** the default value for `args.multiAvailabilityZone` is true.

Related: [SDA-6354](https://issues.redhat.com/browse/SDA-6354)