### PR TITLE
[SDA-7474] Upgrading from pre release would fail to validate version

### DIFF
--- a/cmd/upgrade/cluster/cmd.go
+++ b/cmd/upgrade/cluster/cmd.go
@@ -201,7 +201,7 @@ func run(cmd *cobra.Command, _ []string) {
 	if isSTS {
 		r.Reporter.Infof("Ensuring account and operator role policies for cluster '%s'"+
 			" are compatible with upgrade.", cluster.ID())
-		err = roles.Cmd.RunE(roles.Cmd, []string{mode, cluster.ID(), version})
+		err = roles.Cmd.RunE(roles.Cmd, []string{mode, cluster.ID(), version, cluster.Version().ChannelGroup()})
 		if err != nil {
 			rolesStr := fmt.Sprintf("rosa upgrade roles -c %s --version=%s --mode=%s", clusterKey, version, mode)
 			upgradeClusterStr := fmt.Sprintf("rosa upgrade cluster -c %s", clusterKey)

--- a/cmd/upgrade/roles/cmd.go
+++ b/cmd/upgrade/roles/cmd.go
@@ -109,9 +109,8 @@ func run(cmd *cobra.Command, argv []string) error {
 		aws.SetModeKey(argv[0])
 		ocm.SetClusterKey(argv[1])
 		skipInteractive = true
-		if len(argv) > 2 && argv[2] != "" {
-			args.clusterUpgradeVersion = argv[2]
-		}
+		args.clusterUpgradeVersion = argv[2]
+		args.channelGroup = argv[3]
 		isInvokedFromClusterUpgrade = true
 	}
 	args.isInvokedFromClusterUpgrade = isInvokedFromClusterUpgrade


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-7474

# What
Upgrading from a channel group other than stable would fail to validate version

# Why
Channel group was not being taken into account for some validations