### PR TITLE
Update stage console URL

### DIFF
--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	StageURL      = "https://qaprodauth.cloud.redhat.com/openshift/details/s/"
+	StageURL      = "https://qaprodauth.console.redhat.com/openshift/details/s/"
 	ProductionURL = "https://console.redhat.com/openshift/details/s/"
 	StageEnv      = "https://api.stage.openshift.com"
 	ProductionEnv = "https://api.openshift.com"


### PR DESCRIPTION
Why?: The stage URL changed from `https://qaprodauth.cloud.redhat.com/` to `https://qaprodauth.console.redhat.com/`
