### PR TITLE
[SDA-4764] Hide region from other globally available commands

### DIFF
--- a/cmd/create/cmd.go
+++ b/cmd/create/cmd.go
@@ -60,8 +60,10 @@ func init() {
 	arguments.AddRegionFlag(flags)
 	confirm.AddFlag(flags)
 
-	accountroles.Cmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-		arguments.MarkGlobalFlagsHidden(Cmd, "region")
-		command.Parent().HelpFunc()(command, strings)
-	})
+	globallyAvailableCommands := []*cobra.Command{
+		accountroles.Cmd, operatorroles.Cmd,
+		userrole.Cmd, ocmrole.Cmd,
+		oidcprovider.Cmd,
+	}
+	arguments.MarkRegionHidden(Cmd, globallyAvailableCommands)
 }

--- a/cmd/dlt/cmd.go
+++ b/cmd/dlt/cmd.go
@@ -61,8 +61,10 @@ func init() {
 	arguments.AddRegionFlag(flags)
 	confirm.AddFlag(flags)
 
-	accountroles.Cmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-		arguments.MarkGlobalFlagsHidden(Cmd, "region")
-		command.Parent().HelpFunc()(command, strings)
-	})
+	globallyAvailableCommands := []*cobra.Command{
+		accountroles.Cmd, operatorrole.Cmd,
+		userrole.Cmd, ocmrole.Cmd,
+		oidcprovider.Cmd,
+	}
+	arguments.MarkRegionHidden(Cmd, globallyAvailableCommands)
 }

--- a/cmd/list/cmd.go
+++ b/cmd/list/cmd.go
@@ -63,8 +63,9 @@ func init() {
 	arguments.AddProfileFlag(flags)
 	arguments.AddRegionFlag(flags)
 
-	accountroles.Cmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-		arguments.MarkGlobalFlagsHidden(Cmd, "region")
-		command.Parent().HelpFunc()(command, strings)
-	})
+	globallyAvailableCommands := []*cobra.Command{
+		accountroles.Cmd, userroles.Cmd,
+		ocmroles.Cmd,
+	}
+	arguments.MarkRegionHidden(Cmd, globallyAvailableCommands)
 }

--- a/cmd/upgrade/cmd.go
+++ b/cmd/upgrade/cmd.go
@@ -44,8 +44,9 @@ func init() {
 	arguments.AddRegionFlag(flags)
 	interactive.AddFlag(flags)
 
-	accountroles.Cmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-		arguments.MarkGlobalFlagsHidden(Cmd, "region")
-		command.Parent().HelpFunc()(command, strings)
-	})
+	globallyAvailableCommands := []*cobra.Command{
+		accountroles.Cmd, operatorroles.Cmd,
+		roles.Cmd,
+	}
+	arguments.MarkRegionHidden(Cmd, globallyAvailableCommands)
 }

--- a/pkg/arguments/arguments.go
+++ b/pkg/arguments/arguments.go
@@ -228,11 +228,20 @@ func IsValidMode(modes []string, mode string) bool {
 	return false
 }
 
-func MarkGlobalFlagsHidden(command *cobra.Command, hidden ...string) {
+func markGlobalFlagsHidden(command *cobra.Command, hidden ...string) {
 	command.PersistentFlags().VisitAll(func(flag *pflag.Flag) {
 		name := flag.Name
 		if helper.Contains(hidden, name) {
 			flag.Hidden = true
 		}
 	})
+}
+
+func MarkRegionHidden(parentCmd *cobra.Command, childrenCmds []*cobra.Command) {
+	for _, cmd := range childrenCmds {
+		cmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
+			markGlobalFlagsHidden(parentCmd, "region")
+			command.Parent().HelpFunc()(command, strings)
+		})
+	}
 }


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-4764
# What
Hides region in globally available commands, basically what deals with aws iam service

# Why
Globally available commands should have region hidden in help