### PR TITLE
[SDA-6920] Aws command builder

### DIFF
--- a/cmd/dlt/ocmrole/cmd.go
+++ b/cmd/dlt/ocmrole/cmd.go
@@ -20,13 +20,13 @@ package ocmrole
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/spf13/cobra"
 
 	unlinkocmrole "github.com/openshift/rosa/cmd/unlink/ocmrole"
 	"github.com/openshift/rosa/pkg/aws"
+	awscb "github.com/openshift/rosa/pkg/aws/commandbuilder"
 	"github.com/openshift/rosa/pkg/helper"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
@@ -231,14 +231,17 @@ func buildCommands(roleName string, roleARN string, isLinked bool, awsClient aws
 			return "", err
 		}
 		for _, policy := range policies {
-			detachPolicy := fmt.Sprintf("aws iam detach-role-policy \\\n"+
-				"\t--role-name %s \\\n"+
-				"\t--policy-arn %s",
-				roleName, policy.PolicyArn)
+			detachPolicy := awscb.NewIAMCommandBuilder().
+				SetCommand(awscb.DetachRolePolicy).
+				AddParam(awscb.RoleName, roleName).
+				AddParam(awscb.PolicyArn, policy.PolicyArn).
+				Build()
 			commands = append(commands, detachPolicy)
-			deletePolicy := fmt.Sprintf("aws iam delete-policy \\\n"+
-				"\t--policy-arn %s",
-				policy.PolicyArn)
+
+			deletePolicy := awscb.NewIAMCommandBuilder().
+				SetCommand(awscb.DeletePolicy).
+				AddParam(awscb.PolicyArn, policy.PolicyArn).
+				Build()
 			commands = append(commands, deletePolicy)
 		}
 
@@ -247,16 +250,19 @@ func buildCommands(roleName string, roleARN string, isLinked bool, awsClient aws
 			return "", err
 		}
 		if hasPermissionBoundary {
-			deletePermissionBoundary := fmt.Sprintf("aws iam delete-role-permissions-boundary \\\n"+
-				"\t--role-name %s",
-				roleName)
+			deletePermissionBoundary := awscb.NewIAMCommandBuilder().
+				SetCommand(awscb.DeleteRolePermissionsBoundary).
+				AddParam(awscb.RoleName, roleName).
+				Build()
 			commands = append(commands, deletePermissionBoundary)
 		}
 
-		deleteRole := fmt.Sprintf("aws iam delete-role \\\n"+
-			"\t--role-name %s", roleName)
+		deleteRole := awscb.NewIAMCommandBuilder().
+			SetCommand(awscb.DeleteRole).
+			AddParam(awscb.RoleName, roleName).
+			Build()
 		commands = append(commands, deleteRole)
 	}
 
-	return strings.Join(commands, "\n"), nil
+	return awscb.JoinCommands(commands), nil
 }

--- a/cmd/dlt/oidcprovider/cmd.go
+++ b/cmd/dlt/oidcprovider/cmd.go
@@ -22,6 +22,7 @@ import (
 	"os"
 
 	"github.com/openshift/rosa/pkg/aws"
+	awscb "github.com/openshift/rosa/pkg/aws/commandbuilder"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/ocm"
@@ -148,7 +149,8 @@ func run(cmd *cobra.Command, argv []string) {
 }
 
 func buildCommand(providerARN string) string {
-	return fmt.Sprintf("aws iam delete-open-id-connect-provider \\\n"+
-		"\t--open-id-connect-provider-arn %s \n\n",
-		providerARN)
+	return awscb.NewIAMCommandBuilder().
+		SetCommand(awscb.DeleteOpenIdConnectProvider).
+		AddParam(awscb.OpenIdConnectProviderArn, providerARN).
+		Build()
 }

--- a/cmd/dlt/operatorrole/cmd.go
+++ b/cmd/dlt/operatorrole/cmd.go
@@ -28,6 +28,7 @@ import (
 	errors "github.com/zgalor/weberr"
 
 	"github.com/openshift/rosa/pkg/aws"
+	awscb "github.com/openshift/rosa/pkg/aws/commandbuilder"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/ocm"
@@ -214,11 +215,20 @@ func buildCommand(roleNames []string, policyMap map[string][]string) string {
 		detachPolicy := ""
 		deletePolicy := ""
 		if len(policyARN) > 0 {
-			detachPolicy = fmt.Sprintf("\taws iam detach-role-policy --role-name  %s --policy-arn  %s",
-				roleName, policyARN[0])
-			deletePolicy = fmt.Sprintf("\taws iam delete-policy --policy-arn  %s", policyARN[0])
+			detachPolicy = awscb.NewIAMCommandBuilder().
+				SetCommand(awscb.DetachRolePolicy).
+				AddParam(awscb.RoleName, roleName).
+				AddParam(awscb.PolicyArn, policyARN[0]).Build()
+
+			deletePolicy = awscb.NewIAMCommandBuilder().
+				SetCommand(awscb.DeletePolicy).
+				AddParam(awscb.PolicyArn, policyARN[0]).
+				Build()
 		}
-		deleteRole := fmt.Sprintf("\taws iam delete-role --role-name  %s", roleName)
+		deleteRole := awscb.NewIAMCommandBuilder().
+			SetCommand(awscb.DeleteRole).
+			AddParam(awscb.RoleName, roleName).
+			Build()
 		commands = append(commands, detachPolicy, deleteRole, deletePolicy)
 	}
 	return strings.Join(commands, "\n")

--- a/pkg/aws/commandbuilder/commandbuilder.go
+++ b/pkg/aws/commandbuilder/commandbuilder.go
@@ -1,0 +1,122 @@
+package commandbuilder
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const ParamNewLineSeparator = " \\\n"
+
+type Service string
+
+const (
+	IAM Service = "iam"
+)
+
+type Command string
+
+const (
+	CreateRole                    Command = "create-role"
+	DeleteRole                    Command = "delete-role"
+	CreatePolicy                  Command = "create-policy"
+	DeletePolicy                  Command = "delete-policy"
+	CreatePolicyVersion           Command = "create-policy-version"
+	DeleteRolePolicy              Command = "delete-role-policy"
+	AttachRolePolicy              Command = "attach-role-policy"
+	DetachRolePolicy              Command = "detach-role-policy"
+	TagPolicy                     Command = "tag-policy"
+	TagRole                       Command = "tag-role"
+	CreateOpenIdConnectProvider   Command = "create-open-id-connect-provider"
+	DeleteOpenIdConnectProvider   Command = "delete-open-id-connect-provider"
+	DeleteRolePermissionsBoundary Command = "delete-role-permissions-boundary"
+)
+
+type Param string
+
+const (
+	Tags                     Param = "tags"
+	RoleName                 Param = "role-name"
+	AssumeRolePolicyDocument Param = "assume-role-policy-document"
+	PermissionsBoundary      Param = "permissions-boundary"
+	Path                     Param = "path"
+	PolicyName               Param = "policy-name"
+	PolicyDocument           Param = "policy-document"
+	PolicyArn                Param = "policy-arn"
+	Url                      Param = "url"
+	ClientIdList             Param = "client-id-list"
+	ThumbprintList           Param = "thumbprint-list"
+	OpenIdConnectProviderArn Param = "open-id-connect-provider-arn"
+	SetAsDefault             Param = "set-as-default"
+)
+
+type CommandBuilder struct {
+	service Service
+	command Command
+	params  []string
+	tags    map[string]string
+}
+
+func (b *CommandBuilder) SetService(awsService Service) *CommandBuilder {
+	b.service = awsService
+	return b
+}
+
+func (b *CommandBuilder) SetCommand(awsCommand Command) *CommandBuilder {
+	b.command = awsCommand
+	return b
+}
+
+func (b *CommandBuilder) AddParam(awsParam Param, value string) *CommandBuilder {
+	if value != "" {
+		b.params = append(b.params, createParamString(awsParam, value))
+	}
+	return b
+}
+
+func (b *CommandBuilder) AddTags(value map[string]string) *CommandBuilder {
+	for k, v := range value {
+		b.tags[k] = v
+	}
+	return b
+}
+
+func (b *CommandBuilder) AddParamNoValue(awsParam Param) *CommandBuilder {
+	b.params = append(b.params, fmt.Sprintf("\t--%s", awsParam))
+	return b
+}
+
+func (b *CommandBuilder) Build() string {
+	if len(b.tags) != 0 {
+		b.AddParam(Tags, createTags(b.tags))
+	}
+	sort.Strings(b.params)
+	return fmt.Sprintf(
+		"aws %s %s%s%s",
+		b.service,
+		b.command,
+		ParamNewLineSeparator,
+		strings.Join(b.params, ParamNewLineSeparator),
+	)
+}
+
+func NewIAMCommandBuilder() *CommandBuilder {
+	return &CommandBuilder{service: IAM}
+}
+
+func createParamString(awsParam Param, value string) string {
+	return fmt.Sprintf("\t--%s %s", awsParam, value)
+}
+
+func createTags(m map[string]string) string {
+	keys := make([]string, 0, len(m))
+	for k, v := range m {
+		keys = append(keys, fmt.Sprintf("Key=%s,Value=%s", k, v))
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, " ")
+}
+
+func JoinCommands(commands []string) string {
+	return strings.Join(commands, "\n\n")
+}

--- a/pkg/aws/sts.go
+++ b/pkg/aws/sts.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	awscb "github.com/openshift/rosa/pkg/aws/commandbuilder"
 
 	"github.com/openshift/rosa/pkg/aws/tags"
 	rprtr "github.com/openshift/rosa/pkg/reporter"
@@ -175,36 +176,38 @@ func BuildOperatorRoleCommands(prefix string, accountID string, awsClient Client
 		_, err := awsClient.IsPolicyExists(policyARN)
 		if err != nil {
 			name := GetPolicyName(prefix, operator.Namespace(), operator.Name())
-			iamTags := fmt.Sprintf(
-				"Key=%s,Value=%s Key=%s,Value=%s Key=%s,Value=%s Key=%s,Value=%s",
-				tags.OpenShiftVersion, defaultPolicyVersion,
-				tags.RolePrefix, prefix,
-				"operator_namespace", operator.Namespace(),
-				"operator_name", operator.Name(),
-			)
-			createPolicy := fmt.Sprintf("aws iam create-policy \\\n"+
-				"\t--policy-name %s \\\n"+
-				"\t--policy-document file://openshift_%s_policy.json \\\n"+
-				"\t--tags %s",
-				name, credrequest, iamTags)
-			if policyPath != "" {
-				createPolicy = fmt.Sprintf(createPolicy+" \\\n\t--path %s", policyPath)
+			iamTags := map[string]string{
+				tags.OpenShiftVersion:  defaultPolicyVersion,
+				tags.RolePrefix:        prefix,
+				tags.OperatorNamespace: operator.Namespace(),
+				tags.OperatorName:      operator.Name(),
+				tags.RedHatManaged:     "true",
 			}
+			createPolicy := awscb.NewIAMCommandBuilder().
+				SetCommand(awscb.CreatePolicy).
+				AddParam(awscb.PolicyName, name).
+				AddParam(awscb.PolicyDocument, fmt.Sprintf("file://openshift_%s_policy.json", credrequest)).
+				AddTags(iamTags).
+				AddParam(awscb.Path, policyPath).
+				Build()
 			commands = append(commands, createPolicy)
 		} else {
-			policTags := fmt.Sprintf(
-				"Key=%s,Value=%s",
-				tags.OpenShiftVersion, defaultPolicyVersion,
-			)
-			createPolicy := fmt.Sprintf("aws iam create-policy-version \\\n"+
-				"\t--policy-arn %s \\\n"+
-				"\t--policy-document file://openshift_%s_policy.json \\\n"+
-				"\t--set-as-default",
-				policyARN, credrequest)
-			tagPolicy := fmt.Sprintf("aws iam tag-policy \\\n"+
-				"\t--tags %s \\\n"+
-				"\t--policy-arn %s",
-				policTags, policyARN)
+			policyTags := map[string]string{
+				tags.OpenShiftVersion: defaultPolicyVersion,
+			}
+
+			createPolicy := awscb.NewIAMCommandBuilder().
+				SetCommand(awscb.CreatePolicyVersion).
+				AddParam(awscb.PolicyArn, policyARN).
+				AddParam(awscb.PolicyDocument, fmt.Sprintf("file://openshift_%s_policy.json", credrequest)).
+				AddParamNoValue(awscb.SetAsDefault).
+				Build()
+
+			tagPolicy := awscb.NewIAMCommandBuilder().
+				SetCommand(awscb.TagPolicy).
+				AddTags(policyTags).
+				AddParam(awscb.PolicyArn, policyARN).
+				Build()
 			commands = append(commands, createPolicy, tagPolicy)
 		}
 	}

--- a/pkg/aws/tags/tags.go
+++ b/pkg/aws/tags/tags.go
@@ -49,3 +49,7 @@ const AdminRole = prefix + "admin_role"
 
 // RedHatManaged tags the role as red_hat_managed
 const RedHatManaged = "red-hat-managed"
+
+const OperatorNamespace = "operator_namespace"
+
+const OperatorName = "operator_name"


### PR DESCRIPTION
Related issues: https://issues.redhat.com/browse/SDA-6920
# What
Share behavior for constructing manual aws commands.

# Why
From time to time we change the manual commands, adding or removing parameter. This can cause differences on how they behave throughout each rosa command.

# After Changes example output
`rosa create account-roles --mode manual --prefix=gdb-path --path /gdbsts/ --version=4.9 -y`
```
I: Logged in as 'gbranco.openshift' on 'https://api.stage.openshift.com'
I: Validating AWS credentials...
I: AWS credentials are valid!
I: Validating AWS quota...
I: AWS quota ok. If cluster installation fails, validate actual AWS resource usage against https://docs.openshift.com/rosa/rosa_getting_started/rosa-required-aws-service-quotas.html
I: Verifying whether OpenShift command-line tool is available...
I: Current OpenShift Client Version: 4.11.2
I: Creating account roles
I: All policy files saved to the current directory
I: Run the following commands to create the account roles and policies:

aws iam create-role \
	--assume-role-policy-document file://sts_installer_trust_policy.json \
	--path /gdbsts/ \
	--role-name gdb-path-Installer-Role \
	--tags Key=red-hat-managed,Value=true Key=rosa_openshift_version,Value=4.9 Key=rosa_role_prefix,Value=gdb-path Key=rosa_role_type,Value=installer

aws iam create-policy \
	--path /gdbsts/ \
	--policy-document file://sts_installer_permission_policy.json \
	--policy-name gdb-path-Installer-Role-Policy \
	--tags Key=red-hat-managed,Value=true Key=rosa_openshift_version,Value=4.9 Key=rosa_role_prefix,Value=gdb-path Key=rosa_role_type,Value=installer

aws iam attach-role-policy \
	--policy-arn arn:aws:iam::765374464689:policy/gdbsts/gdb-path-Installer-Role-Policy \
	--role-name gdb-path-Installer-Role

aws iam create-role \
	--assume-role-policy-document file://sts_instance_controlplane_trust_policy.json \
	--path /gdbsts/ \
	--role-name gdb-path-ControlPlane-Role \
	--tags Key=red-hat-managed,Value=true Key=rosa_openshift_version,Value=4.9 Key=rosa_role_prefix,Value=gdb-path Key=rosa_role_type,Value=instance_controlplane

aws iam create-policy \
	--path /gdbsts/ \
	--policy-document file://sts_instance_controlplane_permission_policy.json \
	--policy-name gdb-path-ControlPlane-Role-Policy \
	--tags Key=red-hat-managed,Value=true Key=rosa_openshift_version,Value=4.9 Key=rosa_role_prefix,Value=gdb-path Key=rosa_role_type,Value=instance_controlplane

aws iam attach-role-policy \
	--policy-arn arn:aws:iam::765374464689:policy/gdbsts/gdb-path-ControlPlane-Role-Policy \
	--role-name gdb-path-ControlPlane-Role

aws iam create-role \
	--assume-role-policy-document file://sts_instance_worker_trust_policy.json \
	--path /gdbsts/ \
	--role-name gdb-path-Worker-Role \
	--tags Key=red-hat-managed,Value=true Key=rosa_openshift_version,Value=4.9 Key=rosa_role_prefix,Value=gdb-path Key=rosa_role_type,Value=instance_worker

aws iam create-policy \
	--path /gdbsts/ \
	--policy-document file://sts_instance_worker_permission_policy.json \
	--policy-name gdb-path-Worker-Role-Policy \
	--tags Key=red-hat-managed,Value=true Key=rosa_openshift_version,Value=4.9 Key=rosa_role_prefix,Value=gdb-path Key=rosa_role_type,Value=instance_worker

aws iam attach-role-policy \
	--policy-arn arn:aws:iam::765374464689:policy/gdbsts/gdb-path-Worker-Role-Policy \
	--role-name gdb-path-Worker-Role

aws iam create-role \
	--assume-role-policy-document file://sts_support_trust_policy.json \
	--path /gdbsts/ \
	--role-name gdb-path-Support-Role \
	--tags Key=red-hat-managed,Value=true Key=rosa_openshift_version,Value=4.9 Key=rosa_role_prefix,Value=gdb-path Key=rosa_role_type,Value=support

aws iam create-policy \
	--path /gdbsts/ \
	--policy-document file://sts_support_permission_policy.json \
	--policy-name gdb-path-Support-Role-Policy \
	--tags Key=red-hat-managed,Value=true Key=rosa_openshift_version,Value=4.9 Key=rosa_role_prefix,Value=gdb-path Key=rosa_role_type,Value=support

aws iam attach-role-policy \
	--policy-arn arn:aws:iam::765374464689:policy/gdbsts/gdb-path-Support-Role-Policy \
	--role-name gdb-path-Support-Role
```