### PR TITLE
[SDA-3843] Align spacing listing users

### DIFF
--- a/cmd/list/user/cmd.go
+++ b/cmd/list/user/cmd.go
@@ -18,6 +18,7 @@ package user
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -84,11 +85,14 @@ func run(_ *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
+	longestUserId := 0.0
 	groups := make(map[string][]string)
 	for _, user := range clusterAdmins {
+		longestUserId = math.Max(longestUserId, float64(len(user.ID())))
 		groups[user.ID()] = []string{"cluster-admins"}
 	}
 	for _, user := range dedicatedAdmins {
+		longestUserId = math.Max(longestUserId, float64(len(user.ID())))
 		if _, ok := groups[user.ID()]; ok {
 			groups[user.ID()] = []string{"cluster-admins", "dedicated-admins"}
 		} else {
@@ -98,10 +102,11 @@ func run(_ *cobra.Command, _ []string) {
 
 	// Create the writer that will be used to print the tabulated results:
 	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintf(writer, "ID\t\tGROUPS\n")
+	idLabel := "ID"
+	fmt.Fprintf(writer, "%s%-*sGROUPS\n", idLabel, int(longestUserId)-len(idLabel)+1, "")
 
 	for u, r := range groups {
-		fmt.Fprintf(writer, "%s\t\t%s\n", u, strings.Join(r, ", "))
+		fmt.Fprintf(writer, "%s%-*s%s\n", u, int(longestUserId)-len(u)+1, "", strings.Join(r, ", "))
 		writer.Flush()
 	}
 }


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-3843
# What
Adjust spacing between columns based on longest user id

# Why
Spacing was not aligned

# Changes
`./rosa list users -c sda-7429`
```
ID                           GROUPS
gdb                          cluster-admins
adminnnnnnnnnnnnnnnnnnnnnnnn dedicated-admins
admin                        dedicated-admins
```