### PR TITLE
[SDA-7345] Prompt mode for upgrade cluster when sts and mode is empty

### DIFF
--- a/cmd/upgrade/cluster/cmd.go
+++ b/cmd/upgrade/cluster/cmd.go
@@ -182,6 +182,21 @@ func run(cmd *cobra.Command, _ []string) {
 		interactive.Enable()
 	}
 
+	if isSTS && mode == "" {
+		mode, err = interactive.GetOption(interactive.Input{
+			Question: "IAM Roles/Policies upgrade mode",
+			Help:     cmd.Flags().Lookup("mode").Usage,
+			Default:  aws.ModeAuto,
+			Options:  aws.Modes,
+			Required: true,
+		})
+		if err != nil {
+			r.Reporter.Errorf("Expected a valid role upgrade mode: %s", err)
+			os.Exit(1)
+		}
+		aws.SetModeKey(mode)
+	}
+
 	// if cluster is sts validate roles are compatible with upgrade version
 	if isSTS {
 		r.Reporter.Infof("Ensuring account and operator role policies for cluster '%s'"+

--- a/cmd/upgrade/roles/cmd.go
+++ b/cmd/upgrade/roles/cmd.go
@@ -176,7 +176,7 @@ func run(cmd *cobra.Command, argv []string) error {
 
 	if interactive.Enabled() && !skipInteractive {
 		mode, err = interactive.GetOption(interactive.Input{
-			Question: "Account role upgrade mode",
+			Question: "Roles upgrade mode",
 			Help:     cmd.Flags().Lookup("mode").Usage,
 			Default:  aws.ModeAuto,
 			Options:  aws.Modes,


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-7345
# Changes
`./rosa upgrade cluster -c sda7345`
```
? Version: 4.10.40
? IAM Roles/Policies upgrade mode: auto
```
