### PR TITLE
Using LCP to retrieve operator policy prefix

### DIFF
--- a/cmd/upgrade/roles/cmd.go
+++ b/cmd/upgrade/roles/cmd.go
@@ -516,7 +516,7 @@ func upgradeAccountRolePoliciesFromCluster(
 		if err != nil {
 			return err
 		}
-		promptString := fmt.Sprintf("Upgrade the '%s' role policy latest version (%s) ?", roleName, policyVersion)
+		promptString := fmt.Sprintf("Upgrade the '%s' role policy to latest version (%s) ?", roleName, policyVersion)
 		if isVersionChosen {
 			promptString = fmt.Sprintf("Upgrade the '%s' role policy to version '%s' ?", roleName, policyVersion)
 		}

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -1,6 +1,7 @@
 package helper
 
 import (
+	"math"
 	"math/rand"
 	"os"
 	"sort"
@@ -178,4 +179,26 @@ func HandleEmptyStringOnSlice(slice []string) []string {
 		}
 	}
 	return r
+}
+
+func LongestCommonPrefixBySorting(stringSlice []string) string {
+	ssLength := len(stringSlice)
+	if ssLength == 0 {
+		return ""
+	}
+
+	if ssLength == 1 {
+		return stringSlice[0]
+	}
+
+	sort.Strings(stringSlice)
+	minLengthBetweenFirstAndLast := math.Min(float64(len(stringSlice[0])), float64(len(stringSlice[ssLength-1])))
+	first := stringSlice[0]
+	last := stringSlice[ssLength-1]
+	i := 0
+	for i < int(minLengthBetweenFirstAndLast) && first[i] == last[i] {
+		i++
+	}
+
+	return first[:i]
 }


### PR DESCRIPTION
# What
Uses LCP algorithm to retrieve operator policy prefix

# Why
One more option before resorting to operator role prefix

# After changes
`./rosa upgrade roles -c hss-14855 --mode auto --cluster-version=4.10.43`
```
I: Ensuring account role/policies compatibility for upgrade
I: Starting to upgrade the policies
? Upgrade the 'ROSA-devel-control' role policy latest version (4.11) ? Yes
I: Upgraded policy with ARN 'arn:aws:iam::xxx:policy/ROSA-devel-control-Policy' to version '4.11'
? Upgrade the 'ROSA-devel-worker' role policy latest version (4.11) ? Yes
I: Upgraded policy with ARN 'arn:aws:iam::xxx:policy/ROSA-devel-worker-Policy' to version '4.11'
? Upgrade the 'ROSA-devel-support' role policy latest version (4.11) ? Yes
I: Upgraded policy with ARN 'arn:aws:iam::xxx:policy/ROSA-devel-support-Policy' to version '4.11'
? Upgrade the 'ROSA-devel-install' role policy latest version (4.11) ? Yes
I: Upgraded policy with ARN 'arn:aws:iam::xxx:policy/ROSA-devel-install-Policy' to version '4.11'
I: Ensuring operator role/policies compatibility for upgrade
? Upgrade each operator role policy to latest version (4.11)? Yes
I: Upgraded policy with ARN 'arn:aws:iam::xxx:policy/ROSA-devel-mapi-policy' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::xxx:policy/ROSA-devel-cc-policy' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::xxx:policy/ROSA-devel-registry-policy' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::xxx:policy/ROSA-devel-ingress-policy' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::xxx:policy/ROSA-devel-csi-ebs-policy' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::xxx:policy/ROSA-devel-openshift-cloud-network-config-controller-c' to version '4.11'
? Create the 'ROSA-devel-openshift-cloud-network-config-controller-c' role? Yes
I: Created role 'ROSA-devel-openshift-cloud-network-config-controller-c' with ARN 'arn:aws:iam::xxx:role/ROSA-devel-openshift-cloud-network-config-controller-c'
I: Waiting for operator roles to reconcile
```