### PR TITLE
[SDA-6780] fix: compatibility issue older rosa cli

### DIFF
--- a/cmd/dlt/admin/cmd.go
+++ b/cmd/dlt/admin/cmd.go
@@ -73,7 +73,8 @@ func run(cmd *cobra.Command, _ []string) {
 
 	if confirm.Confirm("delete %s user on cluster %s", idp.ClusterAdminUsername, r.ClusterKey) {
 		// delete `cluster-admin` user from the HTPasswd IDP
-		r.Reporter.Debugf("Deleting user '%s' from cluster-admins group on cluster '%s'", idp.ClusterAdminUsername, r.ClusterKey)
+		r.Reporter.Debugf("Deleting user '%s' from cluster-admins group on cluster '%s'",
+			idp.ClusterAdminUsername, r.ClusterKey)
 		err = r.OCMClient.DeleteUser(clusterID, "cluster-admins", idp.ClusterAdminUsername)
 		if err != nil {
 			r.Reporter.Errorf("Failed to delete '%s' user from cluster-admins groups of cluster '%s': %s",
@@ -97,7 +98,8 @@ func run(cmd *cobra.Command, _ []string) {
 			}
 		} else {
 			//delete now the cluster-admin user from the htpasswd idp
-			r.Reporter.Debugf("Deleting user '%s' from identity provider user list on cluster '%s'", idp.ClusterAdminUsername, r.ClusterKey)
+			r.Reporter.Debugf("Deleting user '%s' from identity provider user list on cluster '%s'",
+				idp.ClusterAdminUsername, r.ClusterKey)
 			err := r.OCMClient.DeleteHTPasswdUser(idp.ClusterAdminUsername, clusterID, identityProvider)
 			if err != nil {
 				r.Reporter.Errorf("Failed to delete '%s' user from htpasswd idp users list of cluster '%s': %s",


### PR DESCRIPTION
# What
Creating an admin with rosa cli 1.1.5 then deleting it with 1.2.6 was not deleting correctly and newly created admin with 1.2.6 would cause 500 response codes on `oc login`.
Related issue: https://issues.redhat.com/browse/SDA-6780

# Why
This causes frustration for clients as they needed to have a second idp with admin access to delete the resources through `oc`.

# Cause
The entire identity provider was being deleted when created from older clis, but a condition was still trying to delete it a second time. I'm not too familiar as to why the second call didn't give back an error or why it caused the 500 response codes, maybe we should look into the delete route of idp for ocm.

# Steps before
`rosa115 create admin -c htpwd-test`
`rosa126 delete admin -c htpwd-test`
`rosa126 create admin -c htpwd-test`
`oc login <url> --username cluster-admin --password <pwd>`
```
Error from server (InternalError): Internal error occurred: unexpected response: 500
```

# Steps after
`rosa115 create admin -c htpwd-test`
`rosaWithChanges delete admin -c htpwd-test`
`rosaWithChanges create admin -c htpwd-test`
`oc login <url> --username cluster-admin --password <pwd>`
```
Login successful.
```

I was also able to delete from the error state into creating a new admin and login just fine.