### PR TITLE
Add default machine pool labels validations

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -640,6 +640,11 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 	}
 
+	if isHostedCP && cmd.Flags().Changed("default-mp-labels") {
+		r.Reporter.Errorf("Setting the default machine pool labels is not supported for hosted clusters")
+		os.Exit(1)
+	}
+
 	// all hosted clusters are sts
 	isSTS := args.sts || args.roleARN != "" || fedramp.Enabled() || isHostedCP
 	isIAM := (cmd.Flags().Changed("sts") && !isSTS) || args.nonSts
@@ -1683,7 +1688,7 @@ func run(cmd *cobra.Command, _ []string) {
 
 	// Default machine pool labels
 	labels := args.defaultMachinePoolLabels
-	if interactive.Enabled() {
+	if interactive.Enabled() && !isHostedCP {
 		labels, err = interactive.GetString(interactive.Input{
 			Question: "Default machine pool labels",
 			Help:     cmd.Flags().Lookup("default-mp-labels").Usage,

--- a/cmd/create/machinepool/machinepool.go
+++ b/cmd/create/machinepool/machinepool.go
@@ -564,7 +564,12 @@ func ParseLabels(labels string) (map[string]string, error) {
 			return nil, fmt.Errorf("name part must consist of alphanumeric characters, " +
 				"'-', '_' or '.', and must start and end with an alphanumeric character")
 		}
-		labelMap[strings.TrimSpace(tokens[0])] = strings.TrimSpace(tokens[1])
+		key := strings.TrimSpace(tokens[0])
+		value := strings.TrimSpace(tokens[1])
+		if _, exists := labelMap[key]; exists {
+			return nil, fmt.Errorf("Duplicated label key '%s' used", key)
+		}
+		labelMap[key] = value
 	}
 	return labelMap, nil
 }


### PR DESCRIPTION
Related: [SDA-7377](https://issues.redhat.com//browse/SDA-7377)

1. Not hypershift cluster
2. No label key duplications