### PR TITLE
Create cluster - use a GET request to describe cluster details

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1918,7 +1918,7 @@ func run(cmd *cobra.Command, _ []string) {
 		r.Reporter.Infof("To view a list of clusters and their status, run 'rosa list clusters'")
 	}
 
-	_, err = r.OCMClient.CreateCluster(clusterConfig)
+	cluster, err := r.OCMClient.CreateCluster(clusterConfig)
 	if err != nil {
 		if args.dryRun {
 			r.Reporter.Errorf("Creating cluster '%s' should fail: %s", clusterName, err)
@@ -1943,7 +1943,7 @@ func run(cmd *cobra.Command, _ []string) {
 				"for more information.")
 	}
 
-	clusterdescribe.Cmd.Run(clusterdescribe.Cmd, []string{clusterName})
+	clusterdescribe.Cmd.Run(clusterdescribe.Cmd, []string{cluster.ID()})
 
 	if isSTS {
 		if mode != "" {

--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -58,6 +58,8 @@ const (
 
 	OCMRoleLabel  = "sts_ocm_role"
 	USERRoleLabel = "sts_user_role"
+
+	maxClusterNameLength = 15
 )
 
 // Regular expression to used to make sure that the identifier or name given by the user is


### PR DESCRIPTION
1. Modify `GetCluster` to try to fetch the cluster using cluster ID or UUID,
if the `clusterKey` is the cluster's name, list the cluster with parameters.
2. Modify `rosa create cluster` to pass the cluster's ID to `describe cluster`
instead of the cluster's name.

**Note:** This change aims to solve the bug where large organizations like `RedHat1` create a cluster,
and then `describeCluster` is listing all clusters and we get **504** from OCM.

Related: [SDA-6551](https://issues.redhat.com/browse/SDA-6551)