### PR TITLE
Refactor `GetPolicies` function

### DIFF
--- a/cmd/install/addon/cmd.go
+++ b/cmd/install/addon/cmd.go
@@ -315,7 +315,7 @@ func createAddonRole(r *rosa.Runtime, roleName string, cr *cmv1.CredentialReques
 	if err != nil {
 		return err
 	}
-	policyDetails := policies["operator_iam_role_policy"]
+	policyDetails := aws.GetSTSPolicyDetails(policies, "operator_iam_role_policy")
 	assumePolicy, err := aws.GenerateAddonPolicyDoc(cluster, r.Creator.AccountID, cr, policyDetails)
 	if err != nil {
 		return err

--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/briandowns/spinner"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/pkg/aws"
@@ -226,7 +227,7 @@ func LogError(key string, ocmClient *ocm.Client, defaultPolicyVersion string, er
 }
 
 func upgradeAccountRolePolicies(reporter *rprtr.Object, awsClient aws.Client, prefix string, accountID string,
-	policies map[string]string, policyVersion string, policyPath string, isVersionChosen bool) error {
+	policies map[string]*cmv1.AWSSTSPolicy, policyVersion string, policyPath string, isVersionChosen bool) error {
 	for file, role := range aws.AccountRoles {
 		roleName := aws.GetRoleName(prefix, role.Name)
 		promptString := fmt.Sprintf("Upgrade the '%s' role policy latest version ?", roleName)
@@ -239,7 +240,7 @@ func upgradeAccountRolePolicies(reporter *rprtr.Object, awsClient aws.Client, pr
 		filename := fmt.Sprintf("sts_%s_permission_policy", file)
 		policyARN := aws.GetPolicyARN(accountID, roleName, policyPath)
 
-		policyDetails := policies[filename]
+		policyDetails := aws.GetSTSPolicyDetails(policies, filename)
 		policyARN, err := awsClient.EnsurePolicy(policyARN, policyDetails,
 			policyVersion, map[string]string{
 				tags.OpenShiftVersion: policyVersion,

--- a/cmd/upgrade/roles/cmd.go
+++ b/cmd/upgrade/roles/cmd.go
@@ -495,7 +495,7 @@ func upgradeAccountRolePoliciesFromCluster(
 	awsClient aws.Client,
 	cluster *v1.Cluster,
 	accountID string,
-	policies map[string]string,
+	policies map[string]*v1.AWSSTSPolicy,
 	policyVersion string,
 	isVersionChosen bool,
 ) error {
@@ -538,7 +538,7 @@ func upgradeAccountRolePoliciesFromCluster(
 			return err
 		}
 
-		policyDetails := policies[filename]
+		policyDetails := aws.GetSTSPolicyDetails(policies, filename)
 		policyARN, err = awsClient.EnsurePolicy(policyARN, policyDetails,
 			policyVersion, map[string]string{
 				tags.OpenShiftVersion: policyVersion,
@@ -652,7 +652,7 @@ func upgradeOperatorPolicies(
 	mode string,
 	r *rosa.Runtime,
 	isAccountRoleUpgradeNeed bool,
-	policies map[string]string,
+	policies map[string]*v1.AWSSTSPolicy,
 	env string,
 	defaultPolicyVersion string,
 	credRequests map[string]*v1.STSOperator,
@@ -730,7 +730,7 @@ func upgradeOperatorRolePoliciesFromCluster(
 	reporter *rprtr.Object,
 	awsClient aws.Client,
 	accountID string,
-	policies map[string]string,
+	policies map[string]*v1.AWSSTSPolicy,
 	defaultPolicyVersion string,
 	credRequests map[string]*v1.STSOperator,
 	operatorRoles []*v1.OperatorIAMRole,
@@ -776,7 +776,7 @@ func upgradeOperatorRolePoliciesFromCluster(
 			}
 		}
 		filename := fmt.Sprintf("openshift_%s_policy", credrequest)
-		policyDetails := policies[filename]
+		policyDetails := aws.GetSTSPolicyDetails(policies, filename)
 		policyARN, err = awsClient.EnsurePolicy(policyARN, policyDetails,
 			defaultPolicyVersion, map[string]string{
 				tags.OpenShiftVersion:  defaultPolicyVersion,
@@ -955,7 +955,7 @@ func createOperatorRole(
 	r *rosa.Runtime,
 	cluster *v1.Cluster,
 	missingRoles map[string]*v1.STSOperator,
-	policies map[string]string,
+	policies map[string]*v1.AWSSTSPolicy,
 	unifiedPath string,
 	operatorRolePolicyPrefix string,
 ) error {
@@ -1010,7 +1010,7 @@ func upgradeMissingOperatorRole(
 	cluster *v1.Cluster,
 	accountID string,
 	r *rosa.Runtime,
-	policies map[string]string,
+	policies map[string]*v1.AWSSTSPolicy,
 	unifiedPath string,
 	operatorRolePolicyPrefix string,
 ) error {
@@ -1022,7 +1022,7 @@ func upgradeMissingOperatorRole(
 			}
 			continue
 		}
-		policyDetails := policies["operator_iam_role_policy"]
+		policyDetails := aws.GetSTSPolicyDetails(policies, "operator_iam_role_policy")
 
 		policyARN := aws.GetOperatorPolicyARN(
 			accountID,

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -89,7 +89,7 @@ type Client interface {
 	GetAWSAccessKeys() (*AccessKey, error)
 	GetLocalAWSAccessKeys() (*AccessKey, error)
 	GetCreator() (*Creator, error)
-	ValidateSCP(*string, map[string]string) (bool, error)
+	ValidateSCP(*string, map[string]*cmv1.AWSSTSPolicy) (bool, error)
 	GetSubnetIDs() ([]*ec2.Subnet, error)
 	GetSubnetAvailabilityZone(subnetID string) (string, error)
 	GetVPCPrivateSubnets(subnetID string) ([]*ec2.Subnet, error)

--- a/pkg/aws/permissions.go
+++ b/pkg/aws/permissions.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/iam"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
 // SimulateParams captures any additional details that should be used
@@ -14,8 +15,8 @@ type SimulateParams struct {
 }
 
 // ValidateSCP attempts to validate SCP policies by ensuring we have the correct permissions
-func (c *awsClient) ValidateSCP(target *string, policies map[string]string) (bool, error) {
-	policyDetails := policies["osd_scp_policy"]
+func (c *awsClient) ValidateSCP(target *string, policies map[string]*cmv1.AWSSTSPolicy) (bool, error) {
+	policyDetails := GetSTSPolicyDetails(policies, "osd_scp_policy")
 
 	sParams := &SimulateParams{
 		Region: *c.awsSession.Config.Region,

--- a/pkg/helper/roles/helpers.go
+++ b/pkg/helper/roles/helpers.go
@@ -29,7 +29,7 @@ func BuildMissingOperatorRoleCommand(
 	cluster *cmv1.Cluster,
 	accountID string,
 	r *rosa.Runtime,
-	policies map[string]string,
+	policies map[string]*cmv1.AWSSTSPolicy,
 	unifiedPath string,
 	operatorRolePolicyPrefix string,
 ) (string, error) {
@@ -43,7 +43,7 @@ func BuildMissingOperatorRoleCommand(
 			operator.Name(),
 			unifiedPath,
 		)
-		policyDetails := policies["operator_iam_role_policy"]
+		policyDetails := aws.GetSTSPolicyDetails(policies, "operator_iam_role_policy")
 		policy, err := aws.GenerateOperatorRolePolicyDoc(cluster, accountID, operator, policyDetails)
 		if err != nil {
 			return "", err

--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -503,11 +503,11 @@ func CheckSupportedVersion(clusterVersion string, operatorVersion string) (bool,
 	return v1.GreaterThanOrEqual(v2), nil
 }
 
-func (c *Client) GetPolicies(policyType string) (map[string]string, error) {
+func (c *Client) GetPolicies(policyType string) (map[string]*cmv1.AWSSTSPolicy, error) {
 
 	query := fmt.Sprintf("policy_type = '%s'", policyType)
 
-	m := make(map[string]string)
+	m := make(map[string]*cmv1.AWSSTSPolicy)
 
 	stmt := c.ocm.ClustersMgmt().V1().AWSInquiries().STSPolicies().List()
 	if policyType != "" {
@@ -518,7 +518,7 @@ func (c *Client) GetPolicies(policyType string) (map[string]string, error) {
 		return m, handleErr(accountRolePoliciesResponse.Error(), err)
 	}
 	accountRolePoliciesResponse.Items().Each(func(awsPolicy *cmv1.AWSSTSPolicy) bool {
-		m[awsPolicy.ID()] = awsPolicy.Details()
+		m[awsPolicy.ID()] = awsPolicy
 		return true
 	})
 	return m, nil


### PR DESCRIPTION
Refactor the function to return a map with `AWSSTSPolicy` values, 
in order to use the `ARN` attribute for managed policies in the future.

Related: [SDA-7609](https://issues.redhat.com/browse/SDA-7609)