### PR TITLE
[SDA-6857] Labels & taints strings containing only quotes ("""") are set to empty string

### DIFF
--- a/pkg/interactive/interactive.go
+++ b/pkg/interactive/interactive.go
@@ -40,6 +40,7 @@ type Input struct {
 
 // Gets string input from the command line
 func GetString(input Input) (a string, err error) {
+	transformer := survey.TransformString(toEmptyString)
 	core.DisableColor = !color.UseColor()
 	dflt, ok := input.Default.(string)
 	if !ok {
@@ -58,6 +59,7 @@ func GetString(input Input) (a string, err error) {
 		input.Validators = append([]Validator{required}, input.Validators...)
 	}
 	err = survey.AskOne(prompt, &a, survey.WithValidator(compose(input.Validators)))
+	a = transformer(a).(string)
 	return
 }
 
@@ -295,6 +297,13 @@ func GetCert(input Input) (a string, err error) {
 	}
 	err = survey.AskOne(prompt, &a, survey.WithValidator(compose(input.Validators)), survey.WithValidator(IsCert))
 	return
+}
+
+func toEmptyString(input string) string {
+	if input == "\"\"" {
+		input = ""
+	}
+	return input
 }
 
 var helpTemplate = `{{color "cyan"}}? {{.Message}}


### PR DESCRIPTION
This change was brought about because you cannot set labels to an empty string (which is supposed to mean no labels) in interactive mode. When  you set the labels to `""` in interactive mode, the CLI thinks you are entering `""""` and does not work as expected.

This change just sets a string containing two quotes to an empty string to fix this problem.