### PR TITLE
Upgrade cluster - manual mode - prompt the aws operator role upgrade commands

### DIFF
--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -250,7 +250,7 @@ func run(cmd *cobra.Command, argv []string) error {
 			reporter.Infof("Run the following command to continue scheduling cluster upgrade"+
 				" once account and operator roles have been upgraded : \n\n"+
 				"\trosa upgrade cluster --cluster %s\n", args.clusterID)
-			os.Exit(0)
+			return nil
 		}
 
 	default:

--- a/cmd/upgrade/operatorroles/cmd.go
+++ b/cmd/upgrade/operatorroles/cmd.go
@@ -385,7 +385,7 @@ func buildMissingOperatorRoleCommand(missingRoles map[string]*cmv1.STSOperator, 
 			"\t--role-name %s \\\n"+
 			"\t--assume-role-policy-document file://%s \\\n"+
 			"%s"+
-			"\t--tags %s \\\n",
+			"\t--tags %s",
 			roleName, filename, permBoundaryFlag, iamTags)
 		if rolePath != "" {
 			createRole = fmt.Sprintf(createRole+"\t--path %s", rolePath)


### PR DESCRIPTION
Related: [SDA-6744](https://issues.redhat.com/browse/SDA-6744)