### PR TITLE
feat: adding -o yaml/json option to cmd whoami

### DIFF
--- a/cmd/whoami/cmd.go
+++ b/cmd/whoami/cmd.go
@@ -136,7 +136,7 @@ func run(_ *cobra.Command, _ []string) {
 	}
 	sort.Strings(keys)
 	for _, key := range keys {
-		fmt.Printf("%-30s:%v\n", key, outputObject[key])
+		fmt.Printf("%-30s%v\n", key+":", outputObject[key])
 	}
 	fmt.Println()
 }

--- a/pkg/object/data.go
+++ b/pkg/object/data.go
@@ -1,0 +1,3 @@
+package object
+
+type Object map[string]interface{}

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -41,7 +41,6 @@ func Print(resource interface{}) error {
 	var b bytes.Buffer
 	switch reflect.TypeOf(resource).String() {
 	case "[]*v1.CloudRegion":
-
 		if cloudRegions, ok := resource.([]*cmv1.CloudRegion); ok {
 			cmv1.MarshalCloudRegionList(cloudRegions, &b)
 		}
@@ -84,6 +83,15 @@ func Print(resource interface{}) error {
 				if err != nil {
 					return err
 				}
+			}
+		}
+	case "object.Object":
+		{
+			reqBodyBytes := new(bytes.Buffer)
+			json.NewEncoder(reqBodyBytes).Encode(resource)
+			err := json.Indent(&b, reqBodyBytes.Bytes(), "", "  ")
+			if err != nil {
+				return err
 			}
 		}
 	}


### PR DESCRIPTION
Adding possibility for -o json/yaml accommodating more usability in automations as stated by #726.

Usual whoami call
```
AWS ARN:                      arn:aws:iam::xxxxx:user/gbranco
AWS Account ID:               xxxxxxxxx
AWS Default Region:           us-east-1
OCM API:                      xxxxxxxx
OCM Account Email:            xxxxx
OCM Account ID:               xxxxxxx
OCM Account Name:             Guilherme Branco
OCM Account Username:         gbranco.openshift
OCM Organization External ID: xxxxx
OCM Organization ID:          xxxxx
OCM Organization Name:        xxxxxx
```

-o json
```
{
  "AWS ARN": "arn:aws:iam::xxxxx:user/gbranco",
  "AWS Account ID": "xxxxxxxxx",
  "AWS Default Region": "us-east-1",
  "OCM API": "xxxxxxxx",
  "OCM Account Email": "xxxxx",
  "OCM Account ID": "xxxxxxx",
  "OCM Account Name": "Guilherme Branco",
  "OCM Account Username": "gbranco.openshift",
  "OCM Organization External ID": "xxxxx",
  "OCM Organization ID": "xxxxx",
  "OCM Organization Name": "xxxxxx"
}
```

-o yaml
```
AWS ARN: arn:aws:iam::xxxxx:user/gbranco
AWS Account ID: xxxxxxxxx
AWS Default Region: us-east-1
OCM API: xxxxxxxx
OCM Account Email: xxxxx
OCM Account ID: xxxxxxx
OCM Account Name: Guilherme Branco
OCM Account Username: gbranco.openshift
OCM Organization External ID: "xxxxx"
OCM Organization ID: xxxxx
OCM Organization Name: 'xxxxxx'
```

PS, blurring some info with xxxxx