### PR TITLE
[OHSS-14855] Retrieve operator role prefix from backend

### DIFF
--- a/pkg/helper/roles/helpers.go
+++ b/pkg/helper/roles/helpers.go
@@ -2,7 +2,6 @@ package roles
 
 import (
 	"fmt"
-	"strings"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/rosa/pkg/aws"
@@ -17,18 +16,7 @@ const (
 )
 
 func GetOperatorRoleName(cluster *cmv1.Cluster, missingOperator *cmv1.STSOperator) string {
-	operatorIAMRoles := cluster.AWS().STS().OperatorIAMRoles()
-	rolePrefix := ""
-	if len(operatorIAMRoles) > 0 {
-		roleARN := operatorIAMRoles[0].RoleARN()
-		roleName, err := aws.GetResourceIdFromARN(roleARN)
-		if err != nil {
-			return ""
-		}
-
-		m := strings.LastIndex(roleName, "-openshift")
-		rolePrefix = roleName[0:m]
-	}
+	rolePrefix := cluster.AWS().STS().OperatorRolePrefix()
 	role := fmt.Sprintf("%s-%s-%s", rolePrefix, missingOperator.Namespace(), missingOperator.Name())
 	if len(role) > 64 {
 		role = role[0:64]


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/OHSS-14855
# What
Uses value for operator roles prefix retrieved from backend

# Why
Doing in the front end means duplicated functionality, plus it should be retrieved from a central place so to minimize possible failure points by having possibility of different strategies in place.

# After Changes
`./rosa upgrade roles -c [ohss-14855](https://issues.redhat.com//browse/ohss-14855) --mode auto --cluster-version=4.10.43`
```
I: Ensuring account role/policies compatibility for upgrade
I: Starting to upgrade the policies
? Upgrade the 'ROSA-devel-posttrade-support' role policy latest version (4.11) ? Yes
I: Upgraded policy with ARN 'arn:aws:iam::xxx:policy/ROSA-devel-posttrade-support-p' to version '4.11'
? Upgrade the 'ROSA-devel-posttrade-install' role policy latest version (4.11) ? Yes
I: Upgraded policy with ARN 'arn:aws:iam::xxx:policy/ROSA-devel-posttrade-install-p' to version '4.11'
? Upgrade the 'ROSA-devel-posttrade-control' role policy latest version (4.11) ? Yes
I: Upgraded policy with ARN 'arn:aws:iam::xxx:policy/ROSA-devel-posttrade-control-p' to version '4.11'
? Upgrade the 'ROSA-devel-posttrade-worker' role policy latest version (4.11) ? Yes
I: Upgraded policy with ARN 'arn:aws:iam::xxx:policy/ROSA-devel-posttrade-worker-p' to version '4.11'
I: Ensuring operator role/policies compatibility for upgrade
? Upgrade each operator role policy to latest version (4.11)? Yes
I: Upgraded policy with ARN 'arn:aws:iam::xxx:policy/ohss-14855-n2o2-openshift-cluster-csi-drivers-ebs-cloud-credenti' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::xxx:policy/ohss-14855-n2o2-openshift-cloud-network-config-controller-cloud-' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::xxx:policy/ohss-14855-n2o2-openshift-machine-api-aws-cloud-credentials' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::xxx:policy/ohss-14855-n2o2-openshift-cloud-credential-operator-cloud-creden' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::xxx:policy/ohss-14855-n2o2-openshift-image-registry-installer-cloud-credent' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::xxx:policy/ohss-14855-n2o2-openshift-ingress-operator-cloud-credentials' to version '4.11'
? Create the 'ROSA-devel-posttrade-openshift-cloud-network-config-controller-c' role? Yes
I: Created role 'ROSA-devel-posttrade-openshift-cloud-network-config-controller-c' with ARN 'arn:aws:iam::xxx:role/ROSA-devel-posttrade-openshift-cloud-network-config-controller-c'
I: Waiting for operator roles to reconcile
```

`./rosa upgrade cluster -c [ohss-14855](https://issues.redhat.com//browse/ohss-14855) --mode auto `
```                   
? Version: 4.10.43
I: Ensuring account and operator role policies for cluster '20j6s36qv5071mqhkh9d416l4n3qa2j7' are compatible with upgrade.
I: Account roles/policies for cluster '20j6s36qv5071mqhkh9d416l4n3qa2j7' are already up-to-date.
I: Missing roles/policies have already been created. Please continue with cluster upgrade process.
I: Account and operator roles for cluster 'ohss-14855' are compatible with upgrade
? Are you sure you want to upgrade cluster to version '4.10.43'? Yes
? Please input desired date in format yyyy-mm-dd: 2022-12-14
? Please input desired UTC time in format HH:mm: 17:15
? Node draining: 1 hour
I: Upgrade successfully scheduled for cluster 'ohss-14855'
```