### PR TITLE
Create cluster - validate availability zones count interactively

### DIFF
--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -537,34 +537,3 @@ func SetSubnetOption(subnet, zone string) string {
 func ParseSubnet(subnetOption string) string {
 	return strings.Split(subnetOption, " ")[0]
 }
-
-const (
-	BYOVPCSingleAZSubnetsCount      = 2
-	BYOVPCMultiAZSubnetsCount       = 6
-	privateLinkSingleAZSubnetsCount = 1
-	privateLinkMultiAZSubnetsCount  = 3
-)
-
-func ValidateSubnetsCount(multiAZ bool, privateLink bool, subnetsInputCount int) error {
-	if privateLink {
-		if multiAZ && subnetsInputCount != privateLinkMultiAZSubnetsCount {
-			return fmt.Errorf("The number of subnets for a multi-AZ private link cluster should be %d, "+
-				"instead received: %d", privateLinkMultiAZSubnetsCount, subnetsInputCount)
-		}
-		if !multiAZ && subnetsInputCount != privateLinkSingleAZSubnetsCount {
-			return fmt.Errorf("The number of subnets for a single AZ private link cluster should be %d, "+
-				"instead received: %d", privateLinkSingleAZSubnetsCount, subnetsInputCount)
-		}
-	} else {
-		if multiAZ && subnetsInputCount != BYOVPCMultiAZSubnetsCount {
-			return fmt.Errorf("The number of subnets for a multi-AZ cluster should be %d, "+
-				"instead received: %d", BYOVPCMultiAZSubnetsCount, subnetsInputCount)
-		}
-		if !multiAZ && subnetsInputCount != BYOVPCSingleAZSubnetsCount {
-			return fmt.Errorf("The number of subnets for a single AZ cluster should be %d, "+
-				"instead received: %d", BYOVPCSingleAZSubnetsCount, subnetsInputCount)
-		}
-	}
-
-	return nil
-}

--- a/pkg/interactive/validation.go
+++ b/pkg/interactive/validation.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/core"
-	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/ocm"
 )
 
 const doubleQuotesToRemove = "\"\""
@@ -142,7 +142,17 @@ func RegExpBoolean(restr string) Validator {
 func SubnetsCountValidator(multiAZ bool, privateLink bool) Validator {
 	return func(input interface{}) error {
 		if answers, ok := input.([]core.OptionAnswer); ok {
-			return aws.ValidateSubnetsCount(multiAZ, privateLink, len(answers))
+			return ocm.ValidateSubnetsCount(multiAZ, privateLink, len(answers))
+		}
+
+		return fmt.Errorf("can only validate a slice of string, got %v", input)
+	}
+}
+
+func AvailabilityZonesCountValidator(multiAZ bool) Validator {
+	return func(input interface{}) error {
+		if answers, ok := input.([]core.OptionAnswer); ok {
+			return ocm.ValidateAvailabilityZonesCount(multiAZ, len(answers))
 		}
 
 		return fmt.Errorf("can only validate a slice of string, got %v", input)

--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -604,3 +604,52 @@ func isOperatorRoleAlreadyExist(cluster *cmv1.Cluster, operator *cmv1.STSOperato
 	}
 	return false
 }
+
+const (
+	BYOVPCSingleAZSubnetsCount      = 2
+	BYOVPCMultiAZSubnetsCount       = 6
+	privateLinkSingleAZSubnetsCount = 1
+	privateLinkMultiAZSubnetsCount  = 3
+)
+
+func ValidateSubnetsCount(multiAZ bool, privateLink bool, subnetsInputCount int) error {
+	if privateLink {
+		if multiAZ && subnetsInputCount != privateLinkMultiAZSubnetsCount {
+			return fmt.Errorf("The number of subnets for a multi-AZ private link cluster should be %d, "+
+				"instead received: %d", privateLinkMultiAZSubnetsCount, subnetsInputCount)
+		}
+		if !multiAZ && subnetsInputCount != privateLinkSingleAZSubnetsCount {
+			return fmt.Errorf("The number of subnets for a single AZ private link cluster should be %d, "+
+				"instead received: %d", privateLinkSingleAZSubnetsCount, subnetsInputCount)
+		}
+	} else {
+		if multiAZ && subnetsInputCount != BYOVPCMultiAZSubnetsCount {
+			return fmt.Errorf("The number of subnets for a multi-AZ cluster should be %d, "+
+				"instead received: %d", BYOVPCMultiAZSubnetsCount, subnetsInputCount)
+		}
+		if !multiAZ && subnetsInputCount != BYOVPCSingleAZSubnetsCount {
+			return fmt.Errorf("The number of subnets for a single AZ cluster should be %d, "+
+				"instead received: %d", BYOVPCSingleAZSubnetsCount, subnetsInputCount)
+		}
+	}
+
+	return nil
+}
+
+const (
+	singleAZCount = 1
+	MultiAZCount  = 3
+)
+
+func ValidateAvailabilityZonesCount(multiAZ bool, availabilityZonesCount int) error {
+	if multiAZ && availabilityZonesCount != MultiAZCount {
+		return fmt.Errorf("The number of availability zones for a multi AZ cluster should be %d, "+
+			"instead received: %d", MultiAZCount, availabilityZonesCount)
+	}
+	if !multiAZ && availabilityZonesCount != singleAZCount {
+		return fmt.Errorf("The number of availability zones for a single AZ cluster should be %d, "+
+			"instead received: %d", singleAZCount, availabilityZonesCount)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Add a validator to the selecting availability zones prompt,
to improve user experience and enable the user to fix their choices.

Related: [SDA-6415](https://issues.redhat.com/browse/SDA-6415)

![image](https://user-images.githubusercontent.com/57869309/179388945-046dccd4-263d-486e-892a-85c0c4d1560a.png)
![image](https://user-images.githubusercontent.com/57869309/179388950-cd981519-8f73-4e78-a8ac-a0fc76f56c21.png)
