### PR TITLE
[SDA-6866] feat/unify role path

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -227,10 +227,10 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	path := args.path
-	if cmd.Flags().Changed("role-path") && interactive.Enabled() {
+	if cmd.Flags().Changed("path") && interactive.Enabled() {
 		path, err = interactive.GetString(interactive.Input{
-			Question: "Role Path",
-			Help:     cmd.Flags().Lookup("role-path").Usage,
+			Question: "Path",
+			Help:     cmd.Flags().Lookup("path").Usage,
 			Default:  path,
 			Validators: []interactive.Validator{
 				aws.ARNPathValidator,

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2260,9 +2260,6 @@ func buildCommand(spec ocm.Spec, operatorRolesPrefix string,
 	if operatorRolesPrefix != "" {
 		command += fmt.Sprintf(" --operator-roles-prefix %s", operatorRolesPrefix)
 	}
-	if operatorRolePath != "" {
-		command += fmt.Sprintf(" --operator-role-path %s", operatorRolePath)
-	}
 	if len(spec.Tags) > 0 {
 		tags := []string{}
 		for k, v := range spec.Tags {

--- a/cmd/create/ocmrole/cmd.go
+++ b/cmd/create/ocmrole/cmd.go
@@ -38,7 +38,6 @@ var args struct {
 	prefix              string
 	permissionsBoundary string
 	admin               bool
-	path                string
 }
 
 var Cmd = &cobra.Command{
@@ -76,14 +75,6 @@ func init() {
 		false,
 		"Enable admin capabilities for the role",
 	)
-
-	flags.StringVar(
-		&args.path,
-		"path",
-		"",
-		"The arn path for the ocm role and policies",
-	)
-	flags.MarkHidden("path")
 
 	aws.AddModeFlag(Cmd)
 
@@ -180,22 +171,6 @@ func run(cmd *cobra.Command, argv []string) {
 		}
 	}
 
-	path := args.path
-	if cmd.Flags().Changed("path") && interactive.Enabled() {
-		path, err = interactive.GetString(interactive.Input{
-			Question: "Role Path",
-			Help:     cmd.Flags().Lookup("path").Usage,
-			Default:  path,
-			Validators: []interactive.Validator{
-				aws.ARNPathValidator,
-			},
-		})
-		if err != nil {
-			r.Reporter.Errorf("Expected a valid path: %s", err)
-			os.Exit(1)
-		}
-	}
-
 	if interactive.Enabled() {
 		mode, err = interactive.GetOption(interactive.Input{
 			Question: "Role creation mode",
@@ -241,7 +216,7 @@ func run(cmd *cobra.Command, argv []string) {
 	switch mode {
 	case aws.ModeAuto:
 		r.Reporter.Infof("Creating role using '%s'", r.Creator.ARN)
-		roleARN, err := createRoles(r, prefix, roleNameRequested, path, permissionsBoundary, r.Creator.AccountID,
+		roleARN, err := createRoles(r, prefix, roleNameRequested, permissionsBoundary, r.Creator.AccountID,
 			orgID, env, isAdmin, policies)
 		if err != nil {
 			r.Reporter.Errorf("There was an error creating the ocm role: %s", err)
@@ -276,7 +251,7 @@ func run(cmd *cobra.Command, argv []string) {
 			r.Reporter.Infof("All policy files saved to the current directory")
 			r.Reporter.Infof("Run the following commands to create the ocm role and policies:\n")
 		}
-		commands := buildCommands(prefix, roleNameRequested, path, permissionsBoundary, r.Creator.AccountID, env, isAdmin)
+		commands := buildCommands(prefix, roleNameRequested, permissionsBoundary, r.Creator.AccountID, env, isAdmin)
 		fmt.Println(commands)
 	default:
 		r.Reporter.Errorf("Invalid mode. Allowed values are %s", aws.Modes)
@@ -284,8 +259,11 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 }
 
-func buildCommands(prefix string, roleName string, rolePath string, permissionsBoundary string,
+func buildCommands(prefix string, roleName string, permissionsBoundary string,
 	accountID string, env string, isAdmin bool) string {
+	//Creating a rolePath string for compatibility, this is always empty as it is currently not supported
+	var rolePath string
+
 	commands := []string{}
 	policyName := fmt.Sprintf("%s-Policy", roleName)
 	iamTags := fmt.Sprintf(
@@ -353,9 +331,12 @@ func buildCommands(prefix string, roleName string, rolePath string, permissionsB
 	return strings.Join(commands, "\n\n")
 }
 
-func createRoles(r *rosa.Runtime, prefix string, roleName string, rolePath string,
+func createRoles(r *rosa.Runtime, prefix string, roleName string,
 	permissionsBoundary string, accountID string, orgID string, env string, isAdmin bool,
 	policies map[string]string) (string, error) {
+	//Creating a rolePath string for compatibility, this is always empty as it is currently not supported
+	var rolePath string
+
 	policyARN := aws.GetPolicyARN(accountID, fmt.Sprintf("%s-Policy", roleName), rolePath)
 	if !confirm.Prompt(true, "Create the '%s' role?", roleName) {
 		os.Exit(0)

--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -283,7 +283,7 @@ func createRoles(r *rosa.Runtime,
 			continue
 		}
 
-		path, err := getPathFromInstanceRole(cluster)
+		path, err := getPathFromInstallerRole(cluster)
 		if err != nil {
 			return err
 		}
@@ -361,7 +361,7 @@ func buildCommands(r *rosa.Runtime, env string,
 			}
 		}
 		roleName, _ := getRoleNameAndARN(cluster, operator)
-		path, err := getPathFromInstanceRole(cluster)
+		path, err := getPathFromInstallerRole(cluster)
 		if err != nil {
 			return "", err
 		}
@@ -441,9 +441,8 @@ func getRoleNameAndARN(cluster *cmv1.Cluster, operator *cmv1.STSOperator) (strin
 	return "", ""
 }
 
-func getPathFromInstanceRole(cluster *cmv1.Cluster) (string, error) {
-	roles, _ := cluster.AWS().STS().GetInstanceIAMRoles()
-	return aws.GetPathFromARN(roles.MasterRoleARN())
+func getPathFromInstallerRole(cluster *cmv1.Cluster) (string, error) {
+	return aws.GetPathFromARN(cluster.AWS().STS().RoleARN())
 }
 
 func getPolicyARN(accountID string, prefix string, namespace string, name string, path string) string {

--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -38,7 +38,6 @@ import (
 var args struct {
 	prefix              string
 	permissionsBoundary string
-	policyPath          string
 }
 
 var Cmd = &cobra.Command{
@@ -73,14 +72,6 @@ func init() {
 		"",
 		"The ARN of the policy that is used to set the permissions boundary for the operator roles.",
 	)
-
-	flags.StringVar(
-		&args.policyPath,
-		"policy-path",
-		"",
-		"The arn path for the operator policies",
-	)
-	flags.MarkHidden("policy-path")
 
 	aws.AddModeFlag(Cmd)
 	confirm.AddFlag(flags)
@@ -145,22 +136,6 @@ func run(cmd *cobra.Command, argv []string) {
 	if err != nil {
 		r.Reporter.Errorf("Failed to find prefix from %s account role", aws.InstallerAccountRole)
 		os.Exit(1)
-	}
-
-	policyPath := args.policyPath
-	if cmd.Flags().Changed("policy-path") && interactive.Enabled() {
-		policyPath, err = interactive.GetString(interactive.Input{
-			Question: "Policy Path",
-			Help:     cmd.Flags().Lookup("policy-path").Usage,
-			Default:  policyPath,
-			Validators: []interactive.Validator{
-				aws.ARNPathValidator,
-			},
-		})
-		if err != nil {
-			r.Reporter.Errorf("Expected a valid path: %s", err)
-			os.Exit(1)
-		}
 	}
 
 	permissionsBoundary := args.permissionsBoundary
@@ -240,7 +215,7 @@ func run(cmd *cobra.Command, argv []string) {
 			r.Reporter.Infof("Creating roles using '%s'", r.Creator.ARN)
 		}
 		err = createRoles(r, prefix, permissionsBoundary, cluster,
-			accountRoleVersion, policies, defaultPolicyVersion, credRequests, policyPath)
+			accountRoleVersion, policies, defaultPolicyVersion, credRequests)
 		if err != nil {
 			r.Reporter.Errorf("There was an error creating the operator roles: %s", err)
 			isThrottle := "false"
@@ -259,7 +234,7 @@ func run(cmd *cobra.Command, argv []string) {
 			ocm.Response:  ocm.Success,
 		})
 	case aws.ModeManual:
-		commands, err := buildCommands(r, env, prefix, permissionsBoundary, defaultPolicyVersion, policyPath,
+		commands, err := buildCommands(r, env, prefix, permissionsBoundary, defaultPolicyVersion,
 			cluster, policies, credRequests)
 		if err != nil {
 			r.Reporter.Errorf("There was an error building the list of resources: %s", err)
@@ -287,7 +262,7 @@ func run(cmd *cobra.Command, argv []string) {
 func createRoles(r *rosa.Runtime,
 	prefix string, permissionsBoundary string,
 	cluster *cmv1.Cluster, accountRoleVersion string, policies map[string]string,
-	defaultVersion string, credRequests map[string]*cmv1.STSOperator, policyPath string) error {
+	defaultVersion string, credRequests map[string]*cmv1.STSOperator) error {
 	for credrequest, operator := range credRequests {
 		ver := cluster.Version()
 		if ver != nil && operator.MinVersion() != "" {
@@ -313,7 +288,7 @@ func createRoles(r *rosa.Runtime,
 			return err
 		}
 		policyARN := aws.GetOperatorPolicyARN(r.Creator.AccountID, prefix, operator.Namespace(),
-			operator.Name(), policyPath)
+			operator.Name(), rolePath)
 		filename := fmt.Sprintf("openshift_%s_policy", credrequest)
 		policyDetails := policies[filename]
 
@@ -324,7 +299,7 @@ func createRoles(r *rosa.Runtime,
 				tags.RedHatManaged:    "true",
 				"operator_namespace":  operator.Namespace(),
 				"operator_name":       operator.Name(),
-			}, policyPath)
+			}, rolePath)
 		if err != nil {
 			return err
 		}
@@ -361,8 +336,7 @@ func createRoles(r *rosa.Runtime,
 }
 
 func buildCommands(r *rosa.Runtime, env string,
-	prefix, permissionsBoundary, defaultPolicyVersion, policyPath string,
-	cluster *cmv1.Cluster,
+	prefix string, permissionsBoundary string, defaultPolicyVersion string, cluster *cmv1.Cluster,
 	policies map[string]string, credRequests map[string]*cmv1.STSOperator) (string, error) {
 
 	err := aws.GeneratePolicyFiles(r.Reporter, env, false,
@@ -387,11 +361,11 @@ func buildCommands(r *rosa.Runtime, env string,
 			}
 		}
 		roleName, roleARN := getRoleNameAndARN(cluster, operator)
-		rolePath, err := aws.GetPathFromARN(roleARN)
+		path, err := aws.GetPathFromARN(roleARN)
 		if err != nil {
 			return "", err
 		}
-		policyARN := getPolicyARN(r.Creator.AccountID, prefix, operator.Namespace(), operator.Name(), policyPath)
+		policyARN := getPolicyARN(r.Creator.AccountID, prefix, operator.Namespace(), operator.Name(), path)
 
 		name := aws.GetPolicyName(prefix, operator.Namespace(), operator.Name())
 		_, err = r.AWSClient.IsPolicyExists(policyARN)
@@ -408,8 +382,8 @@ func buildCommands(r *rosa.Runtime, env string,
 				"\t--policy-document file://openshift_%s_policy.json \\\n"+
 				"\t--tags %s",
 				name, credrequest, iamTags)
-			if policyPath != "" {
-				createPolicy = fmt.Sprintf(createPolicy+"\t--path %s", policyPath)
+			if path != "" {
+				createPolicy = fmt.Sprintf(createPolicy+"\t--path %s", path)
 			}
 			commands = append(commands, createPolicy)
 		}
@@ -445,8 +419,8 @@ func buildCommands(r *rosa.Runtime, env string,
 			"%s"+
 			"\t--tags %s",
 			roleName, filename, permBoundaryFlag, iamTags)
-		if rolePath != "" {
-			createRole = fmt.Sprintf(createRole+"\t--path %s", rolePath)
+		if path != "" {
+			createRole = fmt.Sprintf(createRole+"\t--path %s", path)
 		}
 		attachRolePolicy := fmt.Sprintf("aws iam attach-role-policy \\\n"+
 			"\t--role-name %s \\\n"+


### PR DESCRIPTION
# What
Unify path for account roles and policies, as well as identify this path for operator roles and policies later
Related task: https://issues.redhat.com/browse/SDA-6866

# Why
Currently, there are limitations from AWS that is confusing CX with separate paths for account roles and operator roles and policy. Hence we are limiting our option to use only one path for all IAM  roles and policies 

# Steps to check changes
## create cluster command
### Mutual step setup
`./rosa create account-roles --prefix=ManagedOpenShift-path-test --path /gdbsts/ -i`
```
I: Logged in as 'gbranco.openshift' on 'https://api.stage.openshift.com'
I: Validating AWS credentials...
I: AWS credentials are valid!
I: Validating AWS quota...
I: AWS quota ok. If cluster installation fails, validate actual AWS resource usage against https://docs.openshift.com/rosa/rosa_getting_started/rosa-required-aws-service-quotas.html
I: Verifying whether OpenShift command-line tool is available...
I: Current OpenShift Client Version: 4.11.2
I: Creating account roles
? Role prefix: ManagedOpenShift-path-test
? Permissions boundary ARN (optional): 
? Path: /gdbsts/
? Role creation mode: auto
I: Creating roles using 'arn:aws:iam::765374464689:user/gbranco'
? Create the 'ManagedOpenShift-path-test-Installer-Role' role? Yes
I: Created role 'ManagedOpenShift-path-test-Installer-Role' with ARN 'arn:aws:iam::765374464689:role/gdbsts/ManagedOpenShift-path-test-Installer-Role'
? Create the 'ManagedOpenShift-path-test-ControlPlane-Role' role? Yes
I: Created role 'ManagedOpenShift-path-test-ControlPlane-Role' with ARN 'arn:aws:iam::765374464689:role/gdbsts/ManagedOpenShift-path-test-ControlPlane-Role'
? Create the 'ManagedOpenShift-path-test-Worker-Role' role? Yes
I: Created role 'ManagedOpenShift-path-test-Worker-Role' with ARN 'arn:aws:iam::765374464689:role/gdbsts/ManagedOpenShift-path-test-Worker-Role'
? Create the 'ManagedOpenShift-path-test-Support-Role' role? Yes
I: Created role 'ManagedOpenShift-path-test-Support-Role' with ARN 'arn:aws:iam::765374464689:role/gdbsts/ManagedOpenShift-path-test-Support-Role'
I: To create a cluster with these roles, run the following command:
rosa create cluster --sts
```
`./rosa create cluster --sts -c path-test -i`
```
I: Interactive mode enabled.
Any optional fields can be left empty and a default will be selected.
? Cluster name: path-test
? OpenShift version: 4.11.4
W: More than one Installer role found
? Installer role ARN: arn:aws:iam::765374464689:role/gdbsts/ManagedOpenShift-path-test-Installer-Role
I: Using arn:aws:iam::765374464689:role/gdbsts/ManagedOpenShift-path-test-ControlPlane-Role for the ControlPlane role
I: Using arn:aws:iam::765374464689:role/gdbsts/ManagedOpenShift-path-test-Worker-Role for the Worker role
I: Using arn:aws:iam::765374464689:role/gdbsts/ManagedOpenShift-path-test-Support-Role for the Support role
? External ID (optional): 
? Operator roles prefix: path-test-m2s5
.
.
.
? Encrypt etcd data (optional): No
? Disable Workload monitoring (optional): No
I: Creating cluster 'path-test'
I: To create this cluster again in the future, you can run:
   rosa create cluster --cluster-name path-test --sts --role-arn arn:aws:iam::765374464689:role/gdbsts/ManagedOpenShift-path-test-Installer-Role --support-role-arn arn:aws:iam::765374464689:role/gdbsts/ManagedOpenShift-path-test-Support-Role --controlplane-iam-role arn:aws:iam::765374464689:role/gdbsts/ManagedOpenShift-path-test-ControlPlane-Role --worker-iam-role arn:aws:iam::765374464689:role/gdbsts/ManagedOpenShift-path-test-Worker-Role --operator-roles-prefix path-test-m2s5 --region us-east-1 --version 4.11.4 --compute-nodes 2 --compute-machine-type m5.xlarge --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23
I: To view a list of clusters and their status, run 'rosa list clusters'
I: Cluster 'path-test' has been created.
I: Once the cluster is installed you will need to add an Identity Provider before you can login into the cluster. See 'rosa create idp --help' for more information.
Name:                       path-test
ID:                         1ut6939ove7t6dmuc8mcbhncbrl92feo
.
.
.
STS Role ARN:               arn:aws:iam::765374464689:role/gdbsts/ManagedOpenShift-path-test-Installer-Role
Support Role ARN:           arn:aws:iam::765374464689:role/gdbsts/ManagedOpenShift-path-test-Support-Role
Instance IAM Roles:
 - Control plane:           arn:aws:iam::765374464689:role/gdbsts/ManagedOpenShift-path-test-ControlPlane-Role
 - Worker:                  arn:aws:iam::765374464689:role/gdbsts/ManagedOpenShift-path-test-Worker-Role
Operator IAM Roles:
 - arn:aws:iam::765374464689:role/gdbsts/path-test-m2s5-openshift-machine-api-aws-cloud-credentials
 - arn:aws:iam::765374464689:role/gdbsts/path-test-m2s5-openshift-cloud-credential-operator-cloud-credent
 - arn:aws:iam::765374464689:role/gdbsts/path-test-m2s5-openshift-image-registry-installer-cloud-credenti
 - arn:aws:iam::765374464689:role/gdbsts/path-test-m2s5-openshift-ingress-operator-cloud-credentials
 - arn:aws:iam::765374464689:role/gdbsts/path-test-m2s5-openshift-cluster-csi-drivers-ebs-cloud-credentia
 - arn:aws:iam::765374464689:role/gdbsts/path-test-m2s5-openshift-cloud-network-config-controller-cloud-c
State:                      waiting (Waiting for OIDC configuration)
.
.
.
I: Run the following commands to continue the cluster creation:

	rosa create operator-roles --cluster path-test
	rosa create oidc-provider --cluster path-test

I: To determine when your cluster is Ready, run 'rosa describe cluster -c path-test'.
I: To watch your cluster installation logs, run 'rosa logs install -c path-test --watch'.
```
### Auto
`/rosa create operator-roles --cluster path-test`
```
? Permissions boundary ARN (optional): 
? Role creation mode: auto
I: Creating roles using 'arn:aws:iam::765374464689:user/gbranco'
? Create the 'path-test-m2s5-openshift-machine-api-aws-cloud-credentials' role? Yes
I: Created role 'path-test-m2s5-openshift-machine-api-aws-cloud-credentials' with ARN 'arn:aws:iam::765374464689:role/gdbsts/path-test-m2s5-openshift-machine-api-aws-cloud-credentials'
? Create the 'path-test-m2s5-openshift-cloud-credential-operator-cloud-credent' role? Yes
I: Created role 'path-test-m2s5-openshift-cloud-credential-operator-cloud-credent' with ARN 'arn:aws:iam::765374464689:role/gdbsts/path-test-m2s5-openshift-cloud-credential-operator-cloud-credent'
? Create the 'path-test-m2s5-openshift-image-registry-installer-cloud-credenti' role? Yes
I: Created role 'path-test-m2s5-openshift-image-registry-installer-cloud-credenti' with ARN 'arn:aws:iam::765374464689:role/gdbsts/path-test-m2s5-openshift-image-registry-installer-cloud-credenti'
? Create the 'path-test-m2s5-openshift-ingress-operator-cloud-credentials' role? Yes
I: Created role 'path-test-m2s5-openshift-ingress-operator-cloud-credentials' with ARN 'arn:aws:iam::765374464689:role/gdbsts/path-test-m2s5-openshift-ingress-operator-cloud-credentials'
? Create the 'path-test-m2s5-openshift-cluster-csi-drivers-ebs-cloud-credentia' role? Yes
I: Created role 'path-test-m2s5-openshift-cluster-csi-drivers-ebs-cloud-credentia' with ARN 'arn:aws:iam::765374464689:role/gdbsts/path-test-m2s5-openshift-cluster-csi-drivers-ebs-cloud-credentia'
? Create the 'path-test-m2s5-openshift-cloud-network-config-controller-cloud-c' role? Yes
I: Created role 'path-test-m2s5-openshift-cloud-network-config-controller-cloud-c' with ARN 'arn:aws:iam::765374464689:role/gdbsts/path-test-m2s5-openshift-cloud-network-config-controller-cloud-c'
```
`./rosa create oidc-provider --cluster path-test`
```
? OIDC provider creation mode: auto
I: Creating OIDC provider using 'arn:aws:iam::765374464689:user/gbranco'
? Create the OIDC provider for cluster 'path-test'? Yes
I: Created OIDC provider with ARN 'arn:aws:iam::765374464689:oidc-provider/rh-oidc-staging.s3.us-east-1.amazonaws.com/1ut6939ove7t6dmuc8mcbhncbrl92feo'
```
### Manual
`./rosa create operator-roles --cluster path-test`
```
? Permissions boundary ARN (optional):
? Role creation mode: manual
I: All policy files saved to the current directory
I: Run the following commands to create the operator roles:

aws iam create-role \
	--role-name path-test-c3n0-openshift-image-registry-installer-cloud-credenti \
	--assume-role-policy-document file://operator_image_registry_installer_cloud_credentials_policy.json \
	--tags Key=rosa_cluster_id,Value=1utmv1o5s8ghuj4jo9gpblt1gmb0gupi Key=rosa_role_prefix,Value=ManagedOpenShift-path-test Key=operator_namespace,Value=openshift-image-registry Key=operator_name,Value=installer-cloud-credentials	--path /gdbsts/

aws iam attach-role-policy \
	--role-name path-test-c3n0-openshift-image-registry-installer-cloud-credenti \
	--policy-arn arn:aws:iam::765374464689:policy/gdbsts/ManagedOpenShift-path-test-openshift-image-registry-installer-cl

aws iam create-role \
	--role-name path-test-c3n0-openshift-ingress-operator-cloud-credentials \
	--assume-role-policy-document file://operator_ingress_operator_cloud_credentials_policy.json \
	--tags Key=rosa_cluster_id,Value=1utmv1o5s8ghuj4jo9gpblt1gmb0gupi Key=rosa_role_prefix,Value=ManagedOpenShift-path-test Key=operator_namespace,Value=openshift-ingress-operator Key=operator_name,Value=cloud-credentials	--path /gdbsts/

aws iam attach-role-policy \
	--role-name path-test-c3n0-openshift-ingress-operator-cloud-credentials \
	--policy-arn arn:aws:iam::765374464689:policy/gdbsts/ManagedOpenShift-path-test-openshift-ingress-operator-cloud-cred

aws iam create-role \
	--role-name path-test-c3n0-openshift-cluster-csi-drivers-ebs-cloud-credentia \
	--assume-role-policy-document file://operator_cluster_csi_drivers_ebs_cloud_credentials_policy.json \
	--tags Key=rosa_cluster_id,Value=1utmv1o5s8ghuj4jo9gpblt1gmb0gupi Key=rosa_role_prefix,Value=ManagedOpenShift-path-test Key=operator_namespace,Value=openshift-cluster-csi-drivers Key=operator_name,Value=ebs-cloud-credentials	--path /gdbsts/

aws iam attach-role-policy \
	--role-name path-test-c3n0-openshift-cluster-csi-drivers-ebs-cloud-credentia \
	--policy-arn arn:aws:iam::765374464689:policy/gdbsts/ManagedOpenShift-path-test-openshift-cluster-csi-drivers-ebs-clo

aws iam create-role \
	--role-name path-test-c3n0-openshift-cloud-network-config-controller-cloud-c \
	--assume-role-policy-document file://operator_cloud_network_config_controller_cloud_credentials_policy.json \
	--tags Key=rosa_cluster_id,Value=1utmv1o5s8ghuj4jo9gpblt1gmb0gupi Key=rosa_role_prefix,Value=ManagedOpenShift-path-test Key=operator_namespace,Value=openshift-cloud-network-config-controller Key=operator_name,Value=cloud-credentials	--path /gdbsts/

aws iam attach-role-policy \
	--role-name path-test-c3n0-openshift-cloud-network-config-controller-cloud-c \
	--policy-arn arn:aws:iam::765374464689:policy/gdbsts/ManagedOpenShift-path-test-openshift-cloud-network-config-contro

aws iam create-role \
	--role-name path-test-c3n0-openshift-machine-api-aws-cloud-credentials \
	--assume-role-policy-document file://operator_machine_api_aws_cloud_credentials_policy.json \
	--tags Key=rosa_cluster_id,Value=1utmv1o5s8ghuj4jo9gpblt1gmb0gupi Key=rosa_role_prefix,Value=ManagedOpenShift-path-test Key=operator_namespace,Value=openshift-machine-api Key=operator_name,Value=aws-cloud-credentials	--path /gdbsts/

aws iam attach-role-policy \
	--role-name path-test-c3n0-openshift-machine-api-aws-cloud-credentials \
	--policy-arn arn:aws:iam::765374464689:policy/gdbsts/ManagedOpenShift-path-test-openshift-machine-api-aws-cloud-crede

aws iam create-role \
	--role-name path-test-c3n0-openshift-cloud-credential-operator-cloud-credent \
	--assume-role-policy-document file://operator_cloud_credential_operator_cloud_credential_operator_iam_ro_creds_policy.json \
	--tags Key=rosa_cluster_id,Value=1utmv1o5s8ghuj4jo9gpblt1gmb0gupi Key=rosa_role_prefix,Value=ManagedOpenShift-path-test Key=operator_namespace,Value=openshift-cloud-credential-operator Key=operator_name,Value=cloud-credential-operator-iam-ro-creds	--path /gdbsts/

aws iam attach-role-policy \
	--role-name path-test-c3n0-openshift-cloud-credential-operator-cloud-credent \
	--policy-arn arn:aws:iam::765374464689:policy/gdbsts/ManagedOpenShift-path-test-openshift-cloud-credential-operator-c
```
`./rosa create oidc-provider --cluster path-test`
```
? OIDC provider creation mode: manual
I: Run the following commands to create the OIDC provider:

aws iam create-open-id-connect-provider \
	--url https://rh-oidc-staging.s3.us-east-1.amazonaws.com/1utmv1o5s8ghuj4jo9gpblt1gmb0gupi \
	--client-id-list openshift sts.amazonaws.com \
	--thumbprint-list 9e99a48a9960b14926bb7f3b02e22da2b0ab7280 \
	 --tag Key=rosa_cluster_id,Value=1utmv1o5s8ghuj4jo9gpblt1gmb0gupi
```

### Mutual steps check ready
`./rosa describe cluster -c path-test`
```
.
.
.
State:                      pending (Preparing account)
```
`./rosa describe cluster -c path-test`
```
.
.
.
State:                      installing (DNS setup in progress)
```
`./rosa describe cluster -c path-test`
```
.
.
.
State:                      ready 
```
## upgrade cluster command
`./rosa create account-roles --prefix=ManagedOpenShift-path-test --path /gdbsts/ --version=4.9 -i`
![image](https://user-images.githubusercontent.com/5498205/192033111-cd34df12-7575-4190-837a-24da34583134.png)

`./rosa create cluster -c path-test --sts -i`
`./rosa create operator-roles --cluster path-test`
`./rosa create oidc-provider --cluster path-test`

Wait for the cluster to be ready

`./rosa upgrade account-roles --prefix ManagedOpenShift-path-test`
![image](https://user-images.githubusercontent.com/5498205/192036372-60e086d2-a629-4111-ad73-0de77b4ce109.png)

`./rosa upgrade cluster --cluster path-test`
```
? Version: 4.10.32
I: Ensuring account and operator role policies for cluster '1utqhe0fggmod2cgumj2qcpa3knnsqmq' are compatible with upgrade.
I: Starting to upgrade the operator IAM roles and policies
? Operator IAM role/policy upgrade mode: auto
? Create the 'path-test-f7b5-openshift-cloud-network-config-controller-cloud-c' role? Yes
I: Created role 'path-test-f7b5-openshift-cloud-network-config-controller-cloud-c' with ARN 'arn:aws:iam::765374464689:role/gdbsts/path-test-f7b5-openshift-cloud-network-config-controller-cloud-c'
I: Waiting for operator roles to reconcile
I: Account and operator roles for cluster 'path-test' are compatible with upgrade
? Are you sure you want to upgrade cluster to version '4.10.32'? Yes
W: Missing required acknowledgements to schedule upgrade. 
? Read the below description and acknowledge to proceed with upgrade
  - Description: test
    Warning:     You have been warned
    URL:         
? I acknowledge Yes
? Read the below description and acknowledge to proceed with upgrade
  - Description: test
    Warning:     You have been warned
    URL:         
? I acknowledge Yes
? Please input desired date in format yyyy-mm-dd: 2022-09-23
? Please input desired UTC time in format HH:mm: 19:02
? Node draining: 1 hour
I: Upgrade successfully scheduled for cluster 'path-test'
```
`./rosa describe cluster -c 1utqhe0fggmod2cgumj2qcpa3knnsqmq`
```
Scheduled Upgrade:          pending 4.10.32 on 2022-09-23 19:02 UTC
```
```
Scheduled Upgrade:          started 4.10.32 on 2022-09-26 18:44 UTC
```
Wait for upgrade to complete
```
Name:                       path-test
OpenShift Version:          4.10.32
```