### PR TITLE
[SDA-6986] Consider empty path valid creating acc roles

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -241,7 +241,7 @@ func run(cmd *cobra.Command, argv []string) {
 		}
 	}
 
-	if !aws.ARNPath.MatchString(path) {
+	if path != "" && !aws.ARNPath.MatchString(path) {
 		r.Reporter.Errorf("The specified value for path is invalid. " +
 			"It must begin and end with '/' and contain only alphanumeric characters and/or '/' characters.")
 		os.Exit(1)


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-6986
# What
Validation was being applied when path is empty

# Why
Empty path is a valid path