### PR TITLE
[SDA-6320] feat: set interactive enabled if local flags are unchanged, except for cluster flag

### DIFF
--- a/cmd/edit/ingress/cmd.go
+++ b/cmd/edit/ingress/cmd.go
@@ -226,6 +226,10 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	r.Reporter.Debugf("Updating ingress '%s' on cluster '%s'", ingress.ID(), clusterKey)
+	if private == nil || len(routeSelectors) == 0 {
+		r.Reporter.Warnf("No need to update ingress as there are no changes")
+		os.Exit(0)
+	}
 	_, err = r.OCMClient.UpdateIngress(cluster.ID(), ingress)
 	if err != nil {
 		r.Reporter.Errorf("Failed to update ingress '%s' on cluster '%s': %s",


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-6320

# What
When no flags are passed to `rosa edit ingress` a request without changes was being sent

# Why
Make sure user will input changes if for some reason he forgets to specify arg changes