### PR TITLE
fix: add tags check when b.tags nil

### DIFF
--- a/pkg/aws/commandbuilder/commandbuilder.go
+++ b/pkg/aws/commandbuilder/commandbuilder.go
@@ -75,6 +75,9 @@ func (b *CommandBuilder) AddParam(awsParam Param, value string) *CommandBuilder 
 }
 
 func (b *CommandBuilder) AddTags(value map[string]string) *CommandBuilder {
+	if b.tags == nil {
+		b.tags = make(map[string]string, len(value))
+	}
 	for k, v := range value {
 		b.tags[k] = v
 	}


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-7178
# What
Map was not being setup before use

# Why
go panics when trying to assign an entry to nil map