### PR TITLE
Upgrade account roles with managed policies

### DIFF
--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -207,7 +207,7 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
-	managedPolicies, err := r.AWSClient.HasManagedPolicies(cluster)
+	managedPolicies, err := r.AWSClient.HasManagedPolicies(cluster.AWS().STS().RoleARN())
 	if err != nil {
 		r.Reporter.Errorf("Failed to determine if cluster has managed policies: %v", err)
 		os.Exit(1)

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -156,7 +156,9 @@ type Client interface {
 	DescribeAvailabilityZones() ([]string, error)
 	IsLocalAvailabilityZone(availabilityZoneName string) (bool, error)
 	DetachRolePolicies(roleName string) error
-	HasManagedPolicies(cluster *cmv1.Cluster) (bool, error)
+	HasManagedPolicies(roleARN string) (bool, error)
+	GetAccountRoleARN(prefix string, roleType string) (string, error)
+	ValidateAccountRolesManagedPolicies(prefix string, policies map[string]*cmv1.AWSSTSPolicy) error
 }
 
 // ClientBuilder contains the information and logic needed to build a new AWS client.


### PR DESCRIPTION
If the roles have the tag `rosa_managed_policies:true`, verify that the managed policies are attached and exit. 
Policies upgrade isn't needed for managed policies.

Related: [SDA-7678](https://issues.redhat.com/browse/SDA-7678)

Examples:
1. User provides invalid prefix:
![image](https://user-images.githubusercontent.com/57869309/210560095-7a966cc0-d15d-4423-81e0-92d2c6780ff2.png)
2.  User upgrades roles with managed policies successfully:
![image](https://user-images.githubusercontent.com/57869309/210560178-110ad3de-d474-4c74-8492-8a25c31798f5.png)
3. One of the roles is missing the attached managed policy:
![image](https://user-images.githubusercontent.com/57869309/210560240-18c0f6cb-f7ce-4e8b-b9af-ef6d426bd89a.png)
4. Managed policies are disabled on production:
![image](https://user-images.githubusercontent.com/57869309/210560301-66242e79-cb45-48d2-a3bf-bd0b3bb56316.png)
