### PR TITLE
[SDA-6753] Now updating stsBuilder.AutoMode properly

### DIFF
--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -36,6 +36,7 @@ import (
 )
 
 var NetworkTypes = []string{"OpenShiftSDN", "OVNKubernetes"}
+var modeAuto = "auto"
 
 // Spec is the configuration for a cluster spec.
 type Spec struct {
@@ -779,7 +780,7 @@ func (c *Client) createClusterSpec(config Spec, awsClient aws.Client) (*cmv1.Clu
 		stsBuilder = stsBuilder.InstanceIAMRoles(instanceIAMRolesBuilder)
 
 		mode := false
-		if config.Mode == "auto" {
+		if config.Mode == modeAuto {
 			mode = true
 		}
 		stsBuilder.AutoMode(mode)

--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -777,6 +777,13 @@ func (c *Client) createClusterSpec(config Spec, awsClient aws.Client) (*cmv1.Clu
 			instanceIAMRolesBuilder.WorkerRoleARN(config.WorkerRoleARN)
 		}
 		stsBuilder = stsBuilder.InstanceIAMRoles(instanceIAMRolesBuilder)
+
+		mode := false
+		if config.Mode == "auto" {
+			mode = true
+		}
+		stsBuilder.AutoMode(mode)
+
 		awsBuilder = awsBuilder.STS(stsBuilder)
 	} else {
 		awsBuilder = awsBuilder.

--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -36,7 +36,6 @@ import (
 )
 
 var NetworkTypes = []string{"OpenShiftSDN", "OVNKubernetes"}
-var modeAuto = "auto"
 
 // Spec is the configuration for a cluster spec.
 type Spec struct {
@@ -780,7 +779,7 @@ func (c *Client) createClusterSpec(config Spec, awsClient aws.Client) (*cmv1.Clu
 		stsBuilder = stsBuilder.InstanceIAMRoles(instanceIAMRolesBuilder)
 
 		mode := false
-		if config.Mode == modeAuto {
+		if config.Mode == aws.ModeAuto {
 			mode = true
 		}
 		stsBuilder.AutoMode(mode)


### PR DESCRIPTION
[SDA-6753](https://issues.redhat.com//browse/SDA-6753) was a bug where in ROSA when you created a cluster using auto mode (`rosa create cluster --sts --mode auto` for example), the "credential_configuration_mode" Tracking property was set to `manual`. It is now updated properly by updating `stsBuilder.AutoMode` with the correct value depending on if it's auto mode or manual mode.

This change was tested using Segment and creating a cluster.