### PR TITLE
Create cluster - validate subnets count interactively

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1270,6 +1270,9 @@ func run(cmd *cobra.Command, _ []string) {
 				Required: false,
 				Options:  options,
 				Default:  defaultOptions,
+				Validators: []interactive.Validator{
+					interactive.SubnetsCountValidator(multiAZ, privateLink),
+				},
 			})
 			if err != nil {
 				r.Reporter.Errorf("Expected valid subnet IDs: %s", err)
@@ -1280,10 +1283,13 @@ func run(cmd *cobra.Command, _ []string) {
 			}
 		}
 
-		err = validateSubnetsCount(multiAZ, privateLink, len(subnetIDs))
-		if err != nil {
-			r.Reporter.Errorf("%s", err)
-			os.Exit(1)
+		// Validate subnets in the case the user has provided them using the `args.subnets`
+		if subnetsProvided {
+			err = aws.ValidateSubnetsCount(multiAZ, privateLink, len(subnetIDs))
+			if err != nil {
+				r.Reporter.Errorf("%s", err)
+				os.Exit(1)
+			}
 		}
 
 		for _, subnet := range subnetIDs {
@@ -2098,37 +2104,6 @@ func validateExpiration() (expiration time.Time, err error) {
 	}
 
 	return
-}
-
-const (
-	BYOVPCSingleAZSubnetsCount      = 2
-	BYOVPCMultiAZSubnetsCount       = 6
-	privateLinkSingleAZSubnetsCount = 1
-	privateLinkMultiAZSubnetsCount  = 3
-)
-
-func validateSubnetsCount(multiAZ bool, privateLink bool, subnetsInputCount int) error {
-	if privateLink {
-		if multiAZ && subnetsInputCount != privateLinkMultiAZSubnetsCount {
-			return fmt.Errorf("The number of subnets for a multi-AZ private link cluster should be %d, "+
-				"instead received: %d", privateLinkMultiAZSubnetsCount, subnetsInputCount)
-		}
-		if !multiAZ && subnetsInputCount != privateLinkSingleAZSubnetsCount {
-			return fmt.Errorf("The number of subnets for a single AZ private link cluster should be %d, "+
-				"instead received: %d", privateLinkSingleAZSubnetsCount, subnetsInputCount)
-		}
-	} else {
-		if multiAZ && subnetsInputCount != BYOVPCMultiAZSubnetsCount {
-			return fmt.Errorf("The number of subnets for a multi-AZ cluster should be %d, "+
-				"instead received: %d", BYOVPCMultiAZSubnetsCount, subnetsInputCount)
-		}
-		if !multiAZ && subnetsInputCount != BYOVPCSingleAZSubnetsCount {
-			return fmt.Errorf("The number of subnets for a single AZ cluster should be %d, "+
-				"instead received: %d", BYOVPCSingleAZSubnetsCount, subnetsInputCount)
-		}
-	}
-
-	return nil
 }
 
 const (

--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -537,3 +537,34 @@ func SetSubnetOption(subnet, zone string) string {
 func ParseSubnet(subnetOption string) string {
 	return strings.Split(subnetOption, " ")[0]
 }
+
+const (
+	BYOVPCSingleAZSubnetsCount      = 2
+	BYOVPCMultiAZSubnetsCount       = 6
+	privateLinkSingleAZSubnetsCount = 1
+	privateLinkMultiAZSubnetsCount  = 3
+)
+
+func ValidateSubnetsCount(multiAZ bool, privateLink bool, subnetsInputCount int) error {
+	if privateLink {
+		if multiAZ && subnetsInputCount != privateLinkMultiAZSubnetsCount {
+			return fmt.Errorf("The number of subnets for a multi-AZ private link cluster should be %d, "+
+				"instead received: %d", privateLinkMultiAZSubnetsCount, subnetsInputCount)
+		}
+		if !multiAZ && subnetsInputCount != privateLinkSingleAZSubnetsCount {
+			return fmt.Errorf("The number of subnets for a single AZ private link cluster should be %d, "+
+				"instead received: %d", privateLinkSingleAZSubnetsCount, subnetsInputCount)
+		}
+	} else {
+		if multiAZ && subnetsInputCount != BYOVPCMultiAZSubnetsCount {
+			return fmt.Errorf("The number of subnets for a multi-AZ cluster should be %d, "+
+				"instead received: %d", BYOVPCMultiAZSubnetsCount, subnetsInputCount)
+		}
+		if !multiAZ && subnetsInputCount != BYOVPCSingleAZSubnetsCount {
+			return fmt.Errorf("The number of subnets for a single AZ cluster should be %d, "+
+				"instead received: %d", BYOVPCSingleAZSubnetsCount, subnetsInputCount)
+		}
+	}
+
+	return nil
+}

--- a/pkg/interactive/validation.go
+++ b/pkg/interactive/validation.go
@@ -26,6 +26,8 @@ import (
 	"regexp"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/AlecAivazis/survey/v2/core"
+	"github.com/openshift/rosa/pkg/aws"
 )
 
 const doubleQuotesToRemove = "\"\""
@@ -132,5 +134,17 @@ func RegExpBoolean(restr string) Validator {
 			return nil
 		}
 		return fmt.Errorf("can only validate boolean values, got %v", val)
+	}
+}
+
+// SubnetsCountValidator get a slice of `[]core.OptionAnswer` as an interface.
+// e.g. core.OptionAnswer { Value: subnet-04f67939f44a97dbe (us-west-2b), Index: 0 }
+func SubnetsCountValidator(multiAZ bool, privateLink bool) Validator {
+	return func(input interface{}) error {
+		if answers, ok := input.([]core.OptionAnswer); ok {
+			return aws.ValidateSubnetsCount(multiAZ, privateLink, len(answers))
+		}
+
+		return fmt.Errorf("can only validate a slice of string, got %v", input)
 	}
 }


### PR DESCRIPTION
Use the interactive validation to provide fast feedback to the user,
to achieve a better user experience.

Related: [SDA-6331](https://issues.redhat.com/browse/SDA-6331)

This PR follows up on https://github.com/openshift/rosa/pull/772

[validate_subnet_interactive.webm](https://user-images.githubusercontent.com/57869309/177284154-e415bf8c-717d-43bd-bfd6-ab73de0d5a5c.webm)

![image](https://user-images.githubusercontent.com/57869309/177283983-2e913aa3-a100-42a8-b3ed-3ab853a7e118.png)

