### PR TITLE
[SDA-4764] Hide region arg in account roles commands

### DIFF
--- a/cmd/create/cmd.go
+++ b/cmd/create/cmd.go
@@ -59,4 +59,9 @@ func init() {
 	arguments.AddProfileFlag(flags)
 	arguments.AddRegionFlag(flags)
 	confirm.AddFlag(flags)
+
+	accountroles.Cmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
+		arguments.MarkGlobalFlagsHidden(Cmd, "region")
+		command.Parent().HelpFunc()(command, strings)
+	})
 }

--- a/cmd/dlt/cmd.go
+++ b/cmd/dlt/cmd.go
@@ -60,4 +60,9 @@ func init() {
 	arguments.AddProfileFlag(flags)
 	arguments.AddRegionFlag(flags)
 	confirm.AddFlag(flags)
+
+	accountroles.Cmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
+		arguments.MarkGlobalFlagsHidden(Cmd, "region")
+		command.Parent().HelpFunc()(command, strings)
+	})
 }

--- a/cmd/list/cmd.go
+++ b/cmd/list/cmd.go
@@ -62,4 +62,9 @@ func init() {
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)
 	arguments.AddRegionFlag(flags)
+
+	accountroles.Cmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
+		arguments.MarkGlobalFlagsHidden(Cmd, "region")
+		command.Parent().HelpFunc()(command, strings)
+	})
 }

--- a/cmd/upgrade/cmd.go
+++ b/cmd/upgrade/cmd.go
@@ -43,4 +43,9 @@ func init() {
 	arguments.AddProfileFlag(flags)
 	arguments.AddRegionFlag(flags)
 	interactive.AddFlag(flags)
+
+	accountroles.Cmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
+		arguments.MarkGlobalFlagsHidden(Cmd, "region")
+		command.Parent().HelpFunc()(command, strings)
+	})
 }

--- a/pkg/arguments/arguments.go
+++ b/pkg/arguments/arguments.go
@@ -226,3 +226,22 @@ func IsValidMode(modes []string, mode string) bool {
 	}
 	return false
 }
+
+func MarkGlobalFlagsHidden(command *cobra.Command, hidden ...string) {
+	command.PersistentFlags().VisitAll(func(flag *pflag.Flag) {
+		name := flag.Name
+		if contains(hidden, name) {
+			flag.Hidden = true
+		}
+	})
+}
+
+// contains returns true if the string is in the slice
+func contains(b []string, i string) bool {
+	for _, s := range b {
+		if s == i {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/arguments/arguments.go
+++ b/pkg/arguments/arguments.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openshift/rosa/pkg/aws/profile"
 	"github.com/openshift/rosa/pkg/aws/region"
 	"github.com/openshift/rosa/pkg/debug"
+	"github.com/openshift/rosa/pkg/helper"
 )
 
 var hasUnknownFlags bool
@@ -230,18 +231,8 @@ func IsValidMode(modes []string, mode string) bool {
 func MarkGlobalFlagsHidden(command *cobra.Command, hidden ...string) {
 	command.PersistentFlags().VisitAll(func(flag *pflag.Flag) {
 		name := flag.Name
-		if contains(hidden, name) {
+		if helper.Contains(hidden, name) {
 			flag.Hidden = true
 		}
 	})
-}
-
-// contains returns true if the string is in the slice
-func contains(b []string, i string) bool {
-	for _, s := range b {
-		if s == i {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
Related issue: [SDA-4764](https://issues.redhat.com/browse/SDA-4764)

# What
Account roles region arg should be hidden

# Why
Account roles commands don't need to specify region as they are global


# Before changes
```
Global Flags:
      --color string     Surround certain characters with escape sequences to display them in color on the terminal. Allowed options are [auto never always] (default "auto")
      --debug            Enable debug mode.
      --profile string   Use a specific AWS profile from your credential file.
      --region string    Use a specific AWS region, overriding the AWS_REGION environment variable.
  -y, --yes              Automatically answer yes to confirm operation.
```

# After changes
```
Global Flags:
      --color string     Surround certain characters with escape sequences to display them in color on the terminal. Allowed options are [auto never always] (default "auto")
      --debug            Enable debug mode.
      --profile string   Use a specific AWS profile from your credential file.
  -y, --yes              Automatically answer yes to confirm operation.
```