### PR TITLE
[SDA-7429] Going through all policies to check upgrade

### DIFF
--- a/cmd/upgrade/operatorroles/cmd.go
+++ b/cmd/upgrade/operatorroles/cmd.go
@@ -155,8 +155,7 @@ func run(cmd *cobra.Command, argv []string) error {
 		os.Exit(1)
 	}
 
-	isOperatorPolicyUpgradeNeeded := false
-	isOperatorPolicyUpgradeNeeded, err = r.AWSClient.IsUpgradedNeededForOperatorRolePoliciesUsingPrefix(prefix,
+	isOperatorPolicyUpgradeNeeded, err := r.AWSClient.IsUpgradedNeededForOperatorRolePoliciesUsingPrefix(prefix,
 		r.Creator.AccountID, defaultPolicyVersion, credRequests, policyPath)
 	if err != nil {
 		r.Reporter.Errorf("%s", err)

--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -1459,7 +1459,12 @@ func (c *awsClient) IsUpgradedNeededForOperatorRolePoliciesUsingPrefix(prefix st
 	for _, operator := range credRequests {
 		policyARN := GetOperatorPolicyARN(accountID, prefix, operator.Namespace(), operator.Name(), path)
 		existsAndUpToDate, err := c.checkPolicyExistsAndUpToDate(policyARN, version)
-		return !existsAndUpToDate, err
+		if err != nil {
+			return false, err
+		}
+		if !existsAndUpToDate {
+			return true, nil
+		}
 	}
 	return false, nil
 }


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-7429

# What
Some of the policies were not upgraded but are not being considered when checking

# Why
Check was ending prematurely

#Changes
## Prerequisites
Run the command once, remove the newly created role and it's policy from aws. Now all operator policies will be up to date but one. Run the command again, check if the policy got recreated and the recreated role also has it attached.
`./rosa upgrade operator-roles -c [sda-7429](https://issues.redhat.com//browse/sda-7429) --version=4.10.40`
```
I: Starting to upgrade the operator IAM roles and policies
? Operator IAM role/policy upgrade mode: auto
? Upgrade the operator role policy to version 4.11? Yes
I: Upgraded policy with ARN 'arn:aws:iam::123:policy/sda-7429-openshift-ingress-operator-cloud-credentials' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::123:policy/sda-7429-openshift-cluster-csi-drivers-ebs-cloud-credentials' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::123:policy/sda-7429-openshift-cloud-network-config-controller-cloud-credent' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::123:policy/sda-7429-openshift-machine-api-aws-cloud-credentials' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::123:policy/sda-7429-openshift-cloud-credential-operator-cloud-credential-op' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::123:policy/sda-7429-openshift-image-registry-installer-cloud-credentials' to version '4.11'
? Create the 'sda-7429-j9m3-openshift-cloud-network-config-controller-cloud-cr' role? Yes
I: Created role 'sda-7429-j9m3-openshift-cloud-network-config-controller-cloud-cr' with ARN 'arn:aws:iam::123:role/sda-7429-j9m3-openshift-cloud-network-config-controller-cloud-cr'
I: Waiting for operator roles to reconcile
```