### PR TITLE
add fake cluster parameter to create services

### DIFF
--- a/cmd/create/service/cmd.go
+++ b/cmd/create/service/cmd.go
@@ -132,6 +132,14 @@ func init() {
 			"to \"23\", then each node is assigned a /23 subnet out of the given CIDR.",
 	)
 
+	flags.BoolVar(
+		&args.FakeCluster,
+		"fake-cluster",
+		false,
+		"Create a fake cluster that uses no AWS resources.",
+	)
+	flags.MarkHidden("fake-cluster")
+
 	arguments.AddRegionFlag(flags)
 }
 
@@ -170,6 +178,10 @@ func run(cmd *cobra.Command, argv []string) {
 	args.Properties = map[string]string{
 		properties.CreatorARN: r.Creator.ARN,
 		properties.CLIVersion: info.Version,
+	}
+
+	if args.FakeCluster {
+		args.Properties[properties.FakeCluster] = "true"
 	}
 
 	// Openshift version to use.

--- a/pkg/ocm/managedservice.go
+++ b/pkg/ocm/managedservice.go
@@ -33,6 +33,9 @@ type CreateManagedServiceArgs struct {
 	PodCIDR           net.IPNet
 	ServiceCIDR       net.IPNet
 	HostPrefix        int
+
+	// create a fake cluster with no aws resources
+	FakeCluster bool
 }
 
 func (c *Client) CreateManagedService(args CreateManagedServiceArgs) (*msv1.ManagedService, error) {


### PR DESCRIPTION
Verify create fake cluster service
```
╭─croche@localhost ~/Projects/sda/rosa ‹master*› 
╰─$ rosa create service --name=croche-test --type=ocm-addon-test-operator --fake-cluster  
W: More than one Installer role found, using "arn:aws:iam::765374464689:role/ManagedOpenShift-Installer-Role"
I: Using "arn:aws:iam::765374464689:role/ManagedOpenShift-Support-Role" for the Support role
I: Using "arn:aws:iam::765374464689:role/ManagedOpenShift-ControlPlane-Role" for the ControlPlane role
I: Using "arn:aws:iam::765374464689:role/ManagedOpenShift-Worker-Role" for the Worker role
I: Service created!

        Service ID: 2CDHo6iluqf48vm6ySqO3MBmWlW

I: Run the following commands to continue the cluster creation:

        rosa create operator-roles --cluster croche-test
        rosa create oidc-provider --cluster croche-test

╭─croche@localhost ~/Projects/sda/rosa ‹master*› 
╰─$ rosa describe service --id=2CDHo6iluqf48vm6ySqO3MBmWlW                                
Id:                         2CDHo6iluqf48vm6ySqO3MBmWlW
Href:                       /api/service_mgmt/v1/services/2CDHo6iluqf48vm6ySqO3MBmWlW
Service type:               ocm-addon-test-operator
Service State:              waiting for cluster
Cluster Name:               croche-test
Created At:                 2022-07-20 15:20:06 +0000 UTC
Updated At:                 2022-07-20 15:20:12 +0000 UTC
╭─croche@localhost ~/Projects/sda/rosa ‹master*› 
╰─$ ocm get /api/service_mgmt/v1/services/2CDHo6iluqf48vm6ySqO3MBmWlW
{
  "addon": {
    "href": "/api/clusters_mgmt/v1/clusters/1tisu8cjcbatg6o20m77e52pip2gafsh/addons",
    "kind": "Addon",
    "state": "pending"
  },
  "cluster": {
    "href": "/api/clusters_mgmt/v1/clusters/1tisu8cjcbatg6o20m77e52pip2gafsh",
    "id": "1tisu8cjcbatg6o20m77e52pip2gafsh",
    "name": "croche-test",
    "state": "waiting"
  },
  "created_at": "2022-07-20T15:20:06Z",
  "expired_at": "2022-07-22T03:20:01Z",
  "href": "/api/service_mgmt/v1/services/2CDHo6iluqf48vm6ySqO3MBmWlW",
  "id": "2CDHo6iluqf48vm6ySqO3MBmWlW",
  "kind": "ManagedService",
  "service": "ocm-addon-test-operator",
  "service_details": "service installing, waiting for cluster to provision",
  "service_state": "waiting for cluster",
  "updated_at": "2022-07-20T15:20:12Z"
}
╭─croche@localhost ~/Projects/sda/rosa ‹master*› 
╰─$ ocm get /api/clusters_mgmt/v1/clusters/1tisu8cjcbatg6o20m77e52pip2gafsh | jq .properties
{
  "fake_cluster": "true",
  "rosa_cli_version": "1.2.4",
  "rosa_creator_arn": "arn:aws:iam::765374464689:user/croche"
}
```

Verify create normal service
```
╭─croche@localhost ~/Projects/sda/rosa ‹SDA-6448› 
╰─$ rosa create service --name=croche-test-1 --type=ocm-addon-test-operator             
W: More than one Installer role found, using "arn:aws:iam::765374464689:role/ManagedOpenShift-Installer-Role"
I: Using "arn:aws:iam::765374464689:role/ManagedOpenShift-ControlPlane-Role" for the ControlPlane role
I: Using "arn:aws:iam::765374464689:role/ManagedOpenShift-Worker-Role" for the Worker role
I: Using "arn:aws:iam::765374464689:role/ManagedOpenShift-Support-Role" for the Support role
I: Service created!

        Service ID: 2CDIHCh9TWOLfbJLWGAcb3V8Qlx

I: Run the following commands to continue the cluster creation:

        rosa create operator-roles --cluster croche-test-1
        rosa create oidc-provider --cluster croche-test-1

╭─croche@localhost ~/Projects/sda/rosa ‹SDA-6448› 
╰─$ rosa describe service --id=2CDIHCh9TWOLfbJLWGAcb3V8Qlx
Id:                         2CDIHCh9TWOLfbJLWGAcb3V8Qlx
Href:                       /api/service_mgmt/v1/services/2CDIHCh9TWOLfbJLWGAcb3V8Qlx
Service type:               ocm-addon-test-operator
Service State:              waiting for cluster
Cluster Name:               croche-test-1
Created At:                 2022-07-20 15:23:58 +0000 UTC
Updated At:                 2022-07-20 15:24:12 +0000 UTC
╭─croche@localhost ~/Projects/sda/rosa ‹SDA-6448› 
╰─$ ocm get /api/service_mgmt/v1/services/2CDIHCh9TWOLfbJLWGAcb3V8Qlx
{
  "addon": {
    "href": "/api/clusters_mgmt/v1/clusters/1tit022702mbljai0rhi4v1nsvgurq5b/addons",
    "kind": "Addon",
    "state": "pending"
  },
  "cluster": {
    "href": "/api/clusters_mgmt/v1/clusters/1tit022702mbljai0rhi4v1nsvgurq5b",
    "id": "1tit022702mbljai0rhi4v1nsvgurq5b",
    "name": "croche-test-1",
    "state": "waiting"
  },
  "created_at": "2022-07-20T15:23:58Z",
  "expired_at": "2022-07-22T03:23:52Z",
  "href": "/api/service_mgmt/v1/services/2CDIHCh9TWOLfbJLWGAcb3V8Qlx",
  "id": "2CDIHCh9TWOLfbJLWGAcb3V8Qlx",
  "kind": "ManagedService",
  "service": "ocm-addon-test-operator",
  "service_details": "service installing, waiting for cluster to provision",
  "service_state": "waiting for cluster",
  "updated_at": "2022-07-20T15:24:12Z"
}
╭─croche@localhost ~/Projects/sda/rosa ‹SDA-6448› 
╰─$ ocm get /api/clusters_mgmt/v1/clusters/1tit022702mbljai0rhi4v1nsvgurq5b | jq .properties
{
  "rosa_cli_version": "1.2.4",
  "rosa_creator_arn": "arn:aws:iam::765374464689:user/croche"
}
```

Verify hidden flag
```
╭─croche@localhost ~/Projects/sda/rosa ‹SDA-6448› 
╰─$ rosa create service --help
  Managed Services are OpenShift clusters that provide a specific function.
  Use this command to create managed services.

Usage:
  rosa create managed-service [flags]

Aliases:
  managed-service, appliance, service

Examples:
  # Create a Managed Service of type service1.
  rosa create managed-service --type=service1 --name=clusterName

Flags:
      --type string          Type of service.
      --name string          Name of the service instance.
      --subnet-ids strings   The Subnet IDs to use when installing the cluster. Format should be a comma-separated list. Leave empty for installer provisioned subnet IDs.
      --private-link         Managed service will use a cluster that won't expose traffic to the public internet.
      --machine-cidr ipNet   Block of IP addresses used by OpenShift while installing the cluster, for example "10.0.0.0/16".
      --service-cidr ipNet   Block of IP addresses for services, for example "172.30.0.0/16".
      --pod-cidr ipNet       Block of IP addresses from which Pod IP addresses are allocated, for example "10.128.0.0/14".
      --host-prefix int      Subnet prefix length to assign to each individual node. For example, if host prefix is set to "23", then each node is assigned a /23 subnet out of the given CIDR.
  -h, --help                 help for managed-service

Global Flags:
      --color string     Surround certain characters with escape sequences to display them in color on the terminal. Allowed options are [auto never always] (default "auto")
      --debug            Enable debug mode.
      --profile string   Use a specific AWS profile from your credential file.
      --region string    Use a specific AWS region, overriding the AWS_REGION environment variable.
  -y, --yes              Automatically answer yes to confirm operation.
```

*NOTE* : Creating a service with a fake cluster, will result in a service never getting to a ready state, and should only be used for development and test purposes that do not require a ready service. 

