### PR TITLE
[SDA-6965] Add validation to path ocm/user roles

### DIFF
--- a/cmd/create/ocmrole/cmd.go
+++ b/cmd/create/ocmrole/cmd.go
@@ -195,6 +195,12 @@ func run(cmd *cobra.Command, argv []string) {
 		}
 	}
 
+	if !aws.ARNPath.MatchString(path) {
+		r.Reporter.Errorf("The specified value for path is invalid. " +
+			"It must begin and end with '/' and contain only alphanumeric characters and/or '/' characters.")
+		os.Exit(1)
+	}
+
 	if interactive.Enabled() {
 		mode, err = interactive.GetOption(interactive.Input{
 			Question: "Role creation mode",

--- a/cmd/create/ocmrole/cmd.go
+++ b/cmd/create/ocmrole/cmd.go
@@ -195,7 +195,7 @@ func run(cmd *cobra.Command, argv []string) {
 		}
 	}
 
-	if !aws.ARNPath.MatchString(path) {
+	if path != "" && !aws.ARNPath.MatchString(path) {
 		r.Reporter.Errorf("The specified value for path is invalid. " +
 			"It must begin and end with '/' and contain only alphanumeric characters and/or '/' characters.")
 		os.Exit(1)
@@ -281,7 +281,15 @@ func run(cmd *cobra.Command, argv []string) {
 			r.Reporter.Infof("All policy files saved to the current directory")
 			r.Reporter.Infof("Run the following commands to create the ocm role and policies:\n")
 		}
-		commands := buildCommands(prefix, roleNameRequested, path, permissionsBoundary, r.Creator.AccountID, env, isAdmin)
+		commands := buildCommands(
+			prefix,
+			roleNameRequested,
+			path,
+			permissionsBoundary,
+			r.Creator.AccountID,
+			env,
+			isAdmin,
+		)
 		fmt.Println(commands)
 	default:
 		r.Reporter.Errorf("Invalid mode. Allowed values are %s", aws.Modes)

--- a/cmd/create/userrole/cmd.go
+++ b/cmd/create/userrole/cmd.go
@@ -171,7 +171,7 @@ func run(cmd *cobra.Command, argv []string) {
 		}
 	}
 
-	if !aws.ARNPath.MatchString(path) {
+	if path != "" && !aws.ARNPath.MatchString(path) {
 		r.Reporter.Errorf("The specified value for path is invalid. " +
 			"It must begin and end with '/' and contain only alphanumeric characters and/or '/' characters.")
 		os.Exit(1)
@@ -236,7 +236,14 @@ func run(cmd *cobra.Command, argv []string) {
 			r.Reporter.Infof("All policy files saved to the current directory")
 			r.Reporter.Infof("Run the following commands to create the account roles and policies:\n")
 		}
-		commands := buildCommands(prefix, path, currentAccount.Username(), r.Creator.AccountID, env, permissionsBoundary)
+		commands := buildCommands(
+			prefix,
+			path,
+			currentAccount.Username(),
+			r.Creator.AccountID,
+			env,
+			permissionsBoundary,
+		)
 		fmt.Println(commands)
 
 	default:

--- a/cmd/create/userrole/cmd.go
+++ b/cmd/create/userrole/cmd.go
@@ -171,6 +171,12 @@ func run(cmd *cobra.Command, argv []string) {
 		}
 	}
 
+	if !aws.ARNPath.MatchString(path) {
+		r.Reporter.Errorf("The specified value for path is invalid. " +
+			"It must begin and end with '/' and contain only alphanumeric characters and/or '/' characters.")
+		os.Exit(1)
+	}
+
 	if interactive.Enabled() {
 		mode, err = interactive.GetOption(interactive.Input{
 			Question: "Role creation mode",


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-6965
# What
A validation to the path was done to acc roles, but not for ocm/user roles

# Why
Making sure client knows what is happening if he inputs a wrong path