### PR TITLE
Create/oidcprovider bug sets interactive.Enable

### DIFF
--- a/cmd/create/oidcprovider/cmd.go
+++ b/cmd/create/oidcprovider/cmd.go
@@ -84,7 +84,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// Determine if interactive mode is needed
-	if !interactive.Enabled() && !cmd.Flags().Changed("mode") {
+	if !interactive.Enabled() && !cmd.Flags().Changed("mode") && !skipInteractive {
 		interactive.Enable()
 	}
 


### PR DESCRIPTION
For context:
https://coreos.slack.com/archives/CB53T9ZHQ/p1667278725525159

While working through a pipeline setup I noticed rosa was setting the interactive.Enabled() to true even while passing args:
"--mode auto --yes" 

Root caused this to the oidcProvider missing a check for the skipInteractive condition. 