### PR TITLE
[SDA-7588] Edited query for GetClusterUsingSubscription to fix dlt op-roles and oidc

### DIFF
--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -339,8 +339,8 @@ func (c *Client) GetClusterByID(clusterKey string, creator *aws.Creator) (*cmv1.
 }
 
 func (c *Client) GetClusterUsingSubscription(clusterKey string, creator *aws.Creator) (*amv1.Subscription, error) {
-	query := fmt.Sprintf("plan.id = 'MOA' AND (display_name  = '%s' OR "+
-		"cluster_id = '%s') AND status = 'Deprovisioned'", clusterKey, clusterKey)
+	query := fmt.Sprintf("(plan.id = 'MOA' OR plan.id = 'MOA-HostedControlPlane')"+
+		" AND (display_name  = '%s' OR cluster_id = '%s') AND status = 'Deprovisioned'", clusterKey, clusterKey)
 	response, err := c.ocm.AccountsMgmt().V1().Subscriptions().List().
 		Search(query).
 		Page(1).


### PR DESCRIPTION
[SDA-7588](https://issues.redhat.com//browse/SDA-7588) was a bug where rosa was unable to delete operatorroles and oidcproviders for HS clusters. The query was incorrect, in that it's `plan.id` was `MOA` -- but for HS clusters, the `plan.id` is `MOA-HostedControlPlane`. A simple change to the query solved this bug.