### PR TITLE
Create account roles with existing policies

### DIFF
--- a/cmd/create/ocmrole/cmd.go
+++ b/cmd/create/ocmrole/cmd.go
@@ -401,7 +401,7 @@ func createRoles(r *rosa.Runtime, prefix string, roleName string, rolePath strin
 		r.Reporter.Debugf("Creating role '%s'", roleName)
 
 		roleARN, err = r.AWSClient.EnsureRole(roleName, policy, permissionsBoundary,
-			"", iamTags, rolePath)
+			"", iamTags, rolePath, false)
 		if err != nil {
 			return "", err
 		}

--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -332,7 +332,7 @@ func createRoles(r *rosa.Runtime,
 				tags.OperatorNamespace: operator.Namespace(),
 				tags.OperatorName:      operator.Name(),
 				tags.RedHatManaged:     "true",
-			}, path)
+			}, path, false)
 		if err != nil {
 			return err
 		}
@@ -355,7 +355,7 @@ func buildCommands(r *rosa.Runtime, env string,
 	policies map[string]*cmv1.AWSSTSPolicy, credRequests map[string]*cmv1.STSOperator) (string, error) {
 
 	err := aws.GeneratePolicyFiles(r.Reporter, env, false,
-		true, policies, credRequests)
+		true, policies, credRequests, false)
 	if err != nil {
 		r.Reporter.Errorf("There was an error generating the policy files: %s", err)
 		os.Exit(1)

--- a/cmd/create/userrole/cmd.go
+++ b/cmd/create/userrole/cmd.go
@@ -310,7 +310,7 @@ func createRoles(r *rosa.Runtime,
 			tags.RoleType:      aws.OCMUserRole,
 			tags.Environment:   env,
 			tags.RedHatManaged: "true",
-		}, path)
+		}, path, false)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/install/addon/cmd.go
+++ b/cmd/install/addon/cmd.go
@@ -328,7 +328,7 @@ func createAddonRole(r *rosa.Runtime, roleName string, cr *cmv1.CredentialReques
 			tags.ClusterID:    cluster.ID(),
 			"addon_namespace": cr.Namespace(),
 			"addon_name":      cr.Name(),
-		}, "")
+		}, "", false)
 	if err != nil {
 		return err
 	}

--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -194,7 +194,7 @@ func run(cmd *cobra.Command, argv []string) error {
 		}
 	case aws.ModeManual:
 		err = aws.GeneratePolicyFiles(reporter, env, isUpgradeNeedForAccountRolePolicies,
-			false, policies, nil)
+			false, policies, nil, false)
 		if err != nil {
 			reporter.Errorf("There was an error generating the policy files: %s", err)
 			os.Exit(1)

--- a/cmd/upgrade/operatorroles/cmd.go
+++ b/cmd/upgrade/operatorroles/cmd.go
@@ -281,7 +281,7 @@ func upgradeOperatorPolicies(mode string, r *rosa.Runtime,
 		return nil
 	case aws.ModeManual:
 		err := aws.GeneratePolicyFiles(r.Reporter, env, false,
-			true, policies, credRequests)
+			true, policies, credRequests, false)
 		if err != nil {
 			r.Reporter.Errorf("There was an error generating the policy files: %s", err)
 			os.Exit(1)
@@ -355,7 +355,7 @@ func upgradeMissingOperatorRole(missingRoles map[string]*cmv1.STSOperator, clust
 				tags.OperatorNamespace: operator.Namespace(),
 				tags.OperatorName:      operator.Name(),
 				tags.RedHatManaged:     "true",
-			}, unifiedPath)
+			}, unifiedPath, false)
 		if err != nil {
 			return err
 		}

--- a/cmd/upgrade/roles/cmd.go
+++ b/cmd/upgrade/roles/cmd.go
@@ -250,7 +250,7 @@ func run(cmd *cobra.Command, argv []string) error {
 			}
 		case aws.ModeManual:
 			err = aws.GeneratePolicyFiles(reporter, env, isUpgradeNeedForAccountRolePolicies,
-				false, accountRolePolicies, nil)
+				false, accountRolePolicies, nil, false)
 			if err != nil {
 				reporter.Errorf("There was an error generating the policy files: %s", err)
 				os.Exit(1)
@@ -691,7 +691,7 @@ func upgradeOperatorPolicies(
 		return nil
 	case aws.ModeManual:
 		err := aws.GeneratePolicyFiles(r.Reporter, env, false,
-			true, policies, credRequests)
+			true, policies, credRequests, false)
 		if err != nil {
 			r.Reporter.Errorf("There was an error generating the policy files: %s", err)
 			os.Exit(1)
@@ -1042,7 +1042,7 @@ func upgradeMissingOperatorRole(
 				tags.OperatorNamespace: operator.Namespace(),
 				tags.OperatorName:      operator.Name(),
 				tags.RedHatManaged:     "true",
-			}, unifiedPath)
+			}, unifiedPath, false)
 		if err != nil {
 			return err
 		}

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -97,7 +97,7 @@ type Client interface {
 	TagUserRegion(username string, region string) error
 	GetClusterRegionTagForUser(username string) (string, error)
 	EnsureRole(name string, policy string, permissionsBoundary string,
-		version string, tagList map[string]string, path string) (string, error)
+		version string, tagList map[string]string, path string, managedPolicies bool) (string, error)
 	ValidateRoleNameAvailable(name string) (err error)
 	PutRolePolicy(roleName string, policyName string, policy string) error
 	EnsurePolicy(policyArn string, document string, version string, tagList map[string]string,

--- a/pkg/aws/tags/tags.go
+++ b/pkg/aws/tags/tags.go
@@ -50,6 +50,8 @@ const AdminRole = prefix + "admin_role"
 // RedHatManaged tags the role as red_hat_managed
 const RedHatManaged = "red-hat-managed"
 
+const ManagedPolicies = prefix + "managed_policies"
+
 const OperatorNamespace = "operator_namespace"
 
 const OperatorName = "operator_name"

--- a/pkg/ocm/config.go
+++ b/pkg/ocm/config.go
@@ -26,6 +26,8 @@ import (
 	"github.com/openshift/rosa/pkg/fedramp"
 )
 
+const Production = "production"
+
 // URLAliases allows the value of the `--env` option to map to the various API URLs.
 var URLAliases = map[string]string{
 	"production":  "https://api.openshift.com",


### PR DESCRIPTION
This is a preparation for managed policies.

1. Validate the environment supports the `managed` flag (not production).
2. Don't output the `create policy` commands in manual mode.
3. Validate there aren't existing unmanaged roles with the same names.
4. Add a new role tag `rosa_managed_policies` to managed roles.

**Note:** In order to use this command one has to create policies in the AWS account
with these ARNs https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/blob/master/pkg/aws/loader/aws_sts_managed_policies.go#L6.

Related: [SDA-7656](https://issues.redhat.com/browse/SDA-7656)

Validate environment:
![image](https://user-images.githubusercontent.com/57869309/209675986-ce0842d9-0ce8-45fe-a38e-16efb02d03ee.png)

Don't display `create policy` commands in the manual mode:
![image](https://user-images.githubusercontent.com/57869309/209676048-8e226ba9-53e5-4282-95c2-38b685065656.png)

Check if there are exiting unmanaged roles with the same names:
![image](https://user-images.githubusercontent.com/57869309/209676098-678ebb14-0e9c-4f1e-be89-9058f41c7072.png)
