### PR TITLE
Only display supported machine types by region

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1434,7 +1434,7 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 	// Compute node instance type:
 	computeMachineType := args.computeMachineType
-	computeMachineTypeList, err := r.OCMClient.GetAvailableMachineTypes()
+	computeMachineTypeList, err := r.OCMClient.GetAvailableMachineTypesInRegion(region, roleARN, awsClient)
 	if err != nil {
 		r.Reporter.Errorf(fmt.Sprintf("%s", err))
 		os.Exit(1)

--- a/cmd/create/machinepool/cmd.go
+++ b/cmd/create/machinepool/cmd.go
@@ -416,7 +416,8 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 	// Machine pool instance type:
 	instanceType := args.instanceType
-	instanceTypeList, err := r.OCMClient.GetAvailableMachineTypes()
+	instanceTypeList, err := r.OCMClient.GetAvailableMachineTypesInRegion(cluster.Region().ID(),
+		cluster.AWS().STS().RoleARN(), r.AWSClient)
 	if err != nil {
 		r.Reporter.Errorf(fmt.Sprintf("%s", err))
 		os.Exit(1)


### PR DESCRIPTION
**Note:** the new endpoint requires `role ARN` for STS clusters or
`access keys` for non-STS clusters.

Related: [SDA-6357](https://issues.redhat.com/browse/SDA-6357)

For example `m6a.12xlarge` isn't supported in `ap-southeast-3`:
![image](https://user-images.githubusercontent.com/57869309/186157934-d8b32a8a-c287-43c1-9ea9-80352f8dd06c.png)
