### PR TITLE
ocm: Add aliases for local development

### DIFF
--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -53,7 +53,8 @@ var JumpAccounts = map[string]string{
 	"production":  "710019948333",
 	"staging":     "644306948063",
 	"integration": "896164604406",
-	"dev":         "765374464689",
+	"local":       "765374464689",
+	"crc":         "765374464689",
 }
 
 var ARNPath = regexp.MustCompile(`^\/[a-zA-Z0-9\/]*\/$`)

--- a/pkg/ocm/config.go
+++ b/pkg/ocm/config.go
@@ -31,6 +31,8 @@ var URLAliases = map[string]string{
 	"production":  "https://api.openshift.com",
 	"staging":     "https://api.stage.openshift.com",
 	"integration": "https://api.integration.openshift.com",
+	"local":       "http://localhost:8000",
+	"crc":         "https://clusters-service.apps-crc.testing",
 }
 
 func GetEnv() (string, error) {


### PR DESCRIPTION
This ensures that developers and contributors can use the full flow of
commands necessary for STS cluster requirements.