### PR TITLE
Adding check for Changes in `replicas` flag too

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1549,7 +1549,7 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	isAutoscalingSet := cmd.Flags().Changed("enable-autoscaling")
-	isReplicasSet := cmd.Flags().Changed("compute-nodes")
+	isReplicasSet := cmd.Flags().Changed("compute-nodes") || cmd.Flags().Changed("replicas")
 
 	// Autoscaling
 	autoscaling := args.autoscalingEnabled


### PR DESCRIPTION
Without this `isReplicaSet` was set to false even when `--replicas` was changed.

This affected in the long run because it failed the check in line [#1635](https://github.com/openshift/rosa/blob/master/cmd/create/cluster/cmd.go#L1635) and was assigned the minimum `computeNodes` that was 3.

Signed-off-by: Vicente Zepeda Mas <vzepedam@redhat.com>

fixes #946 