### PR TITLE
Create machinepool - filter supported instances by availability zones

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1523,7 +1523,8 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 	// Compute node instance type:
 	computeMachineType := args.computeMachineType
-	computeMachineTypeList, err := r.OCMClient.GetAvailableMachineTypesInRegion(region, roleARN, awsClient)
+	computeMachineTypeList, err := r.OCMClient.GetAvailableMachineTypesInRegion(region, availabilityZones, roleARN,
+		awsClient)
 	if err != nil {
 		r.Reporter.Errorf(fmt.Sprintf("%s", err))
 		os.Exit(1)

--- a/pkg/ocm/machines.go
+++ b/pkg/ocm/machines.go
@@ -118,11 +118,14 @@ func (mt MachineType) HasQuota(multiAZ bool) bool {
 // GetAvailableMachineTypesInRegion get the supported machine type in the region.
 // The function triggers the 'api/clusters_mgmt/v1/aws_inquiries/machine_types'
 // and passes a role ARN for STS clusters or access keys for non-STS clusters.
-func (c *Client) GetAvailableMachineTypesInRegion(region string, roleARN string,
+func (c *Client) GetAvailableMachineTypesInRegion(region string, availabilityZones []string, roleARN string,
 	awsClient aws.Client) (MachineTypeList, error) {
 	cloudProviderDataBuilder, err := c.createCloudProviderDataBuilder(roleARN, awsClient, "")
 	if err != nil {
 		return MachineTypeList{}, err
+	}
+	if len(availabilityZones) > 0 {
+		cloudProviderDataBuilder = cloudProviderDataBuilder.AvailabilityZones(availabilityZones...)
 	}
 	cloudProviderData, err := cloudProviderDataBuilder.Region(cmv1.NewCloudRegion().ID(region)).Build()
 	if err != nil {


### PR DESCRIPTION
Pass the availability zones to the OCM client to filter supported instances.

Related: [SDA-7160](https://issues.redhat.com/browse/SDA-7160)

![image](https://user-images.githubusercontent.com/57869309/200862540-275623a3-6723-4a81-a1f9-9e5a3e1ae6ba.png)
![image](https://user-images.githubusercontent.com/57869309/200862862-6a082c2f-158e-4485-a11e-cc7db6798705.png)
