### PR TITLE
Fix typo in error message when looking up account role prefix

### DIFF
--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -1192,7 +1192,7 @@ func (c *awsClient) IsUpgradedNeededForAccountRolePolicies(prefix string, versio
 			if aerr, ok := err.(awserr.Error); ok {
 				switch aerr.Code() {
 				case iam.ErrCodeNoSuchEntityException:
-					return false, errors.NotFound.Errorf("Roles with the prefix'%s' not found", prefix)
+					return false, errors.NotFound.Errorf("Roles with the prefix '%s' not found", prefix)
 				}
 			}
 			return false, err


### PR DESCRIPTION
Fix small whitespace typo