### PR TITLE
[SDA-6984] Add support for nightly builds for Hosted CP clusters

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2153,7 +2153,7 @@ func validateVersion(version string, versionList []string, channelGroup string, 
 			return version, err
 		}
 		if isHostedCP {
-			valid, err := ocm.HasHostedCPSupport(version)
+			valid, err := ocm.HasHostedCPSupport(version, channelGroup)
 			if err != nil {
 				return "", fmt.Errorf("error while parsing OCP version '%s': %v", version, err)
 			}

--- a/cmd/create/cluster/cmd_test.go
+++ b/cmd/create/cluster/cmd_test.go
@@ -11,25 +11,40 @@ var _ = Describe("Validates OCP version", func() {
 
 	const (
 		nightly = "nightly"
+		stable  = "stable"
+		fast    = "fast"
 	)
 	var _ = Context("when creating a hosted cluster", func() {
 
-		It("OK: Validates successfully a cluster for HyperShift with a supported version", func() {
-			v, err := validateVersion("4.12.0", []string{"4.12.0"}, nightly, false, true)
+		It("OK: Validates successfully a cluster for hosted clusters with a supported version", func() {
+			v, err := validateVersion("4.12.0", []string{"4.12.0"}, stable, false, true)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(v).To(Equal("openshift-v4.12.0"))
+		})
+
+		It("OK: Validates successfully a nightly version of OCP for hosted cluters with a supported version", func() {
+			v, err := validateVersion("4.11.0-0.nightly-2022-10-17-040259-nightly",
+				[]string{"4.11.0-0.nightly-2022-10-17-040259-nightly"}, nightly, false, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(v).To(Equal("openshift-v4.11.0-0.nightly-2022-10-17-040259-nightly"))
+		})
+
+		It("OK: Validates successfully the first major release of OCP for hosted cluters with a supported version", func() {
+			v, err := validateVersion("4.13.0", []string{"4.13.0"}, fast, false, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(v).To(Equal("openshift-v4.13.0"))
 		})
 		It(`KO: Fails to validate a cluster for a hosted
 		cluster when the user provides an unsupported version`,
 			func() {
-				v, err := validateVersion("4.11.5", []string{"4.11.5"}, nightly, false, true)
+				v, err := validateVersion("4.11.5", []string{"4.11.5"}, stable, false, true)
 				Expect(err).To(BeEquivalentTo(fmt.Errorf("version '4.11.5' is not supported for hosted clusters")))
 				Expect(v).To(BeEmpty())
 			})
 		It(`KO: Fails to validate a cluster for a hosted cluster
 		when the user provides an invalid or malformed version`,
 			func() {
-				v, err := validateVersion("foo.bar", []string{"foo.bar"}, nightly, false, true)
+				v, err := validateVersion("foo.bar", []string{"foo.bar"}, stable, false, true)
 				Expect(err).To(BeEquivalentTo(
 					fmt.Errorf("error while parsing OCP version 'foo.bar': Malformed version: foo.bar")))
 				Expect(v).To(BeEmpty())

--- a/pkg/ocm/versions.go
+++ b/pkg/ocm/versions.go
@@ -27,9 +27,10 @@ import (
 
 const (
 	DefaultChannelGroup   = "stable"
+	NightlyChannelGroup   = "nightly"
 	LowestSTSSupport      = "4.7.11"
 	LowestSTSMinor        = "4.7"
-	LowestHostedCPSupport = "4.11.6-candidate"
+	LowestHostedCPSupport = "4.11.6"
 )
 
 func (c *Client) GetVersions(channelGroup string) (versions []*cmv1.Version, err error) {
@@ -78,7 +79,7 @@ func (c *Client) GetVersions(channelGroup string) (versions []*cmv1.Version, err
 }
 
 func HasSTSSupport(rawID string, channelGroup string) bool {
-	if channelGroup == "nightly" {
+	if channelGroup == NightlyChannelGroup {
 		return true
 	}
 
@@ -101,8 +102,8 @@ func HasSTSSupportMinor(minor string) bool {
 	return a.GreaterThanOrEqual(b)
 }
 
-func HasHostedCPSupport(rawID string) (bool, error) {
-	a, err := ver.NewVersion(rawID)
+func HasHostedCPSupport(rawVersion, channelGroup string) (bool, error) {
+	v, err := ver.NewVersion(rawVersion)
 	if err != nil {
 		return false, err
 	}
@@ -110,9 +111,9 @@ func HasHostedCPSupport(rawID string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	//TODO: Currently, the minimum OCP supported version for development is 4.11.6-candidate.
+	//TODO: Currently, the minimum OCP supported version for development is 4.11.6 and nightly releases
 	//This comparison needs to be updated to 4.12 when it is released.
-	return a.GreaterThanOrEqual(b), nil
+	return v.GreaterThanOrEqual(b) || channelGroup == NightlyChannelGroup, nil
 }
 
 func GetVersionID(cluster *cmv1.Cluster) string {
@@ -156,7 +157,7 @@ func (c *Client) GetAvailableUpgrades(versionID string) ([]string, error) {
 
 func createVersionID(version string, channelGroup string) string {
 	versionID := fmt.Sprintf("openshift-v%s", version)
-	if channelGroup != "stable" {
+	if channelGroup != DefaultChannelGroup {
 		versionID = fmt.Sprintf("%s-%s", versionID, channelGroup)
 	}
 	return versionID

--- a/pkg/ocm/versions_test.go
+++ b/pkg/ocm/versions_test.go
@@ -1,9 +1,6 @@
 package ocm
 
 import (
-	"fmt"
-	"strings"
-
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/ginkgo/v2/dsl/decorators"
 	. "github.com/onsi/ginkgo/v2/dsl/table"
@@ -12,34 +9,29 @@ import (
 
 var _ = Describe("Versions", Ordered, func() {
 
-	var (
-		lowestVersionWithoutChannelGroup string
-	)
-	_ = BeforeAll(func() {
-
-		lowestVersionWithoutChannelGroup = strings.Split(LowestHostedCPSupport, "-")[0]
-	})
 	Context("when creating a HyperShift cluster", func() {
 		DescribeTable("Should correctly validate the minimum version with a given channel group",
 			validateVersion,
 			Entry("OK: When the minimum version is provided",
 				func() string { return LowestHostedCPSupport },
+				func() string { return DefaultChannelGroup },
 				true, nil),
-			Entry("OK: When the minimum version with stable channel group",
-				func() string { return fmt.Sprintf("%s-stable", lowestVersionWithoutChannelGroup) }, true, nil),
+			Entry("OK: When the version matches the nightly channel group",
+				func() string { return "4.11.0-0.nightly-2022-10-17-040259-nightly" },
+				func() string { return NightlyChannelGroup }, true, nil),
 			Entry("OK: When a greater version than the minimum is provided",
-				func() string { return "4.13.0" }, true, nil),
+				func() string { return "4.13.0" },
+				func() string { return DefaultChannelGroup }, true, nil),
 			Entry("KO: When the minimum version requirement is not met",
-				func() string { return "4.11.5" }, false, nil),
-			Entry("KO: When it contains an invalid version",
-				func() string { return "foo.bar" }, false, fmt.Errorf("Malformed version: foo.bar")),
+				func() string { return "4.11.5" },
+				func() string { return DefaultChannelGroup }, false, nil),
 		)
 	})
 })
 
-func validateVersion(version func() string, expectedValidation bool, expectedErr error) {
+func validateVersion(version func() string, channelGroup func() string, expectedValidation bool, expectedErr error) {
 
-	b, err := HasHostedCPSupport(version())
+	b, err := HasHostedCPSupport(version(), channelGroup())
 	if expectedErr != nil {
 		Expect(err).To(BeEquivalentTo(expectedErr))
 	}


### PR DESCRIPTION
Adds support for nightly builds of OCP as viable versions for Hosted Clusters. Previously only 4.11.6-candidate and newer were supported, but not nightly builds as they are tagged with `<major>.<minor>.0-nightly-<timestamp>-nightly`, example:

```
  4.11.0-0.nightly-2022-10-17-040259-nightly
  4.10.0-0.nightly-2022-10-17-082154-nightly
  4.10.0-0.nightly-2022-10-14-023020-nightly
  4.10.0-0.nightly-2022-10-13-011121-nightly
  4.10.0-0.nightly-2022-10-12-184111-nightly
  4.8.0-0.nightly-2022-10-14-021947-nightly
  4.8.0-0.nightly-2021-05-26-071911-nightly
```

@pvasant @jakub-dzon  PTAL