### PR TITLE
[SDA-7342] Fixing wrongful behaviors on upgrade roles

### DIFF
--- a/cmd/upgrade/roles/cmd.go
+++ b/cmd/upgrade/roles/cmd.go
@@ -288,7 +288,7 @@ func run(cmd *cobra.Command, argv []string) error {
 	}
 
 	//OPERATOR ROLES
-	if !isInvokedFromClusterUpgrade {
+	if !args.isInvokedFromClusterUpgrade {
 		reporter.Infof("Ensuring operator role policies compatibility for upgrade")
 	}
 
@@ -338,18 +338,19 @@ func run(cmd *cobra.Command, argv []string) error {
 		return err
 	}
 
-	if len(missingRolesInCS) <= 0 && !isOperatorPolicyUpgradeNeeded {
-		if !args.isInvokedFromClusterUpgrade {
-			r.Reporter.Infof(
-				"Operator roles/policies associated with the cluster '%s' are already up-to-date.",
-				cluster.ID(),
-			)
-		}
-		os.Exit(0)
-	}
-
 	if spin != nil {
 		spin.Stop()
+	}
+
+	if len(missingRolesInCS) <= 0 && !isOperatorPolicyUpgradeNeeded {
+		r.Reporter.Infof(
+			"Operator roles/policies associated with the cluster '%s' are already up-to-date.",
+			cluster.ID(),
+		)
+		if !isInvokedFromClusterUpgrade {
+			os.Exit(0)
+		}
+		return nil
 	}
 
 	operatorRolePolicies, err := ocmClient.GetPolicies("OperatorRole")
@@ -410,7 +411,7 @@ func run(cmd *cobra.Command, argv []string) error {
 			)
 		}
 	}
-	return err
+	return nil
 }
 
 func LogError(key string, ocmClient *ocm.Client, defaultPolicyVersion string, err error, reporter *rprtr.Object) {

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -62,6 +62,13 @@ func RankMapStringInt(values map[string]int) []string {
 	for i, kv := range ss {
 		ranked[i] = kv.Key
 	}
+	sort.Slice(ranked, func(i, j int) bool {
+		l1, l2 := len(ranked[i]), len(ranked[j])
+		if l1 != l2 {
+			return l1 > l2
+		}
+		return ranked[i] > ranked[j]
+	})
 	return ranked
 }
 

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -63,9 +63,11 @@ func RankMapStringInt(values map[string]int) []string {
 		ranked[i] = kv.Key
 	}
 	sort.Slice(ranked, func(i, j int) bool {
-		l1, l2 := len(ranked[i]), len(ranked[j])
-		if l1 != l2 {
-			return l1 > l2
+		if ranked[i] == ranked[j] {
+			l1, l2 := len(ranked[i]), len(ranked[j])
+			if l1 != l2 {
+				return l1 > l2
+			}
 		}
 		return ranked[i] > ranked[j]
 	})


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-7342
* Remove os exit when roles are up to date
* Sort prefixes to ensure consistency when they are the same rank
* Order of messages
* Does not os exit when called from other command