### PR TITLE
Create cluster - list region filtered by OCP version

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1144,7 +1144,7 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
-	regionList, regionAZ, err := r.OCMClient.GetRegionList(multiAZ, roleARN, externalID)
+	regionList, regionAZ, err := r.OCMClient.GetRegionList(multiAZ, roleARN, externalID, version, awsClient)
 	if err != nil {
 		r.Reporter.Errorf(fmt.Sprintf("%s", err))
 		os.Exit(1)


### PR DESCRIPTION
Use the `aws_inquiries` endpoint and pass the `version` to fetch the supported regions.

Related: [SDA-6765](https://issues.redhat.com/browse/SDA-6765)

![image](https://user-images.githubusercontent.com/57869309/190174388-9cb8f3e2-25b0-4c1d-a704-a4f25eb66cd5.png)
