### PR TITLE
SDA-4308: use root CA to generate OIDC thubmnail

### DIFF
--- a/cmd/create/oidcprovider/cmd.go
+++ b/cmd/create/oidcprovider/cmd.go
@@ -18,7 +18,8 @@ package oidcprovider
 
 import (
 	// nolint:gosec
-	"crypto/sha1"
+	"bytes"
+	"crypto/sha1" //#nosec GSC-G505 -- Import blacklist: crypto/sha1
 	"encoding/hex"
 	"fmt"
 	"net/http"
@@ -232,7 +233,9 @@ func getThumbprint(oidcEndpointURL string) (string, error) {
 	// Grab the CA in the chain
 	for _, cert := range certChain {
 		if cert.IsCA {
-			return sha1Hash(cert.Raw), nil
+			if bytes.Equal(cert.RawIssuer, cert.RawSubject) {
+				return sha1Hash(cert.Raw), nil
+			}
 		}
 	}
 


### PR DESCRIPTION
Retrieves the root CA from the SSL certificate of the URL where the OIDC provider endpoint.
Additionally, to get the PR green I had to make the following changes to the code, which are not related to the change previously mentioned:

* <del>Moved to use `crypto/sha512` when calculating the Thumbnail for the OIDC SSL endpoint certificate due to [security issues](https://deepsource.io/gh/gogs/gogs/issue/GSC-G505/occurrences).</del>