### PR TITLE
[SDA-6784] fix: enable path arg visibility

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -79,7 +79,6 @@ func init() {
 		"",
 		"The arn path for the account/operator roles as well as their policies",
 	)
-	flags.MarkHidden("path")
 
 	flags.StringVar(
 		&args.version,

--- a/cmd/create/ocmrole/cmd.go
+++ b/cmd/create/ocmrole/cmd.go
@@ -83,7 +83,6 @@ func init() {
 		"",
 		"The arn path for the ocm role and policies",
 	)
-	flags.MarkHidden("path")
 
 	aws.AddModeFlag(Cmd)
 

--- a/cmd/create/userrole/cmd.go
+++ b/cmd/create/userrole/cmd.go
@@ -76,7 +76,6 @@ func init() {
 		"",
 		"The arn path for the user role and policies.",
 	)
-	flags.MarkHidden("path")
 
 	aws.AddModeFlag(Cmd)
 	confirm.AddFlag(flags)


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-6784

# What
path arg visibility for account, ocm and user roles was hidden

# Why
Allows clients to see the help for path arg