### PR TITLE
fix: setting path arg in a new line for all commands

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -338,7 +338,7 @@ func buildCommands(prefix string, permissionsBoundary string, accountID string, 
 			name, file, permBoundaryFlag, iamTags)
 
 		if path != "" {
-			createRole = fmt.Sprintf(createRole+"\t--path %s", path)
+			createRole = fmt.Sprintf(createRole+"\\\n\t--path %s", path)
 		}
 		createPolicy := fmt.Sprintf("aws iam create-policy \\\n"+
 			"\t--policy-name %s \\\n"+
@@ -346,7 +346,7 @@ func buildCommands(prefix string, permissionsBoundary string, accountID string, 
 			"\t--tags %s",
 			policyName, file, iamTags)
 		if path != "" {
-			createPolicy = fmt.Sprintf(createPolicy+"\t--path %s", path)
+			createPolicy = fmt.Sprintf(createPolicy+"\\\n\t--path %s", path)
 		}
 		attachRolePolicy := fmt.Sprintf("aws iam attach-role-policy \\\n"+
 			"\t--role-name %s \\\n"+

--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -393,7 +393,7 @@ func buildCommands(r *rosa.Runtime, env string,
 				"\t--tags %s",
 				name, credrequest, iamTags)
 			if path != "" {
-				createPolicy = fmt.Sprintf(createPolicy+"\t--path %s", path)
+				createPolicy = fmt.Sprintf(createPolicy+"\\\n\t--path %s", path)
 			}
 			commands = append(commands, createPolicy)
 		}
@@ -431,7 +431,7 @@ func buildCommands(r *rosa.Runtime, env string,
 			"\t--tags %s",
 			roleName, filename, permBoundaryFlag, iamTags)
 		if path != "" {
-			createRole = fmt.Sprintf(createRole+"\t--path %s", path)
+			createRole = fmt.Sprintf(createRole+"\\\n\t--path %s", path)
 		}
 		attachRolePolicy := fmt.Sprintf("aws iam attach-role-policy \\\n"+
 			"\t--role-name %s \\\n"+

--- a/cmd/create/userrole/cmd.go
+++ b/cmd/create/userrole/cmd.go
@@ -263,7 +263,7 @@ func buildCommands(prefix string, path string, userName string,
 		"\t--tags %s",
 		roleName, aws.OCMUserRolePolicyFile, permBoundaryFlag, iamTags)
 	if path != "" {
-		createRole = fmt.Sprintf(createRole+"\t--path %s", path)
+		createRole = fmt.Sprintf(createRole+"\\\n\t--path %s", path)
 	}
 	linkRole := fmt.Sprintf("rosa link user-role --role-arn %s", roleARN)
 	commands = append(commands, createRole, linkRole)

--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -333,8 +333,8 @@ func buildCommands(prefix string, accountID string, isUpgradeNeedForAccountRoleP
 				)
 				createPolicy := fmt.Sprintf("aws iam create-policy \\\n"+
 					"\t--policy-name %s \\\n"+
-					"\t--policy-document file://sts_%s_permission_policy.json"+
-					"\t--tags %s"+
+					"\t--policy-document file://sts_%s_permission_policy.json \\\n"+
+					"\t--tags %s \\\n"+
 					"\t--path %s",
 					policyName, file, iamTags, policyPath)
 				attachRolePolicy := fmt.Sprintf("aws iam attach-role-policy \\\n"+

--- a/cmd/upgrade/operatorroles/cmd.go
+++ b/cmd/upgrade/operatorroles/cmd.go
@@ -388,7 +388,7 @@ func buildMissingOperatorRoleCommand(missingRoles map[string]*cmv1.STSOperator, 
 			"\t--tags %s",
 			roleName, filename, permBoundaryFlag, iamTags)
 		if rolePath != "" {
-			createRole = fmt.Sprintf(createRole+"\t--path %s", rolePath)
+			createRole = fmt.Sprintf(createRole+"\\\n\t--path %s", rolePath)
 		}
 		attachRolePolicy := fmt.Sprintf("aws iam attach-role-policy \\\n"+
 			"\t--role-name %s \\\n"+

--- a/pkg/aws/sts.go
+++ b/pkg/aws/sts.go
@@ -188,7 +188,7 @@ func BuildOperatorRoleCommands(prefix string, accountID string, awsClient Client
 				"\t--tags %s",
 				name, credrequest, iamTags)
 			if policyPath != "" {
-				createPolicy = fmt.Sprintf(createPolicy+"\t--path %s", policyPath)
+				createPolicy = fmt.Sprintf(createPolicy+"\\\n\t--path %s", policyPath)
 			}
 			commands = append(commands, createPolicy)
 		} else {


### PR DESCRIPTION
# What
Path arg should be in a new line so that each argument for the aws commands are in a new line

# Why
Helps the identify each arg for the command easing understanding