### PR TITLE
[SDA-6443] Message deprecation non sts (legacy iam creds)

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -680,7 +680,7 @@ func run(cmd *cobra.Command, _ []string) {
 		r.Reporter.Warnf("--sts flag won't be necessary.")
 	}
 
-	if r.Reporter.IsTerminal() && (cmd.Flags().Changed("non-sts") || cmd.Flags().Changed("mint-mode")) {
+	if r.Reporter.IsTerminal() && (cmd.Flags().Changed("non-sts") || cmd.Flags().Changed("mint-mode") || !cmd.Flags().Changed("sts")) {
 		r.Reporter.Warnf("--non-sts/--mint-mode flag will be necessary in a future release if you do not wish to use STS.")
 	}
 

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -112,6 +112,9 @@ var args struct {
 	// Force STS mode for interactive and validation
 	sts bool
 
+	// Force IAM mode (mint mode) for interactive
+	nonSts bool
+
 	// Account IAM Roles
 	roleARN             string
 	externalID          string
@@ -175,6 +178,18 @@ func init() {
 		"sts",
 		false,
 		"Use AWS Security Token Service (STS) instead of IAM credentials to deploy your cluster.",
+	)
+	flags.BoolVar(
+		&args.nonSts,
+		"non-sts",
+		false,
+		"Use legacy method of creating clusters (IAM mode).",
+	)
+	flags.BoolVar(
+		&args.nonSts,
+		"mint-mode",
+		false,
+		"Use legacy method of creating clusters (IAM mode). This is an alias for --non-sts.",
 	)
 	flags.StringVar(
 		&args.roleARN,
@@ -659,6 +674,15 @@ func run(cmd *cobra.Command, _ []string) {
 	workerRoleARN := args.workerRoleARN
 
 	isSTS = isSTS || awsCreator.IsSTS
+
+	r.Reporter.Warnf("In a future release STS will be the default mode.")
+	if cmd.Flags().Changed("sts") && r.Reporter.IsTerminal() {
+		r.Reporter.Warnf("This flag won't be necessary.")
+	}
+
+	if r.Reporter.IsTerminal() && (cmd.Flags().Changed("non-sts") || cmd.Flags().Changed("mint-mode")) {
+		r.Reporter.Warnf("This flag will be necessary in a future release if you do not wish to use STS.")
+	}
 
 	// OpenShift version:
 	version := args.version

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -677,11 +677,11 @@ func run(cmd *cobra.Command, _ []string) {
 
 	r.Reporter.Warnf("In a future release STS will be the default mode.")
 	if cmd.Flags().Changed("sts") && r.Reporter.IsTerminal() {
-		r.Reporter.Warnf("This flag won't be necessary.")
+		r.Reporter.Warnf("--sts flag won't be necessary.")
 	}
 
 	if r.Reporter.IsTerminal() && (cmd.Flags().Changed("non-sts") || cmd.Flags().Changed("mint-mode")) {
-		r.Reporter.Warnf("This flag will be necessary in a future release if you do not wish to use STS.")
+		r.Reporter.Warnf("--non-sts/--mint-mode flag will be necessary in a future release if you do not wish to use STS.")
 	}
 
 	// OpenShift version:

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -676,11 +676,11 @@ func run(cmd *cobra.Command, _ []string) {
 	isSTS = isSTS || awsCreator.IsSTS
 
 	r.Reporter.Warnf("In a future release STS will be the default mode.")
-	if cmd.Flags().Changed("sts") && r.Reporter.IsTerminal() {
+	if (isSTS || cmd.Flags().Changed("sts")) && r.Reporter.IsTerminal() {
 		r.Reporter.Warnf("--sts flag won't be necessary.")
 	}
 
-	if r.Reporter.IsTerminal() && (cmd.Flags().Changed("non-sts") || cmd.Flags().Changed("mint-mode") || !cmd.Flags().Changed("sts")) {
+	if !isSTS && r.Reporter.IsTerminal() && (cmd.Flags().Changed("non-sts") || cmd.Flags().Changed("mint-mode") || !cmd.Flags().Changed("sts")) {
 		r.Reporter.Warnf("--non-sts/--mint-mode flag will be necessary in a future release if you do not wish to use STS.")
 	}
 

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -675,13 +675,15 @@ func run(cmd *cobra.Command, _ []string) {
 
 	isSTS = isSTS || awsCreator.IsSTS
 
-	r.Reporter.Warnf("In a future release STS will be the default mode.")
-	if (isSTS || cmd.Flags().Changed("sts")) && r.Reporter.IsTerminal() {
-		r.Reporter.Warnf("--sts flag won't be necessary.")
-	}
+	if r.Reporter.IsTerminal() {
+		r.Reporter.Warnf("In a future release STS will be the default mode.")
+		if isSTS || cmd.Flags().Changed("sts") {
+			r.Reporter.Warnf("--sts flag won't be necessary.")
+		}
 
-	if !isSTS && r.Reporter.IsTerminal() && (cmd.Flags().Changed("non-sts") || cmd.Flags().Changed("mint-mode") || !cmd.Flags().Changed("sts")) {
-		r.Reporter.Warnf("--non-sts/--mint-mode flag will be necessary in a future release if you do not wish to use STS.")
+		if !isSTS && (cmd.Flags().Changed("non-sts") || cmd.Flags().Changed("mint-mode") || !cmd.Flags().Changed("sts")) {
+			r.Reporter.Warnf("--non-sts/--mint-mode flag will be necessary in a future release if you do not wish to use STS.")
+		}
 	}
 
 	// OpenShift version:


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-6643


# Changes
`rosa create cluster --sts --mode auto`
```
I: Enabling interactive mode
? Cluster name: test
W: In a future release STS will be the default mode.
W: --sts flag won't be necessary.
```

`rosa create cluster --mode auto`
```
I: Enabling interactive mode
? Cluster name: test
? Deploy cluster using AWS STS: No
W: In a future release STS will be the default mode.
W: --non-sts/--mint-mode flag will be necessary in a future release if you do not wish to use STS.
```