### PR TITLE
[SDA-7633] Remove channel group from recreate output

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2413,10 +2413,12 @@ func buildCommand(spec ocm.Spec, operatorRolesPrefix string,
 		command += " --disable-scp-checks"
 	}
 	if spec.Version != "" {
+		commandVersion := strings.TrimPrefix(spec.Version, "openshift-v")
 		if spec.ChannelGroup != ocm.DefaultChannelGroup {
 			command += fmt.Sprintf(" --channel-group %s", spec.ChannelGroup)
+			commandVersion = strings.TrimSuffix(commandVersion, fmt.Sprintf("-%s", spec.ChannelGroup))
 		}
-		command += fmt.Sprintf(" --version %s", strings.TrimPrefix(spec.Version, "openshift-v"))
+		command += fmt.Sprintf(" --version %s", commandVersion)
 	}
 
 	// Only account for expiration duration, as a fixed date may be obsolete if command is re-run later


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-7633

# What
Remove "-<channel_group> from output version command if present

# Why
This is treated within creation flow

# Before changes
`rosa create cluster --cluster-name [test-2](https://issues.redhat.com//browse/test-2) --sts --role-arn arn:aws:iam::xxx:role/ManagedOpenShift-Installer-Role --support-role-arn arn:aws:iam::xxx:role/ManagedOpenShift-Support-Role --controlplane-iam-role arn:aws:iam::xxx:role/ManagedOpenShift-ControlPlane-Role --worker-iam-role arn:aws:iam::xxx:role/ManagedOpenShift-Worker-Role --operator-roles-prefix test-p2n3 --region us-east-1 --channel-group candidate --version 4.12.0-rc.4-candidate --replicas 2 --compute-machine-type m5.xlarge --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23`

# After changes
`rosa create cluster --cluster-name [test-2](https://issues.redhat.com//browse/test-2) --sts --role-arn arn:aws:iam::xxx:role/ManagedOpenShift-Installer-Role --support-role-arn arn:aws:iam::xxx:role/ManagedOpenShift-Support-Role --controlplane-iam-role arn:aws:iam::xxx:role/ManagedOpenShift-ControlPlane-Role --worker-iam-role arn:aws:iam::xxx:role/ManagedOpenShift-Worker-Role --operator-roles-prefix test-p2n3 --region us-east-1 --channel-group candidate --version 4.12.0-rc.4 --replicas 2 --compute-machine-type m5.xlarge --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23`