### PR TITLE
[SDA-6984] Better not clarify channel group when validating OCP version for HyperShift

### DIFF
--- a/cmd/create/cluster/cluster_suite_test.go
+++ b/cmd/create/cluster/cluster_suite_test.go
@@ -1,0 +1,13 @@
+package cluster_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCluster(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cluster Suite")
+}

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2156,11 +2156,7 @@ func validateVersion(version string, versionList []string, channelGroup string, 
 				return "", fmt.Errorf("error while parsing OCP version '%s': %v", version, err)
 			}
 			if !valid {
-				v := version
-				if len(channelGroup) > 0 {
-					v = fmt.Sprintf("%s-%s", version, channelGroup)
-				}
-				return "", fmt.Errorf("version '%s' is not suported for HyperShift clusters", v)
+				return "", fmt.Errorf("version '%s' is not supported for hosted clusters", version)
 			}
 		}
 

--- a/cmd/create/cluster/cmd_test.go
+++ b/cmd/create/cluster/cmd_test.go
@@ -1,0 +1,39 @@
+package cluster
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Validates OCP version", func() {
+
+	const (
+		nightly = "nightly"
+	)
+	var _ = Context("when creating a hosted cluster", func() {
+
+		It("OK: Validates successfully a cluster for HyperShift with a supported version", func() {
+			v, err := validateVersion("4.12.0", []string{"4.12.0"}, nightly, false, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(v).To(Equal("openshift-v4.12.0"))
+		})
+		It(`KO: Fails to validate a cluster for a hosted
+		cluster when the user provides an unsupported version`,
+			func() {
+				v, err := validateVersion("4.11.5", []string{"4.11.5"}, nightly, false, true)
+				Expect(err).To(BeEquivalentTo(fmt.Errorf("version '4.11.5' is not supported for hosted clusters")))
+				Expect(v).To(BeEmpty())
+			})
+		It(`KO: Fails to validate a cluster for a hosted cluster
+		when the user provides an invalid or malformed version`,
+			func() {
+				v, err := validateVersion("foo.bar", []string{"foo.bar"}, nightly, false, true)
+				Expect(err).To(BeEquivalentTo(
+					fmt.Errorf("error while parsing OCP version 'foo.bar': Malformed version: foo.bar")))
+				Expect(v).To(BeEmpty())
+			})
+
+	})
+})


### PR DESCRIPTION
Removes the channel group from the error message when the OCP cluster version is not compatible with HyperShift.

