### PR TITLE
[SDA-7006] aws acc id on whoami

### DIFF
--- a/cmd/whoami/cmd.go
+++ b/cmd/whoami/cmd.go
@@ -107,7 +107,7 @@ func run(_ *cobra.Command, _ []string) {
 		}
 	}
 	outputObject := object.Object{
-		"AWS Account ID":        account.ID(),
+		"AWS Account ID":        r.Creator.AccountID,
 		"AWS Default Region":    awsRegion,
 		"AWS ARN":               r.Creator.ARN,
 		"OCM API":               cfg.URL,


### PR DESCRIPTION
# What
Mistakenly setup with acc id instead of aws acc id

# Why
Should be aws acc id

## Before Changes
`rosa whoami`
```
AWS ARN:                      arn:aws:iam::765374464689:user/gbranco
AWS Account ID:               2E7ZB4lftoPorDGklnWU0pNX3Zw
AWS Default Region:           us-east-2
OCM API:                      https://api.stage.openshift.com
OCM Account Email:            gbranco@redhat.com
OCM Account ID:               2E7ZB4lftoPorDGklnWU0pNX3Zw
OCM Account Name:             Guilherme Branco
OCM Account Username:         gbranco.openshift
OCM Organization External ID: 12541229
OCM Organization ID:          1MKVU4otCIuogoLtgtyU6wajxjW
OCM Organization Name:        Red Hat : Service Delivery : SDA/B
```

## After Changes
`rosa whoami`
```
AWS ARN:                      arn:aws:iam::765374464689:user/gbranco
AWS Account ID:               765374464689
AWS Default Region:           us-east-2
OCM API:                      https://api.stage.openshift.com
OCM Account Email:            gbranco@redhat.com
OCM Account ID:               2E7ZB4lftoPorDGklnWU0pNX3Zw
OCM Account Name:             Guilherme Branco
OCM Account Username:         gbranco.openshift
OCM Organization External ID: 12541229
OCM Organization ID:          1MKVU4otCIuogoLtgtyU6wajxjW
OCM Organization Name:        Red Hat : Service Delivery : SDA/B
```