### PR TITLE
[SDA-7593] Disabled `Replicas` question when autoscaling is enabled

### DIFF
--- a/cmd/edit/machinepool/machinepool.go
+++ b/cmd/edit/machinepool/machinepool.go
@@ -294,6 +294,7 @@ func getMachinePoolReplicas(cmd *cobra.Command,
 			}
 		}
 		scalingUpdated = true
+	} else {
 		if !isReplicasSet {
 			replicas = existingReplicas
 		}


### PR DESCRIPTION
[SDA-7593](https://issues.redhat.com//browse/SDA-7593) is a critical bug where ROSA incorrectly prompts users how many replicas they'd like to set when autoscaling is enabled.