### PR TITLE
Using aws helper ARNValidator instead of arn Parse when parsed arn is not used

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -21,8 +21,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws/arn"
-	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/cmd/login"
@@ -35,6 +33,8 @@ import (
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
 var args struct {
@@ -237,8 +237,9 @@ func run(cmd *cobra.Command, argv []string) {
 			os.Exit(1)
 		}
 	}
+
 	if permissionsBoundary != "" {
-		_, err := arn.Parse(permissionsBoundary)
+		err = aws.ARNValidator(permissionsBoundary)
 		if err != nil {
 			r.Reporter.Errorf("Expected a valid policy ARN for permissions boundary: %s", err)
 			os.Exit(1)

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	awssdk "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/arn"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/rosa/cmd/create/machinepool"
 	"github.com/spf13/cobra"
@@ -678,7 +677,7 @@ func run(cmd *cobra.Command, _ []string) {
 
 	permissionsBoundary := args.operatorRolesPermissionsBoundary
 	if permissionsBoundary != "" {
-		_, err := arn.Parse(permissionsBoundary)
+		err = aws.ARNValidator(permissionsBoundary)
 		if err != nil {
 			r.Reporter.Errorf("Expected a valid policy ARN for permissions boundary: %s", err)
 			os.Exit(1)
@@ -883,8 +882,9 @@ func run(cmd *cobra.Command, _ []string) {
 			os.Exit(1)
 		}
 	}
+
 	if roleARN != "" {
-		_, err = arn.Parse(roleARN)
+		err = aws.ARNValidator(roleARN)
 		if err != nil {
 			r.Reporter.Errorf("Expected a valid Role ARN: %s", err)
 			os.Exit(1)
@@ -932,7 +932,7 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 	}
 	if supportRoleARN != "" {
-		_, err = arn.Parse(supportRoleARN)
+		err = aws.ARNValidator(supportRoleARN)
 		if err != nil {
 			r.Reporter.Errorf("Expected a valid Support Role ARN: %s", err)
 			os.Exit(1)
@@ -965,7 +965,7 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 	}
 	if controlPlaneRoleARN != "" {
-		_, err = arn.Parse(controlPlaneRoleARN)
+		err = aws.ARNValidator(controlPlaneRoleARN)
 		if err != nil {
 			r.Reporter.Errorf("Expected a valid control plane instance IAM role ARN: %s", err)
 			os.Exit(1)
@@ -991,7 +991,7 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 	}
 	if workerRoleARN != "" {
-		_, err = arn.Parse(workerRoleARN)
+		err = aws.ARNValidator(workerRoleARN)
 		if err != nil {
 			r.Reporter.Errorf("Expected a valid worker instance IAM role ARN: %s", err)
 			os.Exit(1)

--- a/cmd/create/ocmrole/cmd.go
+++ b/cmd/create/ocmrole/cmd.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/aws/aws-sdk-go/aws/arn"
-	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
 	linkocmrole "github.com/openshift/rosa/cmd/link/ocmrole"
@@ -33,6 +31,8 @@ import (
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
 var args struct {
@@ -172,8 +172,9 @@ func run(cmd *cobra.Command, argv []string) {
 			os.Exit(1)
 		}
 	}
+
 	if permissionsBoundary != "" {
-		_, err := arn.Parse(permissionsBoundary)
+		err = aws.ARNValidator(permissionsBoundary)
 		if err != nil {
 			r.Reporter.Errorf("Expected a valid policy ARN for permissions boundary: %s", err)
 			os.Exit(1)

--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws/arn"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
@@ -154,8 +153,9 @@ func run(cmd *cobra.Command, argv []string) {
 			os.Exit(1)
 		}
 	}
+
 	if permissionsBoundary != "" {
-		_, err := arn.Parse(permissionsBoundary)
+		err = aws.ARNValidator(permissionsBoundary)
 		if err != nil {
 			r.Reporter.Errorf("Expected a valid policy ARN for permissions boundary: %s", err)
 			os.Exit(1)

--- a/cmd/create/userrole/cmd.go
+++ b/cmd/create/userrole/cmd.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/aws/aws-sdk-go/aws/arn"
-	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
 	linkuser "github.com/openshift/rosa/cmd/link/userrole"
@@ -34,6 +32,8 @@ import (
 	"github.com/openshift/rosa/pkg/ocm"
 	rprtr "github.com/openshift/rosa/pkg/reporter"
 	"github.com/openshift/rosa/pkg/rosa"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
 var args struct {
@@ -148,8 +148,9 @@ func run(cmd *cobra.Command, argv []string) {
 			os.Exit(1)
 		}
 	}
+
 	if permissionsBoundary != "" {
-		_, err := arn.Parse(permissionsBoundary)
+		err = aws.ARNValidator(permissionsBoundary)
 		if err != nil {
 			r.Reporter.Errorf("Expected a valid policy ARN for permissions boundary: %s", err)
 			os.Exit(1)

--- a/cmd/dlt/ocmrole/cmd.go
+++ b/cmd/dlt/ocmrole/cmd.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/spf13/cobra"
 
 	unlinkocmrole "github.com/openshift/rosa/cmd/unlink/ocmrole"
@@ -113,7 +112,7 @@ func run(cmd *cobra.Command, argv []string) error {
 		}
 	}
 
-	_, err = arn.Parse(roleARN)
+	err = aws.ARNValidator(roleARN)
 	if err != nil {
 		r.Reporter.Errorf("Expected a valid ocm role ARN to delete from the current organization: %s", err)
 		os.Exit(1)

--- a/cmd/dlt/userrole/cmd.go
+++ b/cmd/dlt/userrole/cmd.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/spf13/cobra"
 
 	unlinkuserrole "github.com/openshift/rosa/cmd/unlink/userrole"
@@ -101,7 +100,7 @@ func run(cmd *cobra.Command, argv []string) {
 		}
 	}
 
-	_, err = arn.Parse(roleARN)
+	err = aws.ARNValidator(roleARN)
 	if err != nil {
 		r.Reporter.Errorf("Expected a valid user role ARN to delete from the current AWS account: %s", err)
 		os.Exit(1)

--- a/cmd/link/ocmrole/cmd.go
+++ b/cmd/link/ocmrole/cmd.go
@@ -17,7 +17,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/spf13/cobra"
 	errors "github.com/zgalor/weberr"
 
@@ -109,7 +108,7 @@ func run(cmd *cobra.Command, argv []string) (err error) {
 		}
 	}
 	if roleArn != "" {
-		_, err := arn.Parse(roleArn)
+		err = aws.ARNValidator(roleArn)
 		if err != nil {
 			r.Reporter.Errorf("Expected a valid ocm role ARN to link to a current organization: %s", err)
 			os.Exit(1)

--- a/cmd/link/userrole/cmd.go
+++ b/cmd/link/userrole/cmd.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/spf13/cobra"
 	errors "github.com/zgalor/weberr"
 
@@ -109,7 +108,7 @@ func run(cmd *cobra.Command, argv []string) (err error) {
 		}
 	}
 	if roleArn != "" {
-		_, err := arn.Parse(roleArn)
+		err = aws.ARNValidator(roleArn)
 		if err != nil {
 			r.Reporter.Errorf("Expected a valid user role ARN to link to a current account: %s", err)
 			os.Exit(1)

--- a/cmd/unlink/ocmrole/cmd.go
+++ b/cmd/unlink/ocmrole/cmd.go
@@ -17,7 +17,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/spf13/cobra"
 	errors "github.com/zgalor/weberr"
 
@@ -108,7 +107,7 @@ func run(cmd *cobra.Command, argv []string) (err error) {
 		}
 	}
 	if roleArn != "" {
-		_, err := arn.Parse(roleArn)
+		err = aws.ARNValidator(roleArn)
 		if err != nil {
 			r.Reporter.Errorf("Expected a valid ocm role ARN to unlink from the current organization: %s", err)
 			os.Exit(1)

--- a/cmd/unlink/userrole/cmd.go
+++ b/cmd/unlink/userrole/cmd.go
@@ -17,7 +17,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/spf13/cobra"
 	errors "github.com/zgalor/weberr"
 
@@ -107,7 +106,7 @@ func run(cmd *cobra.Command, argv []string) (err error) {
 		}
 	}
 	if roleArn != "" {
-		_, err := arn.Parse(roleArn)
+		err = aws.ARNValidator(roleArn)
 		if err != nil {
 			r.Reporter.Errorf("Expected a valid user role ARN to unlink from the current account: %s", err)
 			os.Exit(1)

--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -223,7 +223,7 @@ func resolveSTSRole(ARN arn.ARN) (*string, error) {
 		roleARNString := fmt.Sprintf(
 			"arn:%s:iam::%s:role/%s", ARN.Partition, ARN.AccountID, resource[parentResource])
 		// Parse it to validate its ok
-		_, err := arn.Parse(roleARNString)
+		err := ARNValidator(roleARNString)
 		if err != nil {
 			return nil, fmt.Errorf("Unable to parse role ARN %s created from sts role: %v", roleARNString, err)
 		}


### PR DESCRIPTION
# What
Lots of code sections were using arn.Parse instead of the aws.ARNValidator when only validation was needed and parsed ARN was not used subsequently

# Why
Unifies calls making it more easy to maintain