### PR TITLE
path for account and operator roles and policies

### DIFF
--- a/cmd/create/ocmrole/cmd.go
+++ b/cmd/create/ocmrole/cmd.go
@@ -83,6 +83,7 @@ func init() {
 		"",
 		"The arn path for the ocm role and policies",
 	)
+	flags.MarkHidden("path")
 
 	aws.AddModeFlag(Cmd)
 
@@ -180,7 +181,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	path := args.path
-	if interactive.Enabled() {
+	if cmd.Flags().Changed("path") && interactive.Enabled() {
 		path, err = interactive.GetString(interactive.Input{
 			Question: "Role Path",
 			Help:     cmd.Flags().Lookup("path").Usage,

--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -216,6 +216,12 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
+	env, err := ocm.GetEnv()
+	if err != nil {
+		r.Reporter.Errorf("Failed to determine OCM environment: %v", err)
+		os.Exit(1)
+	}
+
 	defaultPolicyVersion, err := r.OCMClient.GetDefaultVersion()
 	if err != nil {
 		r.Reporter.Errorf("Error getting latest default version: %s", err)
@@ -253,7 +259,7 @@ func run(cmd *cobra.Command, argv []string) {
 			ocm.Response:  ocm.Success,
 		})
 	case aws.ModeManual:
-		commands, err := buildCommands(r, prefix, permissionsBoundary, accountRoleVersion, policyPath,
+		commands, err := buildCommands(r, env, prefix, permissionsBoundary, defaultPolicyVersion, policyPath,
 			cluster, policies, credRequests)
 		if err != nil {
 			r.Reporter.Errorf("There was an error building the list of resources: %s", err)
@@ -354,10 +360,18 @@ func createRoles(r *rosa.Runtime,
 	return nil
 }
 
-func buildCommands(r *rosa.Runtime,
-	prefix, permissionsBoundary, accountRoleVersion, policyPath string,
+func buildCommands(r *rosa.Runtime, env string,
+	prefix, permissionsBoundary, defaultPolicyVersion, policyPath string,
 	cluster *cmv1.Cluster,
 	policies map[string]string, credRequests map[string]*cmv1.STSOperator) (string, error) {
+
+	err := aws.GeneratePolicyFiles(r.Reporter, env, false,
+		true, policies, credRequests)
+	if err != nil {
+		r.Reporter.Errorf("There was an error generating the policy files: %s", err)
+		os.Exit(1)
+	}
+
 	commands := []string{}
 
 	for credrequest, operator := range credRequests {
@@ -383,12 +397,11 @@ func buildCommands(r *rosa.Runtime,
 		_, err = r.AWSClient.IsPolicyExists(policyARN)
 		if err != nil {
 			iamTags := fmt.Sprintf(
-				"Key=%s,Value=%s Key=%s,Value=%s Key=%s,Value=%s Key=%s,Value=%s Key=%s,Value=%s",
-				tags.OpenShiftVersion, accountRoleVersion,
+				"Key=%s,Value=%s Key=%s,Value=%s Key=%s,Value=%s Key=%s,Value=%s",
+				tags.OpenShiftVersion, defaultPolicyVersion,
 				tags.RolePrefix, prefix,
 				"operator_namespace", operator.Namespace(),
 				"operator_name", operator.Name(),
-				tags.RedHatManaged, "true",
 			)
 			createPolicy := fmt.Sprintf("aws iam create-policy \\\n"+
 				"\t--policy-name %s \\\n"+

--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -302,7 +302,7 @@ func createRoles(r *rosa.Runtime,
 			continue
 		}
 
-		rolePath, err := aws.GetRolePath(roleARN)
+		rolePath, err := aws.GetPathFromARN(roleARN)
 		if err != nil {
 			return err
 		}
@@ -373,7 +373,7 @@ func buildCommands(r *rosa.Runtime,
 			}
 		}
 		roleName, roleARN := getRoleNameAndARN(cluster, operator)
-		rolePath, err := aws.GetRolePath(roleARN)
+		rolePath, err := aws.GetPathFromARN(roleARN)
 		if err != nil {
 			return "", err
 		}

--- a/cmd/create/userrole/cmd.go
+++ b/cmd/create/userrole/cmd.go
@@ -76,6 +76,7 @@ func init() {
 		"",
 		"The arn path for the user role and policies.",
 	)
+	flags.MarkHidden("path")
 
 	aws.AddModeFlag(Cmd)
 	confirm.AddFlag(flags)
@@ -156,7 +157,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	path := args.path
-	if interactive.Enabled() {
+	if cmd.Flags().Changed("path") && interactive.Enabled() {
 		path, err = interactive.GetString(interactive.Input{
 			Question: "Role Path",
 			Help:     cmd.Flags().Lookup("path").Usage,
@@ -300,7 +301,7 @@ func createRoles(r *rosa.Runtime,
 			tags.RoleType:      aws.OCMUserRole,
 			tags.Environment:   env,
 			tags.RedHatManaged: "true",
-		}, "")
+		}, path)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -388,8 +388,8 @@ func GetPolicyARN(accountID string, name string, path string) string {
 	return fmt.Sprintf("%s/%s", str, name)
 }
 
-func GetRolePath(roleARN string) (string, error) {
-	parse, err := arn.Parse(roleARN)
+func GetPathFromARN(arnStr string) (string, error) {
+	parse, err := arn.Parse(arnStr)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -1252,7 +1252,7 @@ func (c *awsClient) GetRoleARNPath(prefix string) (string, error) {
 				return "", errors.NotFound.Errorf("Roles with the prefix'%s' not found", prefix)
 			}
 		}
-		return GetRolePath(aws.StringValue(role.Role.Arn))
+		return GetPathFromARN(aws.StringValue(role.Role.Arn))
 	}
 	return "", nil
 }

--- a/pkg/aws/sts.go
+++ b/pkg/aws/sts.go
@@ -168,10 +168,10 @@ func UpgradeOperatorPolicies(reporter *rprtr.Object, awsClient Client, accountID
 }
 
 func BuildOperatorRoleCommands(prefix string, accountID string, awsClient Client,
-	defaultPolicyVersion string, credRequests map[string]*cmv1.STSOperator, path string) []string {
+	defaultPolicyVersion string, credRequests map[string]*cmv1.STSOperator, policyPath string) []string {
 	commands := []string{}
 	for credrequest, operator := range credRequests {
-		policyARN := GetOperatorPolicyARN(accountID, prefix, operator.Namespace(), operator.Name(), path)
+		policyARN := GetOperatorPolicyARN(accountID, prefix, operator.Namespace(), operator.Name(), policyPath)
 		_, err := awsClient.IsPolicyExists(policyARN)
 		if err != nil {
 			name := GetPolicyName(prefix, operator.Namespace(), operator.Name())
@@ -187,6 +187,9 @@ func BuildOperatorRoleCommands(prefix string, accountID string, awsClient Client
 				"\t--policy-document file://openshift_%s_policy.json \\\n"+
 				"\t--tags %s",
 				name, credrequest, iamTags)
+			if policyPath != "" {
+				createPolicy = fmt.Sprintf(createPolicy+"\t--path %s", policyPath)
+			}
 			commands = append(commands, createPolicy)
 		} else {
 			policTags := fmt.Sprintf(


### PR DESCRIPTION
the operator policies moved back to account roles commands
this commit is for supporting the latest changes
[sda-6246](https://issues.redhat.com//browse/sda-6246) [sda-6560](https://issues.redhat.com//browse/sda-6560) [sda-6579](https://issues.redhat.com//browse/sda-6579) [sda-6621](https://issues.redhat.com//browse/sda-6621) [sda-6620](https://issues.redhat.com//browse/sda-6620) [sda-6619](https://issues.redhat.com//browse/sda-6619) [sda-6634](https://issues.redhat.com//browse/sda-6634) [sda-6647](https://issues.redhat.com//browse/sda-6647) [sda-6606](https://issues.redhat.com//browse/sda-6606) [sda-6737](https://issues.redhat.com//browse/sda-6737)
[sda-6740](https://issues.redhat.com//browse/sda-6740)

Signed-off-by: Yaron Dayagi <ydayagi@redhat.com>