### PR TITLE
Accomodate inline policies in new upgrade roles flow

### DIFF
--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -675,20 +675,6 @@ func BuildOperatorRolePolicies(prefix string, accountID string, awsClient Client
 	return commands
 }
 
-func HasMoreThanOneAttachedPolicy(policiesDetails []PolicyDetail) bool {
-	return countAttachedPoliciesInDetails(policiesDetails) > 1
-}
-
-func countAttachedPoliciesInDetails(policiesDetails []PolicyDetail) int {
-	totalAttachedPolicies := 0
-	for _, policy := range policiesDetails {
-		if policy.PolicType == Attached {
-			totalAttachedPolicies++
-		}
-	}
-	return totalAttachedPolicies
-}
-
 func FindAllAttachedPolicyDetails(policiesDetails []PolicyDetail) []PolicyDetail {
 	attachedPolicies := make([]PolicyDetail, 0)
 	for _, policy := range policiesDetails {


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/OHSS-14855

# What
Generates a new policy name/ARN when there are only inline policies, later in the flow the inline policies get removed from the role and the new policy is attached.

# Why
Older versions of CLI set inline policies which needs to be taken into account

# Before changes
`rosa upgrade roles -c inline-test --mode=auto --cluster-version=4.10.43 --yes`
```
I: Ensuring account role/policies compatibility for upgrade
I: Starting to upgrade the policies
I: Upgraded policy with ARN 'arn:aws:iam::xxx:policy/test-49-Support-Role-Policy' to version '4.11'
E: Error upgrading the account role polices: arn: invalid prefix
```

# After changes
`rosa upgrade roles -c inline-test --mode=auto --cluster-version=4.10.43 --yes`
```
I: Ensuring account role/policies compatibility for upgrade
I: Starting to upgrade the policies
I: Upgraded policy with ARN 'arn:aws:iam::xxx:policy/test-49-ControlPlane-Role-Policy' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::xxx:policy/test-49-Worker-Role-Policy' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::xxx:policy/test-49-Support-Role-Policy' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::xxx:policy/test-49-Installer-Role-Policy' to version '4.11'
I: Ensuring operator role/policies compatibility for upgrade
I: Upgraded policy with ARN 'arn:aws:iam::xxx:policy/test-49-openshift-image-registry-installer-cloud-credentials' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::xxx:policy/test-49-openshift-ingress-operator-cloud-credentials' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::xxx:policy/test-49-openshift-cluster-csi-drivers-ebs-cloud-credentials' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::xxx:policy/test-49-openshift-cloud-network-config-controller-cloud-credenti' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::xxx:policy/test-49-openshift-machine-api-aws-cloud-credentials' to version '4.11'
I: Upgraded policy with ARN 'arn:aws:iam::xxx:policy/test-49-openshift-cloud-credential-operator-cloud-credential-ope' to version '4.11'
I: Created role 'inline-test-n8y2-openshift-cloud-network-config-controller-cloud' with ARN 'arn:aws:iam::xxx:role/inline-test-n8y2-openshift-cloud-network-config-controller-cloud'
I: Waiting for operator roles to reconcile
```