### PR TITLE
Create operator role with existing policies

### DIFF
--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -209,7 +209,7 @@ func run(cmd *cobra.Command, argv []string) {
 
 	managedPolicies, err := r.AWSClient.HasManagedPolicies(cluster)
 	if err != nil {
-		r.Reporter.Errorf("Failed to determine if cluster has managed policies", err)
+		r.Reporter.Errorf("Failed to determine if cluster has managed policies: %v", err)
 		os.Exit(1)
 	}
 	// TODO: remove once AWS managed policies are in place
@@ -246,7 +246,7 @@ func run(cmd *cobra.Command, argv []string) {
 			r.Reporter.Errorf("There was an error creating the operator roles: %s", err)
 			isThrottle := "false"
 			if strings.Contains(err.Error(), "Throttling") {
-				isThrottle = "true"
+				isThrottle = helper.True
 			}
 			r.OCMClient.LogEvent("ROSACreateOperatorRolesModeAuto", map[string]string{
 				ocm.ClusterID:  clusterKey,
@@ -330,7 +330,7 @@ func createRoles(r *rosa.Runtime,
 				defaultVersion, map[string]string{
 					tags.OpenShiftVersion:  accountRoleVersion,
 					tags.RolePrefix:        prefix,
-					tags.RedHatManaged:     "true",
+					tags.RedHatManaged:     helper.True,
 					tags.OperatorNamespace: operator.Namespace(),
 					tags.OperatorName:      operator.Name(),
 				}, path)
@@ -350,10 +350,10 @@ func createRoles(r *rosa.Runtime,
 			tags.ClusterID:         cluster.ID(),
 			tags.OperatorNamespace: operator.Namespace(),
 			tags.OperatorName:      operator.Name(),
-			tags.RedHatManaged:     "true",
+			tags.RedHatManaged:     helper.True,
 		}
 		if managedPolicies {
-			tagsList[tags.ManagedPolicies] = "true"
+			tagsList[tags.ManagedPolicies] = helper.True
 		}
 
 		roleARN, err := r.AWSClient.EnsureRole(roleName, policy, permissionsBoundary, accountRoleVersion,
@@ -422,7 +422,7 @@ func buildCommands(r *rosa.Runtime, env string,
 					tags.RolePrefix:        prefix,
 					tags.OperatorNamespace: operator.Namespace(),
 					tags.OperatorName:      operator.Name(),
-					tags.RedHatManaged:     "true",
+					tags.RedHatManaged:     helper.True,
 				}
 				createPolicy := awscb.NewIAMCommandBuilder().
 					SetCommand(awscb.CreatePolicy).
@@ -453,10 +453,10 @@ func buildCommands(r *rosa.Runtime, env string,
 			tags.RolePrefix:        prefix,
 			tags.OperatorNamespace: operator.Namespace(),
 			tags.OperatorName:      operator.Name(),
-			tags.RedHatManaged:     "true",
+			tags.RedHatManaged:     helper.True,
 		}
 		if managedPolicies {
-			iamTags[tags.ManagedPolicies] = "true"
+			iamTags[tags.ManagedPolicies] = helper.True
 		}
 		createRole := awscb.NewIAMCommandBuilder().
 			SetCommand(awscb.CreateRole).

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -156,6 +156,7 @@ type Client interface {
 	DescribeAvailabilityZones() ([]string, error)
 	IsLocalAvailabilityZone(availabilityZoneName string) (bool, error)
 	DetachRolePolicies(roleName string) error
+	HasManagedPolicies(cluster *cmv1.Cluster) (bool, error)
 }
 
 // ClientBuilder contains the information and logic needed to build a new AWS client.

--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -1342,6 +1342,19 @@ func (c *awsClient) IsUpgradedNeededForAccountRolePolicies(prefix string, versio
 	return false, nil
 }
 
+func (c *awsClient) HasManagedPolicies(cluster *cmv1.Cluster) (bool, error) {
+	if cluster.AWS().STS().RoleARN() == "" {
+		return false, nil
+	}
+
+	role, err := c.GetRoleByARN(cluster.AWS().STS().RoleARN())
+	if err != nil {
+		return false, err
+	}
+
+	return c.isManagedRole(role.Tags), nil
+}
+
 func (c *awsClient) IsUpgradedNeededForAccountRolePoliciesForCluster(cluster *cmv1.Cluster,
 	version string) (bool, error) {
 

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -31,6 +31,8 @@ const (
 	digitCount  = nineCode - zeroCode + 1
 )
 
+const True = "true"
+
 func RandomLabel(size int) string {
 	value := rand.Int() // #nosec G404
 	chars := make([]byte, size)


### PR DESCRIPTION
Determine if the cluster account roles have managed policies, 
if so, create the operator roles accordingly.

Related: [SDA-7660](https://issues.redhat.com/browse/SDA-7660)

The CLI detects that the account roles have managed policies:
![image](https://user-images.githubusercontent.com/57869309/210218195-fb0fe332-c2ac-49b9-9586-f10f794c3710.png)
and creates operator roles with managed policies:
![image](https://user-images.githubusercontent.com/57869309/210218101-9e738324-dc56-40bd-a060-fadd13a2484f.png)
