### PR TITLE
feat: deprecate 'compute-nodes' args in favor of 'replicas' in create cluster cmd

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -373,9 +373,18 @@ func init() {
 		"",
 		"Instance type for the compute nodes. Determines the amount of memory and vCPU allocated to each compute node.",
 	)
+
 	flags.IntVar(
 		&args.computeNodes,
 		"compute-nodes",
+		2,
+		"Number of worker nodes to provision. Single zone clusters need at least 2 nodes, "+
+			"multizone clusters need at least 3 nodes.",
+	)
+	flags.MarkDeprecated("compute-nodes", "use --replicas instead")
+	flags.IntVar(
+		&args.computeNodes,
+		"replicas",
 		2,
 		"Number of worker nodes to provision. Single zone clusters need at least 2 nodes, "+
 			"multizone clusters need at least 3 nodes.",


### PR DESCRIPTION
Related issue: [SDA-5286](https://issues.redhat.com/browse/SDA-5286)

# What
Deprecate 'compute-nodes' arg in favor of 'replicas'
Keep old hidden to make sure automations don't fail
# Why
To be consistent with other commands