### PR TITLE
Fix OAuth callback URL logic for HyperShift clusters

### DIFF
--- a/cmd/create/cluster/cmd_test.go
+++ b/cmd/create/cluster/cmd_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Validates OCP version", func() {
 			v, err := validateVersion("4.12.0-0.nightly-2022-11-25-185455-nightly",
 				[]string{"4.12.0-0.nightly-2022-11-25-185455-nightly"}, nightly, false, true)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(v).To(Equal("openshift-v4.12.0-0.nightly-2022-11-25-185455-nightly"))
+			Expect(v).To(Equal("openshift-v4.12.0-0.nightly-2022-11-25-185455-nightly-nightly"))
 		})
 
 		It("KO: Fails with a nightly version of OCP for hosted clusters "+
@@ -44,7 +44,7 @@ var _ = Describe("Validates OCP version", func() {
 			"with a supported version", func() {
 			v, err := validateVersion("4.13.0", []string{"4.13.0"}, fast, false, true)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(v).To(Equal("openshift-v4.13.0"))
+			Expect(v).To(Equal("openshift-v4.13.0-fast"))
 		})
 
 		It(`KO: Fails to validate a cluster for a hosted

--- a/cmd/create/idp/gitlab.go
+++ b/cmd/create/idp/gitlab.go
@@ -21,9 +21,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/url"
-	"strings"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/pkg/interactive"
@@ -62,8 +62,10 @@ func buildGitlabIdp(cmd *cobra.Command,
 
 	if interactive.Enabled() {
 		instructionsURL := fmt.Sprintf("%s/profile/applications", gitlabURL)
-		consoleURL := cluster.Console().URL()
-		oauthURL := strings.Replace(consoleURL, "console-openshift-console", "oauth-openshift", 1)
+		oauthURL, err := ocm.BuildOAuthURL(cluster)
+		if err != nil {
+			return idpBuilder, fmt.Errorf("Error building OAuth URL: %v", err)
+		}
 		err = interactive.PrintHelp(interactive.Help{
 			Message: "To use GitLab as an identity provider, register the application by opening:",
 			Steps:   []string{instructionsURL},

--- a/cmd/create/idp/google.go
+++ b/cmd/create/idp/google.go
@@ -19,13 +19,13 @@ package idp
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/dchest/validator"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/ocm"
 )
 
 func buildGoogleIdp(cmd *cobra.Command,
@@ -40,8 +40,10 @@ func buildGoogleIdp(cmd *cobra.Command,
 
 	if interactive.Enabled() {
 		instructionsURL := "https://console.developers.google.com/projectcreate"
-		consoleURL := cluster.Console().URL()
-		oauthURL := strings.Replace(consoleURL, "console-openshift-console", "oauth-openshift", 1)
+		oauthURL, err := ocm.BuildOAuthURL(cluster)
+		if err != nil {
+			return idpBuilder, fmt.Errorf("Error building OAuth URL: %v", err)
+		}
 		err = interactive.PrintHelp(interactive.Help{
 			Message: "To use Google as an identity provider, you must first register the application:",
 			Steps: []string{

--- a/cmd/create/idp/openid.go
+++ b/cmd/create/idp/openid.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/ocm"
 )
 
 func buildOpenidIdp(cmd *cobra.Command,
@@ -48,7 +49,10 @@ func buildOpenidIdp(cmd *cobra.Command,
 	if interactive.Enabled() {
 		instructionsURL := "https://docs.openshift.com/dedicated/identity_providers/" +
 			"config-identity-providers.html#config-openid-idp_config-identity-providers"
-		oauthURL := strings.Replace(cluster.Console().URL(), "console-openshift-console", "oauth-openshift", 1)
+		oauthURL, err := ocm.BuildOAuthURL(cluster)
+		if err != nil {
+			return idpBuilder, fmt.Errorf("Error building OAuth URL: %v", err)
+		}
 		err = interactive.PrintHelp(interactive.Help{
 			Message: "To use OpenID as an identity provider, you must first register the application:",
 			Steps: []string{

--- a/pkg/ocm/idps_test.go
+++ b/pkg/ocm/idps_test.go
@@ -1,0 +1,43 @@
+package ocm
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+)
+
+var _ = Describe("IDPs", func() {
+	Context("OAuthURL", func() {
+		Context("BuildOAuthURL", func() {
+			It("Checks Hive cluster", func() {
+				consoleURL := cmv1.NewClusterConsole().
+					URL("https://console-openshift-console.apps.cluster.example.com")
+				cluster, err := cmv1.NewCluster().Name("cluster1").ID("id1").Console(consoleURL).Build()
+				Expect(err).To(BeNil())
+				url, err := BuildOAuthURL(cluster)
+				Expect(url).To(Equal("https://oauth-openshift.apps.cluster.example.com"))
+				Expect(err).To(BeNil())
+			})
+			It("Checks HyperShift cluster - Empty API URL", func() {
+				hypershift := cmv1.NewHypershift().Enabled(true)
+				apiURL := cmv1.NewClusterAPI().URL("")
+				cluster, err := cmv1.NewCluster().Name("cluster1").
+					ID("id1").Hypershift(hypershift).API(apiURL).Build()
+				Expect(err).To(BeNil())
+				url, err := BuildOAuthURL(cluster)
+				Expect(url).To(Equal(""))
+				Expect(err).To(Not(BeNil()))
+			})
+			It("Checks HyperShift cluster - Valid API URL", func() {
+				hypershift := cmv1.NewHypershift().Enabled(true)
+				apiURL := cmv1.NewClusterAPI().URL("https://api.example.com:6443")
+				cluster, err := cmv1.NewCluster().Name("cluster1").
+					ID("id1").Hypershift(hypershift).API(apiURL).Build()
+				Expect(err).To(BeNil())
+				url, err := BuildOAuthURL(cluster)
+				Expect(url).To(Equal("https://oauth.example.com"))
+				Expect(err).To(BeNil())
+			})
+		})
+	})
+})


### PR DESCRIPTION
The implementation leverages ExternalDNS which will be the default for all the clusters. 
No change for the non HyperShift clusters

Fixes: [SDA-7648](https://issues.redhat.com//browse/SDA-7648)