### PR TITLE
[SDA-5894] fix: adding trim spaces and tabs when validating cluster name

### DIFF
--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -83,6 +83,7 @@ func IsValidClusterName(clusterName string) bool {
 
 func ClusterNameValidator(name interface{}) error {
 	if str, ok := name.(string); ok {
+		str := strings.Trim(str, " \t")
 		if !IsValidClusterName(str) {
 			return fmt.Errorf("Cluster name must consist of no more than 15 lowercase " +
 				"alphanumeric characters or '-', start with a letter, and end with an " +


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-5894
# What
Interactive mode of input is still not trimming 'invisible characters'

# Why
Facilitates user input