### PR TITLE
[SDA-6791] fix: path compatibility issue with inline policies from acc roles

### DIFF
--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -88,6 +88,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) error {
 	r := rosa.NewRuntime().WithAWS().WithOCM()
+	defer r.Cleanup()
 	reporter := r.Reporter
 	awsClient := r.AWSClient
 	ocmClient := r.OCMClient

--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -109,7 +109,7 @@ func run(cmd *cobra.Command, argv []string) error {
 	args.isInvokedFromClusterUpgrade = isInvokedFromClusterUpgrade
 	mode, err := aws.GetMode()
 	if err != nil {
-		r.Reporter.Errorf("%s", err)
+		reporter.Errorf("%s", err)
 		os.Exit(1)
 	}
 	prefix := args.prefix


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-6791

# What
Compatibility issue with upgrading account roles policies when the policy was created as inline instead of attached, this happened when the acc roles were created from older ROSA CLI

# Why
Clients couldn't upgrade their account roles if they created it from an older ROSA CLI version (tested with 1.1.3)

# Changes
If policy type is 'inline' than consider the path from the role, as it will be the same considering current implementation. This might be changed in the future to support different paths, so it might need to be revised later.

With this path in consideration, it deletes the inline policy and creates an attached one with the path from role as the flow is supposed to be.

## After
![image](https://user-images.githubusercontent.com/5498205/193296958-b391e097-e0f8-4eae-a752-b97fa0f45c7d.png)
