### PR TITLE
[SDE-1816] Retrieving roles from cluster instead of using prefix from args when called from upgrade command

### DIFF
--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -132,7 +132,7 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(0)
 	}
 
-	prefix, err := aws.GetPrefixFromAccountRole(cluster)
+	prefix, err := aws.GetPrefixFromInstallerAccRole(cluster)
 	if err != nil {
 		r.Reporter.Errorf("Failed to find prefix from %s account role", aws.InstallerAccountRole)
 		os.Exit(1)
@@ -175,7 +175,7 @@ func run(cmd *cobra.Command, argv []string) {
 		}
 	}
 
-	roleName, err := aws.GetAccountRoleName(cluster)
+	roleName, err := aws.GetInstallerAccountRoleName(cluster)
 	if err != nil {
 		r.Reporter.Errorf("Expected parsing role account role '%s': %v", cluster.AWS().STS().RoleARN(), err)
 		os.Exit(1)

--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -23,9 +23,9 @@ import (
 	"time"
 
 	"github.com/briandowns/spinner"
-	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
+	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/aws/tags"
 	"github.com/openshift/rosa/pkg/interactive"

--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -98,10 +98,10 @@ func run(cmd *cobra.Command, argv []string) error {
 	isInvokedFromClusterUpgrade := false
 	skipInteractive := false
 	var cluster *v1.Cluster
-	if len(argv) >= 2 && !cmd.Flag("prefix").Changed {
+	if len(argv) == 2 && !cmd.Flag("prefix").Changed {
+		aws.SetModeKey(argv[0])
 		ocm.SetClusterKey(argv[1])
 		cluster = r.FetchCluster()
-		aws.SetModeKey(argv[0])
 		if argv[1] != "" {
 			skipInteractive = true
 		}

--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -174,7 +174,11 @@ func run(cmd *cobra.Command, argv []string) error {
 		if args.isInvokedFromClusterUpgrade {
 			return nil
 		}
-		reporter.Infof("Account role with the prefix '%s' is already up-to-date.", prefix)
+		if useClusterOption {
+			reporter.Infof("Account roles for cluster '%s' are already up-to-date.", r.ClusterKey)
+		} else {
+			reporter.Infof("Account roles with the prefix '%s' are already up-to-date.", prefix)
+		}
 		os.Exit(0)
 	}
 
@@ -216,8 +220,8 @@ func run(cmd *cobra.Command, argv []string) error {
 
 	switch mode {
 	case aws.ModeAuto:
-		reporter.Infof("Starting to upgrade the policies")
 		if isUpgradeNeedForAccountRolePolicies {
+			reporter.Infof("Starting to upgrade the policies")
 			if useClusterOption {
 				err = upgradeAccountRolePoliciesFromCluster(
 					reporter,

--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -98,7 +98,7 @@ func run(cmd *cobra.Command, argv []string) error {
 	isInvokedFromClusterUpgrade := false
 	skipInteractive := false
 	var cluster *v1.Cluster
-	if len(argv) == 2 && !cmd.Flag("prefix").Changed {
+	if len(argv) == 2 && !cmd.Flag("prefix").Changed && !cmd.Flag("cluster").Changed {
 		aws.SetModeKey(argv[0])
 		ocm.SetClusterKey(argv[1])
 		cluster = r.FetchCluster()

--- a/cmd/upgrade/cluster/cmd.go
+++ b/cmd/upgrade/cluster/cmd.go
@@ -204,7 +204,7 @@ func run(cmd *cobra.Command, _ []string) {
 	if isSTS {
 		r.Reporter.Infof("Ensuring account and operator role policies for cluster '%s'"+
 			" are compatible with upgrade.", cluster.ID())
-		err = accountroles.Cmd.RunE(accountroles.Cmd, []string{mode, cluster.ID(), version})
+		err = accountroles.Cmd.RunE(accountroles.Cmd, []string{mode, cluster.ID()})
 		if err != nil {
 			prefix, err := aws.GetPrefixFromInstallerAccRole(cluster)
 			if err != nil {

--- a/cmd/upgrade/cluster/cmd.go
+++ b/cmd/upgrade/cluster/cmd.go
@@ -204,13 +204,13 @@ func run(cmd *cobra.Command, _ []string) {
 	if isSTS {
 		r.Reporter.Infof("Ensuring account and operator role policies for cluster '%s'"+
 			" are compatible with upgrade.", cluster.ID())
-		prefix, err := aws.GetPrefixFromAccountRole(cluster)
+		err = accountroles.Cmd.RunE(accountroles.Cmd, []string{mode, cluster.ID(), version})
 		if err != nil {
-			r.Reporter.Errorf("Could not get role prefix for cluster '%s' : %v", clusterKey, err)
-			os.Exit(1)
-		}
-		err = accountroles.Cmd.RunE(accountroles.Cmd, []string{prefix, mode, cluster.ID(), version})
-		if err != nil {
+			prefix, err := aws.GetPrefixFromAccountRole(cluster)
+			if err != nil {
+				r.Reporter.Errorf("Could not get role prefix for cluster '%s' : %v", clusterKey, err)
+				os.Exit(1)
+			}
 			accountRoleStr := fmt.Sprintf("rosa upgrade account-roles --prefix %s", prefix)
 			upgradeClusterStr := fmt.Sprintf("rosa upgrade cluster -c %s", clusterKey)
 

--- a/cmd/upgrade/cluster/cmd.go
+++ b/cmd/upgrade/cluster/cmd.go
@@ -206,7 +206,7 @@ func run(cmd *cobra.Command, _ []string) {
 			" are compatible with upgrade.", cluster.ID())
 		err = accountroles.Cmd.RunE(accountroles.Cmd, []string{mode, cluster.ID(), version})
 		if err != nil {
-			prefix, err := aws.GetPrefixFromAccountRole(cluster)
+			prefix, err := aws.GetPrefixFromInstallerAccRole(cluster)
 			if err != nil {
 				r.Reporter.Errorf("Could not get role prefix for cluster '%s' : %v", clusterKey, err)
 				os.Exit(1)

--- a/cmd/upgrade/operatorroles/cmd.go
+++ b/cmd/upgrade/operatorroles/cmd.go
@@ -134,7 +134,7 @@ func run(cmd *cobra.Command, argv []string) error {
 			clusterKey)
 	}
 
-	prefix, err := aws.GetPrefixFromAccountRole(cluster)
+	prefix, err := aws.GetPrefixFromInstallerAccRole(cluster)
 	if err != nil {
 		r.Reporter.Errorf("Error getting account role prefix for the cluster '%s'",
 			clusterKey)

--- a/pkg/ocm/flag.go
+++ b/pkg/ocm/flag.go
@@ -27,6 +27,17 @@ import (
 
 var clusterKey string
 
+func AddOptionalClusterFlag(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(
+		&clusterKey,
+		"cluster",
+		"c",
+		"",
+		"Name or ID of the cluster.",
+	)
+	cmd.RegisterFlagCompletionFunc("cluster", clusterCompletion)
+}
+
 func AddClusterFlag(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(
 		&clusterKey,


### PR DESCRIPTION
Related issues: 
https://issues.redhat.com/browse/SDA-6407
https://issues.redhat.com/browse/SDE-1816
# What
Providing a way to retrieve account role information from the cluster id instead of using the prefix to reconstruct everything

# Why
Easier and less prone to error, also fixes clients using acc roles from older not standardized role prefixes.


Prefix kept as optional for someone who wants to upgrade only acc without having them linked to a cluster.
Cluster added as optional for someone who wants to upgrade acc roles linked too a cluster.. Also solves the problem with acc roles that don't match expected prefix