### PR TITLE
[SDA-7420] Check if any new operator roles have been created before hand

### DIFF
--- a/cmd/upgrade/operatorroles/cmd.go
+++ b/cmd/upgrade/operatorroles/cmd.go
@@ -214,6 +214,7 @@ func run(cmd *cobra.Command, argv []string) error {
 	}
 
 	if len(missingRolesInCS) > 0 {
+		createdMissingRoles := 0
 		for _, operator := range missingRolesInCS {
 			roleName := roles.GetOperatorRoleName(cluster, operator)
 			exists, _, err := r.AWSClient.CheckRoleExists(roleName)
@@ -226,7 +227,13 @@ func run(cmd *cobra.Command, argv []string) error {
 					r.Reporter.Errorf("%s", err)
 					os.Exit(1)
 				}
+				createdMissingRoles++
 			}
+		}
+		if createdMissingRoles == 0 {
+			r.Reporter.Infof(
+				"Missing roles/policies have already been created. Please continue with cluster upgrade process.",
+			)
 		}
 	}
 	return nil


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-7420

# What
Running the command for a second time in sequence had missing info about the status of the roles/policies.

# Why
The API does not return newly created operator until the upgrade is scheduled. So a check is needed to make sure the expected new roles were actually created or if they have been previously.

# Changes
## Common step
`./rosa upgrade operator-roles -c [sda-7420](https://issues.redhat.com//browse/sda-7420) --version=4.10.42 --mode auto -y`
```
I: Starting to upgrade the operator IAM roles and policies
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sda-7420-openshift-machine-api-aws-cloud-credentials' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sda-7420-openshift-cloud-credential-operator-cloud-credential-op' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sda-7420-openshift-image-registry-installer-cloud-credentials' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sda-7420-openshift-ingress-operator-cloud-credentials' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sda-7420-openshift-cluster-csi-drivers-ebs-cloud-credentials' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/sda-7420-openshift-cloud-network-config-controller-cloud-credent' to version '4.11'
I: Created role 'sda-7420-w6o5-openshift-cloud-network-config-controller-cloud-cr' with ARN 'arn:aws:iam::765374464689:role/sda-7420-w6o5-openshift-cloud-network-config-controller-cloud-cr'
I: Waiting for operator roles to reconcile
```

## Before
Running for a second time in sequence
`/rosa upgrade operator-roles -c [sda-7420](https://issues.redhat.com//browse/sda-7420) --version=4.10.42 --mode auto -y`
```
I: Starting to upgrade the operator IAM roles and policies
```
## After
Running for a second time in sequence
`./rosa upgrade operator-roles -c [sda-7420](https://issues.redhat.com//browse/sda-7420) --version=4.10.42 --mode auto -y`
```
I: Starting to upgrade the operator IAM roles and policies
I: Missing roles/policies have already been created. Please continue with cluster upgrade process.
```