### PR TITLE
[SDA-6858] Adding leading space before all path args when building commands

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -344,7 +344,7 @@ func buildCommands(prefix string, permissionsBoundary string, accountID string, 
 			name, file, permBoundaryFlag, iamTags)
 
 		if path != "" {
-			createRole = fmt.Sprintf(createRole+"\\\n\t--path %s", path)
+			createRole = fmt.Sprintf(createRole+" \\\n\t--path %s", path)
 		}
 		createPolicy := fmt.Sprintf("aws iam create-policy \\\n"+
 			"\t--policy-name %s \\\n"+
@@ -352,7 +352,7 @@ func buildCommands(prefix string, permissionsBoundary string, accountID string, 
 			"\t--tags %s",
 			policyName, file, iamTags)
 		if path != "" {
-			createPolicy = fmt.Sprintf(createPolicy+"\\\n\t--path %s", path)
+			createPolicy = fmt.Sprintf(createPolicy+" \\\n\t--path %s", path)
 		}
 		attachRolePolicy := fmt.Sprintf("aws iam attach-role-policy \\\n"+
 			"\t--role-name %s \\\n"+

--- a/cmd/create/ocmrole/cmd.go
+++ b/cmd/create/ocmrole/cmd.go
@@ -275,7 +275,15 @@ func run(cmd *cobra.Command, argv []string) {
 			r.Reporter.Infof("All policy files saved to the current directory")
 			r.Reporter.Infof("Run the following commands to create the ocm role and policies:\n")
 		}
-		commands := buildCommands(prefix, roleNameRequested, path, permissionsBoundary, r.Creator.AccountID, env, isAdmin)
+		commands := buildCommands(
+			prefix,
+			roleNameRequested,
+			path,
+			permissionsBoundary,
+			r.Creator.AccountID,
+			env,
+			isAdmin,
+		)
 		fmt.Println(commands)
 	default:
 		r.Reporter.Errorf("Invalid mode. Allowed values are %s", aws.Modes)

--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -393,7 +393,7 @@ func buildCommands(r *rosa.Runtime, env string,
 				"\t--tags %s",
 				name, credrequest, iamTags)
 			if path != "" {
-				createPolicy = fmt.Sprintf(createPolicy+"\\\n\t--path %s", path)
+				createPolicy = fmt.Sprintf(createPolicy+" \\\n\t--path %s", path)
 			}
 			commands = append(commands, createPolicy)
 		}
@@ -430,7 +430,7 @@ func buildCommands(r *rosa.Runtime, env string,
 			"\t--tags %s",
 			roleName, filename, permBoundaryFlag, iamTags)
 		if path != "" {
-			createRole = fmt.Sprintf(createRole+"\\\n\t--path %s", path)
+			createRole = fmt.Sprintf(createRole+" \\\n\t--path %s", path)
 		}
 		attachRolePolicy := fmt.Sprintf("aws iam attach-role-policy \\\n"+
 			"\t--role-name %s \\\n"+

--- a/cmd/create/userrole/cmd.go
+++ b/cmd/create/userrole/cmd.go
@@ -230,7 +230,14 @@ func run(cmd *cobra.Command, argv []string) {
 			r.Reporter.Infof("All policy files saved to the current directory")
 			r.Reporter.Infof("Run the following commands to create the account roles and policies:\n")
 		}
-		commands := buildCommands(prefix, path, currentAccount.Username(), r.Creator.AccountID, env, permissionsBoundary)
+		commands := buildCommands(
+			prefix,
+			path,
+			currentAccount.Username(),
+			r.Creator.AccountID,
+			env,
+			permissionsBoundary,
+		)
 		fmt.Println(commands)
 
 	default:
@@ -263,7 +270,7 @@ func buildCommands(prefix string, path string, userName string,
 		"\t--tags %s",
 		roleName, aws.OCMUserRolePolicyFile, permBoundaryFlag, iamTags)
 	if path != "" {
-		createRole = fmt.Sprintf(createRole+"\\\n\t--path %s", path)
+		createRole = fmt.Sprintf(createRole+" \\\n\t--path %s", path)
 	}
 	linkRole := fmt.Sprintf("rosa link user-role --role-arn %s", roleARN)
 	commands = append(commands, createRole, linkRole)

--- a/cmd/upgrade/operatorroles/cmd.go
+++ b/cmd/upgrade/operatorroles/cmd.go
@@ -388,7 +388,7 @@ func buildMissingOperatorRoleCommand(missingRoles map[string]*cmv1.STSOperator, 
 			"\t--tags %s",
 			roleName, filename, permBoundaryFlag, iamTags)
 		if rolePath != "" {
-			createRole = fmt.Sprintf(createRole+"\\\n\t--path %s", rolePath)
+			createRole = fmt.Sprintf(createRole+" \\\n\t--path %s", rolePath)
 		}
 		attachRolePolicy := fmt.Sprintf("aws iam attach-role-policy \\\n"+
 			"\t--role-name %s \\\n"+

--- a/pkg/aws/sts.go
+++ b/pkg/aws/sts.go
@@ -188,7 +188,7 @@ func BuildOperatorRoleCommands(prefix string, accountID string, awsClient Client
 				"\t--tags %s",
 				name, credrequest, iamTags)
 			if policyPath != "" {
-				createPolicy = fmt.Sprintf(createPolicy+"\\\n\t--path %s", policyPath)
+				createPolicy = fmt.Sprintf(createPolicy+" \\\n\t--path %s", policyPath)
 			}
 			commands = append(commands, createPolicy)
 		} else {


### PR DESCRIPTION
Related issues: https://issues.redhat.com/browse/SDA-6858
# What
There was no leading space to the '\' on last line

# Why
Making sure commands will run without issues