### PR TITLE
[SDA-6826] Handle empty strings before validation

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1875,7 +1875,7 @@ func run(cmd *cobra.Command, _ []string) {
 			r.Reporter.Errorf("Expected a valid set of no proxy domains/CIDR's: %s", err)
 			os.Exit(1)
 		}
-		noProxySlice = strings.Split(noProxyInput, ",")
+		noProxySlice = helper.HandleEmptyStringOnSlice(strings.Split(noProxyInput, ","))
 	}
 
 	if len(noProxySlice) > 0 {

--- a/cmd/edit/cluster/cmd.go
+++ b/cmd/edit/cluster/cmd.go
@@ -26,6 +26,7 @@ import (
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/helper"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/ocm"
@@ -389,7 +390,7 @@ func run(cmd *cobra.Command, _ []string) {
 			r.Reporter.Errorf("Expected a valid set of no proxy domains/CIDR's: %s", err)
 			os.Exit(1)
 		}
-		noProxySlice = strings.Split(noProxyInput, ",")
+		noProxySlice = helper.HandleEmptyStringOnSlice(strings.Split(noProxyInput, ","))
 	}
 	if isExpectedHTTPProxyOrHTTPSProxy(httpProxy, httpsProxy, noProxySlice, cluster) {
 		r.Reporter.Errorf("Expected at least one of the following: http-proxy, https-proxy")

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -169,3 +169,13 @@ func HandleEscapedEmptyString(input string) string {
 	}
 	return input
 }
+
+func HandleEmptyStringOnSlice(slice []string) []string {
+	r := []string{}
+	for _, s := range slice {
+		if s != "" {
+			r = append(r, s)
+		}
+	}
+	return r
+}


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-6826

# What
No proxy value should not be sent if it contains empty string

# Why
Empty string was being sent as part of the no proxy values

# Changes
```
.
.
.
? PrivateLink cluster (optional): Yes
? Subnet IDs (optional): subnet-xxxx (us-east-1b)
.
.
.
? Use cluster-wide proxy (optional): Yes
? HTTP proxy (optional): http://xxx.us-west-2.compute.internal
? HTTPS proxy (optional): https://xxx.us-west-2.compute.internal
? No proxy (optional): 
.
.
.
I: To create this cluster again in the future, you can run:
   rosa create cluster --cluster-name no-proxy --sts --role-arn arn:aws:iam::xxx:role/ManagedOpenShift-Installer-Role --support-role-arn arn:aws:iam::xxx:role/ManagedOpenShift-Support-Role --controlplane-iam-role arn:aws:iam::xxx:role/ManagedOpenShift-ControlPlane-Role --worker-iam-role arn:aws:iam::xxx:role/ManagedOpenShift-Worker-Role --operator-roles-prefix no-proxy-d3f9 --region us-east-1 --version 4.11.13 --replicas 2 --compute-machine-type m5.xlarge --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23 --private-link --subnet-ids subnet-05ab40e27103d8c61 --http-proxy http://xxx.us-west-2.compute.internal --https-proxy https://xxx.us-west-2.compute.internal
I: To view a list of clusters and their status, run 'rosa list clusters'
I: Cluster 'no-proxy' has been created.
I: Once the cluster is installed you will need to add an Identity Provider before you can login into the cluster. See 'rosa create idp --help' for more information.
.
.
.
```