### PR TITLE
[SDA-4611] Check if rosa cli is up to date

### DIFF
--- a/cmd/version/cmd.go
+++ b/cmd/version/cmd.go
@@ -17,10 +17,15 @@ limitations under the License.
 package version
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/zgalor/weberr"
 
 	"github.com/openshift/rosa/pkg/info"
 )
@@ -32,6 +37,37 @@ var Cmd = &cobra.Command{
 	Run:   run,
 }
 
+const (
+	releaseURL = "https://api.github.com/repos/openshift/rosa/releases/latest"
+)
+
 func run(cmd *cobra.Command, argv []string) {
 	fmt.Fprintf(os.Stdout, "%s\n", info.Version)
+	req, err := http.NewRequest("GET", releaseURL, nil)
+	if err != nil {
+		weberr.Errorf("Error setting up request for latest released rosa cli: %v", err)
+		os.Exit(1)
+	}
+	client := http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		weberr.Errorf("Error while requesting latest released rosa cli: %v", err)
+		os.Exit(1)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		weberr.Errorf("Error while requesting latest released rosa cli: %d %s", resp.StatusCode, resp.Status)
+		os.Exit(1)
+	}
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		weberr.Errorf("Error reading response body: %v", err)
+	}
+	result := make(map[string]interface{})
+	json.Unmarshal(respBody, &result)
+
+	if strings.Contains(result["tag_name"].(string), info.Version) {
+		fmt.Fprintf(os.Stdout, "Your ROSA CLI is up to date.\n")
+	} else {
+		fmt.Fprintf(os.Stdout, "There is a newer release version, please consider updating: %s\n", result["html_url"].(string))
+	}
 }

--- a/cmd/version/cmd.go
+++ b/cmd/version/cmd.go
@@ -39,6 +39,8 @@ var Cmd = &cobra.Command{
 
 const (
 	releaseURL = "https://api.github.com/repos/openshift/rosa/releases/latest"
+	HTML_URL   = "html_url"
+	TAG_NAME   = "tag_name"
 )
 
 func run(cmd *cobra.Command, argv []string) {
@@ -65,9 +67,10 @@ func run(cmd *cobra.Command, argv []string) {
 	result := make(map[string]interface{})
 	json.Unmarshal(respBody, &result)
 
-	if strings.Contains(result["tag_name"].(string), info.Version) {
+	if strings.Contains(result[TAG_NAME].(string), info.Version) {
 		fmt.Fprintf(os.Stdout, "Your ROSA CLI is up to date.\n")
 	} else {
-		fmt.Fprintf(os.Stdout, "There is a newer release version, please consider updating: %s\n", result["html_url"].(string))
+		fmt.Fprintf(os.Stdout, "There is a newer release version, please consider updating: %s\n",
+			result[HTML_URL].(string))
 	}
 }

--- a/cmd/version/cmd.go
+++ b/cmd/version/cmd.go
@@ -67,10 +67,12 @@ func run(cmd *cobra.Command, argv []string) {
 	result := make(map[string]interface{})
 	json.Unmarshal(respBody, &result)
 
-	if strings.Contains(result[TAG_NAME].(string), info.Version) {
-		fmt.Fprintf(os.Stdout, "Your ROSA CLI is up to date.\n")
-	} else {
-		fmt.Fprintf(os.Stdout, "There is a newer release version, please consider updating: %s\n",
-			result[HTML_URL].(string))
+	message := "Your ROSA CLI is up to date.\n"
+	if !strings.Contains(result[TAG_NAME].(string), info.Version) {
+		message = fmt.Sprintf(
+			"There is a newer release version, please consider updating: %s\n",
+			result[HTML_URL].(string),
+		)
 	}
+	fmt.Fprint(os.Stdout, message)
 }


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-4611
# What
Check if rosa version is up to date when running `rosa version`

# Why
Easier for user to check latest released version