### PR TITLE
[SDA-7436] Ensure operator roles have attached policies

### DIFF
--- a/cmd/upgrade/operatorroles/cmd.go
+++ b/cmd/upgrade/operatorroles/cmd.go
@@ -235,6 +235,23 @@ func run(cmd *cobra.Command, argv []string) error {
 			)
 		}
 	}
+
+	r.Reporter.Infof("Ensuring operator roles have their attached policies")
+	err = roles.EnsureOperatorRolesHaveAttachedPolicies(
+		cluster,
+		credRequests,
+		version,
+		r.AWSClient,
+		r.Creator.AccountID,
+		prefix,
+		policyPath)
+	if err != nil {
+		r.Reporter.Errorf("%s", err)
+		os.Exit(1)
+	}
+	r.Reporter.Infof(
+		"All needed operator roles have their policies attached. Please proceed with cluster upgrade process.",
+	)
 	return nil
 }
 

--- a/cmd/upgrade/operatorroles/cmd.go
+++ b/cmd/upgrade/operatorroles/cmd.go
@@ -244,7 +244,7 @@ func run(cmd *cobra.Command, argv []string) error {
 		r.AWSClient,
 		r.Creator.AccountID,
 		prefix,
-		policyPath)
+		unifiedPath)
 	if err != nil {
 		r.Reporter.Errorf("%s", err)
 		os.Exit(1)

--- a/cmd/upgrade/roles/cmd.go
+++ b/cmd/upgrade/roles/cmd.go
@@ -422,7 +422,7 @@ func run(cmd *cobra.Command, argv []string) error {
 		r.AWSClient,
 		r.Creator.AccountID,
 		operatorRolePolicyPrefix,
-		operatorPolicyPath)
+		unifiedPath)
 	if err != nil {
 		r.Reporter.Errorf("%s", err)
 		os.Exit(1)


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-7436

# What
Ensures operator roles have expected attached policy

# Why
Upgrading of cluster could happen even though operator role didn't have attached policy

# Concerns
If the user used non standard names for policies we can't auto identify the correct policy it will fail and from my point of view requires user to manually check on aws to solve it