### PR TITLE
[SDA-6075] Add upgrade policy to rosa struct information when displayed with the rosa describe cluster with -o json or -o yaml

### DIFF
--- a/cmd/describe/cluster/cluster_suite_test.go
+++ b/cmd/describe/cluster/cluster_suite_test.go
@@ -1,0 +1,13 @@
+package cluster_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCluster(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cluster Suite")
+}

--- a/cmd/describe/cluster/cmd_test.go
+++ b/cmd/describe/cluster/cmd_test.go
@@ -1,0 +1,119 @@
+package cluster
+
+import (
+	"encoding/json"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/ginkgo/v2/dsl/decorators"
+	. "github.com/onsi/ginkgo/v2/dsl/table"
+	. "github.com/onsi/gomega"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+)
+
+const (
+	version string = "4.10.1"
+	state   string = "running"
+)
+
+var (
+	now                             = time.Now()
+	expectEmptyCuster               = []byte(`{"kind":"Cluster"}`)
+	expectClusterWithNameAndIDValue = []byte(
+		`{"id":"bar","kind":"Cluster","name":"foo"}`)
+	expectClusterWithNameAndValueAndUpgradeInformation = []byte(
+		`{"id":"bar","kind":"Cluster","name":"foo","scheduledUpgrade":{"nextRun":"` +
+			now.Format("2006-01-02 15:04 MST") + `","state":"` + state + `","version":"` +
+			version + `"}}`)
+	expectEmptyClusterWithNameAndValueAndUpgradeInformation = []byte(
+		`{"kind":"Cluster","scheduledUpgrade":{"nextRun":"` +
+			now.Format("2006-01-02 15:04 MST") + `","state":"` +
+			state + `","version":"` +
+			version + `"}}`)
+	clusterWithNameAndID, emptyCluster                     *cmv1.Cluster
+	emptyUpgradePolicy, upgradePolicyWithVersionAndNextRun *cmv1.UpgradePolicy
+	emptyUpgradeState, upgradePolicyWithState              *cmv1.UpgradePolicyState
+
+	berr error
+)
+var _ = BeforeSuite(func() {
+	clusterWithNameAndID, berr = cmv1.NewCluster().Name("foo").ID("bar").Build()
+	Expect(berr).NotTo(HaveOccurred())
+	emptyCluster, berr = cmv1.NewCluster().Build()
+	Expect(berr).NotTo(HaveOccurred())
+	emptyUpgradePolicy, berr = cmv1.NewUpgradePolicy().Build()
+	Expect(berr).NotTo(HaveOccurred())
+	emptyUpgradeState, berr = cmv1.NewUpgradePolicyState().Build()
+	Expect(berr).NotTo(HaveOccurred())
+	upgradePolicyWithVersionAndNextRun, berr = cmv1.NewUpgradePolicy().Version(version).NextRun(now).Build()
+	Expect(berr).NotTo(HaveOccurred())
+	upgradePolicyWithState, berr = cmv1.NewUpgradePolicyState().Value(cmv1.UpgradePolicyStateValue(state)).Build()
+	Expect(berr).NotTo(HaveOccurred())
+
+})
+var _ = Describe("Cluster description", Ordered, func() {
+
+	Context("when displaying clusters with output json", func() {
+
+		DescribeTable("When displaying clusters with output json",
+			printJson,
+			Entry("Prints empty when all values are empty",
+				func() *cmv1.Cluster { return emptyCluster },
+				func() *cmv1.UpgradePolicy { return emptyUpgradePolicy },
+				func() *cmv1.UpgradePolicyState { return emptyUpgradeState }, expectEmptyCuster, nil),
+
+			Entry("Prints cluster information only",
+				func() *cmv1.Cluster { return clusterWithNameAndID },
+				func() *cmv1.UpgradePolicy { return emptyUpgradePolicy },
+				func() *cmv1.UpgradePolicyState { return emptyUpgradeState }, expectClusterWithNameAndIDValue, nil),
+
+			Entry("Prints cluster and upgrade information",
+				func() *cmv1.Cluster { return clusterWithNameAndID },
+				func() *cmv1.UpgradePolicy { return upgradePolicyWithVersionAndNextRun },
+				func() *cmv1.UpgradePolicyState { return upgradePolicyWithState },
+				expectClusterWithNameAndValueAndUpgradeInformation, nil),
+
+			Entry("Prints empty cluster with cluster information",
+				func() *cmv1.Cluster { return emptyCluster },
+				func() *cmv1.UpgradePolicy { return upgradePolicyWithVersionAndNextRun },
+				func() *cmv1.UpgradePolicyState { return upgradePolicyWithState },
+				expectEmptyClusterWithNameAndValueAndUpgradeInformation, nil),
+
+			Entry("Prints cluster information only when no upgrade policy state is found",
+				func() *cmv1.Cluster { return clusterWithNameAndID },
+				func() *cmv1.UpgradePolicy { return upgradePolicyWithVersionAndNextRun },
+				func() *cmv1.UpgradePolicyState { return emptyUpgradeState }, expectClusterWithNameAndIDValue, nil),
+
+			Entry("Prints cluster information only when no upgrade policy version and next run is found",
+				func() *cmv1.Cluster { return clusterWithNameAndID },
+				func() *cmv1.UpgradePolicy { return emptyUpgradePolicy },
+				func() *cmv1.UpgradePolicyState { return emptyUpgradeState }, expectClusterWithNameAndIDValue, nil),
+
+			Entry("Prints cluster information only when upgrade policy is nil",
+				func() *cmv1.Cluster { return clusterWithNameAndID },
+				func() *cmv1.UpgradePolicy { return nil },
+				func() *cmv1.UpgradePolicyState { return emptyUpgradeState }, expectClusterWithNameAndIDValue, nil),
+
+			Entry("Prints cluster information only when upgrade policy state is nil",
+				func() *cmv1.Cluster { return clusterWithNameAndID },
+				func() *cmv1.UpgradePolicy { return emptyUpgradePolicy },
+				func() *cmv1.UpgradePolicyState { return nil }, expectClusterWithNameAndIDValue, nil),
+		)
+	})
+})
+
+func printJson(cluster func() *cmv1.Cluster,
+	upgrade func() *cmv1.UpgradePolicy,
+	state func() *cmv1.UpgradePolicyState,
+	expected []byte,
+	err error) {
+	f, er := formatCluster(cluster(), upgrade(), state())
+	if err != nil {
+		Expect(er).To(Equal(err))
+	}
+	Expect(er).To(BeNil())
+	v, er := json.Marshal(f)
+	Expect(er).NotTo(HaveOccurred())
+	Expect(v).To(Equal(expected))
+}

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -85,7 +85,7 @@ func Print(resource interface{}) error {
 				}
 			}
 		}
-	case "object.Object":
+	case "object.Object", "map[string]interface {}":
 		{
 			reqBodyBytes := new(bytes.Buffer)
 			json.NewEncoder(reqBodyBytes).Encode(resource)

--- a/vendor/github.com/onsi/ginkgo/v2/dsl/core/core_dsl.go
+++ b/vendor/github.com/onsi/ginkgo/v2/dsl/core/core_dsl.go
@@ -1,0 +1,59 @@
+/*
+Ginkgo isusually dot-imported via:
+
+    import . "github.com/onsi/ginkgo/v2"
+
+however some parts of the DSL may conflict with existing symbols in the user's code.
+
+To mitigate this without losing the brevity of dot-importing Ginkgo the various packages in the
+dsl directory provide pieces of the Ginkgo DSL that can be dot-imported separately.
+
+This "core" package pulls in the core Ginkgo DSL - most test suites will only need to import this package.
+*/
+package core
+
+import (
+	"github.com/onsi/ginkgo/v2"
+)
+
+const GINKGO_VERSION = ginkgo.GINKGO_VERSION
+
+type GinkgoWriterInterface = ginkgo.GinkgoWriterInterface
+type GinkgoTestingT = ginkgo.GinkgoTestingT
+type GinkgoTInterface = ginkgo.GinkgoTInterface
+
+var GinkgoWriter = ginkgo.GinkgoWriter
+var GinkgoConfiguration = ginkgo.GinkgoConfiguration
+var GinkgoRandomSeed = ginkgo.GinkgoRandomSeed
+var GinkgoParallelProcess = ginkgo.GinkgoParallelProcess
+var PauseOutputInterception = ginkgo.PauseOutputInterception
+var ResumeOutputInterception = ginkgo.ResumeOutputInterception
+var RunSpecs = ginkgo.RunSpecs
+var Skip = ginkgo.Skip
+var Fail = ginkgo.Fail
+var AbortSuite = ginkgo.AbortSuite
+var GinkgoRecover = ginkgo.GinkgoRecover
+var Describe = ginkgo.Describe
+var FDescribe = ginkgo.FDescribe
+var PDescribe = ginkgo.PDescribe
+var XDescribe = PDescribe
+var Context, FContext, PContext, XContext = Describe, FDescribe, PDescribe, XDescribe
+var When, FWhen, PWhen, XWhen = Describe, FDescribe, PDescribe, XDescribe
+var It = ginkgo.It
+var FIt = ginkgo.FIt
+var PIt = ginkgo.PIt
+var XIt = PIt
+var Specify, FSpecify, PSpecify, XSpecify = It, FIt, PIt, XIt
+var By = ginkgo.By
+var BeforeSuite = ginkgo.BeforeSuite
+var AfterSuite = ginkgo.AfterSuite
+var SynchronizedBeforeSuite = ginkgo.SynchronizedBeforeSuite
+var SynchronizedAfterSuite = ginkgo.SynchronizedAfterSuite
+var BeforeEach = ginkgo.BeforeEach
+var JustBeforeEach = ginkgo.JustBeforeEach
+var AfterEach = ginkgo.AfterEach
+var JustAfterEach = ginkgo.JustAfterEach
+var BeforeAll = ginkgo.BeforeAll
+var AfterAll = ginkgo.AfterAll
+var DeferCleanup = ginkgo.DeferCleanup
+var GinkgoT = ginkgo.GinkgoT

--- a/vendor/github.com/onsi/ginkgo/v2/dsl/decorators/decorators_dsl.go
+++ b/vendor/github.com/onsi/ginkgo/v2/dsl/decorators/decorators_dsl.go
@@ -1,0 +1,29 @@
+/*
+Ginkgo isusually dot-imported via:
+
+    import . "github.com/onsi/ginkgo/v2"
+
+however some parts of the DSL may conflict with existing symbols in the user's code.
+
+To mitigate this without losing the brevity of dot-importing Ginkgo the various packages in the
+dsl directory provide pieces of the Ginkgo DSL that can be dot-imported separately.
+
+This "decorators" package pulls in the various decorators defined in the Ginkgo DSL.
+*/
+package decorators
+
+import (
+	"github.com/onsi/ginkgo/v2"
+)
+
+type Offset = ginkgo.Offset
+type FlakeAttempts = ginkgo.FlakeAttempts
+type Labels = ginkgo.Labels
+
+const Focus = ginkgo.Focus
+const Pending = ginkgo.Pending
+const Serial = ginkgo.Serial
+const Ordered = ginkgo.Ordered
+const OncePerOrdered = ginkgo.OncePerOrdered
+
+var Label = ginkgo.Label

--- a/vendor/github.com/onsi/ginkgo/v2/dsl/table/table_dsl.go
+++ b/vendor/github.com/onsi/ginkgo/v2/dsl/table/table_dsl.go
@@ -1,0 +1,31 @@
+/*
+Ginkgo isusually dot-imported via:
+
+    import . "github.com/onsi/ginkgo/v2"
+
+however some parts of the DSL may conflict with existing symbols in the user's code.
+
+To mitigate this without losing the brevity of dot-importing Ginkgo the various packages in the
+dsl directory provide pieces of the Ginkgo DSL that can be dot-imported separately.
+
+This "table" package pulls in the Ginkgo's table-testing DSL
+*/
+package table
+
+import (
+	"github.com/onsi/ginkgo/v2"
+)
+
+type EntryDescription = ginkgo.EntryDescription
+
+var DescribeTable = ginkgo.DescribeTable
+var FDescribeTable = ginkgo.FDescribeTable
+var PDescribeTable = ginkgo.PDescribeTable
+var XDescribeTable = ginkgo.XDescribeTable
+
+type TableEntry = ginkgo.TableEntry
+
+var Entry = ginkgo.Entry
+var FEntry = ginkgo.FEntry
+var PEntry = ginkgo.PEntry
+var XEntry = ginkgo.XEntry

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -157,6 +157,9 @@ github.com/nathan-fiscaletti/consolesize-go
 ## explicit; go 1.18
 github.com/onsi/ginkgo/v2
 github.com/onsi/ginkgo/v2/config
+github.com/onsi/ginkgo/v2/dsl/core
+github.com/onsi/ginkgo/v2/dsl/decorators
+github.com/onsi/ginkgo/v2/dsl/table
 github.com/onsi/ginkgo/v2/formatter
 github.com/onsi/ginkgo/v2/internal
 github.com/onsi/ginkgo/v2/internal/global
@@ -178,7 +181,7 @@ github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
 # github.com/openshift-online/ocm-sdk-go v0.1.287
-## explicit
+## explicit; go 1.16
 github.com/openshift-online/ocm-sdk-go
 github.com/openshift-online/ocm-sdk-go/accountsmgmt
 github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1


### PR DESCRIPTION
Adds the upgrade policy fields into the json/yaml content with `rosa describe cluster -o[json|yaml]` as when displayed without the `-o` flag.

@vkareh @pvasant  PTAL.