### PR TITLE
[SDA-7663] Check current ingress values to see if there are no changes

### DIFF
--- a/cmd/edit/ingress/cmd.go
+++ b/cmd/edit/ingress/cmd.go
@@ -222,9 +222,9 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
-	sameRouteSelectors := reflect.DeepEqual(curRouteSelectors, ingress.RouteSelectors()) || ingress.RouteSelectors() == nil
+	sameRouteSelectors := ingress.RouteSelectors() == nil || reflect.DeepEqual(curRouteSelectors, ingress.RouteSelectors())
 	// If private arg is nil no change to listening method will be made anyway
-	sameListeningMethod := curListening == ingress.Listening() || private == nil
+	sameListeningMethod := private == nil || curListening == ingress.Listening()
 
 	if sameListeningMethod && sameRouteSelectors {
 		r.Reporter.Warnf("No need to update ingress as there are no changes")

--- a/cmd/edit/ingress/cmd.go
+++ b/cmd/edit/ingress/cmd.go
@@ -19,6 +19,7 @@ package ingress
 import (
 	"fmt"
 	"os"
+	"reflect"
 	"regexp"
 	"strings"
 
@@ -196,6 +197,9 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
+	curListening := ingress.Listening()
+	curRouteSelectors := ingress.RouteSelectors()
+
 	ingressBuilder := cmv1.NewIngress().ID(ingress.ID())
 
 	// Toggle private mode
@@ -218,7 +222,11 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
-	if private == nil && len(routeSelectors) == 0 {
+	sameRouteSelectors := reflect.DeepEqual(curRouteSelectors, ingress.RouteSelectors()) || ingress.RouteSelectors() == nil
+	// If private arg is nil no change to listening method will be made anyway
+	sameListeningMethod := curListening == ingress.Listening() || private == nil
+
+	if sameListeningMethod && sameRouteSelectors {
 		r.Reporter.Warnf("No need to update ingress as there are no changes")
 		os.Exit(0)
 	}


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-7663

# What
Checks current values from ingress to make sure there will be changes or not

# Why
Changes were not going through due to some conditions

# Changes
`./rosa create ingress  -c non-sts --label-match a=b`
```
I: Ingress has been created on cluster 'non-sts'.
I: To view all ingresses, run 'rosa list ingresses -c non-sts'
```

`./rosa edit ingress c4r1 -c non-sts --label-match="a=b"`
```
W: No need to update ingress as there are no changes
```

`./rosa list ingresses -c non-sts`
```
ID    APPLICATION ROUTER                              PRIVATE    DEFAULT    ROUTE SELECTORS
c4r1  https://apps2.non-sts.9so3.s1.devshift.org      no         no         a=b
p2s8  https://apps.non-sts.9so3.s1.devshift.org       no         yes        
```

`./rosa edit ingress c4r1 -c non-sts --label-match=""`
```
I: Updated ingress 'c4r1' on cluster 'non-sts'
```

`./rosa list ingresses -c non-sts`
```
ID    APPLICATION ROUTER                              PRIVATE    DEFAULT    ROUTE SELECTORS
c4r1  https://apps2.non-sts.9so3.s1.devshift.org      no         no         
p2s8  https://apps.non-sts.9so3.s1.devshift.org       no         yes        
```

`./rosa edit ingress c4r1 -c non-sts`
```
? Label match for ingress (optional): 
? Private ingress (optional): No
W: No need to update ingress as there are no changes
```