### PR TITLE
[SDA-6974] add managed services path support

### DIFF
--- a/cmd/create/service/cmd.go
+++ b/cmd/create/service/cmd.go
@@ -398,10 +398,6 @@ func run(cmd *cobra.Command, argv []string) {
 		r.Reporter.Errorf("Expected a valid path for  '%s': %v", roleARN, err)
 		os.Exit(1)
 	}
-	if path != "" {
-		r.Reporter.Errorf("Managed Services currently does not support path in ARN")
-		os.Exit(1)
-	}
 
 	// operator role logic.
 	operatorRolesPrefix := getRolePrefix(args.ClusterName)

--- a/cmd/create/service/cmd.go
+++ b/cmd/create/service/cmd.go
@@ -393,6 +393,16 @@ func run(cmd *cobra.Command, argv []string) {
 	args.AwsControlPlaneRoleARN = controlPlaneRoleARN
 	args.AwsWorkerRoleARN = workerRoleARN
 
+	path, err := aws.GetPathFromARN(roleARN)
+	if err != nil {
+		r.Reporter.Errorf("Expected a valid path for  '%s': %v", roleARN, err)
+		os.Exit(1)
+	}
+	if path != "" {
+		r.Reporter.Errorf("Managed Services currently does not support path in ARN")
+		os.Exit(1)
+	}
+
 	// operator role logic.
 	operatorRolesPrefix := getRolePrefix(args.ClusterName)
 	operatorIAMRoleList := []ocm.OperatorIAMRole{}
@@ -419,7 +429,7 @@ func run(cmd *cobra.Command, argv []string) {
 		operatorIAMRoleList = append(operatorIAMRoleList, ocm.OperatorIAMRole{
 			Name:      operator.Name(),
 			Namespace: operator.Namespace(),
-			RoleARN:   getOperatorRoleArn(operatorRolesPrefix, operator, r.Creator),
+			RoleARN:   getOperatorRoleArn(operatorRolesPrefix, operator, r.Creator, path),
 		})
 	}
 
@@ -494,10 +504,10 @@ func getRolePrefix(clusterName string) string {
 	return fmt.Sprintf("%s-%s", clusterName, ocm.RandomLabel(4))
 }
 
-func getOperatorRoleArn(prefix string, operator *cmv1.STSOperator, creator *aws.Creator) string {
+func getOperatorRoleArn(prefix string, operator *cmv1.STSOperator, creator *aws.Creator, path string) string {
 	role := fmt.Sprintf("%s-%s-%s", prefix, operator.Namespace(), operator.Name())
 	if len(role) > 64 {
 		role = role[0:64]
 	}
-	return aws.GetRoleARN(creator.AccountID, role, "")
+	return aws.GetRoleARN(creator.AccountID, role, path)
 }


### PR DESCRIPTION
Related issues: https://issues.redhat.com/browse/SDA-6974
# What
Adding support for path in acc roles ARN

# Why
Adds feature parity to ms even though clients might not be using it