### PR TITLE
[SDA-6405] feat: add version and channelGroup args to create/update acc. roles

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -102,7 +102,7 @@ func init() {
 		&args.channelGroup,
 		"channel-group",
 		ocm.DefaultChannelGroup,
-		"Channel group is the name of the group where this image belongs, for example \"stable\" or \"fast\".",
+		"Channel group is the name of the channel where this image belongs, for example \"stable\" or \"fast\".",
 	)
 	flags.MarkHidden("channel-group")
 

--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -94,7 +94,7 @@ func init() {
 		&args.version,
 		"version",
 		"",
-		"Version of OpenShift that will be used to install the cluster, for example \"4.3.10\"",
+		"Version of OpenShift that will be used to setup policy tag, for example \"4.11\"",
 	)
 	flags.MarkHidden("version")
 

--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -78,7 +78,7 @@ func init() {
 		&args.channelGroup,
 		"channel-group",
 		ocm.DefaultChannelGroup,
-		"Channel group is the name of the group where this image belongs, for example \"stable\" or \"fast\".",
+		"Channel group is the name of the channel where this image belongs, for example \"stable\" or \"fast\".",
 	)
 	flags.MarkHidden("channel-group")
 

--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -70,7 +70,7 @@ func init() {
 		&args.version,
 		"version",
 		"",
-		"Version of OpenShift that will be used to install the cluster, for example \"4.3.10\"",
+		"Version of OpenShift that will be used to setup policy tag, for example \"4.11\"",
 	)
 	flags.MarkHidden("version")
 


### PR DESCRIPTION
Allows version of policy to be chosen from available openshift versions

Before using command `rosa create account-roles` it autos to the latest default version, in this case 4.11
![image](https://user-images.githubusercontent.com/5498205/190467088-bf5d5dd3-6849-4343-854f-a4cdb07b0cb9.png)

After using command `rosa create account-roles --version=4.10` the roles are created tagged with the chosen version. `--channel-group` could also be specified if a new version gets released in a specific channel, but it makes no difference for the example currently as the possible versions in the 'major.minor' format are the same.
![image](https://user-images.githubusercontent.com/5498205/190466964-468850a3-a993-433f-96da-1527b2160bbb.png)