### PR TITLE
[SDA-5825] Remove auth url info from LDAP idp when listing

### DIFF
--- a/pkg/ocm/idps.go
+++ b/pkg/ocm/idps.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/rosa/pkg/helper"
 )
 
 const (
@@ -137,4 +138,12 @@ func IdentityProviderType(idp *cmv1.IdentityProvider) string {
 	}
 
 	return ""
+}
+
+func HasAuthURLSupport(idp *cmv1.IdentityProvider) bool {
+	return !helper.Contains(getIDPListWithoutAuthURLSupport(), IdentityProviderType(idp))
+}
+
+func getIDPListWithoutAuthURLSupport() []string {
+	return []string{HTPasswdIDPType, LDAPIDPType}
 }


### PR DESCRIPTION
# What
LDAP IDP type is showing auth url info when listing idps

# Why
LDAP IDP type shouldn't show this info

# Before
`./rosa list idps -c sda-5825`
```
NAME        TYPE        AUTH URL
github-1    GitHub      https://xxx/oauth2callback/github-1
github-2    GitHub      https://xxx/oauth2callback/github-2
ldap-1      LDAP        https://xxx/oauth2callback/ldap-1
htpasswd    HTPasswd    
```

# After
`./rosa list idps -c sda-5825`
```
NAME        TYPE        AUTH URL
github-1    GitHub      https://xxx/oauth2callback/github-1
github-2    GitHub      https://xxx/oauth2callback/github-2
ldap-1      LDAP        
htpasswd    HTPasswd    
```