### PR TITLE
add `--yes` to create cluster cmd

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -544,6 +544,7 @@ func init() {
 	aws.AddModeFlag(Cmd)
 	interactive.AddFlag(flags)
 	output.AddFlag(Cmd)
+	confirm.AddFlag(flags)
 }
 
 func networkTypeCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {


### PR DESCRIPTION
Allow for passing `--yes` to `create cluster` which gets passed down the
the operator-roles and oidc-provider create commands, blocking on a
prompt otherwise.

resolves #914

Signed-off-by: Brady Pratt <bpratt@redhat.com>
