### PR TITLE
fix: remove path arg from -h ocm-roles description

### DIFF
--- a/cmd/create/ocmrole/cmd.go
+++ b/cmd/create/ocmrole/cmd.go
@@ -49,7 +49,7 @@ var Cmd = &cobra.Command{
   rosa create ocm-role
 
   # Create ocm role with a specific permissions boundary
-  rosa create ocm-role --permissions-boundary arn:aws:iam::123456789012:policy/perm-boundary --path /roles/`,
+  rosa create ocm-role --permissions-boundary arn:aws:iam::123456789012:policy/perm-boundary`,
 	Run: run,
 }
 


### PR DESCRIPTION
# What
Remove path arg from ocm-roles -h description

# Why
It was still showing --path but the actual arg is hidden