### PR TITLE
aws empty path is different than ours when creating existing acc roles

### DIFF
--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -110,14 +110,11 @@ func (c *awsClient) EnsureRole(name string, policy string, permissionsBoundary s
 		}
 	}
 
-	// verify that the paths are the same
-	localPath := "/"
-	if path != "" {
-		//FIXME (gbranco): this needs to be refactored
-		//AWS empty path corresponds to '/', hacking this instead of refactoring our path to work with "/" everyhwere else due to deadline
-		localPath = path
+	outputPath, err := GetPathFromARN(aws.StringValue(output.Role.Arn))
+	if err != nil {
+		return "", err
 	}
-	if aws.StringValue(output.Role.Path) != localPath {
+	if outputPath != path {
 		return "", fmt.Errorf("Role with same name but different path exists. Existing role ARN: %s",
 			*output.Role.Arn)
 	}


### PR DESCRIPTION
# What
AWS path response when path is empty is '/'

# Why
Making sure creating account roles stay idempotent when no path is specified

# Changes
`rosa create account-roles -y`
```
I: Logged in as 'gbranco.openshift' on 'https://api.stage.openshift.com'
I: Validating AWS credentials...
I: AWS credentials are valid!
I: Validating AWS quota...
I: AWS quota ok. If cluster installation fails, validate actual AWS resource usage against https://docs.openshift.com/rosa/rosa_getting_started/rosa-required-aws-service-quotas.html
I: Verifying whether OpenShift command-line tool is available...
I: Current OpenShift Client Version: 4.11.2
I: Creating account roles
? Role prefix: ManagedOpenShift
? Permissions boundary ARN (optional): 
? Path (optional): 
? Role creation mode: auto
I: Creating roles using 'arn:aws:iam::765374464689:user/gbranco'
I: Created role 'ManagedOpenShift-ControlPlane-Role' with ARN 'arn:aws:iam::765374464689:role/ManagedOpenShift-ControlPlane-Role'
I: Created role 'ManagedOpenShift-Worker-Role' with ARN 'arn:aws:iam::765374464689:role/ManagedOpenShift-Worker-Role'
I: Created role 'ManagedOpenShift-Support-Role' with ARN 'arn:aws:iam::765374464689:role/ManagedOpenShift-Support-Role'
I: Created role 'ManagedOpenShift-Installer-Role' with ARN 'arn:aws:iam::765374464689:role/ManagedOpenShift-Installer-Role'
I: To create a cluster with these roles, run the following command:
rosa create cluster --sts
```