### PR TITLE
SDCICD-893: cmd/create/machinepool: support output flag

### DIFF
--- a/cmd/create/machinepool/cmd.go
+++ b/cmd/create/machinepool/cmd.go
@@ -22,6 +22,7 @@ import (
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/rosa"
 	"github.com/spf13/cobra"
 
@@ -169,6 +170,7 @@ func init() {
 		"Select subnet to create a single AZ machine pool for BYOVPC cluster")
 
 	interactive.AddFlag(flags)
+	output.AddFlag(Cmd)
 }
 
 func run(cmd *cobra.Command, _ []string) {

--- a/cmd/create/machinepool/machinepool.go
+++ b/cmd/create/machinepool/machinepool.go
@@ -459,7 +459,7 @@ func addMachinePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster
 
 	if output.HasFlag() {
 		if err = output.Print(createdMachinePool); err != nil {
-			r.Reporter.Errorf("unable to print nodepool: %v", err)
+			r.Reporter.Errorf("Unable to print machine pool: %v", err)
 			os.Exit(1)
 		}
 	} else {

--- a/cmd/create/machinepool/machinepool.go
+++ b/cmd/create/machinepool/machinepool.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openshift/rosa/pkg/helper"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
+	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/rosa"
 	"github.com/spf13/cobra"
 )
@@ -247,7 +248,7 @@ func addMachinePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster
 	}
 
 	var spin *spinner.Spinner
-	if r.Reporter.IsTerminal() {
+	if r.Reporter.IsTerminal() && !output.HasFlag() {
 		spin = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
 	}
 	if spin != nil {
@@ -450,14 +451,21 @@ func addMachinePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster
 		os.Exit(1)
 	}
 
-	_, err = r.OCMClient.CreateMachinePool(cluster.ID(), machinePool)
+	createdMachinePool, err := r.OCMClient.CreateMachinePool(cluster.ID(), machinePool)
 	if err != nil {
 		r.Reporter.Errorf("Failed to add machine pool to cluster '%s': %v", clusterKey, err)
 		os.Exit(1)
 	}
 
-	r.Reporter.Infof("Machine pool '%s' created successfully on cluster '%s'", name, clusterKey)
-	r.Reporter.Infof("To view all machine pools, run 'rosa list machinepools -c %s'", clusterKey)
+	if output.HasFlag() {
+		if err = output.Print(createdMachinePool); err != nil {
+			r.Reporter.Errorf("unable to print nodepool: %v", err)
+			os.Exit(1)
+		}
+	} else {
+		r.Reporter.Infof("Machine pool '%s' created successfully on cluster '%s'", name, clusterKey)
+		r.Reporter.Infof("To view all machine pools, run 'rosa list machinepools -c %s'", clusterKey)
+	}
 }
 
 func Split(r rune) bool {

--- a/cmd/create/machinepool/nodepool.go
+++ b/cmd/create/machinepool/nodepool.go
@@ -192,7 +192,7 @@ func addNodePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster, r
 
 	if output.HasFlag() {
 		if err = output.Print(createdNodePool); err != nil {
-			r.Reporter.Errorf("unable to print nodepool: %v", err)
+			r.Reporter.Errorf("Unable to print node pool: %v", err)
 			os.Exit(1)
 		}
 	} else {

--- a/cmd/create/machinepool/nodepool.go
+++ b/cmd/create/machinepool/nodepool.go
@@ -192,7 +192,7 @@ func addNodePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster, r
 
 	if output.HasFlag() {
 		if err = output.Print(createdNodePool); err != nil {
-			r.Reporter.Errorf("Unable to print node pool: %v", err)
+			r.Reporter.Errorf("Unable to print machine pool: %v", err)
 			os.Exit(1)
 		}
 	} else {

--- a/cmd/create/machinepool/nodepool.go
+++ b/cmd/create/machinepool/nodepool.go
@@ -8,6 +8,7 @@ import (
 	"github.com/briandowns/spinner"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/rosa"
 	"github.com/spf13/cobra"
 )
@@ -128,7 +129,7 @@ func addNodePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster, r
 	// NodePools don't support MultiAZ yet, so the availabilityZonesFilters is calculated from the cluster
 
 	var spin *spinner.Spinner
-	if r.Reporter.IsTerminal() {
+	if r.Reporter.IsTerminal() && !output.HasFlag() {
 		spin = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
 	}
 	if spin != nil {
@@ -189,6 +190,13 @@ func addNodePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster, r
 		os.Exit(1)
 	}
 
-	r.Reporter.Infof("Machine pool '%s' created successfully on hosted cluster '%s'", createdNodePool.ID(), clusterKey)
-	r.Reporter.Infof("To view all machine pools, run 'rosa list machinepools -c %s'", clusterKey)
+	if output.HasFlag() {
+		if err = output.Print(createdNodePool); err != nil {
+			r.Reporter.Errorf("unable to print nodepool: %v", err)
+			os.Exit(1)
+		}
+	} else {
+		r.Reporter.Infof("Machine pool '%s' created successfully on hosted cluster '%s'", createdNodePool.ID(), clusterKey)
+		r.Reporter.Infof("To view all machine pools, run 'rosa list machinepools -c %s'", clusterKey)
+	}
 }

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -64,9 +64,17 @@ func Print(resource interface{}) error {
 		if machinePools, ok := resource.([]*cmv1.MachinePool); ok {
 			cmv1.MarshalMachinePoolList(machinePools, &b)
 		}
+	case "*v1.MachinePool":
+		if machinePool, ok := resource.(*cmv1.MachinePool); ok {
+			cmv1.MarshalMachinePool(machinePool, &b)
+		}
 	case "[]*v1.MachineType":
 		if machineTypes, ok := resource.([]*cmv1.MachineType); ok {
 			cmv1.MarshalMachineTypeList(machineTypes, &b)
+		}
+	case "*v1.NodePool":
+		if nodePool, ok := resource.(*cmv1.NodePool); ok {
+			cmv1.MarshalNodePool(nodePool, &b)
 		}
 	case "[]*v1.Version":
 		if versions, ok := resource.([]*cmv1.Version); ok {


### PR DESCRIPTION
allow outputing the newly created pools as json/yaml to allow easier use
from automation

Signed-off-by: Brady Pratt <bpratt@redhat.com>

```
$ ./rosa create machinepool --replicas=3 rw-hyper-osde2e --cluster=rw-hyper --output=json
{
  "kind": "NodePool",
  "id": "216tlklcjdu14fq1fddbl9ohs20f6jel",
  "href": "/api/clusters_mgmt/v1/clusters/.../node_pools/216tlklcjdu14fq1fddbl9ohs20f6jel",
  "aws_node_pool": {
    "kind": "AWSNodePool",
    "instance_profile": "staging-...-rw-hyper-worker",
    "instance_type": "m5.xlarge",
    "tags": {
      "api.openshift.com/environment": "staging",
      "api.openshift.com/id": "...",
      "api.openshift.com/legal-entity-id": "...",
      "api.openshift.com/name": "rw-hyper",
      "api.openshift.com/nodepool": "rw-hyper-workers1",
      "red-hat-clustertype": "rosa",
      "red-hat-managed": "true"
    }
  },
  "auto_repair": false,
  "availability_zone": "us-east-1a",
  "replicas": 3,
  "subnet": "subnet-0bddfe882e3efb354"
}
```

```
$ ./rosa create machinepool --replicas=3 rw-hyper-osde2e --cluster=rw-hyper --output=yaml
auto_repair: false
availability_zone: us-east-1a
aws_node_pool:
  instance_profile: staging-...-rw-hyper-worker
  instance_type: m5.xlarge
  kind: AWSNodePool
  tags:
    api.openshift.com/environment: staging
    api.openshift.com/id: ...
    api.openshift.com/legal-entity-id: ...
    api.openshift.com/name: rw-hyper
    api.openshift.com/nodepool: rw-hyper-workers1
    red-hat-clustertype: rosa
    red-hat-managed: "true"
href: /api/clusters_mgmt/v1/clusters/.../node_pools/216tncqb3pecs39d7cq02ntbb02kn9s4
id: 216tncqb3pecs39d7cq02ntbb02kn9s4
kind: NodePool
replicas: 3
subnet: subnet-...
```
