### PR TITLE
OHSS-14855: Making sure extracting the current operator roles prefix does not crash when upgrading the roles

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -987,7 +987,7 @@ func run(cmd *cobra.Command, _ []string) {
 	operatorIAMRoleList := []ocm.OperatorIAMRole{}
 	if isSTS {
 		if operatorRolesPrefix == "" {
-			operatorRolesPrefix = getRolePrefix(clusterName)
+			operatorRolesPrefix = ocm.ComputeDefaultOperatorRolesPrefix(clusterName)
 		}
 		if interactive.Enabled() {
 			operatorRolesPrefix, err = interactive.GetString(interactive.Input{
@@ -2418,8 +2418,4 @@ func buildCommand(spec ocm.Spec, operatorRolesPrefix string,
 	}
 
 	return command
-}
-
-func getRolePrefix(clusterName string) string {
-	return fmt.Sprintf("%s-%s", clusterName, ocm.RandomLabel(4))
 }

--- a/cmd/create/service/cmd.go
+++ b/cmd/create/service/cmd.go
@@ -400,7 +400,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// operator role logic.
-	operatorRolesPrefix := getRolePrefix(args.ClusterName)
+	operatorRolesPrefix := ocm.ComputeDefaultOperatorRolesPrefix(args.ClusterName)
 	operatorIAMRoleList := []ocm.OperatorIAMRole{}
 
 	// Managed Services does not support Hypershift at this time.
@@ -494,10 +494,6 @@ func getAccountRolePrefix(roleARN string, role aws.AccountRole) (string, error) 
 	}
 	rolePrefix := aws.TrimRoleSuffix(roleName, fmt.Sprintf("-%s-Role", role.Name))
 	return rolePrefix, nil
-}
-
-func getRolePrefix(clusterName string) string {
-	return fmt.Sprintf("%s-%s", clusterName, ocm.RandomLabel(4))
 }
 
 func getOperatorRoleArn(prefix string, operator *cmv1.STSOperator, creator *aws.Creator, path string) string {

--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -579,6 +579,10 @@ func (c *Client) GetCredRequests(isHypershift bool) (map[string]*cmv1.STSOperato
 	return m, nil
 }
 
+func ComputeDefaultOperatorRolesPrefix(clusterName string) string {
+	return fmt.Sprintf("%s-%s", clusterName, RandomLabel(4))
+}
+
 func (c *Client) FindMissingOperatorRolesForUpgrade(cluster *cmv1.Cluster,
 	newMinorVersion string) (map[string]*cmv1.STSOperator, error) {
 	missingRoles := make(map[string]*cmv1.STSOperator)


### PR DESCRIPTION
A default prefix (based on the cluster name) will be created if no prefix can be extracted from the existing operator roles.

This change has been discussed here:
https://coreos.slack.com/archives/CB53T9ZHQ/p1663701584121839?thread_ts=1662139356.619269&cid=CB53T9ZHQ

- If the existing operator roles are prefixed: the code is still re-using their prefix for the operator role(s) to create during upgrade.
- If the existing operator roles are not prefixed:
  - Current code is crashing, this is the issue we have in [OHSS-14855](https://issues.redhat.com/browse/OHSS-14855).
  - With the new proposed code:
    - Command `rosa upgrade operator-roles` will crash no more.
    - The new operator roles to create will be created with a default prefix.
    - So the operator roles will then not all follow the same naming convention (as the old roles will be unprefixed)... but that's NOT an issue as the only place where this naming convention is used & reversed engineered (which is a bad practice) is precisely when the `rosa upgrade operator-roles` command is trying to extract the prefix.