### PR TITLE
[SDA-7003] Block --watch when on manual mode for creating cluster

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -807,8 +807,16 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	if args.watch && isSTS && mode == aws.ModeAuto && !confirm.Yes() {
-		r.Reporter.Errorf("Cannot watch for STS cluster installation logs in mode 'auto'." +
+		r.Reporter.Errorf("Cannot watch for STS cluster installation logs in mode 'auto' " +
+			"without also supplying '--yes' option." +
 			"To watch your cluster installation logs, run 'rosa logs install' instead after the cluster has began creating.")
+		os.Exit(1)
+	}
+
+	if args.watch && isSTS && mode == aws.ModeManual {
+		r.Reporter.Errorf("Cannot watch for STS cluster installation logs in mode 'manual'." +
+			"It requires manual commands to be performed as part of the process." +
+			"To watch your cluster installation logs, run 'rosa logs install' after the cluster has began creating.")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-7003

# What
Block watch param when on manual mode for creating cluster

# Why
User need to input outputted commands so we can't watch

# Changes
`rosa create cluster --sts --mode=manual --yes --watch`
```
I: Enabling interactive mode
? Cluster name: asd
W: In a future release STS will be the default mode.
W: --sts flag won't be necessary.
? OpenShift version: 4.11.12
E: Cannot watch in mode 'manual' since the user will need to run outputted commands.
```