### PR TITLE
make rosa describe upgrade

### DIFF
--- a/cmd/describe/cmd.go
+++ b/cmd/describe/cmd.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openshift/rosa/cmd/describe/cluster"
 	"github.com/openshift/rosa/cmd/describe/installation"
 	"github.com/openshift/rosa/cmd/describe/service"
+	"github.com/openshift/rosa/cmd/describe/upgrade"
 	"github.com/openshift/rosa/pkg/arguments"
 )
 
@@ -39,6 +40,7 @@ func init() {
 	Cmd.AddCommand(cluster.Cmd)
 	Cmd.AddCommand(service.Cmd)
 	Cmd.AddCommand(installation.Cmd)
+	Cmd.AddCommand(upgrade.Cmd)
 
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)

--- a/cmd/describe/upgrade/cmd.go
+++ b/cmd/describe/upgrade/cmd.go
@@ -1,0 +1,86 @@
+/*
+Copyright (c) 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+var Cmd = &cobra.Command{
+	Use:     "upgrade",
+	Aliases: []string{"appliance", "upgrade"},
+	Short:   "Show details of an upgrade",
+	Long:    "Show details of an upgrade",
+	Example: `  # Describe an upgrade-policy"
+  rosa describe upgrade`,
+	Run:    run,
+	Hidden: false,
+}
+
+func init() {
+	ocm.AddClusterFlag(Cmd)
+}
+
+func run(cmd *cobra.Command, argv []string) {
+	r := rosa.NewRuntime().WithOCM()
+	defer r.Cleanup()
+	cluster := r.FetchCluster()
+
+	// Try to find the cluster:
+	r.Reporter.Debugf("Loading upgrade with id '%s'", cluster.ID())
+	upgrades, err := r.OCMClient.GetUpgradePolicies(cluster.ID())
+	if err != nil {
+		r.Reporter.Errorf("Failed to get upgrade with cluster id '%s': %v", cluster.ID(), err)
+		os.Exit(1)
+	}
+	_, upgradeState, err := r.OCMClient.GetScheduledUpgrade(cluster.ID())
+	if err != nil {
+		r.Reporter.Errorf("Failed to get scheduled upgrades for cluster '%s': %v", cluster.ID(), err)
+		os.Exit(1)
+	}
+	if len(upgrades) < 1 {
+		r.Reporter.Errorf("No available upgrades for cluster id '%s'", cluster.ID())
+		os.Exit(1)
+	}
+
+	for _, upgrade := range upgrades {
+		fmt.Printf(`
+                %-28s%s
+		%-28s%s
+		%-28s%s
+                %-28s%s
+`,
+			"ID:", upgrade.ID(),
+			"Cluster ID:", upgrade.ClusterID(),
+			"Next Run:", upgrade.NextRun(),
+			"Upgrade State:", upgradeState.Value())
+		if upgrade.Schedule() != "" {
+			fmt.Printf(`                %-28s%s
+`, "Schedule At:", upgrade.Schedule())
+		}
+		if upgrade.Version() != "" {
+			fmt.Printf(`                %-28s%s
+`, "Version:", upgrade.Version())
+		}
+	}
+}

--- a/pkg/ocm/upgrades.go
+++ b/pkg/ocm/upgrades.go
@@ -51,7 +51,7 @@ func (c *Client) GetScheduledUpgrade(clusterID string) (*cmv1.UpgradePolicy, *cm
 		return nil, nil, err
 	}
 	for _, upgradePolicy := range upgradePolicies {
-		if upgradePolicy.ScheduleType() == "manual" && upgradePolicy.UpgradeType() == "OSD" {
+		if upgradePolicy.UpgradeType() == "OSD" {
 			state, err := c.ocm.ClustersMgmt().V1().
 				Clusters().Cluster(clusterID).
 				UpgradePolicies().UpgradePolicy(upgradePolicy.ID()).


### PR DESCRIPTION
[SDA-3653](https://issues.redhat.com//browse/SDA-3653)
@etabak @oriAdler 


```
~/workPlace/rosa (describe-upgrade)! S $ ./rosa describe upgrade -c=20mv05nk2dk8ghfbcvn9tm378mrt0bft

                ID:                         3b8f9265-7f9b-11ed-a809-0a580a820878
                Cluster ID:                 20mv05nk2dk8ghfbcvn9tm378mrt0bft
                Schedule At:                
                Next Run:                   2022-12-19 12:56:00 +0000 UTC

```