### PR TITLE
[SDA-6858] adding escaped carrier to start of --path argument in ocm-role

### DIFF
--- a/cmd/create/ocmrole/cmd.go
+++ b/cmd/create/ocmrole/cmd.go
@@ -317,8 +317,8 @@ func buildCommands(prefix string, roleName string, rolePath string, permissionsB
 		"\t--tags %s",
 		policyName, aws.OCMRolePolicyFile, iamTags)
 	if rolePath != "" {
-		createRole = fmt.Sprintf(createRole+"\t--path %s", rolePath)
-		createPolicy = fmt.Sprintf(createPolicy+"\t--path %s", rolePath)
+		createRole = fmt.Sprintf(createRole+" \\\n\t--path %s", rolePath)
+		createPolicy = fmt.Sprintf(createPolicy+" \\\n\t--path %s", rolePath)
 	}
 	attachRolePolicy := fmt.Sprintf("aws iam attach-role-policy \\\n"+
 		"\t--role-name %s \\\n"+
@@ -336,7 +336,7 @@ func buildCommands(prefix string, roleName string, rolePath string, permissionsB
 			"\t--tags %s",
 			policyName, aws.OCMAdminRolePolicyFile, adminTags)
 		if rolePath != "" {
-			createAdminPolicy = fmt.Sprintf(createAdminPolicy+"\t--path %s", rolePath)
+			createAdminPolicy = fmt.Sprintf(createAdminPolicy+" \\\n\t--path %s", rolePath)
 		}
 		attachRoleAdminPolicy := fmt.Sprintf("aws iam attach-role-policy \\\n"+
 			"\t--role-name %s \\\n"+


### PR DESCRIPTION
This PR only adds an escaped \n before adding the --path prefix to create ocm-roles in manual mode, simply to make sure the args will be separated. Aims to solve [SDA-6858](https://issues.redhat.com/browse/SDA-6858)

Original issue the --path arg was not separated from the rest of the command for some reason, could not reproduce
```
aws iam create-role \
        --role-name xxxxxxx \
        --assume-role-policy-document file://sts_ocm_trust_policy.json \
        --tags Key=rosa_role_prefix,Value=ManagedOpenShift Key=rosa_role_type,Value=OCM Key=rosa_environment,Value=staging Key=red-hat-managed,Value=true--path /test2/
```

Changed to make sure it is in a new line
```
aws iam create-role \
        --role-name xxxxxxx \
        --assume-role-policy-document file://sts_ocm_trust_policy.json \
        --tags Key=rosa_role_prefix,Value=ManagedOpenShift Key=rosa_role_type,Value=OCM Key=rosa_environment,Value=staging Key=red-hat-managed,Value=true \
        --path /test2/
```

