### PR TITLE
Fetch all regions for non-interactive mode

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1144,7 +1144,15 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
-	regionList, regionAZ, err := r.OCMClient.GetRegionList(multiAZ, roleARN, externalID, version, awsClient)
+	// Filter regions by OCP version for displaying in interactive mode
+	var versionFilter string
+	if interactive.Enabled() {
+		versionFilter = version
+	} else {
+		versionFilter = ""
+	}
+
+	regionList, regionAZ, err := r.OCMClient.GetRegionList(multiAZ, roleARN, externalID, versionFilter, awsClient)
 	if err != nil {
 		r.Reporter.Errorf(fmt.Sprintf("%s", err))
 		os.Exit(1)

--- a/pkg/ocm/regions.go
+++ b/pkg/ocm/regions.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift/rosa/pkg/logging"
 )
 
+// GetFilteredRegionsByVersion fetches a list of regions. The 'version' argument is optional for filtering.
 func (c *Client) GetFilteredRegionsByVersion(roleARN string, version string,
 	awsClient aws.Client, externalID string) (regions []*cmv1.CloudRegion, err error) {
 	cloudProviderDataBuilder, err := c.createCloudProviderDataBuilder(roleARN, awsClient, externalID)


### PR DESCRIPTION
For non-interactive mode, the CLI doesn't display the regions to the user, 
therefore fetching all regions to get the correct error message eventually.

Related: [SDA-6837](https://issues.redhat.com/browse/SDA-6837)

![image](https://user-images.githubusercontent.com/57869309/191486225-3f789c17-903c-4464-8b5c-0719f2192046.png)
