### PR TITLE
[SDA-6939] feat: adding message about operator roles and policies path

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1013,6 +1013,9 @@ func run(cmd *cobra.Command, _ []string) {
 
 	credRequests, err := r.OCMClient.GetCredRequests(isHostedCP)
 	if isSTS {
+		if operatorRolePath != "" && (!output.HasFlag() || r.Reporter.IsTerminal()) {
+			r.Reporter.Infof("Path '%s' detected, this path will be used for subsequent created operator roles and policies.", operatorRolePath)
+		}
 		if err != nil {
 			r.Reporter.Errorf("Error getting operator credential request from OCM %s", err)
 			os.Exit(1)

--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -180,6 +180,14 @@ func run(cmd *cobra.Command, argv []string) {
 		r.Reporter.Errorf("Expected parsing role account role '%s': %v", cluster.AWS().STS().RoleARN(), err)
 		os.Exit(1)
 	}
+	path, err := getPathFromInstallerRole(cluster)
+	if err != nil {
+		r.Reporter.Errorf("Expected a valid path for  '%s': %v", cluster.AWS().STS().RoleARN(), err)
+		os.Exit(1)
+	}
+	if path != "" {
+		r.Reporter.Infof("Path '%s' detected, this path will be used for subsequent created operator roles and policies.", path)
+	}
 	accountRoleVersion, err := r.AWSClient.GetAccountRoleVersion(roleName)
 	if err != nil {
 		r.Reporter.Errorf("Error getting account role version %s", err)


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-6939

# What
There should be a message informing the client, the message should be made available in create cluster and create operator-roles

# Why
The client is not currently informed of this behavior, which might cause confusion.