### PR TITLE
[SDA-7741] Machine pool label validation

### DIFF
--- a/cmd/create/machinepool/machinepool.go
+++ b/cmd/create/machinepool/machinepool.go
@@ -3,7 +3,6 @@ package machinepool
 import (
 	"fmt"
 	"os"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -17,8 +16,6 @@ import (
 	"github.com/openshift/rosa/pkg/rosa"
 	"github.com/spf13/cobra"
 )
-
-var labelRE = regexp.MustCompile(`^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$`)
 
 func addMachinePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster, r *rosa.Runtime) {
 	var err error
@@ -558,11 +555,11 @@ func ParseLabels(labels string) (map[string]string, error) {
 			return nil, fmt.Errorf("Expected key=value format for labels")
 		}
 		tokens := strings.Split(label, "=")
-		keyToken := labelRE.MatchString(tokens[0])
-		valueToken := labelRE.MatchString(tokens[1])
-		if !keyToken || !valueToken {
-			return nil, fmt.Errorf("name part must consist of alphanumeric characters, " +
-				"'-', '_' or '.', and must start and end with an alphanumeric character")
+		if strings.Contains(tokens[0], "\"") {
+			return nil, fmt.Errorf("Invalid label key '%s': name part must not contain '\"'", tokens[0])
+		}
+		if strings.Contains(tokens[1], "\"") {
+			return nil, fmt.Errorf("Invalid label value '%s': name part must not contain '\"'", tokens[1])
 		}
 		key := strings.TrimSpace(tokens[0])
 		value := strings.TrimSpace(tokens[1])


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-7741
# What
Changes introduced in https://issues.redhat.com/browse/SDA-7233 aimed at resolving an issue but created another. Decided to move to a simplified solution instead of going for regex as it is due to a single case

# Why
Empty value in labels value part should be accept


# Changes
`rosa create machinepool -c <cluster_key> --name workload --instance-type m5.2xlarge --labels node-role.kubernetes.io/workload= --taints role=workload:NoSchedule --replicas 3 -i`
```
? Machine pool name: workload3
? Replicas: 3
I: Fetching instance types
? Instance type: m5.2xlarge
? Labels: node-role.kubernetes.io/workload=
? Taints: [? for help] (role=workload:NoSchedule)
```

`./rosa create machinepool -c <cluster_key>`
```
I: Enabling interactive mode
? Machine pool name: test
? Enable autoscaling (optional): No
? Replicas: 1
I: Fetching instance types
? Instance type: m5.xlarge
X Sorry, your reply was invalid: Invalid label value 'ddd"': name part must not contain '"'
```

`./rosa create machinepool -c <cluster_key> --name workload3 --instance-type m5.2xlarge --labels node-role.kubernetes.io/workload= --taints role=workload:NoSchedule --replicas 3  `
```
I: Fetching instance types
I: Machine pool 'workload3' created successfully on cluster '<cluster_key>'
I: To view all machine pools, run 'rosa list machinepools -c '<cluster_key>'
```

`./rosa list machinepool -c <cluster_key>`
```
ID         AUTOSCALING  REPLICAS  INSTANCE TYPE  LABELS                               TAINTS                      AVAILABILITY ZONES    SUBNETS    SPOT INSTANCES
Default    No           2         m5.xlarge                                                                       us-east-1a                       N/A
workload3  No           3         m5.2xlarge     node-role.kubernetes.io/workload=    role=workload:NoSchedule    us-east-1a                       No
```