### PR TITLE
reprompt user when passed invalid addon argument

### DIFF
--- a/cmd/edit/addon/cmd.go
+++ b/cmd/edit/addon/cmd.go
@@ -150,18 +150,7 @@ func run(cmd *cobra.Command, argv []string) {
 			val = flag.Value.String()
 		}
 		if interactive.Enabled() {
-			input := interactive.Input{}
-			input.Question = param.Name()
-			input.Help = fmt.Sprintf("%s: %s", param.ID(), param.Description())
-			input.Required = param.Required()
-			input.Options = options
-
-			dflt := param.DefaultValue()
-			if addOnInstallationParam != nil {
-				dflt = addOnInstallationParam.Value()
-			}
-
-			val, err = interactive.GetAddonArgument(param, input, dflt)
+			val, err = interactive.GetAddonArgument(*param, dflt)
 			if err != nil {
 				r.Reporter.Errorf("%s", err)
 				os.Exit(1)

--- a/pkg/interactive/addon.go
+++ b/pkg/interactive/addon.go
@@ -3,73 +3,117 @@ package interactive
 import (
 	"fmt"
 	"net"
+	"regexp"
 	"strconv"
 	"strings"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
-func GetAddonArgument(param *cmv1.AddOnParameter, input Input, dflt string) (string, error) {
-	// Set default value based on existing parameter, otherwise use parameter default
-
-	// add a prompt to question name to indicate if the boolean param is required and check validation
-	if param.ValueType() == "boolean" && param.Validation() == "^true$" && param.Required() {
-		input.Question = fmt.Sprintf("%s (required)", param.Name())
-		input.Validators = []Validator{
-			RegExpBoolean(param.Validation()),
-		}
+func GetAddonArgument(param cmv1.AddOnParameter, dflt string) (string, error) {
+	var input = Input{
+		Question: param.Name(),
+		Help:     fmt.Sprintf("%s: %s", param.ID(), param.Description()),
+		Required: param.Required(),
+		Options:  getOptionNames(param),
+		Default:  dflt,
 	}
-
-	var err error
-	var value string
 
 	if len(input.Options) > 0 {
-		value, err = GetOption(input)
-		for _, paramOption := range param.Options() {
-			if strings.Compare(paramOption.Name(), value) == 0 {
-				value = paramOption.Value()
-			}
+		optionName, err := GetOption(input)
+		if err != nil {
+			return "", fmt.Errorf("expected a valid option for '%s': %v", param.ID(), err)
 		}
 
-		if err != nil {
-			return "", fmt.Errorf("expected a valid value for '%s': %v", param.ID(), err)
+		var optionValue string
+		for _, paramOption := range param.Options() {
+			if strings.Compare(paramOption.Name(), optionName) == 0 {
+				optionValue = paramOption.Value()
+				break
+			}
 		}
-		return value, nil
+		return optionValue, nil
 	}
+
+	if param.Validation() != "" {
+		input.Validators = []Validator{
+			func(ans interface{}) error {
+				strAns := ans.(string)
+				if strAns == input.Default {
+					return nil
+				}
+				if isValid, err := regexp.MatchString(param.Validation(), strAns); err != nil || !isValid {
+					if param.ValidationErrMsg() != "" {
+						return fmt.Errorf(param.ValidationErrMsg())
+					}
+					return fmt.Errorf("expected %q to match /%s/", strAns, param.Validation())
+				}
+				return nil
+			},
+		}
+	}
+
 	switch param.ValueType() {
 	case "boolean":
 		var boolVal bool
 		input.Default, _ = strconv.ParseBool(dflt)
-		boolVal, err = GetBool(input)
-		if boolVal {
-			value = "true"
-		} else {
-			value = "false"
+		// Set default value based on existing parameter, otherwise use parameter default
+		// add a prompt to question name to indicate if the boolean param is required and check validation
+		if param.Validation() == "^true$" && param.Required() {
+			input.Question = fmt.Sprintf("%s (required)", param.Name())
+			input.Validators = []Validator{
+				RegExpBoolean(param.Validation()),
+			}
 		}
+		boolVal, err := GetBool(input)
+		if err != nil {
+			return "", fmt.Errorf("expected a valid boolean value for '%s': %v", param.ID(), err)
+		}
+		if boolVal {
+			return "true", nil
+		}
+		return "false", nil
 	case "cidr":
 		var cidrVal net.IPNet
 		if dflt != "" {
 			_, defaultIDR, _ := net.ParseCIDR(dflt)
 			input.Default = *defaultIDR
 		}
-		cidrVal, err = GetIPNet(input)
-		value = cidrVal.String()
-		if value == "<nil>" {
-			value = ""
+		cidrVal, err := GetIPNet(input)
+		if err != nil {
+			return "", fmt.Errorf("expected a valid CIDR value for '%s': %v", param.ID(), err)
 		}
+		if cidrVal.String() == "<nil>" {
+			return "", nil
+		}
+		return cidrVal.String(), nil
 	case "number", "resource":
-		var numVal int
 		input.Default, _ = strconv.Atoi(dflt)
-		numVal, err = GetInt(input)
-		value = fmt.Sprintf("%d", numVal)
+		numVal, err := GetInt(input)
+		if err != nil {
+			return "", fmt.Errorf("expected a valid numerical value for '%s': %v", param.ID(), err)
+		}
+		return fmt.Sprintf("%d", numVal), nil
 
 	case "string":
 		input.Default = dflt
-		value, err = GetString(input)
+		value, err := GetString(input)
+		if err != nil {
+			return "", fmt.Errorf("expected a valid string value for '%s': %v", param.ID(), err)
+		}
+		return value, nil
 	}
 
-	if err != nil {
-		return "", fmt.Errorf("expected a valid value for '%s': %v", param.ID(), err)
+	// If the parameter type wasn't handled in the above switch statement
+	// then this parameter type is not supported by interactive mode yet.
+	return "", fmt.Errorf("The parameter '%s' does not support interactive mode", param.ID())
+}
+
+func getOptionNames(param cmv1.AddOnParameter) []string {
+	var optionNames []string
+	options, _ := param.GetOptions()
+	for _, option := range options {
+		optionNames = append(optionNames, option.Name())
 	}
-	return value, nil
+	return optionNames
 }

--- a/pkg/interactive/addon.go
+++ b/pkg/interactive/addon.go
@@ -9,7 +9,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
-func GetAddonParameter(param *cmv1.AddOnParameter, input Input, dflt string) (string, error) {
+func GetAddonArgument(param *cmv1.AddOnParameter, input Input, dflt string) (string, error) {
 	// Set default value based on existing parameter, otherwise use parameter default
 
 	// add a prompt to question name to indicate if the boolean param is required and check validation


### PR DESCRIPTION
The interactive mode was terminating if the user passed an invalid string argument when installing an addon.
This set of commits modifies the behavior of _interactive.GetAddonArgument()_ to continue prompting the user.

[SDA-6852](https://issues.redhat.com/browse/SDA-6852)