### PR TITLE
fix: Allow deleting OIDC Provider by Cluster Name

### DIFF
--- a/cmd/dlt/oidcprovider/cmd.go
+++ b/cmd/dlt/oidcprovider/cmd.go
@@ -82,7 +82,7 @@ func run(cmd *cobra.Command, argv []string) {
 	if sub != nil {
 		clusterID = sub.ClusterID()
 	}
-	c, err := r.OCMClient.GetClusterByID(clusterID, r.Creator)
+	c, err := r.OCMClient.GetCluster(clusterID, r.Creator)
 	if err != nil {
 		if errors.GetType(err) != errors.NotFound {
 			r.Reporter.Errorf("Error validating cluster '%s': %v", clusterKey, err)


### PR DESCRIPTION
When running `rosa delete oidc-provider -c [cluster-name|cluster-id]` if you use a cluster name, the name is ignored and the first OIDC provider found in AWS is deleted.  If you have more than one OIDC Provider, the CLI will sometimes delete the wrong provider.

The `-c` argument is supposed to honor ClusterID or Cluster Name, but currently the lookup only supports ClusterID.

```
  -c, --cluster string   Name or ID of the cluster.
```

This allows `-c` to have a value of ClusterID or Cluster Name

