### PR TITLE
fix for - Not able to remove or add a new cluster-admin in rosa cli

### DIFF
--- a/cmd/create/idp/htpasswd.go
+++ b/cmd/create/idp/htpasswd.go
@@ -54,6 +54,19 @@ func createHTPasswdIDP(cmd *cobra.Command,
 					"Clusters may only have 1 HTPasswd IDP.", clusterKey, htpasswdIDP.Name())
 			os.Exit(1)
 		}
+
+		idp, ok := htpasswdIDP.GetHtpasswd()
+		if !ok {
+			r.Reporter.Errorf(
+				"Failed to get htpasswd idp of cluster '%s': %v", clusterKey, err)
+			os.Exit(1)
+		}
+		if idp.Username() != "" {
+			r.Reporter.Errorf("Users can't be added to a single user HTPasswd IDP. Delete the IDP and recreate " +
+				"it as a multi user HTPasswd IDP")
+			return
+		}
+
 		// Existing IDP contains only admin. Add new user to it
 		r.Reporter.Infof("Cluster already has an HTPasswd IDP named '%s', new users will be added to it.",
 			htpasswdIDP.Name())

--- a/cmd/grant/user/cmd.go
+++ b/cmd/grant/user/cmd.go
@@ -23,6 +23,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/rosa/cmd/create/idp"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
 )
@@ -85,8 +86,8 @@ func run(_ *cobra.Command, argv []string) {
 		)
 		os.Exit(1)
 	}
-	if username == "cluster-admin" {
-		r.Reporter.Errorf("Username 'cluster-admin' is not allowed")
+	if username == idp.ClusterAdminUsername {
+		r.Reporter.Errorf("Username '%s' is not allowed", idp.ClusterAdminUsername)
 		os.Exit(1)
 	}
 

--- a/cmd/list/user/cmd.go
+++ b/cmd/list/user/cmd.go
@@ -25,6 +25,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/rosa/cmd/create/idp"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
 )
@@ -66,7 +67,7 @@ func run(_ *cobra.Command, _ []string) {
 	}
 	// Remove cluster-admin user
 	for i, user := range clusterAdmins {
-		if user.ID() == "cluster-admin" {
+		if user.ID() == idp.ClusterAdminUsername {
 			clusterAdmins = append(clusterAdmins[:i], clusterAdmins[i+1:]...)
 		}
 	}

--- a/cmd/revoke/user/cmd.go
+++ b/cmd/revoke/user/cmd.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/rosa/cmd/create/idp"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
@@ -85,8 +86,8 @@ func run(_ *cobra.Command, argv []string) {
 		)
 		os.Exit(1)
 	}
-	if username == "cluster-admin" {
-		r.Reporter.Errorf("Username 'cluster-admin' is not allowed")
+	if username == idp.ClusterAdminUsername {
+		r.Reporter.Errorf("Username '%s' is not allowed", idp.ClusterAdminUsername)
 		os.Exit(1)
 	}
 

--- a/pkg/ocm/idps.go
+++ b/pkg/ocm/idps.go
@@ -81,28 +81,43 @@ func (c *Client) AddHTPasswdUser(username, password, clusterID, idpID string) er
 
 func (c *Client) DeleteHTPasswdUser(username, clusterID string, htpasswdIDP *cmv1.IdentityProvider) error {
 	var userID string
-	listResponse, err := c.ocm.ClustersMgmt().V1().Clusters().Cluster(clusterID).
-		IdentityProviders().IdentityProvider(htpasswdIDP.ID()).HtpasswdUsers().List().Send()
-	if err != nil {
-		if listResponse.Error().Status() == http.StatusNotFound {
-			return nil
-		}
-		return handleErr(listResponse.Error(), err)
+
+	idp, ok := htpasswdIDP.GetHtpasswd()
+	if !ok {
+		return fmt.Errorf("Failed to get htpasswd idp for cluster '%s'", clusterID)
 	}
-	listResponse.Items().Each(func(user *cmv1.HTPasswdUser) bool {
-		if user.Username() == username {
-			userID = user.ID()
+	if idp.Username() != "" {
+		//the admin was created with ROSA release less than 4.10
+		//remove the entire idp
+		response, err := c.ocm.ClustersMgmt().V1().Clusters().Cluster(clusterID).
+			IdentityProviders().IdentityProvider(htpasswdIDP.ID()).Delete().Send()
+		if err != nil {
+			return handleErr(response.Error(), err)
 		}
-		return true
-	})
-	if userID == "" {
-		return fmt.Errorf("HTPasswd user named '%s' on cluster '%s' does not exist", username, clusterID)
-	}
-	deleteResponse, err := c.ocm.ClustersMgmt().V1().Clusters().Cluster(clusterID).
-		IdentityProviders().IdentityProvider(htpasswdIDP.ID()).HtpasswdUsers().
-		HtpasswdUser(userID).Delete().Send()
-	if err != nil {
-		return handleErr(deleteResponse.Error(), err)
+	} else {
+		listResponse, err := c.ocm.ClustersMgmt().V1().Clusters().Cluster(clusterID).
+			IdentityProviders().IdentityProvider(htpasswdIDP.ID()).HtpasswdUsers().List().Send()
+		if err != nil {
+			if listResponse.Error().Status() == http.StatusNotFound {
+				return nil
+			}
+			return handleErr(listResponse.Error(), err)
+		}
+		listResponse.Items().Each(func(user *cmv1.HTPasswdUser) bool {
+			if user.Username() == username {
+				userID = user.ID()
+			}
+			return true
+		})
+		if userID == "" && listResponse.Items().Len() != 0 {
+			return fmt.Errorf("HTPasswd user named '%s' on cluster '%s' does not exist", username, clusterID)
+		}
+		deleteResponse, err := c.ocm.ClustersMgmt().V1().Clusters().Cluster(clusterID).
+			IdentityProviders().IdentityProvider(htpasswdIDP.ID()).HtpasswdUsers().
+			HtpasswdUser(userID).Delete().Send()
+		if err != nil {
+			return handleErr(deleteResponse.Error(), err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
fix for - Can't create temporary admin user for ROSA cluster

Signed-off-by: Tzvika Avni <tavni@redhat.com>

[SDA-6170](https://issues.redhat.com//browse/SDA-6170)
[SDA-6106](https://issues.redhat.com//browse/SDA-6106)