### PR TITLE
[SDA-6982] Change message from one minute wait for several minutes

### DIFF
--- a/cmd/create/admin/cmd.go
+++ b/cmd/create/admin/cmd.go
@@ -120,7 +120,11 @@ func run(cmd *cobra.Command, _ []string) {
 			Htpasswd(htpasswdIDP).
 			Build()
 		if err != nil {
-			r.Reporter.Errorf("Failed to create '%s' identity provider for cluster '%s'", idp.HTPasswdIDPName, clusterKey)
+			r.Reporter.Errorf(
+				"Failed to create '%s' identity provider for cluster '%s'",
+				idp.HTPasswdIDPName,
+				clusterKey,
+			)
 			os.Exit(1)
 		}
 
@@ -181,7 +185,7 @@ func run(cmd *cobra.Command, _ []string) {
 	r.Reporter.Infof("To login, run the following command:\n\n"+
 		"   oc login %s --username %s --password %s\n",
 		outputObject["api_url"], outputObject["username"], outputObject["password"])
-	r.Reporter.Infof("It may take up to a minute for the account to become active.")
+	r.Reporter.Infof("It may take several minutes for this access to become active.")
 }
 
 func generateRandomPassword(length int) (string, error) {

--- a/cmd/create/idp/cmd.go
+++ b/cmd/create/idp/cmd.go
@@ -125,7 +125,10 @@ func init() {
 		&args.mappingMethod,
 		"mapping-method",
 		"claim",
-		fmt.Sprintf("Specifies how new identities are mapped to users when they log in. Options are %s", validMappingMethods),
+		fmt.Sprintf(
+			"Specifies how new identities are mapped to users when they log in. Options are %s",
+			validMappingMethods,
+		),
 	)
 	flags.StringVar(
 		&args.clientID,
@@ -431,7 +434,7 @@ func doCreateIDP(
 
 	r.Reporter.Infof(
 		"Identity Provider '%s' has been created.\n"+
-			"   It will take up to 1 minute for this configuration to be enabled.\n"+
+			"   It may take several minutes for this access to become active.\n"+
 			"   To add cluster administrators, see 'rosa grant user --help'.\n"+
 			"   To login into the console, open %s and click on %s.",
 		idpName, cluster.Console().URL(), idpName,


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-6982
# What
When a user does `rosa create-admin` or does other htpasswd idp setup, the ROSA CLI indicates "It may take up to a minute for the account to become active."

# Why
We should change this to a more realistic number because almost always, it takes longer.