### PR TITLE
Add channel group and option to choose version for policy tags in upgrade roles cmd

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -169,7 +169,7 @@ func run(cmd *cobra.Command, argv []string) {
 
 	version := args.version
 	channelGroup := args.channelGroup
-	policyVersion, err := r.OCMClient.GetVersion(version, channelGroup)
+	policyVersion, err := r.OCMClient.GetPolicyVersion(version, channelGroup)
 	if err != nil {
 		r.Reporter.Errorf("Error getting version: %s", err)
 		os.Exit(1)

--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -105,7 +105,7 @@ func run(cmd *cobra.Command, argv []string) error {
 	version := args.version
 	isVersionChosen := version != ""
 	channelGroup := args.channelGroup
-	policyVersion, err := ocmClient.GetVersion(version, channelGroup)
+	policyVersion, err := ocmClient.GetPolicyVersion(version, channelGroup)
 	if err != nil {
 		reporter.Errorf("Error getting version: %s", err)
 		os.Exit(1)

--- a/cmd/upgrade/cluster/cmd.go
+++ b/cmd/upgrade/cluster/cmd.go
@@ -155,7 +155,6 @@ func run(cmd *cobra.Command, _ []string) {
 		r.Reporter.Warnf("There are no available upgrades")
 		os.Exit(0)
 	}
-
 	if version == "" || interactive.Enabled() {
 		if version == "" {
 			version = availableUpgrades[0]
@@ -172,26 +171,10 @@ func run(cmd *cobra.Command, _ []string) {
 			os.Exit(1)
 		}
 	}
-	clusterVersion := cluster.OpenshiftVersion()
-	if clusterVersion == "" {
-		clusterVersion = cluster.Version().RawID()
-	}
-	// Check that the version is valid
-	validVersion := false
-	for _, v := range availableUpgrades {
 
-		isValidVersion, err := ocm.IsValidVersion(version, v, clusterVersion)
-		if err != nil {
-			r.Reporter.Errorf("Error validating the version")
-			os.Exit(1)
-		}
-		if isValidVersion {
-			validVersion = true
-			break
-		}
-	}
-	if !validVersion {
-		r.Reporter.Errorf("Expected a valid version to upgrade to")
+	err = r.OCMClient.CheckUpgradeClusterVersion(availableUpgrades, version, cluster)
+	if err != nil {
+		r.Reporter.Errorf("%v", err)
 		os.Exit(1)
 	}
 

--- a/pkg/aws/commandbuilder/commandbuilder.go
+++ b/pkg/aws/commandbuilder/commandbuilder.go
@@ -129,7 +129,13 @@ func createTags(m map[string]string) string {
 	for k, v := range m {
 		keys = append(keys, fmt.Sprintf("Key=%s,Value=%s", k, v))
 	}
-	sort.Strings(keys)
+	sort.Slice(keys, func(i, j int) bool {
+		l1, l2 := len(keys[i]), len(keys[j])
+		if l1 != l2 {
+			return l1 < l2
+		}
+		return keys[i] < keys[j]
+	})
 	return strings.Join(keys, " ")
 }
 

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -4,6 +4,7 @@ import (
 	"math/rand"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/briandowns/spinner"
@@ -82,6 +83,32 @@ func SliceToMap(s []string) map[string]bool {
 	}
 
 	return m
+}
+
+func SliceToString(s []string) string {
+	sort.Slice(s, func(i, j int) bool {
+		l1, l2 := len(s[i]), len(s[j])
+		if l1 != l2 {
+			return l1 < l2
+		}
+		return s[i] < s[j]
+	})
+	return "[" + strings.Join(s, ", ") + "]"
+}
+
+func MapKeysToString(m map[string]bool) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		l1, l2 := len(keys[i]), len(keys[j])
+		if l1 != l2 {
+			return l1 < l2
+		}
+		return keys[i] < keys[j]
+	})
+	return "[" + strings.Join(keys, ", ") + "]"
 }
 
 // RemoveStrFromSlice removes one occurrence of 'str' from the 's' slice if exists.


### PR DESCRIPTION
# What
User couldn't upgrade roles to tag policies with the nightly release

# Why
Allow option to choose nightly channel group when upgrading policy tags