### PR TITLE
[SDA-7662] Display Tags question in interactive mode

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1149,7 +1149,7 @@ func run(cmd *cobra.Command, _ []string) {
 	// Custom tags for AWS resources
 	tags := args.tags
 	tagsList := map[string]string{}
-	if len(tags) > 0 && interactive.Enabled() {
+	if interactive.Enabled() {
 		tagsInput, err := interactive.GetString(interactive.Input{
 			Question: "Tags",
 			Help:     cmd.Flags().Lookup("tags").Usage,


### PR DESCRIPTION
[SDA-7662](https://issues.redhat.com/browse/SDA-7662)

The Tags question which prompts what tags youd like to add to the cluster, was disabled if `--tags` wasn't passed with at least one tag. Now it runs all the time in interactive mode.