### PR TITLE
[SDA-6936] Favor replicas instead of deprecated compute-nodes param

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2338,7 +2338,7 @@ func buildCommand(spec ocm.Spec, operatorRolesPrefix string,
 		}
 	} else {
 		if spec.ComputeNodes != 0 {
-			command += fmt.Sprintf(" --compute-nodes %d", spec.ComputeNodes)
+			command += fmt.Sprintf(" --replicas %d", spec.ComputeNodes)
 		}
 	}
 	if spec.ComputeMachineType != "" {


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-6936

# What
When creating the cluster the manual commands still list --compute-nodes instead of --replicas

# Why
-- compute nodes has been deprecated