### PR TITLE
[SDA-7021] --hosted-cp flag now forces byo vpc prompt like privatelink does

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1262,7 +1262,7 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
-	if privateLink {
+	if privateLink || isHostedCP {
 		useExistingVPC = true
 	}
 


### PR DESCRIPTION
[SDA-7021](https://issues.redhat.com/browse/SDA-7021)

Now, if you include the `--hosted-cp` flag when creating a cluster:

`rosa create cluster --sts --mode auto --hosted-cp`

Then once you get to the `Would you like to install on an existing VPC?`  step, it automatically responds Yes and asks you which subnets to use.Before, it always prompted Would you like to install on an existing VPC? even with the `--hosted-cp`  flag