### PR TITLE
Set `clusterKey` properly to support `r.FetchCluster`

### DIFF
--- a/cmd/list/addon/cmd.go
+++ b/cmd/list/addon/cmd.go
@@ -60,7 +60,8 @@ func run(_ *cobra.Command, _ []string) {
 
 	// Check that the cluster key (name, identifier or external identifier) given by the user
 	// is reasonably safe so that there is no risk of SQL injection:
-	clusterKey := args.clusterKey
+	ocm.SetClusterKey(args.clusterKey)
+	clusterKey := r.GetClusterKey()
 	if clusterKey != "" && !ocm.IsValidClusterKey(clusterKey) {
 		r.Reporter.Errorf(
 			"Cluster name, identifier or external identifier '%s' isn't valid: it "+


### PR DESCRIPTION
Use the `SetClusterKey` to assign the `cluster key` to the global variable.
In order to use it in the `r.FetchCluster` function.

Related: [SDA-6362](https://issues.redhat.com/browse/SDA-6362)

Follows up on https://github.com/openshift/rosa/pull/768

![image](https://user-images.githubusercontent.com/57869309/177529808-80b6bef6-1641-4cac-b6ed-21ad2bdb41b1.png)
