### PR TITLE
[SDA-3685] Add error message when CA is passed but github hostname is not

### DIFF
--- a/cmd/create/idp/github.go
+++ b/cmd/create/idp/github.go
@@ -189,6 +189,9 @@ func buildGithubIdp(cmd *cobra.Command,
 			return idpBuilder, fmt.Errorf("Expected a valid Hostname: %s", err)
 		}
 	}
+	if githubHostname == "" && args.caPath != "" {
+		return idpBuilder, fmt.Errorf("CA is not expected when not using a hosted instance of Github Enterprise")
+	}
 	if githubHostname != "" {
 		_, err = url.ParseRequestURI(githubHostname)
 		if err != nil {


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-3685
# What
Adds error message to alert user CA is not be passed as param if github hostname is empty

# Why
CA is not expected to be used when not using a hosted instance of Github  Enterprise

# After changes
`./rosa create idp -c cluster --type github --ca notexisted --client-id aaa --client-secret aaa --teams aaa/bbb`
```
E: Failed to create IDP for cluster 'cluster': CA is not expected when not using a hosted instance of Github Enterprise
```
