### PR TITLE
[SDE-1816] new command upgrade roles from cluster

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2448,5 +2448,5 @@ func buildCommand(spec ocm.Spec, operatorRolesPrefix string,
 }
 
 func getRolePrefix(clusterName string) string {
-	return fmt.Sprintf("%s-%s", clusterName, ocm.RandomLabel(4))
+	return fmt.Sprintf("%s-%s", clusterName, helper.RandomLabel(4))
 }

--- a/cmd/create/service/cmd.go
+++ b/cmd/create/service/cmd.go
@@ -30,6 +30,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/helper"
 	"github.com/openshift/rosa/pkg/info"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/output"
@@ -497,7 +498,7 @@ func getAccountRolePrefix(roleARN string, role aws.AccountRole) (string, error) 
 }
 
 func getRolePrefix(clusterName string) string {
-	return fmt.Sprintf("%s-%s", clusterName, ocm.RandomLabel(4))
+	return fmt.Sprintf("%s-%s", clusterName, helper.RandomLabel(4))
 }
 
 func getOperatorRoleArn(prefix string, operator *cmv1.STSOperator, creator *aws.Creator, path string) string {

--- a/cmd/upgrade/cmd.go
+++ b/cmd/upgrade/cmd.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openshift/rosa/cmd/upgrade/accountroles"
 	"github.com/openshift/rosa/cmd/upgrade/cluster"
 	"github.com/openshift/rosa/cmd/upgrade/operatorroles"
+	"github.com/openshift/rosa/cmd/upgrade/roles"
 	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/interactive"
 )
@@ -36,6 +37,7 @@ func init() {
 	Cmd.AddCommand(cluster.Cmd)
 	Cmd.AddCommand(accountroles.Cmd)
 	Cmd.AddCommand(operatorroles.Cmd)
+	Cmd.AddCommand(roles.Cmd)
 
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)

--- a/cmd/upgrade/roles/cmd.go
+++ b/cmd/upgrade/roles/cmd.go
@@ -1,0 +1,1013 @@
+/*
+Copyright (c) 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package roles
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/briandowns/spinner"
+	"github.com/spf13/cobra"
+	"github.com/zgalor/weberr"
+
+	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/rosa/pkg/aws"
+	awscb "github.com/openshift/rosa/pkg/aws/commandbuilder"
+	awscbRoles "github.com/openshift/rosa/pkg/aws/commandbuilder/helper/roles"
+	"github.com/openshift/rosa/pkg/aws/tags"
+	"github.com/openshift/rosa/pkg/helper"
+	"github.com/openshift/rosa/pkg/helper/roles"
+	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/interactive/confirm"
+	"github.com/openshift/rosa/pkg/ocm"
+	rprtr "github.com/openshift/rosa/pkg/reporter"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+var args struct {
+	isInvokedFromClusterUpgrade bool
+	clusterID                   string
+	upgradeVersion              string
+}
+
+var Cmd = &cobra.Command{
+	Use:     "roles",
+	Aliases: []string{},
+	Short:   "Upgrade account-wide IAM roles to the latest version.",
+	Long:    "Upgrade account-wide IAM roles to the latest version before upgrading your cluster.",
+	Example: `  # Upgrade account/operator roles for ROSA STS clusters 
+		rosa upgrade roles -c <cluster_key>`,
+	RunE: run,
+}
+
+func init() {
+	flags := Cmd.Flags()
+
+	ocm.AddClusterFlag(Cmd)
+
+	aws.AddModeFlag(Cmd)
+
+	flags.StringVar(
+		&args.upgradeVersion,
+		"version",
+		"",
+		"Version of OpenShift that the cluster will be upgraded to",
+	)
+
+	Cmd.MarkFlagRequired("version")
+
+	confirm.AddFlag(flags)
+	interactive.AddFlag(flags)
+}
+
+func run(cmd *cobra.Command, argv []string) error {
+	r := rosa.NewRuntime().WithAWS().WithOCM()
+	defer r.Cleanup()
+	reporter := r.Reporter
+	awsClient := r.AWSClient
+	ocmClient := r.OCMClient
+
+	isInvokedFromClusterUpgrade := false
+	skipInteractive := false
+	var cluster *v1.Cluster
+	if len(argv) >= 2 && !cmd.Flag("cluster").Changed {
+		aws.SetModeKey(argv[0])
+		ocm.SetClusterKey(argv[1])
+		skipInteractive = true
+		if len(argv) > 2 && argv[2] != "" {
+			args.upgradeVersion = argv[2]
+		}
+		isInvokedFromClusterUpgrade = true
+	}
+	args.isInvokedFromClusterUpgrade = isInvokedFromClusterUpgrade
+
+	r.GetClusterKey()
+	cluster = r.FetchCluster()
+
+	mode, err := aws.GetMode()
+	if err != nil {
+		reporter.Errorf("%s", err)
+		os.Exit(1)
+	}
+
+	policyVersion, err := ocmClient.GetDefaultVersion()
+	if err != nil {
+		reporter.Errorf("Error getting version: %s", err)
+		os.Exit(1)
+	}
+
+	env, err := ocm.GetEnv()
+	if err != nil {
+		reporter.Errorf("Failed to determine OCM environment: %v", err)
+		os.Exit(1)
+	}
+
+	creator, err := awsClient.GetCreator()
+	if err != nil {
+		reporter.Errorf("Failed to get IAM credentials: %s", err)
+		os.Exit(1)
+	}
+
+	// Determine if interactive mode is needed
+	if !interactive.Enabled() && !cmd.Flags().Changed("mode") && !skipInteractive {
+		interactive.Enable()
+	}
+
+	if interactive.Enabled() && !skipInteractive {
+		mode, err = interactive.GetOption(interactive.Input{
+			Question: "Account role upgrade mode",
+			Help:     cmd.Flags().Lookup("mode").Usage,
+			Default:  aws.ModeAuto,
+			Options:  aws.Modes,
+			Required: true,
+		})
+		if err != nil {
+			reporter.Errorf("Expected a valid Account role upgrade mode: %s", err)
+			os.Exit(1)
+		}
+		aws.SetModeKey(mode)
+	}
+
+	var spin *spinner.Spinner
+	if reporter.IsTerminal() {
+		spin = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+	}
+	if !args.isInvokedFromClusterUpgrade {
+		reporter.Infof("Ensuring account role/policies compatibility for upgrade")
+	}
+
+	if spin != nil {
+		spin.Start()
+	}
+
+	//ACCOUNT ROLES
+
+	isUpgradeNeedForAccountRolePolicies, err := awsClient.IsUpgradedNeededForAccountRolePoliciesForCluster(
+		cluster,
+		policyVersion,
+	)
+	if err != nil {
+		reporter.Errorf("%s", err)
+		LogError(roles.RosaUpgradeAccRolesModeAuto, ocmClient, policyVersion, err, reporter)
+		os.Exit(1)
+	}
+
+	if spin != nil {
+		spin.Stop()
+	}
+
+	if !isUpgradeNeedForAccountRolePolicies {
+		reporter.Infof("Account roles/policies for cluster '%s' are already up-to-date.", r.ClusterKey)
+	} else {
+		accountRolePolicies, err := ocmClient.GetPolicies("")
+		if err != nil {
+			reporter.Errorf("Expected a valid role creation mode: %s", err)
+			os.Exit(1)
+		}
+
+		switch mode {
+		case aws.ModeAuto:
+			if isUpgradeNeedForAccountRolePolicies {
+				reporter.Infof("Starting to upgrade the policies")
+				err = upgradeAccountRolePoliciesFromCluster(
+					mode,
+					reporter,
+					awsClient,
+					cluster,
+					creator.AccountID,
+					accountRolePolicies,
+					policyVersion,
+				)
+				if err != nil {
+					LogError(roles.RosaUpgradeAccRolesModeAuto, ocmClient, policyVersion, err, reporter)
+					if args.isInvokedFromClusterUpgrade {
+						return err
+					}
+					reporter.Errorf("Error upgrading the role polices: %s", err)
+					os.Exit(1)
+				}
+			}
+		case aws.ModeManual:
+			err = aws.GeneratePolicyFiles(reporter, env, isUpgradeNeedForAccountRolePolicies,
+				false, accountRolePolicies, nil)
+			if err != nil {
+				reporter.Errorf("There was an error generating the policy files: %s", err)
+				os.Exit(1)
+			}
+			if reporter.IsTerminal() {
+				reporter.Infof("All policy files saved to the current directory")
+				reporter.Infof("Run the following commands to upgrade the account role policies:\n")
+			}
+
+			commands, err := buildAccountRoleCommandsFromCluster(
+				mode,
+				cluster,
+				creator.AccountID,
+				isUpgradeNeedForAccountRolePolicies,
+				awsClient,
+				policyVersion,
+			)
+			if err != nil {
+				return err
+			}
+
+			fmt.Println(commands)
+			if args.isInvokedFromClusterUpgrade {
+				reporter.Infof("Run the following command to continue scheduling cluster upgrade"+
+					" once account and operator roles have been upgraded : \n\n"+
+					"\trosa upgrade cluster --cluster %s\n", r.ClusterKey)
+				return nil
+			}
+
+		default:
+			reporter.Errorf("Invalid mode. Allowed values are %s", aws.Modes)
+			os.Exit(1)
+		}
+	}
+
+	//OPERATOR ROLES
+	if !isInvokedFromClusterUpgrade {
+		reporter.Infof("Ensuring operator role policies compatibility for upgrade")
+	}
+
+	if spin != nil {
+		spin.Start()
+	}
+
+	operatorRoles, hasOperatorRoles := cluster.AWS().STS().GetOperatorIAMRoles()
+	if !hasOperatorRoles || len(operatorRoles) == 0 {
+		r.Reporter.Errorf("Cluster '%s' doesnt have any operator roles associated with it",
+			r.ClusterKey)
+		os.Exit(1)
+	}
+
+	operatorRolePath, operatorPolicyPath, err := roles.GetOperatorPaths(r.AWSClient, operatorRoles)
+	if err != nil {
+		r.Reporter.Errorf("%s", err)
+		os.Exit(1)
+	}
+
+	credRequests, err := ocmClient.GetCredRequests(cluster.Hypershift().Enabled())
+	if err != nil {
+		r.Reporter.Errorf("Error getting operator credential request from OCM %s", err)
+		os.Exit(1)
+	}
+
+	operatorRolePolicyPrefix, err := aws.GetOperatorRolePolicyPrefixFromCluster(cluster, r.AWSClient)
+	if err != nil {
+		return err
+	}
+
+	isOperatorPolicyUpgradeNeeded := false
+	isOperatorPolicyUpgradeNeeded, err = r.AWSClient.IsUpgradedNeededForOperatorRolePoliciesUsingCluster(
+		cluster,
+		r.Creator.AccountID,
+		policyVersion,
+		credRequests,
+		operatorRolePolicyPrefix,
+	)
+	if err != nil {
+		r.Reporter.Errorf("%s", err)
+		os.Exit(1)
+	}
+
+	version := args.upgradeVersion
+
+	missingRolesInCS, err := ocmClient.FindMissingOperatorRolesForUpgrade(cluster, version)
+	if err != nil {
+		return err
+	}
+
+	if len(missingRolesInCS) <= 0 && !isOperatorPolicyUpgradeNeeded {
+		if !args.isInvokedFromClusterUpgrade {
+			r.Reporter.Infof(
+				"Operator roles/policies associated with the cluster '%s' are already up-to-date.",
+				cluster.ID(),
+			)
+		}
+		os.Exit(0)
+	}
+
+	if spin != nil {
+		spin.Stop()
+	}
+
+	operatorRolePolicies, err := ocmClient.GetPolicies("OperatorRole")
+	if err != nil {
+		r.Reporter.Errorf("Expected a valid role creation mode: %s", err)
+		os.Exit(1)
+	}
+
+	if isOperatorPolicyUpgradeNeeded {
+		err = upgradeOperatorPolicies(
+			args.isInvokedFromClusterUpgrade,
+			mode,
+			r,
+			isUpgradeNeedForAccountRolePolicies,
+			operatorRolePolicies,
+			env,
+			policyVersion,
+			credRequests,
+			cluster,
+			operatorRolePolicyPrefix,
+		)
+		if err != nil {
+			r.Reporter.Errorf("%s", err)
+			os.Exit(1)
+		}
+	}
+
+	if len(missingRolesInCS) > 0 {
+		createdMissingRoles := 0
+		for _, operator := range missingRolesInCS {
+			roleName := roles.GetOperatorRoleName(cluster, operator)
+			exists, _, err := r.AWSClient.CheckRoleExists(roleName)
+			if err != nil {
+				return r.Reporter.Errorf("Error when detecting checking missing operator IAM roles %s", err)
+			}
+			if !exists {
+				err = createOperatorRole(
+					mode,
+					r,
+					cluster,
+					missingRolesInCS,
+					args.isInvokedFromClusterUpgrade,
+					operatorRolePolicies,
+					operatorRolePath,
+					operatorPolicyPath,
+					operatorRolePolicyPrefix,
+				)
+				if err != nil {
+					r.Reporter.Errorf("%s", err)
+					os.Exit(1)
+				}
+				createdMissingRoles++
+			}
+		}
+		if createdMissingRoles == 0 {
+			r.Reporter.Infof(
+				"Missing roles/policies have already been created. Please continue with cluster upgrade process.",
+			)
+		}
+	}
+	return err
+}
+
+func LogError(key string, ocmClient *ocm.Client, defaultPolicyVersion string, err error, reporter *rprtr.Object) {
+	reporter.Debugf("Logging throttle error")
+	if strings.Contains(err.Error(), "Throttling") {
+		ocmClient.LogEvent(key, map[string]string{
+			ocm.Response:   ocm.Failure,
+			ocm.Version:    defaultPolicyVersion,
+			ocm.IsThrottle: "true",
+		})
+	}
+}
+
+func handleAccountRolePolicyARN(
+	mode string,
+	awsClient aws.Client,
+	roleName string,
+	rolePath string,
+	accountID string,
+) (string, []string, error) {
+	commands := make([]string, 0)
+	policiesDetails, err := awsClient.GetAttachedPolicy(&roleName)
+	if err != nil {
+		return "", commands, err
+	}
+
+	hasMoreThanOneAttachedPolicy := aws.HasMoreThanOneAttachedPolicy(policiesDetails)
+	if hasMoreThanOneAttachedPolicy {
+		promptString := fmt.Sprintf("More than one policy attached to account role '%s'.\n"+
+			"\tWould you like to dettach current policies and setup a new one ?", roleName)
+		if !confirm.Prompt(true, promptString) {
+			attachedPoliciesDetail := aws.FindAllAttachedPolicyDetails(policiesDetails)
+			attachedPoliciesArns := make([]string, len(attachedPoliciesDetail))
+			for _, attachedPolicyDetail := range attachedPoliciesDetail {
+				attachedPoliciesArns = append(attachedPoliciesArns, attachedPolicyDetail.PolicyArn)
+			}
+			chosenPolicyARN, err := interactive.GetOption(interactive.Input{
+				Question: "Choose Policy ARN to upgrade",
+				Options:  attachedPoliciesArns,
+				Default:  attachedPoliciesArns[0],
+				Required: true,
+			})
+			if err != nil {
+				return "", commands, err
+			}
+			return chosenPolicyARN, commands, nil
+		}
+
+		switch mode {
+		case aws.ModeAuto:
+			err := awsClient.DetachRolePolicies(roleName)
+			if err != nil {
+				return "", commands, err
+			}
+		case aws.ModeManual:
+			for _, policyDetail := range policiesDetails {
+				detachManagedPoliciesCommand := awscbRoles.ManualCommandsForDetachRolePolicy(
+					awscbRoles.ManualCommandsForDetachRolePolicyInput{
+						RoleName:  roleName,
+						PolicyARN: policyDetail.PolicyArn,
+					},
+				)
+				commands = append(commands, detachManagedPoliciesCommand)
+			}
+		default:
+			return "", commands, weberr.Errorf("Invalid mode. Allowed values are %s", aws.Modes)
+		}
+
+		generatedPolicyARN := aws.GetPolicyARN(
+			accountID,
+			roleName,
+			rolePath,
+		)
+		return generatedPolicyARN, commands, nil
+	}
+	policyDetail := policiesDetails[0]
+	return policyDetail.PolicyArn, commands, nil
+}
+
+func upgradeAccountRolePoliciesFromCluster(
+	mode string,
+	reporter *rprtr.Object,
+	awsClient aws.Client,
+	cluster *v1.Cluster,
+	accountID string,
+	policies map[string]string,
+	policyVersion string,
+) error {
+	for file, role := range aws.AccountRoles {
+		roleName, err := aws.GetAccountRoleName(cluster, role.Name)
+		if err != nil {
+			return err
+		}
+		if roleName == "" {
+			reporter.Debugf("Cluster '%s' does not include expected role '%s'", cluster.ID(), role.Name)
+			continue
+		}
+		prefix, err := aws.GetPrefixFromAccountRole(cluster, role.Name)
+		if err != nil {
+			return err
+		}
+		rolePath, err := aws.GetPathFromAccountRole(cluster, role.Name)
+		if err != nil {
+			return err
+		}
+		promptString := fmt.Sprintf("Upgrade the '%s' role policy latest version (%s) ?", roleName, policyVersion)
+		if !confirm.Prompt(true, promptString) {
+			if args.isInvokedFromClusterUpgrade {
+				return reporter.Errorf("Account roles need to be upgraded to proceed")
+			}
+			continue
+		}
+		filename := fmt.Sprintf("sts_%s_permission_policy", file)
+
+		policyARN, _, err := handleAccountRolePolicyARN(mode, awsClient, roleName, rolePath, accountID)
+		if err != nil {
+			return err
+		}
+
+		accountPolicyPath, err := aws.GetPathFromARN(policyARN)
+		if err != nil {
+			return err
+		}
+
+		policyDetails := policies[filename]
+		policyARN, err = awsClient.EnsurePolicy(policyARN, policyDetails,
+			policyVersion, map[string]string{
+				tags.OpenShiftVersion: policyVersion,
+				tags.RolePrefix:       prefix,
+				tags.RoleType:         file,
+				tags.RedHatManaged:    "true",
+			}, accountPolicyPath)
+		if err != nil {
+			return err
+		}
+
+		err = awsClient.AttachRolePolicy(roleName, policyARN)
+		if err != nil {
+			return err
+		}
+		//Delete if present else continue
+		err = awsClient.DeleteInlineRolePolicies(roleName)
+		if err != nil {
+			reporter.Debugf("Error deleting inline role policy %s : %s", policyARN, err)
+		}
+		reporterString := fmt.Sprintf("Upgraded policy with ARN '%s' to version '%s'", policyARN, policyVersion)
+		reporter.Infof(reporterString)
+		err = awsClient.UpdateTag(roleName, policyVersion)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func buildAccountRoleCommandsFromCluster(
+	mode string,
+	cluster *v1.Cluster,
+	accountID string,
+	isUpgradeNeedForAccountRolePolicies bool,
+	awsClient aws.Client,
+	defaultPolicyVersion string,
+) (string, error) {
+	commands := []string{}
+	if isUpgradeNeedForAccountRolePolicies {
+		for file, role := range aws.AccountRoles {
+			accRoleName, err := aws.GetAccountRoleName(cluster, role.Name)
+			if err != nil {
+				return "", err
+			}
+			prefix, err := aws.GetPrefixFromAccountRole(cluster, role.Name)
+			if err != nil {
+				return "", err
+			}
+			rolePath, err := aws.GetPathFromAccountRole(cluster, role.Name)
+			if err != nil {
+				return "", err
+			}
+
+			policyARN, detachPoliciesCommands, err := handleAccountRolePolicyARN(
+				mode,
+				awsClient,
+				accRoleName,
+				rolePath,
+				accountID,
+			)
+			if err != nil {
+				return "", err
+			}
+
+			commands = append(commands, detachPoliciesCommands...)
+
+			accountPolicyPath, err := aws.GetPathFromARN(policyARN)
+			if err != nil {
+				return "", err
+			}
+			_, err = awsClient.IsPolicyExists(policyARN)
+			hasPolicy := err == nil
+			policyName := aws.GetPolicyName(accRoleName)
+			_, err = awsClient.IsRolePolicyExists(accRoleName, policyName)
+			hasInlinePolicy := err == nil
+			hasDetachPolicyCommandsForExpectedPolicy := checkHasDetachPolicyCommandsForExpectedPolicy(
+				detachPoliciesCommands,
+				policyARN,
+			)
+			upgradeAccountPolicyCommands := awscbRoles.ManualCommandsForUpgradeAccountRolePolicy(
+				awscbRoles.ManualCommandsForUpgradeAccountRolePolicyInput{
+					DefaultPolicyVersion:                     defaultPolicyVersion,
+					RoleName:                                 accRoleName,
+					HasPolicy:                                hasPolicy,
+					Prefix:                                   prefix,
+					File:                                     file,
+					PolicyName:                               policyName,
+					AccountPolicyPath:                        accountPolicyPath,
+					PolicyARN:                                policyARN,
+					HasInlinePolicy:                          hasInlinePolicy,
+					HasDetachPolicyCommandsForExpectedPolicy: hasDetachPolicyCommandsForExpectedPolicy,
+				},
+			)
+			commands = append(commands, upgradeAccountPolicyCommands...)
+		}
+	}
+	return awscb.JoinCommands(commands), nil
+}
+
+func checkHasDetachPolicyCommandsForExpectedPolicy(detachedPoliciesCommands []string, policyARN string) bool {
+	for _, command := range detachedPoliciesCommands {
+		if strings.Contains(command, policyARN) {
+			return true
+		}
+	}
+	return false
+}
+
+func upgradeOperatorPolicies(
+	isProgrammaticallyCalled bool,
+	mode string,
+	r *rosa.Runtime,
+	isAccountRoleUpgradeNeed bool,
+	policies map[string]string,
+	env string,
+	defaultPolicyVersion string,
+	credRequests map[string]*v1.STSOperator,
+	cluster *v1.Cluster,
+	operatorRolePolicyPrefix string,
+) error {
+	switch mode {
+	case aws.ModeAuto:
+		if !confirm.Prompt(true, "Upgrade each operator role policy to latest version (%s)?", defaultPolicyVersion) {
+			if isProgrammaticallyCalled {
+				return r.Reporter.Errorf("Operator roles need to be upgraded to proceed")
+			}
+			return nil
+		}
+		err := upgradeOperatorRolePoliciesFromCluster(
+			mode,
+			r.Reporter,
+			r.AWSClient,
+			r.Creator.AccountID,
+			policies,
+			defaultPolicyVersion,
+			credRequests,
+			cluster.AWS().STS().OperatorIAMRoles(),
+			operatorRolePolicyPrefix,
+		)
+		if err != nil {
+			if strings.Contains(err.Error(), "Throttling") {
+				r.OCMClient.LogEvent("ROSAUpgradeOperatorRolesModeAuto", map[string]string{
+					ocm.Response:   ocm.Failure,
+					ocm.Version:    defaultPolicyVersion,
+					ocm.IsThrottle: "true",
+				})
+			}
+			return r.Reporter.Errorf("Error upgrading the operator policies: %s", err)
+		}
+		return nil
+	case aws.ModeManual:
+		err := aws.GeneratePolicyFiles(r.Reporter, env, false,
+			true, policies, credRequests)
+		if err != nil {
+			r.Reporter.Errorf("There was an error generating the policy files: %s", err)
+			os.Exit(1)
+		}
+
+		if r.Reporter.IsTerminal() {
+			r.Reporter.Infof("All policy files saved to the current directory")
+			r.Reporter.Infof("Run the following commands to upgrade the operator IAM policies:\n")
+			if isAccountRoleUpgradeNeed {
+				r.Reporter.Warnf("Operator role policies MUST only be upgraded after " +
+					"Account Role policies upgrade has completed.\n")
+			}
+		}
+		commands, err := buildOperatorRoleCommandsFromCluster(
+			mode,
+			operatorRolePolicyPrefix,
+			r.Creator.AccountID,
+			r.AWSClient,
+			defaultPolicyVersion,
+			credRequests,
+			cluster.AWS().STS().OperatorIAMRoles(),
+		)
+		if err != nil {
+			r.Reporter.Errorf("There was an error generating the commands: %s", err)
+			os.Exit(1)
+		}
+		fmt.Println(commands)
+	default:
+		return r.Reporter.Errorf("Invalid mode. Allowed values are %s", aws.Modes)
+	}
+	return nil
+}
+
+func upgradeOperatorRolePoliciesFromCluster(
+	mode string,
+	reporter *rprtr.Object,
+	awsClient aws.Client,
+	accountID string,
+	policies map[string]string,
+	defaultPolicyVersion string,
+	credRequests map[string]*v1.STSOperator,
+	operatorRoles []*v1.OperatorIAMRole,
+	operatorRolePolicyPrefix string,
+) error {
+	generalPath, err := aws.GetPathFromARN(operatorRoles[0].RoleARN())
+	if err != nil {
+		return err
+	}
+	for credrequest, operator := range credRequests {
+		policyARN := ""
+		operatorPolicyPath := generalPath
+		operatorRoleARN := aws.FindOperatorRoleBySTSOperator(operatorRoles, operator)
+		if operatorRoleARN == "" {
+			policyARN = aws.GetOperatorPolicyARN(
+				accountID,
+				operatorRolePolicyPrefix,
+				operator.Namespace(),
+				operator.Name(),
+				operatorPolicyPath,
+			)
+		} else {
+			operatorRoleName, err := aws.GetResourceIdFromARN(operatorRoleARN)
+			if err != nil {
+				return err
+			}
+
+			policyARN, _, err = handleOperatorRolePolicyARN(
+				mode,
+				awsClient,
+				operatorRoleName,
+				operatorRolePolicyPrefix,
+				operatorPolicyPath,
+				operator,
+				accountID,
+			)
+			if err != nil {
+				return err
+			}
+			operatorPolicyPath, err = aws.GetPathFromARN(policyARN)
+			if err != nil {
+				return err
+			}
+		}
+		filename := fmt.Sprintf("openshift_%s_policy", credrequest)
+		policyDetails := policies[filename]
+		policyARN, err = awsClient.EnsurePolicy(policyARN, policyDetails,
+			defaultPolicyVersion, map[string]string{
+				tags.OpenShiftVersion:  defaultPolicyVersion,
+				tags.RolePrefix:        operatorRolePolicyPrefix,
+				tags.OperatorNamespace: operator.Namespace(),
+				tags.OperatorName:      operator.Name(),
+			}, operatorPolicyPath)
+		if err != nil {
+			return err
+		}
+		reporter.Infof("Upgraded policy with ARN '%s' to version '%s'", policyARN, defaultPolicyVersion)
+	}
+	return nil
+}
+
+func buildOperatorRoleCommandsFromCluster(
+	mode string,
+	operatorRolePolicyPrefix string,
+	accountID string,
+	awsClient aws.Client,
+	defaultPolicyVersion string,
+	credRequests map[string]*v1.STSOperator,
+	operatorRoles []*v1.OperatorIAMRole,
+) (string, error) {
+	commands := []string{}
+	generalPath, err := aws.GetPathFromARN(operatorRoles[0].RoleARN())
+	if err != nil {
+		return "", err
+	}
+	for credrequest, operator := range credRequests {
+		policyARN := ""
+		operatorPolicyPath := generalPath
+		hasDetachPolicyCommandsForExpectedPolicy := false
+		operatorRoleARN := aws.FindOperatorRoleBySTSOperator(operatorRoles, operator)
+		operatorRoleName := ""
+		if operatorRoleARN == "" {
+			policyARN = aws.GetOperatorPolicyARN(
+				accountID,
+				operatorRolePolicyPrefix,
+				operator.Namespace(),
+				operator.Name(),
+				operatorPolicyPath,
+			)
+		} else {
+			operatorRoleName, err = aws.GetResourceIdFromARN(operatorRoleARN)
+			if err != nil {
+				return "", err
+			}
+			foundPolicyARN, detachPoliciesCommands, err := handleOperatorRolePolicyARN(
+				mode,
+				awsClient,
+				operatorRoleName,
+				operatorRolePolicyPrefix,
+				operatorPolicyPath,
+				operator,
+				accountID,
+			)
+			if err != nil {
+				return "", err
+			}
+			hasDetachPolicyCommandsForExpectedPolicy = checkHasDetachPolicyCommandsForExpectedPolicy(
+				detachPoliciesCommands,
+				foundPolicyARN,
+			)
+
+			commands = append(commands, detachPoliciesCommands...)
+			operatorPolicyPath, err = aws.GetPathFromARN(foundPolicyARN)
+			if err != nil {
+				return "", err
+			}
+			policyARN = foundPolicyARN
+		}
+		policyName := aws.GetOperatorPolicyName(
+			operatorRolePolicyPrefix,
+			operator.Namespace(),
+			operator.Name(),
+		)
+		_, err = awsClient.IsPolicyExists(policyARN)
+		hasPolicy := err == nil
+
+		upgradePoliciesCommands := awscbRoles.ManualCommandsForUpgradeOperatorRolePolicy(
+			awscbRoles.ManualCommandsForUpgradeOperatorRolePolicyInput{
+				HasPolicy:                                hasPolicy,
+				OperatorRolePolicyPrefix:                 operatorRolePolicyPrefix,
+				Operator:                                 operator,
+				CredRequest:                              credrequest,
+				OperatorPolicyPath:                       operatorPolicyPath,
+				PolicyARN:                                policyARN,
+				DefaultPolicyVersion:                     defaultPolicyVersion,
+				PolicyName:                               policyName,
+				HasDetachPolicyCommandsForExpectedPolicy: hasDetachPolicyCommandsForExpectedPolicy,
+				OperatorRoleName:                         operatorRoleName,
+			},
+		)
+		commands = append(commands, upgradePoliciesCommands...)
+	}
+	return awscb.JoinCommands(commands), nil
+}
+
+func handleOperatorRolePolicyARN(
+	mode string,
+	awsClient aws.Client,
+	operatorRoleName string,
+	operatorRolePolicyPrefix string,
+	operatorPolicyPath string,
+	operator *v1.STSOperator,
+	accountID string,
+) (string, []string, error) {
+	commands := make([]string, 0)
+	policiesDetails, err := awsClient.GetAttachedPolicy(&operatorRoleName)
+	if err != nil {
+		return "", commands, err
+	}
+
+	hasMoreThanOneAttachedPolicy := aws.HasMoreThanOneAttachedPolicy(policiesDetails)
+	if hasMoreThanOneAttachedPolicy {
+		promptString := fmt.Sprintf("More than one policy attached to operator role '%s'.\n"+
+			"\tWould you like to dettach current policies and setup a new one ?", operatorRoleName)
+		if !confirm.Prompt(true, promptString) {
+			attachedPoliciesDetails := aws.FindAllAttachedPolicyDetails(policiesDetails)
+			attachedPoliciesArns := make([]string, len(attachedPoliciesDetails))
+			for _, attachedPolicyDetail := range attachedPoliciesDetails {
+				attachedPoliciesArns = append(attachedPoliciesArns, attachedPolicyDetail.PolicyArn)
+			}
+			chosenPolicyARN, err := interactive.GetOption(interactive.Input{
+				Question: "Choose Policy ARN to upgrade",
+				Options:  attachedPoliciesArns,
+				Default:  attachedPoliciesArns[0],
+				Required: true,
+			})
+			if err != nil {
+				return "", commands, err
+			}
+			return chosenPolicyARN, commands, nil
+		}
+		switch mode {
+		case aws.ModeAuto:
+			err := awsClient.DetachRolePolicies(operatorRoleName)
+			if err != nil {
+				return "", commands, err
+			}
+		case aws.ModeManual:
+			for _, policyDetail := range policiesDetails {
+				detachManagedPoliciesCommand := awscbRoles.ManualCommandsForDetachRolePolicy(
+					awscbRoles.ManualCommandsForDetachRolePolicyInput{
+						RoleName:  operatorRoleName,
+						PolicyARN: policyDetail.PolicyArn,
+					},
+				)
+				commands = append(commands, detachManagedPoliciesCommand)
+			}
+		default:
+			return "", commands, weberr.Errorf("Invalid mode. Allowed values are %s", aws.Modes)
+		}
+		generatedPolicyARN := aws.GetOperatorPolicyARN(
+			accountID,
+			operatorRolePolicyPrefix,
+			operator.Namespace(),
+			operator.Name(),
+			operatorPolicyPath,
+		)
+		return generatedPolicyARN, commands, nil
+	}
+	policyDetail := policiesDetails[0]
+	return policyDetail.PolicyArn, commands, nil
+}
+
+func createOperatorRole(
+	mode string,
+	r *rosa.Runtime,
+	cluster *v1.Cluster,
+	missingRoles map[string]*v1.STSOperator,
+	isProgrammaticallyCalled bool,
+	policies map[string]string,
+	rolePath string,
+	policyPath string,
+	operatorRolePolicyPrefix string,
+) error {
+	accountID := r.Creator.AccountID
+	switch mode {
+	case aws.ModeAuto:
+		err := upgradeMissingOperatorRole(
+			missingRoles,
+			cluster,
+			accountID,
+			r,
+			isProgrammaticallyCalled,
+			policies,
+			rolePath,
+			policyPath,
+			operatorRolePolicyPrefix,
+		)
+		if err != nil {
+			return err
+		}
+		helper.DisplaySpinnerWithDelay(r.Reporter, "Waiting for operator roles to reconcile", 5*time.Second)
+	case aws.ModeManual:
+		commands, err := roles.BuildMissingOperatorRoleCommand(
+			missingRoles,
+			cluster,
+			accountID,
+			r,
+			policies,
+			rolePath,
+			policyPath,
+			operatorRolePolicyPrefix,
+		)
+		if err != nil {
+			return err
+		}
+		if r.Reporter.IsTerminal() {
+			r.Reporter.Infof("Run the following commands to create the operator roles:\n")
+		}
+		fmt.Println(commands)
+		if isProgrammaticallyCalled {
+			r.Reporter.Infof("Run the following command to continue scheduling cluster upgrade"+
+				" once account and operator roles have been upgraded : \n\n"+
+				"\trosa upgrade cluster --cluster %s\n", cluster.ID())
+			os.Exit(0)
+		}
+	default:
+		r.Reporter.Errorf("Invalid mode. Allowed values are %s", aws.Modes)
+		os.Exit(1)
+	}
+	return nil
+}
+
+func upgradeMissingOperatorRole(
+	missingRoles map[string]*v1.STSOperator,
+	cluster *v1.Cluster,
+	accountID string,
+	r *rosa.Runtime,
+	isProgrammaticallyCalled bool,
+	policies map[string]string,
+	rolePath string,
+	policyPath string,
+	operatorRolePolicyPrefix string,
+) error {
+	for _, operator := range missingRoles {
+		roleName := roles.GetOperatorRoleName(cluster, operator)
+		if !confirm.Prompt(true, "Create the '%s' role?", roleName) {
+			if isProgrammaticallyCalled {
+				return weberr.Errorf("Operator roles need to be upgraded to proceed with cluster upgrade")
+			}
+			continue
+		}
+		policyDetails := policies["operator_iam_role_policy"]
+
+		policyARN := aws.GetOperatorPolicyARN(
+			accountID,
+			operatorRolePolicyPrefix,
+			operator.Namespace(),
+			operator.Name(),
+			policyPath,
+		)
+		policy, err := aws.GenerateOperatorRolePolicyDoc(cluster, accountID, operator, policyDetails)
+		if err != nil {
+			return err
+		}
+		r.Reporter.Debugf("Creating role '%s'", roleName)
+		roleARN, err := r.AWSClient.EnsureRole(roleName, policy, "", "",
+			map[string]string{
+				tags.ClusterID:         cluster.ID(),
+				tags.OperatorNamespace: operator.Namespace(),
+				tags.OperatorName:      operator.Name(),
+				tags.RedHatManaged:     "true",
+			}, rolePath)
+		if err != nil {
+			return err
+		}
+		r.Reporter.Infof("Created role '%s' with ARN '%s'", roleName, roleARN)
+		r.Reporter.Debugf("Attaching permission policy '%s' to role '%s'", policyARN, roleName)
+		err = r.AWSClient.AttachRolePolicy(roleName, policyARN)
+		if err != nil {
+			return weberr.Errorf("Failed to attach role policy. Check your prefix or run "+
+				"'rosa create operator-roles' to create the necessary policies: %s", err)
+		}
+	}
+	return nil
+}

--- a/pkg/aws/commandbuilder/helper/roles/roles.go
+++ b/pkg/aws/commandbuilder/helper/roles/roles.go
@@ -1,0 +1,194 @@
+package roles
+
+import (
+	"fmt"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	awscb "github.com/openshift/rosa/pkg/aws/commandbuilder"
+	"github.com/openshift/rosa/pkg/aws/tags"
+)
+
+type ManualCommandsForMissingOperatorRolesInput struct {
+	ClusterID                string
+	OperatorRolePolicyPrefix string
+	Operator                 *cmv1.STSOperator
+	RoleName                 string
+	Filename                 string
+	RolePath                 string
+	PolicyARN                string
+}
+
+func ManualCommandsForMissingOperatorRole(input ManualCommandsForMissingOperatorRolesInput) []string {
+	commands := make([]string, 0)
+	iamTags := map[string]string{
+		tags.ClusterID:         input.ClusterID,
+		tags.RolePrefix:        input.OperatorRolePolicyPrefix,
+		tags.OperatorNamespace: input.Operator.Namespace(),
+		tags.OperatorName:      input.Operator.Name(),
+		tags.RedHatManaged:     "true",
+	}
+
+	createRole := awscb.NewIAMCommandBuilder().
+		SetCommand(awscb.CreateRole).
+		AddParam(awscb.RoleName, input.RoleName).
+		AddParam(awscb.AssumeRolePolicyDocument, fmt.Sprintf("file://%s", input.Filename)).
+		AddTags(iamTags).
+		AddParam(awscb.Path, input.RolePath).
+		Build()
+	attachRolePolicy := awscb.NewIAMCommandBuilder().
+		SetCommand(awscb.AttachRolePolicy).
+		AddParam(awscb.RoleName, input.RoleName).
+		AddParam(awscb.PolicyArn, input.PolicyARN).
+		Build()
+	commands = append(commands, createRole, attachRolePolicy)
+	return commands
+}
+
+type ManualCommandsForUpgradeOperatorRolePolicyInput struct {
+	HasPolicy                                bool
+	OperatorRolePolicyPrefix                 string
+	Operator                                 *cmv1.STSOperator
+	CredRequest                              string
+	OperatorPolicyPath                       string
+	PolicyARN                                string
+	DefaultPolicyVersion                     string
+	PolicyName                               string
+	HasDetachPolicyCommandsForExpectedPolicy bool
+	OperatorRoleName                         string
+}
+
+func ManualCommandsForUpgradeOperatorRolePolicy(input ManualCommandsForUpgradeOperatorRolePolicyInput) []string {
+	commands := make([]string, 0)
+	if !input.HasPolicy {
+		iamTags := map[string]string{
+			tags.OpenShiftVersion:  input.DefaultPolicyVersion,
+			tags.RolePrefix:        input.OperatorRolePolicyPrefix,
+			tags.OperatorNamespace: input.Operator.Namespace(),
+			tags.OperatorName:      input.Operator.Name(),
+			tags.RedHatManaged:     "true",
+		}
+		createPolicy := awscb.NewIAMCommandBuilder().
+			SetCommand(awscb.CreatePolicy).
+			AddParam(awscb.PolicyName, input.PolicyName).
+			AddParam(awscb.PolicyDocument, fmt.Sprintf("file://openshift_%s_policy.json", input.CredRequest)).
+			AddTags(iamTags).
+			AddParam(awscb.Path, input.OperatorPolicyPath).
+			Build()
+		commands = append(commands, createPolicy)
+	} else {
+		if input.HasDetachPolicyCommandsForExpectedPolicy {
+			attachRolePolicy := awscb.NewIAMCommandBuilder().
+				SetCommand(awscb.AttachRolePolicy).
+				AddParam(awscb.RoleName, input.OperatorRoleName).
+				AddParam(awscb.PolicyArn, input.PolicyARN).
+				Build()
+			commands = append(commands, attachRolePolicy)
+		}
+		policyTags := map[string]string{
+			tags.OpenShiftVersion: input.DefaultPolicyVersion,
+		}
+
+		createPolicyVersion := awscb.NewIAMCommandBuilder().
+			SetCommand(awscb.CreatePolicyVersion).
+			AddParam(awscb.PolicyArn, input.PolicyARN).
+			AddParam(awscb.PolicyDocument, fmt.Sprintf("file://openshift_%s_policy.json", input.CredRequest)).
+			AddParamNoValue(awscb.SetAsDefault).
+			Build()
+
+		tagPolicy := awscb.NewIAMCommandBuilder().
+			SetCommand(awscb.TagPolicy).
+			AddTags(policyTags).
+			AddParam(awscb.PolicyArn, input.PolicyARN).
+			Build()
+		commands = append(commands, createPolicyVersion, tagPolicy)
+	}
+	return commands
+}
+
+type ManualCommandsForUpgradeAccountRolePolicyInput struct {
+	DefaultPolicyVersion                     string
+	RoleName                                 string
+	HasPolicy                                bool
+	Prefix                                   string
+	File                                     string
+	PolicyName                               string
+	AccountPolicyPath                        string
+	PolicyARN                                string
+	HasInlinePolicy                          bool
+	HasDetachPolicyCommandsForExpectedPolicy bool
+}
+
+func ManualCommandsForUpgradeAccountRolePolicy(input ManualCommandsForUpgradeAccountRolePolicyInput) []string {
+	commands := make([]string, 0)
+	iamRoleTags := map[string]string{
+		tags.OpenShiftVersion: input.DefaultPolicyVersion,
+	}
+
+	tagRole := awscb.NewIAMCommandBuilder().
+		SetCommand(awscb.TagRole).
+		AddTags(iamRoleTags).
+		AddParam(awscb.RoleName, input.RoleName).
+		Build()
+
+	attachRolePolicy := awscb.NewIAMCommandBuilder().
+		SetCommand(awscb.AttachRolePolicy).
+		AddParam(awscb.RoleName, input.RoleName).
+		AddParam(awscb.PolicyArn, input.PolicyARN).
+		Build()
+	if !input.HasPolicy {
+		iamTags := map[string]string{
+			tags.OpenShiftVersion: input.DefaultPolicyVersion,
+			tags.RolePrefix:       input.Prefix,
+			tags.RoleType:         input.File,
+			tags.RedHatManaged:    "true",
+		}
+		createPolicy := awscb.NewIAMCommandBuilder().
+			SetCommand(awscb.CreatePolicy).
+			AddParam(awscb.PolicyName, input.PolicyName).
+			AddParam(awscb.PolicyDocument, fmt.Sprintf("file://sts_%s_permission_policy.json", input.File)).
+			AddTags(iamTags).
+			AddParam(awscb.Path, input.AccountPolicyPath).
+			Build()
+
+		if input.HasInlinePolicy {
+			deletePolicy := awscb.NewIAMCommandBuilder().
+				SetCommand(awscb.DeleteRolePolicy).
+				AddParam(awscb.RoleName, input.RoleName).
+				AddParam(awscb.PolicyName, input.PolicyName).
+				Build()
+			commands = append(commands, deletePolicy)
+		}
+		commands = append(commands, createPolicy, attachRolePolicy, tagRole)
+	} else {
+		if input.HasDetachPolicyCommandsForExpectedPolicy {
+			commands = append(commands, attachRolePolicy)
+		}
+		createPolicyVersion := awscb.NewIAMCommandBuilder().
+			SetCommand(awscb.CreatePolicyVersion).
+			AddParam(awscb.PolicyArn, input.PolicyARN).
+			AddParam(awscb.PolicyDocument, fmt.Sprintf("file://sts_%s_permission_policy.json", input.File)).
+			AddParamNoValue(awscb.SetAsDefault).
+			Build()
+
+		tagPolicies := awscb.NewIAMCommandBuilder().
+			SetCommand(awscb.TagPolicy).
+			AddTags(iamRoleTags).
+			AddParam(awscb.PolicyArn, input.PolicyARN).
+			Build()
+		commands = append(commands, createPolicyVersion, tagPolicies, tagRole)
+	}
+	return commands
+}
+
+type ManualCommandsForDetachRolePolicyInput struct {
+	RoleName  string
+	PolicyARN string
+}
+
+func ManualCommandsForDetachRolePolicy(input ManualCommandsForDetachRolePolicyInput) string {
+	return awscb.NewIAMCommandBuilder().
+		SetCommand(awscb.DetachRolePolicy).
+		AddParam(awscb.RoleName, input.RoleName).
+		AddParam(awscb.PolicyArn, input.PolicyARN).
+		Build()
+}

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -1,13 +1,68 @@
 package helper
 
 import (
+	"math/rand"
 	"os"
+	"sort"
 	"time"
 
 	"github.com/briandowns/spinner"
 	"github.com/google/uuid"
 	"github.com/openshift/rosa/pkg/reporter"
 )
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+// ASCII codes of important characters:
+const (
+	aCode    = 97
+	zCode    = 122
+	zeroCode = 48
+	nineCode = 57
+)
+
+// Number of letters and digits:
+const (
+	letterCount = zCode - aCode + 1
+	digitCount  = nineCode - zeroCode + 1
+)
+
+func RandomLabel(size int) string {
+	value := rand.Int() // #nosec G404
+	chars := make([]byte, size)
+	for size > 0 {
+		size--
+		if size%2 == 0 {
+			chars[size] = byte(aCode + value%letterCount)
+			value = value / letterCount
+		} else {
+			chars[size] = byte(zeroCode + value%digitCount)
+			value = value / digitCount
+		}
+	}
+	return string(chars)
+}
+
+func RankMapStringInt(values map[string]int) []string {
+	type kv struct {
+		Key   string
+		Value int
+	}
+	var ss []kv
+	for k, v := range values {
+		ss = append(ss, kv{k, v})
+	}
+	sort.Slice(ss, func(i, j int) bool {
+		return ss[i].Value > ss[j].Value
+	})
+	ranked := make([]string, len(values))
+	for i, kv := range ss {
+		ranked[i] = kv.Key
+	}
+	return ranked
+}
 
 func Contains(s []string, str string) bool {
 	for _, v := range s {

--- a/pkg/helper/roles/helpers.go
+++ b/pkg/helper/roles/helpers.go
@@ -1,0 +1,119 @@
+package roles
+
+import (
+	"fmt"
+	"strings"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/rosa/pkg/aws"
+	awscb "github.com/openshift/rosa/pkg/aws/commandbuilder"
+	awscbRoles "github.com/openshift/rosa/pkg/aws/commandbuilder/helper/roles"
+	"github.com/openshift/rosa/pkg/helper"
+	"github.com/openshift/rosa/pkg/rosa"
+	"github.com/zgalor/weberr"
+)
+
+const (
+	RosaUpgradeAccRolesModeAuto = "ROSAUpgradeAccountRolesModeAuto"
+)
+
+func GetOperatorRoleName(cluster *cmv1.Cluster, missingOperator *cmv1.STSOperator) string {
+	operatorIAMRoles := cluster.AWS().STS().OperatorIAMRoles()
+	rolePrefix := ""
+	if len(operatorIAMRoles) > 0 {
+		roleARN := operatorIAMRoles[0].RoleARN()
+		roleName, err := aws.GetResourceIdFromARN(roleARN)
+		if err != nil {
+			return ""
+		}
+
+		m := strings.LastIndex(roleName, "-openshift")
+		rolePrefix = roleName[0:m]
+	}
+	role := fmt.Sprintf("%s-%s-%s", rolePrefix, missingOperator.Namespace(), missingOperator.Name())
+	if len(role) > 64 {
+		role = role[0:64]
+	}
+	return role
+}
+
+func GetOperatorPaths(awsClient aws.Client, operatorRoles []*cmv1.OperatorIAMRole) (
+	string, string, error) {
+	for _, operatorRole := range operatorRoles {
+		roleName, err := aws.GetResourceIdFromARN(operatorRole.RoleARN())
+		if err != nil {
+			return "", "", err
+		}
+		rolePolicies, err := awsClient.GetAttachedPolicy(&roleName)
+		if err != nil {
+			return "", "", err
+		}
+		policySuffix := aws.GetOperatorPolicyName("", operatorRole.Namespace(), operatorRole.Name())
+		for _, rolePolicy := range rolePolicies {
+			index := strings.LastIndex(rolePolicy.PolicyName, "-openshift")
+			policyNameSuffixOnly := rolePolicy.PolicyName[index:]
+			if strings.Contains(policySuffix, policyNameSuffixOnly) {
+				rolePath, err := aws.GetPathFromARN(operatorRole.RoleARN())
+				if err != nil {
+					return "", "", err
+				}
+				policyPath, err := aws.GetPathFromARN(rolePolicy.PolicyArn)
+				if err != nil {
+					return "", "", err
+				}
+				return rolePath, policyPath, nil
+			}
+		}
+	}
+	return "", "", weberr.Errorf("Can not detect operator policy path. " +
+		"Existing operator roles do not have operator policies attached to them")
+}
+
+func BuildMissingOperatorRoleCommand(
+	missingRoles map[string]*cmv1.STSOperator,
+	cluster *cmv1.Cluster,
+	accountID string,
+	r *rosa.Runtime,
+	policies map[string]string,
+	rolePath string,
+	policyPath string,
+	operatorRolePolicyPrefix string,
+) (string, error) {
+	commands := []string{}
+	for missingRole, operator := range missingRoles {
+		roleName := GetOperatorRoleName(cluster, operator)
+		policyARN := aws.GetOperatorPolicyARN(
+			accountID,
+			operatorRolePolicyPrefix,
+			operator.Namespace(),
+			operator.Name(),
+			policyPath,
+		)
+		policyDetails := policies["operator_iam_role_policy"]
+		policy, err := aws.GenerateOperatorRolePolicyDoc(cluster, accountID, operator, policyDetails)
+		if err != nil {
+			return "", err
+		}
+		filename := fmt.Sprintf("operator_%s_policy", missingRole)
+		filename = aws.GetFormattedFileName(filename)
+		r.Reporter.Debugf("Saving '%s' to the current directory", filename)
+		err = helper.SaveDocument(policy, filename)
+		if err != nil {
+			return "", err
+		}
+		missingCommands := awscbRoles.ManualCommandsForMissingOperatorRole(
+			awscbRoles.ManualCommandsForMissingOperatorRolesInput{
+				ClusterID:                cluster.ID(),
+				OperatorRolePolicyPrefix: operatorRolePolicyPrefix,
+				Operator:                 operator,
+				RoleName:                 roleName,
+				Filename:                 filename,
+				RolePath:                 rolePath,
+				PolicyARN:                policyARN,
+			},
+		)
+		commands = append(commands, missingCommands...)
+
+	}
+	return awscb.JoinCommands(commands), nil
+}

--- a/pkg/ocm/flag.go
+++ b/pkg/ocm/flag.go
@@ -27,6 +27,17 @@ import (
 
 var clusterKey string
 
+func AddOptionalClusterFlag(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(
+		&clusterKey,
+		"cluster",
+		"c",
+		"",
+		"Name or ID of the cluster.",
+	)
+	cmd.RegisterFlagCompletionFunc("cluster", clusterCompletion)
+}
+
 func AddClusterFlag(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(
 		&clusterKey,


### PR DESCRIPTION
Related Issues: 
https://issues.redhat.com/browse/SDA-6407
https://issues.redhat.com/browse/SDE-1816
# What
Setting up a new command to upgrade acc/operator roles/policies

# Why
Easier flow for the client to use when roles are linked to a cluster

# Steps to check changes

## Running under upgrade cluster roles without standard suffix acc roles
`./rosa upgrade cluster -c ns --mode auto -y`
```
? Version: 4.10.37
I: Ensuring account and operator role policies for cluster '1vosh3jn3trq9101s4dm4tt30d4qq9u2' are compatible with upgrade.
I: Starting to upgrade the policies
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/rosa-ccoe-dev-installer-Policy' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/rosa-ccoe-dev-controlplane-Policy' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/rosa-ccoe-dev-compute-Policy' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/rosa-ccoe-dev-rh-rosa-sre-Policy' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/rosa-ccoe-dev-installer-openshift-cluster-csi-drivers-ebs-' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/rosa-ccoe-dev-installer-openshift-cloud-network-config-con' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/rosa-ccoe-dev-installer-openshift-machine-api-aws-cloud-cr' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/rosa-ccoe-dev-installer-openshift-cloud-credential-operato' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/rosa-ccoe-dev-installer-openshift-image-registry-installer' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/rosa-ccoe-dev-installer-openshift-ingress-operator-cloud-c' to version '4.11'
I: Created role 'rosa-ccoe-dev-openshift-cloud-network-config-controller-cl' with ARN 'arn:aws:iam::765374464689:role/rosa-ccoe-dev-openshift-cloud-network-config-controller-cl'
I: Waiting for operator roles to reconcile
I: Account and operator roles for cluster 'ns' are compatible with upgrade
? Please input desired date in format yyyy-mm-dd: 2022-11-03
? Please input desired UTC time in format HH:mm: 20:48
? Node draining: 1 hour
I: Upgrade successfully scheduled for cluster 'ns'
```

## Running under upgrade roles without standard suffix acc roles
`./rosa upgrade roles -c gdb-test --mode auto --version=4.10.36`
```
I: Ensuring account role policies compatibility for upgrade
I: Starting to upgrade the policies
? Upgrade the 'sde-1816-6-support' role policy latest version (4.11) ? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sde-1816-6-support-policy' to latest version
? Upgrade the 'sde-1816-6-installer' role policy latest version (4.11) ? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sde-1816-6-installer-policy' to latest version
? Upgrade the 'sde-1816-6-controlplane' role policy latest version (4.11) ? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sde-1816-6-controleplane-policy' to latest version
? Upgrade the 'sde-1816-6-worker' role policy latest version (4.11) ? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sde-1816-6-worker-policy' to latest version
I: Starting to upgrade the operator IAM roles and policies
? Upgrade each operator role policy to latest version (4.11)? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sde-1816-6-openshift-image-registry-installer-cloud-credentials' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sde-1816-6-openshift-ingress-operator-cloud-credentials' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sde-1816-6-openshift-cluster-csi-drivers-ebs-cloud-credentials' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sde-1816-6-installer-openshift-cloud-network-config-controller-c' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sde-1816-6-openshift-machine-api-aws-cloud-credentials' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sde-1816-6-openshift-cloud-credential-operator-cloud-credential-' to version '4.11'
? Create the 'gdb-test-e3t7-openshift-cloud-network-config-controller-cloud-cr' role? Yes
I: Created role 'gdb-test-e3t7-openshift-cloud-network-config-controller-cloud-cr' with ARN 'arn:aws:iam::765374464689:role/gdb-test-e3t7-openshift-cloud-network-config-controller-cloud-cr'
I: Waiting for operator roles to reconcile
```

## Running under upgrade roles
`./rosa create account-roles --mode auto --version=4.9 --prefix=sde-1816-4 -y`
```
I: Logged in as 'gbranco.openshift' on 'https://api.stage.openshift.com'
I: Validating AWS credentials...
I: AWS credentials are valid!
I: Validating AWS quota...
I: AWS quota ok. If cluster installation fails, validate actual AWS resource usage against https://docs.openshift.com/rosa/rosa_getting_started/rosa-required-aws-service-quotas.html
I: Verifying whether OpenShift command-line tool is available...
I: Current OpenShift Client Version: 4.11.2
I: Creating account roles
I: Creating roles using 'arn:aws:iam::765374464689:user/gbranco'
I: Created role 'sde-1816-4-ControlPlane-Role' with ARN 'arn:aws:iam::765374464689:role/sde-1816-4-ControlPlane-Role'
I: Created role 'sde-1816-4-Worker-Role' with ARN 'arn:aws:iam::765374464689:role/sde-1816-4-Worker-Role'
I: Created role 'sde-1816-4-Support-Role' with ARN 'arn:aws:iam::765374464689:role/sde-1816-4-Support-Role'
I: Created role 'sde-1816-4-Installer-Role' with ARN 'arn:aws:iam::765374464689:role/sde-1816-4-Installer-Role'
I: To create a cluster with these roles, run the following command:
rosa create cluster --sts
```

`./rosa create cluster --sts --mode auto --yes `
```
I: Enabling interactive mode
? Cluster name: gdb-49-2
? OpenShift version: 4.9.49
W: More than one Installer role found
? Installer role ARN: arn:aws:iam::765374464689:role/sde-1816-4-Installer-Role
I: Using arn:aws:iam::765374464689:role/sde-1816-4-ControlPlane-Role for the ControlPlane role
I: Using arn:aws:iam::765374464689:role/sde-1816-4-Worker-Role for the Worker role
I: Using arn:aws:iam::765374464689:role/sde-1816-4-Support-Role for the Support role
? External ID (optional): 
? Operator roles prefix: gdb-49-2-d8s2
? Multiple availability zones (optional): No
? AWS region: us-east-1
? PrivateLink cluster (optional): No
? Install into an existing VPC (optional): No
? Select availability zones (optional): No
? Enable Customer Managed key (optional): No
? Compute nodes instance type: m5.xlarge
? Enable autoscaling (optional): No
? Compute nodes: 2
? Machine CIDR: 10.0.0.0/16
? Service CIDR: 172.30.0.0/16
? Pod CIDR: 10.128.0.0/14
? Host prefix: 23
? Encrypt etcd data (optional): No
? Disable Workload monitoring (optional): No
I: Creating cluster 'gdb-49-2'
I: To create this cluster again in the future, you can run:
   rosa create cluster --cluster-name gdb-49-2 --sts --mode auto --role-arn arn:aws:iam::765374464689:role/sde-1816-4-Installer-Role --support-role-arn arn:aws:iam::765374464689:role/sde-1816-4-Support-Role --controlplane-iam-role arn:aws:iam::765374464689:role/sde-1816-4-ControlPlane-Role --worker-iam-role arn:aws:iam::765374464689:role/sde-1816-4-Worker-Role --operator-roles-prefix gdb-49-2-d8s2 --region us-east-1 --version 4.9.49 --compute-nodes 2 --compute-machine-type m5.xlarge --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23
I: To view a list of clusters and their status, run 'rosa list clusters'
I: Cluster 'gdb-49-2' has been created.
I: Once the cluster is installed you will need to add an Identity Provider before you can login into the cluster. See 'rosa create idp --help' for more information.
Name:                       gdb-49-2
ID:                         1vg49g0vh6977voife3eoef3qp0ssa9f
External ID:                
Control Plane:              Customer hosted
OpenShift Version:          
Channel Group:              stable
DNS:                        gdb-49-2.hgnf.s1.devshift.org
AWS Account:                765374464689
API URL:                    
Console URL:                
Region:                     us-east-1
Multi-AZ:                   false
Nodes:
 - Control plane:           3
 - Infra:                   2
 - Compute:                 2
Network:
 - Service CIDR:            172.30.0.0/16
 - Machine CIDR:            10.0.0.0/16
 - Pod CIDR:                10.128.0.0/14
 - Host Prefix:             /23
STS Role ARN:               arn:aws:iam::765374464689:role/sde-1816-4-Installer-Role
Support Role ARN:           arn:aws:iam::765374464689:role/sde-1816-4-Support-Role
Instance IAM Roles:
 - Control plane:           arn:aws:iam::765374464689:role/sde-1816-4-ControlPlane-Role
 - Worker:                  arn:aws:iam::765374464689:role/sde-1816-4-Worker-Role
Operator IAM Roles:
 - arn:aws:iam::765374464689:role/gdb-49-2-d8s2-openshift-machine-api-aws-cloud-credentials
 - arn:aws:iam::765374464689:role/gdb-49-2-d8s2-openshift-cloud-credential-operator-cloud-credenti
 - arn:aws:iam::765374464689:role/gdb-49-2-d8s2-openshift-image-registry-installer-cloud-credentia
 - arn:aws:iam::765374464689:role/gdb-49-2-d8s2-openshift-ingress-operator-cloud-credentials
 - arn:aws:iam::765374464689:role/gdb-49-2-d8s2-openshift-cluster-csi-drivers-ebs-cloud-credential
State:                      waiting (Waiting for OIDC configuration)
Private:                    No
Created:                    Oct 21 2022 12:38:27 UTC
Details Page:               https://qaprodauth.console.redhat.com/openshift/details/s/2GRed5TbwLWiA5UiQGkqeZz1TvH
OIDC Endpoint URL:          https://d3gt1gce2zmg3d.cloudfront.net/1vg49g0vh6977voife3eoef3qp0ssa9f

I: Preparing to create operator roles.
? Permissions boundary ARN (optional): 
I: Creating roles using 'arn:aws:iam::765374464689:user/gbranco'
I: Created role 'gdb-49-2-d8s2-openshift-machine-api-aws-cloud-credentials' with ARN 'arn:aws:iam::765374464689:role/gdb-49-2-d8s2-openshift-machine-api-aws-cloud-credentials'
I: Created role 'gdb-49-2-d8s2-openshift-cloud-credential-operator-cloud-credenti' with ARN 'arn:aws:iam::765374464689:role/gdb-49-2-d8s2-openshift-cloud-credential-operator-cloud-credenti'
I: Created role 'gdb-49-2-d8s2-openshift-image-registry-installer-cloud-credentia' with ARN 'arn:aws:iam::765374464689:role/gdb-49-2-d8s2-openshift-image-registry-installer-cloud-credentia'
I: Created role 'gdb-49-2-d8s2-openshift-ingress-operator-cloud-credentials' with ARN 'arn:aws:iam::765374464689:role/gdb-49-2-d8s2-openshift-ingress-operator-cloud-credentials'
I: Created role 'gdb-49-2-d8s2-openshift-cluster-csi-drivers-ebs-cloud-credential' with ARN 'arn:aws:iam::765374464689:role/gdb-49-2-d8s2-openshift-cluster-csi-drivers-ebs-cloud-credential'
I: Preparing to create OIDC Provider.
I: Creating OIDC provider using 'arn:aws:iam::765374464689:user/gbranco'
I: Created OIDC provider with ARN 'arn:aws:iam::765374464689:oidc-provider/d3gt1gce2zmg3d.cloudfront.net/1vg49g0vh6977voife3eoef3qp0ssa9f'
I: To determine when your cluster is Ready, run 'rosa describe cluster -c gdb-49-2'.
I: To watch your cluster installation logs, run 'rosa logs install -c gdb-49-2 --watch'.
```

`./rosa upgrade roles -c gdb-49-2 --mode auto --version=4.10.36`
```
I: Ensuring account role policies compatibility for upgrade
I: Starting to upgrade the policies
? Upgrade the 'sde-1816-4-Installer-Role' role policy latest version ? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sde-1816-4-Installer-Role-Policy' to latest version
? Upgrade the 'sde-1816-4-ControlPlane-Role' role policy latest version ? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sde-1816-4-ControlPlane-Role-Policy' to latest version
? Upgrade the 'sde-1816-4-Worker-Role' role policy latest version ? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sde-1816-4-Worker-Role-Policy' to latest version
? Upgrade the 'sde-1816-4-Support-Role' role policy latest version ? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sde-1816-4-Support-Role-Policy' to latest version
I: Starting to upgrade the operator IAM roles and policies
? Upgrade the operator role policy to version 4.11? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sde-1816-4-openshift-cloud-network-config-controller-cloud-crede' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sde-1816-4-openshift-machine-api-aws-cloud-credentials' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sde-1816-4-openshift-cloud-credential-operator-cloud-credential-' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sde-1816-4-openshift-image-registry-installer-cloud-credentials' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sde-1816-4-openshift-ingress-operator-cloud-credentials' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sde-1816-4-openshift-cluster-csi-drivers-ebs-cloud-credentials' to version '4.11'
? Create the 'gdb-49-2-d8s2-openshift-cloud-network-config-controller-cloud-cr' role? Yes
I: Created role 'gdb-49-2-d8s2-openshift-cloud-network-config-controller-cloud-cr' with ARN 'arn:aws:iam::765374464689:role/gdb-49-2-d8s2-openshift-cloud-network-config-controller-cloud-cr'
I: Waiting for operator roles to reconcile
```
`./rosa upgrade cluster -c gdb-49-2`
```
? Version: 4.10.36
I: Ensuring account and operator role policies for cluster '1vg49g0vh6977voife3eoef3qp0ssa9f' are compatible with upgrade.
I: Account and operator roles for cluster 'gdb-49-2' are compatible with upgrade
? Are you sure you want to upgrade cluster to version '4.10.36'? Yes
? Please input desired date in format yyyy-mm-dd: 2022-10-21
? Please input desired UTC time in format HH:mm: 13:59
? Node draining: 1 hour
I: Upgrade successfully scheduled for cluster 'gdb-49-2'
```

`./rosa describe cluster -c gdb-49-2`
```
Name:                       gdb-49-2
ID:                         1vg49g0vh6977voife3eoef3qp0ssa9f
External ID:                b39e97c7-d3ea-4b0e-bcae-1928344859ca
Control Plane:              Customer hosted
OpenShift Version:          4.9.49
Channel Group:              stable
DNS:                        gdb-49-2.hgnf.s1.devshift.org
AWS Account:                765374464689
API URL:                    https://api.gdb-49-2.hgnf.s1.devshift.org:6443
Console URL:                https://console-openshift-console.apps.gdb-49-2.hgnf.s1.devshift.org
Region:                     us-east-1
Multi-AZ:                   false
Nodes:
 - Control plane:           3
 - Infra:                   2
 - Compute:                 2
Network:
 - Service CIDR:            172.30.0.0/16
 - Machine CIDR:            10.0.0.0/16
 - Pod CIDR:                10.128.0.0/14
 - Host Prefix:             /23
STS Role ARN:               arn:aws:iam::765374464689:role/sde-1816-4-Installer-Role
Support Role ARN:           arn:aws:iam::765374464689:role/sde-1816-4-Support-Role
Instance IAM Roles:
 - Control plane:           arn:aws:iam::765374464689:role/sde-1816-4-ControlPlane-Role
 - Worker:                  arn:aws:iam::765374464689:role/sde-1816-4-Worker-Role
Operator IAM Roles:
 - arn:aws:iam::765374464689:role/gdb-49-2-d8s2-openshift-machine-api-aws-cloud-credentials
 - arn:aws:iam::765374464689:role/gdb-49-2-d8s2-openshift-cloud-credential-operator-cloud-credenti
 - arn:aws:iam::765374464689:role/gdb-49-2-d8s2-openshift-image-registry-installer-cloud-credentia
 - arn:aws:iam::765374464689:role/gdb-49-2-d8s2-openshift-ingress-operator-cloud-credentials
 - arn:aws:iam::765374464689:role/gdb-49-2-d8s2-openshift-cluster-csi-drivers-ebs-cloud-credential
 - arn:aws:iam::765374464689:role/gdb-49-2-d8s2-openshift-cloud-network-config-controller-cloud-cr
State:                      ready 
Private:                    No
Created:                    Oct 21 2022 12:38:27 UTC
Details Page:               https://qaprodauth.console.redhat.com/openshift/details/s/2GRed5TbwLWiA5UiQGkqeZz1TvH
OIDC Endpoint URL:          https://d3gt1gce2zmg3d.cloudfront.net/1vg49g0vh6977voife3eoef3qp0ssa9f
Scheduled Upgrade:          scheduled 4.10.36 on 2022-10-21 13:59 UTC
```


## Running under upgrade cluster
`./rosa create account-roles --mode auto --version=4.9 --prefix=sde-1816-5 -y`

```
I: Logged in as 'gbranco.openshift' on 'https://api.stage.openshift.com'
I: Validating AWS credentials...
I: AWS credentials are valid!
I: Validating AWS quota...
I: AWS quota ok. If cluster installation fails, validate actual AWS resource usage against https://docs.openshift.com/rosa/rosa_getting_started/rosa-required-aws-service-quotas.html
I: Verifying whether OpenShift command-line tool is available...
I: Current OpenShift Client Version: 4.11.2
I: Creating account roles
I: Creating roles using 'arn:aws:iam::765374464689:user/gbranco'
I: Created role 'sde-1816-5-Installer-Role' with ARN 'arn:aws:iam::765374464689:role/sde-1816-5-Installer-Role'
I: Created role 'sde-1816-5-ControlPlane-Role' with ARN 'arn:aws:iam::765374464689:role/sde-1816-5-ControlPlane-Role'
I: Created role 'sde-1816-5-Worker-Role' with ARN 'arn:aws:iam::765374464689:role/sde-1816-5-Worker-Role'
I: Created role 'sde-1816-5-Support-Role' with ARN 'arn:aws:iam::765374464689:role/sde-1816-5-Support-Role'
I: To create a cluster with these roles, run the following command:
rosa create cluster --sts
```

`./rosa create cluster --sts --mode auto --yes`
```
I: Enabling interactive mode
? Cluster name: gdb-49-3
? OpenShift version: 4.9.49
W: More than one Installer role found
? Installer role ARN: arn:aws:iam::765374464689:role/sde-1816-5-Installer-Role
I: Using arn:aws:iam::765374464689:role/sde-1816-5-ControlPlane-Role for the ControlPlane role
I: Using arn:aws:iam::765374464689:role/sde-1816-5-Worker-Role for the Worker role
I: Using arn:aws:iam::765374464689:role/sde-1816-5-Support-Role for the Support role
? External ID (optional): 
? Operator roles prefix: gdb-49-3-w6m1
? Multiple availability zones (optional): No
? AWS region: us-east-1
? PrivateLink cluster (optional): No
? Install into an existing VPC (optional): No
? Select availability zones (optional): No
? Enable Customer Managed key (optional): No
? Compute nodes instance type: m5.xlarge
? Enable autoscaling (optional): No
? Compute nodes: 2
? Machine CIDR: 10.0.0.0/16
? Service CIDR: 172.30.0.0/16
? Pod CIDR: 10.128.0.0/14
? Host prefix: 23
? Encrypt etcd data (optional): No
? Disable Workload monitoring (optional): No
I: Creating cluster 'gdb-49-3'
I: To create this cluster again in the future, you can run:
   rosa create cluster --cluster-name gdb-49-3 --sts --mode auto --role-arn arn:aws:iam::765374464689:role/sde-1816-5-Installer-Role --support-role-arn arn:aws:iam::765374464689:role/sde-1816-5-Support-Role --controlplane-iam-role arn:aws:iam::765374464689:role/sde-1816-5-ControlPlane-Role --worker-iam-role arn:aws:iam::765374464689:role/sde-1816-5-Worker-Role --operator-roles-prefix gdb-49-3-w6m1 --region us-east-1 --version 4.9.49 --compute-nodes 2 --compute-machine-type m5.xlarge --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23
I: To view a list of clusters and their status, run 'rosa list clusters'
I: Cluster 'gdb-49-3' has been created.
I: Once the cluster is installed you will need to add an Identity Provider before you can login into the cluster. See 'rosa create idp --help' for more information.
Name:                       gdb-49-3
ID:                         1vg4mr8eh6gb6tlemh4vjcj5jt0i6nja
External ID:                
Control Plane:              Customer hosted
OpenShift Version:          
Channel Group:              stable
DNS:                        gdb-49-3.3um5.s1.devshift.org
AWS Account:                765374464689
API URL:                    
Console URL:                
Region:                     us-east-1
Multi-AZ:                   false
Nodes:
 - Control plane:           3
 - Infra:                   2
 - Compute:                 2
Network:
 - Service CIDR:            172.30.0.0/16
 - Machine CIDR:            10.0.0.0/16
 - Pod CIDR:                10.128.0.0/14
 - Host Prefix:             /23
STS Role ARN:               arn:aws:iam::765374464689:role/sde-1816-5-Installer-Role
Support Role ARN:           arn:aws:iam::765374464689:role/sde-1816-5-Support-Role
Instance IAM Roles:
 - Control plane:           arn:aws:iam::765374464689:role/sde-1816-5-ControlPlane-Role
 - Worker:                  arn:aws:iam::765374464689:role/sde-1816-5-Worker-Role
Operator IAM Roles:
 - arn:aws:iam::765374464689:role/gdb-49-3-w6m1-openshift-cluster-csi-drivers-ebs-cloud-credential
 - arn:aws:iam::765374464689:role/gdb-49-3-w6m1-openshift-machine-api-aws-cloud-credentials
 - arn:aws:iam::765374464689:role/gdb-49-3-w6m1-openshift-cloud-credential-operator-cloud-credenti
 - arn:aws:iam::765374464689:role/gdb-49-3-w6m1-openshift-image-registry-installer-cloud-credentia
 - arn:aws:iam::765374464689:role/gdb-49-3-w6m1-openshift-ingress-operator-cloud-credentials
State:                      waiting (Waiting for OIDC configuration)
Private:                    No
Created:                    Oct 21 2022 13:06:56 UTC
Details Page:               https://qaprodauth.console.redhat.com/openshift/details/s/2GRi5oVgBh5KUzAlBdhtsg5ffSI
OIDC Endpoint URL:          https://d3gt1gce2zmg3d.cloudfront.net/1vg4mr8eh6gb6tlemh4vjcj5jt0i6nja

I: Preparing to create operator roles.
? Permissions boundary ARN (optional): 
I: Creating roles using 'arn:aws:iam::765374464689:user/gbranco'
I: Created role 'gdb-49-3-w6m1-openshift-cloud-credential-operator-cloud-credenti' with ARN 'arn:aws:iam::765374464689:role/gdb-49-3-w6m1-openshift-cloud-credential-operator-cloud-credenti'
I: Created role 'gdb-49-3-w6m1-openshift-image-registry-installer-cloud-credentia' with ARN 'arn:aws:iam::765374464689:role/gdb-49-3-w6m1-openshift-image-registry-installer-cloud-credentia'
I: Created role 'gdb-49-3-w6m1-openshift-ingress-operator-cloud-credentials' with ARN 'arn:aws:iam::765374464689:role/gdb-49-3-w6m1-openshift-ingress-operator-cloud-credentials'
I: Created role 'gdb-49-3-w6m1-openshift-cluster-csi-drivers-ebs-cloud-credential' with ARN 'arn:aws:iam::765374464689:role/gdb-49-3-w6m1-openshift-cluster-csi-drivers-ebs-cloud-credential'
I: Created role 'gdb-49-3-w6m1-openshift-machine-api-aws-cloud-credentials' with ARN 'arn:aws:iam::765374464689:role/gdb-49-3-w6m1-openshift-machine-api-aws-cloud-credentials'
I: Preparing to create OIDC Provider.
I: Creating OIDC provider using 'arn:aws:iam::765374464689:user/gbranco'
I: Created OIDC provider with ARN 'arn:aws:iam::765374464689:oidc-provider/d3gt1gce2zmg3d.cloudfront.net/1vg4mr8eh6gb6tlemh4vjcj5jt0i6nja'
I: To determine when your cluster is Ready, run 'rosa describe cluster -c gdb-49-3'.
I: To watch your cluster installation logs, run 'rosa logs install -c gdb-49-3 --watch'.
```

`./rosa upgrade cluster -c gdb-49-3 --mode auto`
```
? Version: 4.10.36
I: Ensuring account and operator role policies for cluster '1vg4mr8eh6gb6tlemh4vjcj5jt0i6nja' are compatible with upgrade.
I: Starting to upgrade the policies
? Upgrade the 'sde-1816-5-Installer-Role' role policy latest version (4.11) ? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sde-1816-5-Installer-Role-Policy' to latest version
? Upgrade the 'sde-1816-5-ControlPlane-Role' role policy latest version (4.11) ? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sde-1816-5-ControlPlane-Role-Policy' to latest version
? Upgrade the 'sde-1816-5-Worker-Role' role policy latest version (4.11) ? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sde-1816-5-Worker-Role-Policy' to latest version
? Upgrade the 'sde-1816-5-Support-Role' role policy latest version (4.11) ? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sde-1816-5-Support-Role-Policy' to latest version
I: Starting to upgrade the operator IAM roles and policies
? Upgrade each operator role policy to latest version (4.11)? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sde-1816-5-openshift-ingress-operator-cloud-credentials' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sde-1816-5-openshift-cluster-csi-drivers-ebs-cloud-credentials' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sde-1816-5-openshift-cloud-network-config-controller-cloud-crede' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sde-1816-5-openshift-machine-api-aws-cloud-credentials' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sde-1816-5-openshift-cloud-credential-operator-cloud-credential-' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sde-1816-5-openshift-image-registry-installer-cloud-credentials' to version '4.11'
? Create the 'gdb-49-3-w6m1-openshift-cloud-network-config-controller-cloud-cr' role? Yes
I: Created role 'gdb-49-3-w6m1-openshift-cloud-network-config-controller-cloud-cr' with ARN 'arn:aws:iam::765374464689:role/gdb-49-3-w6m1-openshift-cloud-network-config-controller-cloud-cr'
I: Waiting for operator roles to reconcile
I: Account and operator roles for cluster 'gdb-49-3' are compatible with upgrade
? Are you sure you want to upgrade cluster to version '4.10.36'? Yes
? Please input desired date in format yyyy-mm-dd: 2022-10-21
? Please input desired UTC time in format HH:mm: 14:03
? Node draining: 1 hour
I: Upgrade successfully scheduled for cluster 'gdb-49-3'
```

`./rosa describe cluster -c gdb-49-3`
```
Name:                       gdb-49-3
ID:                         1vg4mr8eh6gb6tlemh4vjcj5jt0i6nja
External ID:                61aea6e8-0f42-4922-844d-3675062cf78c
Control Plane:              Customer hosted
OpenShift Version:          
Channel Group:              stable
DNS:                        gdb-49-3.3um5.s1.devshift.org
AWS Account:                765374464689
API URL:                    https://api.gdb-49-3.3um5.s1.devshift.org:6443
Console URL:                https://console-openshift-console.apps.gdb-49-3.3um5.s1.devshift.org
Region:                     us-east-1
Multi-AZ:                   false
Nodes:
 - Control plane:           3
 - Infra:                   2
 - Compute:                 2
Network:
 - Service CIDR:            172.30.0.0/16
 - Machine CIDR:            10.0.0.0/16
 - Pod CIDR:                10.128.0.0/14
 - Host Prefix:             /23
STS Role ARN:               arn:aws:iam::765374464689:role/sde-1816-5-Installer-Role
Support Role ARN:           arn:aws:iam::765374464689:role/sde-1816-5-Support-Role
Instance IAM Roles:
 - Control plane:           arn:aws:iam::765374464689:role/sde-1816-5-ControlPlane-Role
 - Worker:                  arn:aws:iam::765374464689:role/sde-1816-5-Worker-Role
Operator IAM Roles:
 - arn:aws:iam::765374464689:role/gdb-49-3-w6m1-openshift-cluster-csi-drivers-ebs-cloud-credential
 - arn:aws:iam::765374464689:role/gdb-49-3-w6m1-openshift-machine-api-aws-cloud-credentials
 - arn:aws:iam::765374464689:role/gdb-49-3-w6m1-openshift-cloud-credential-operator-cloud-credenti
 - arn:aws:iam::765374464689:role/gdb-49-3-w6m1-openshift-image-registry-installer-cloud-credentia
 - arn:aws:iam::765374464689:role/gdb-49-3-w6m1-openshift-ingress-operator-cloud-credentials
 - arn:aws:iam::765374464689:role/gdb-49-3-w6m1-openshift-cloud-network-config-controller-cloud-cr
State:                      ready 
Private:                    No
Created:                    Oct 21 2022 13:06:56 UTC
Details Page:               https://qaprodauth.console.redhat.com/openshift/details/s/2GRi5oVgBh5KUzAlBdhtsg5ffSI
OIDC Endpoint URL:          https://d3gt1gce2zmg3d.cloudfront.net/1vg4mr8eh6gb6tlemh4vjcj5jt0i6nja
Scheduled Upgrade:          scheduled 4.10.36 on 2022-10-21 14:03 UTC
```