### PR TITLE
[SDA-7233] Validating regex for machine pool label key and value

### DIFF
--- a/cmd/create/machinepool/machinepool.go
+++ b/cmd/create/machinepool/machinepool.go
@@ -3,6 +3,7 @@ package machinepool
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -16,6 +17,8 @@ import (
 	"github.com/openshift/rosa/pkg/rosa"
 	"github.com/spf13/cobra"
 )
+
+var labelRE = regexp.MustCompile(`^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$`)
 
 func addMachinePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster, r *rosa.Runtime) {
 	var err error
@@ -555,6 +558,12 @@ func parseLabels(labels string) (map[string]string, error) {
 			return nil, fmt.Errorf("Expected key=value format for labels")
 		}
 		tokens := strings.Split(label, "=")
+		keyToken := labelRE.MatchString(tokens[0])
+		valueToken := labelRE.MatchString(tokens[1])
+		if !keyToken || !valueToken {
+			return nil, fmt.Errorf("name part must consist of alphanumeric characters, " +
+				"'-', '_' or '.', and must start and end with an alphanumeric character")
+		}
 		labelMap[strings.TrimSpace(tokens[0])] = strings.TrimSpace(tokens[1])
 	}
 	return labelMap, nil


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-7233
# What
Quotes are not being validated for machine pool labels in the CLI

# Why
The regex does not allow quotes

# After changes
`./rosa create machinepool -c oadler-byo-mlt`
```
I: Enabling interactive mode
? Machine pool name: a
? Create multi-AZ machine pool: Yes
? Enable autoscaling (optional): No
? Replicas: 3
I: Fetching instance types
? Instance type: m5.xlarge
X Sorry, your reply was invalid: name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character
? Labels (optional): aaa=bbb
? Taints (optional): [? for help] 
```