### PR TITLE
Fix tags passing in cluster creation interactive mode

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1163,7 +1163,7 @@ func run(cmd *cobra.Command, _ []string) {
 			r.Reporter.Errorf("Expected a valid set of tags: %s", err)
 			os.Exit(1)
 		}
-		if len(tags) > 0 {
+		if len(tagsInput) > 0 {
 			tags = strings.Split(tagsInput, ",")
 		}
 	}


### PR DESCRIPTION
We were skipping the string splitting if no tag was passed in input