### PR TITLE
[SDA-5966]: Rosa STS mode auto conflicts with the watch option

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -708,6 +708,12 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 	}
 
+	if args.watch && isSTS && mode == aws.ModeAuto && !confirm.Yes() {
+		r.Reporter.Errorf("Cannot watch for STS cluster installation logs in mode 'auto'." +
+			"To watch your cluster installation logs, run 'rosa logs install' instead after the cluster has began creating.")
+		os.Exit(1)
+	}
+
 	hasRoles := false
 	if isSTS && roleARN == "" {
 		minor := ocm.GetVersionMinor(version)


### PR DESCRIPTION
Adds a check for STS clusters when running the cluster create command that fails if the user specifies the `--watch` flag with `--mode auto`, unless the confirmation flag `-y` is also used.

@vkareh @pvasant PTAL.