### PR TITLE
[SDA-6965] fix: adding arn path validator to create account roles --path arg

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -241,6 +241,11 @@ func run(cmd *cobra.Command, argv []string) {
 		}
 	}
 
+	if !aws.ARNPath.MatchString(path) {
+		r.Reporter.Errorf("It must begin and end with / and contain only alphanumeric characters and/or / characters.")
+		os.Exit(1)
+	}
+
 	if interactive.Enabled() {
 		mode, err = interactive.GetOption(interactive.Input{
 			Question: "Role creation mode",

--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -243,7 +243,7 @@ func run(cmd *cobra.Command, argv []string) {
 
 	if !aws.ARNPath.MatchString(path) {
 		r.Reporter.Errorf("The specified value for path is invalid. " +
-			"It must begin and end with / and contain only alphanumeric characters and/or / characters.")
+			"It must begin and end with '/' and contain only alphanumeric characters and/or '/' characters.")
 		os.Exit(1)
 	}
 

--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -242,7 +242,8 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	if !aws.ARNPath.MatchString(path) {
-		r.Reporter.Errorf("It must begin and end with / and contain only alphanumeric characters and/or / characters.")
+		r.Reporter.Errorf("The specified value for path is invalid. " +
+			"It must begin and end with / and contain only alphanumeric characters and/or / characters.")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-6965
# What
Path was not being validate outside interactive mode

# Why
Clients may setup a wrong path and won't be able to continue with their flow

# After changes
`./rosa create account-roles --mode manual -y --prefix xueli --path /xueli/test/t1`
```
I: Logged in as 'gbranco.openshift' on 'https://api.stage.openshift.com'
I: Validating AWS credentials...
I: AWS credentials are valid!
I: Validating AWS quota...
I: AWS quota ok. If cluster installation fails, validate actual AWS resource usage against https://docs.openshift.com/rosa/rosa_getting_started/rosa-required-aws-service-quotas.html
I: Verifying whether OpenShift command-line tool is available...
I: Current OpenShift Client Version: 4.11.2
I: Creating account roles
E: The specified value for path is invalid. It must begin and end with / and contain only alphanumeric characters and/or / characters.
```