### PR TITLE
[SDA-7382] Checking undefined aws region on init and create cluster

### DIFF
--- a/pkg/aws/region/flag.go
+++ b/pkg/aws/region/flag.go
@@ -21,6 +21,7 @@ package region
 import (
 	"os"
 
+	"github.com/openshift/rosa/pkg/helper"
 	"github.com/spf13/pflag"
 )
 
@@ -36,11 +37,11 @@ func AddFlag(flags *pflag.FlagSet) {
 
 // Region returns a string with the name of the AWS region being used.
 func Region() string {
-	if region != "" {
+	if helper.HandleEscapedEmptyString(region) != "" {
 		return region
 	}
 	awsRegion := os.Getenv("AWS_REGION")
-	if awsRegion != "" {
+	if helper.HandleEscapedEmptyString(awsRegion) != "" {
 		return awsRegion
 	}
 	return ""

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -162,3 +162,10 @@ func IsValidUUID(u string) bool {
 	_, err := uuid.Parse(u)
 	return err == nil
 }
+
+func HandleEscapedEmptyString(input string) string {
+	if input == "\"\"" {
+		input = ""
+	}
+	return input
+}

--- a/pkg/interactive/interactive.go
+++ b/pkg/interactive/interactive.go
@@ -27,6 +27,7 @@ import (
 	"github.com/AlecAivazis/survey/v2/terminal"
 
 	"github.com/openshift/rosa/pkg/color"
+	"github.com/openshift/rosa/pkg/helper"
 )
 
 type Input struct {
@@ -40,7 +41,7 @@ type Input struct {
 
 // Gets string input from the command line
 func GetString(input Input) (a string, err error) {
-	transformer := survey.TransformString(toEmptyString)
+	transformer := survey.TransformString(helper.HandleEscapedEmptyString)
 	core.DisableColor = !color.UseColor()
 	dflt, ok := input.Default.(string)
 	if !ok {
@@ -308,13 +309,6 @@ func GetCert(input Input) (a string, err error) {
 	}
 	err = survey.AskOne(prompt, &a, survey.WithValidator(compose(input.Validators)), survey.WithValidator(IsCert))
 	return
-}
-
-func toEmptyString(input string) string {
-	if input == "\"\"" {
-		input = ""
-	}
-	return input
 }
 
 var helpTemplate = `{{color "cyan"}}? {{.Message}}

--- a/pkg/ocm/regions.go
+++ b/pkg/ocm/regions.go
@@ -23,6 +23,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/logging"
+	"github.com/zgalor/weberr"
 )
 
 // GetFilteredRegionsByVersion fetches a list of regions. The 'version' argument is optional for filtering.
@@ -228,4 +229,17 @@ func (c *Client) ListHostedCPSupportedRegion() (regions map[string]bool, err err
 		return true
 	})
 	return regions, nil
+}
+
+func (c *Client) GetDatabaseRegionList() ([]string, error) {
+	response, err := c.ocm.ClustersMgmt().V1().CloudProviders().CloudProvider("aws").Regions().List().Send()
+	if err != nil {
+		return []string{}, weberr.Errorf("Failed to get regions listing: %v", err)
+	}
+	supportedRegions := []string{}
+	response.Items().Range(func(index int, item *cmv1.CloudRegion) bool {
+		supportedRegions = append(supportedRegions, item.ID())
+		return true
+	})
+	return supportedRegions, nil
 }


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-7382

# What
Non existing region should be validated

# Why
The command is stuck and returns only after 20 minutes return only after 20 minutes with not user-friendly error. 

# Changes
`./rosa create cluster -c region-check --region="undefined"`
```
E: Unsupported region 'undefined', available regions: [ap-east-1, eu-west-1, eu-west-2, eu-west-3, sa-east-1, us-east-1, us-east-2, us-west-1, us-west-2, af-south-1, ap-south-1, eu-north-1, eu-south-1, me-south-1, ca-central-1, eu-central-1, us-gov-east-1, us-gov-west-1, ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-southeast-1, ap-southeast-2, ap-southeast-3]
```