### PR TITLE
Upgrade operator roles with managed policies

### DIFF
--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -301,7 +301,7 @@ func createRoles(r *rosa.Runtime,
 				continue
 			}
 		}
-		roleName, _ := getRoleNameAndARN(cluster, operator)
+		roleName, _ := aws.FindOperatorRoleNameBySTSOperator(cluster, operator)
 		if roleName == "" {
 			return fmt.Errorf("Failed to find operator IAM role")
 		}
@@ -400,7 +400,7 @@ func buildCommands(r *rosa.Runtime, env string,
 				continue
 			}
 		}
-		roleName, _ := getRoleNameAndARN(cluster, operator)
+		roleName, _ := aws.FindOperatorRoleNameBySTSOperator(cluster, operator)
 		path, err := getPathFromInstallerRole(cluster)
 		if err != nil {
 			return "", err
@@ -475,16 +475,6 @@ func buildCommands(r *rosa.Runtime, env string,
 		commands = append(commands, createRole, attachRolePolicy)
 	}
 	return awscb.JoinCommands(commands), nil
-}
-
-func getRoleNameAndARN(cluster *cmv1.Cluster, operator *cmv1.STSOperator) (string, string) {
-	for _, role := range cluster.AWS().STS().OperatorIAMRoles() {
-		if role.Namespace() == operator.Namespace() && role.Name() == operator.Name() {
-			name, _ := aws.GetResourceIdFromARN(role.RoleARN())
-			return name, role.RoleARN()
-		}
-	}
-	return "", ""
 }
 
 func getPathFromInstallerRole(cluster *cmv1.Cluster) (string, error) {

--- a/cmd/upgrade/roles/cmd.go
+++ b/cmd/upgrade/roles/cmd.go
@@ -984,6 +984,8 @@ func createOperatorRole(
 			policies,
 			unifiedPath,
 			operatorRolePolicyPrefix,
+			// TODO: pass the actual managed policies value when the command is updated
+			false,
 		)
 		if err != nil {
 			return err

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -159,6 +159,8 @@ type Client interface {
 	HasManagedPolicies(roleARN string) (bool, error)
 	GetAccountRoleARN(prefix string, roleType string) (string, error)
 	ValidateAccountRolesManagedPolicies(prefix string, policies map[string]*cmv1.AWSSTSPolicy) error
+	ValidateOperatorRolesManagedPolicies(cluster *cmv1.Cluster, operatorRoles map[string]*cmv1.STSOperator,
+		policies map[string]*cmv1.AWSSTSPolicy) error
 }
 
 // ClientBuilder contains the information and logic needed to build a new AWS client.

--- a/pkg/aws/commandbuilder/helper/roles/roles.go
+++ b/pkg/aws/commandbuilder/helper/roles/roles.go
@@ -16,6 +16,7 @@ type ManualCommandsForMissingOperatorRolesInput struct {
 	Filename                 string
 	RolePath                 string
 	PolicyARN                string
+	ManagedPolicies          bool
 }
 
 func ManualCommandsForMissingOperatorRole(input ManualCommandsForMissingOperatorRolesInput) []string {
@@ -26,6 +27,9 @@ func ManualCommandsForMissingOperatorRole(input ManualCommandsForMissingOperator
 		tags.OperatorNamespace: input.Operator.Namespace(),
 		tags.OperatorName:      input.Operator.Name(),
 		tags.RedHatManaged:     "true",
+	}
+	if input.ManagedPolicies {
+		iamTags[tags.ManagedPolicies] = "true"
 	}
 
 	createRole := awscb.NewIAMCommandBuilder().

--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -762,6 +762,17 @@ func GetResourceIdFromARN(stringARN string) (string, error) {
 	return parsedARN.Resource[index+1:], nil
 }
 
+func FindOperatorRoleNameBySTSOperator(cluster *cmv1.Cluster, operator *cmv1.STSOperator) (string, bool) {
+	for _, role := range cluster.AWS().STS().OperatorIAMRoles() {
+		if role.Namespace() == operator.Namespace() && role.Name() == operator.Name() {
+			name, _ := GetResourceIdFromARN(role.RoleARN())
+			return name, true
+		}
+	}
+
+	return "", false
+}
+
 func FindOperatorRoleBySTSOperator(operatorRoles []*cmv1.OperatorIAMRole, operator *cmv1.STSOperator) string {
 	for _, operatorRole := range operatorRoles {
 		if operatorRole.Name() == operator.Name() && operatorRole.Namespace() == operator.Namespace() {


### PR DESCRIPTION
1. Check that managed policies are attached to the roles.
2. If the user specified the upgrade version, check for missing roles.

Related: [SDA-7679](https://issues.redhat.com/browse/SDA-7679)

![image](https://user-images.githubusercontent.com/57869309/211195265-01818e29-d562-49f2-ab54-27e665bf1c68.png)
![image](https://user-images.githubusercontent.com/57869309/211195269-a2b85c5d-f963-4968-94b7-36f0a97129b6.png)
