### PR TITLE
[SDA-6784] fix: path args need not to be explicitly set for interactive mode to ask about it

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -226,7 +226,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	path := args.path
-	if cmd.Flags().Changed("path") && interactive.Enabled() {
+	if interactive.Enabled() {
 		path, err = interactive.GetString(interactive.Input{
 			Question: "Path",
 			Help:     cmd.Flags().Lookup("path").Usage,

--- a/cmd/create/ocmrole/cmd.go
+++ b/cmd/create/ocmrole/cmd.go
@@ -180,7 +180,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	path := args.path
-	if cmd.Flags().Changed("path") && interactive.Enabled() {
+	if interactive.Enabled() {
 		path, err = interactive.GetString(interactive.Input{
 			Question: "Role Path",
 			Help:     cmd.Flags().Lookup("path").Usage,

--- a/cmd/create/userrole/cmd.go
+++ b/cmd/create/userrole/cmd.go
@@ -156,7 +156,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	path := args.path
-	if cmd.Flags().Changed("path") && interactive.Enabled() {
+	if interactive.Enabled() {
 		path, err = interactive.GetString(interactive.Input{
 			Question: "Role Path",
 			Help:     cmd.Flags().Lookup("path").Usage,


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-6784

# What
'path' arg was being check for explicitly set to accept interactive mode question

# Why
'path' arg does not need to be explicitly set for the user to use it in interactive mode