### PR TITLE
Switch from `github.com/pkg/errors` to stdlib

### DIFF
--- a/cmd/upgrade/cluster/cmd.go
+++ b/cmd/upgrade/cluster/cmd.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/cmd/upgrade/accountroles"
@@ -417,7 +416,7 @@ func checkAndAckMissingAgreements(r *rosa.Runtime, cluster *cmv1.Cluster, upgrad
 	// check if the cluster upgrade requires gate agreements
 	gates, err := r.OCMClient.GetMissingGateAgreements(cluster.ID(), upgradePolicy)
 	if err != nil {
-		return errors.Errorf("Failed to check for missing gate agreements upgrade for "+
+		return fmt.Errorf("failed to check for missing gate agreements upgrade for "+
 			"cluster '%s': %v", clusterKey, err)
 	}
 	isWarningDisplayed := false
@@ -441,7 +440,7 @@ func checkAndAckMissingAgreements(r *rosa.Runtime, cluster *cmv1.Cluster, upgrad
 				Steps:   []string{str},
 			})
 			if err != nil {
-				return errors.Errorf("Failed to get version gate '%s' for cluster '%s': %v",
+				return fmt.Errorf("failed to get version gate '%s' for cluster '%s': %v",
 					gate.ID(), clusterKey, err)
 			}
 			// for non sts gates we require user agreement
@@ -451,7 +450,7 @@ func checkAndAckMissingAgreements(r *rosa.Runtime, cluster *cmv1.Cluster, upgrad
 		}
 		err = r.OCMClient.AckVersionGate(cluster.ID(), gate.ID())
 		if err != nil {
-			return errors.Errorf("Failed to acknowledge version gate '%s' for cluster '%s': %v",
+			return fmt.Errorf("failed to acknowledge version gate '%s' for cluster '%s': %v",
 				gate.ID(), clusterKey, err)
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.19.0
 	github.com/openshift-online/ocm-sdk-go v0.1.275
-	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5

--- a/pkg/aws/sts.go
+++ b/pkg/aws/sts.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/openshift/rosa/pkg/aws/tags"
 	rprtr "github.com/openshift/rosa/pkg/reporter"
-	"github.com/pkg/errors"
 )
 
 func (c *awsClient) DeleteUserRole(roleName string) error {
@@ -72,22 +71,22 @@ func RoleARNToRoleName(roleARN string) (string, error) {
 		return ARNResourceSubStr[1], nil
 	}
 
-	return "", errors.Errorf("Couldn't extract the role name from role ARN")
+	return "", fmt.Errorf("couldn't extract the role name from role ARN")
 }
 
 func (c *awsClient) ValidateRoleARNAccountIDMatchCallerAccountID(roleARN string) error {
 	creator, err := c.GetCreator()
 	if err != nil {
-		return errors.Errorf("Failed to get AWS creator: %v", err)
+		return fmt.Errorf("failed to get AWS creator: %v", err)
 	}
 
 	parsedARN, err := arn.Parse(roleARN)
 	if err != nil {
-		return errors.Errorf("%s", err)
+		return err
 	}
 
 	if creator.AccountID != parsedARN.AccountID {
-		return errors.Errorf("Role ARN '%s' doesn't match the user's account ID '%s'", roleARN, creator.AccountID)
+		return fmt.Errorf("role ARN '%s' doesn't match the user's account ID '%s'", roleARN, creator.AccountID)
 	}
 
 	return nil

--- a/pkg/ocm/managedservice.go
+++ b/pkg/ocm/managedservice.go
@@ -5,7 +5,6 @@ import (
 	"net"
 
 	msv1 "github.com/openshift-online/ocm-sdk-go/servicemgmt/v1"
-	"github.com/pkg/errors"
 )
 
 type CreateManagedServiceArgs struct {
@@ -114,7 +113,7 @@ func (c *Client) CreateManagedService(args CreateManagedServiceArgs) (*msv1.Mana
 		Build()
 
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to create Managed Service call")
+		return nil, fmt.Errorf("failed to create Managed Service call: %w", err)
 	}
 
 	serviceCall, err := c.ocm.ServiceMgmt().V1().Services().
@@ -130,15 +129,12 @@ func (c *Client) CreateManagedService(args CreateManagedServiceArgs) (*msv1.Mana
 
 func (c *Client) ListManagedServices(count int) (*msv1.ManagedServiceList, error) {
 	if count < 0 {
-		err := errors.Errorf("Invalid services count")
-		return nil, err
+		return nil, fmt.Errorf("invalid services count")
 	}
 
 	response, err := c.ocm.ServiceMgmt().V1().Services().List().Send()
 	if err != nil {
-		fmt.Printf("%s", err)
-		err := errors.Errorf("Cannot retrieve services list")
-		return nil, err
+		return nil, fmt.Errorf("cannot retrieve services list: %w", err)
 	}
 	return response.Items(), nil
 
@@ -151,7 +147,7 @@ type DescribeManagedServiceArgs struct {
 func (c *Client) GetManagedService(args DescribeManagedServiceArgs) (*msv1.ManagedService, error) {
 	response, err := c.ocm.ServiceMgmt().V1().Services().Service(args.ID).Get().Send()
 	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to get managed service with id %s:", args.ID)
+		return nil, fmt.Errorf("failed to get managed service with id %s: %w", args.ID, err)
 	}
 	return response.Body(), nil
 }
@@ -189,7 +185,7 @@ func (c *Client) UpdateManagedService(args UpdateManagedServiceArgs) error {
 		Build()
 
 	if err != nil {
-		return errors.Wrap(err, "Failed to create Managed Service call")
+		return fmt.Errorf("failed to create Managed Service call: %w", err)
 	}
 
 	serviceCall, err := c.ocm.ServiceMgmt().V1().Services().Service(args.ID).

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -183,7 +183,6 @@ github.com/openshift-online/ocm-sdk-go/statusboard/v1
 github.com/openshift-online/ocm-sdk-go/webrca
 github.com/openshift-online/ocm-sdk-go/webrca/v1
 # github.com/pkg/errors v0.9.1
-## explicit
 github.com/pkg/errors
 # github.com/prometheus/client_golang v1.12.1
 github.com/prometheus/client_golang/prometheus


### PR DESCRIPTION
https://github.com/pkg/errors has been archived due to essentially all of its capabilities being added to the standard library in [Go 1.13](https://go.dev/blog/go1.13-errors). So, I've replaced all of the places its used with the `fmt` equivalent.

Furthermore, typically with Go, [error messages are not capitalized](https://github.com/golang/go/wiki/CodeReviewComments#error-strings), so I also applied those fixes for the errors I interacted with.