### PR TITLE
[SDA-7207] Invert condition for no reason to update ingress

### DIFF
--- a/cmd/edit/ingress/cmd.go
+++ b/cmd/edit/ingress/cmd.go
@@ -218,7 +218,7 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
-	if private == nil || len(routeSelectors) == 0 {
+	if private == nil && len(routeSelectors) == 0 {
 		r.Reporter.Warnf("No need to update ingress as there are no changes")
 		os.Exit(0)
 	}


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-7207

# Changes
Moved through, but can't edit a default ingress in this example

`./rosa edit ingress -c sda7345 --private o1r3`
```
E: Failed to update ingress 'o1r3' on cluster 'sda7345': Can't update listening mode of default ingress on an AWS STS cluster
```
