### PR TITLE
[SDA-7758] Accept pre release version during upgrade

### DIFF
--- a/pkg/ocm/versions.go
+++ b/pkg/ocm/versions.go
@@ -322,8 +322,9 @@ func CheckAndParseVersion(availableUpgrades []string, version string) (string, e
 	if err != nil {
 		return "", err
 	}
+	isPreRelease := a.Prerelease() != ""
 	versionSplit := a.Segments64()
-	if versionSplit[2] > 0 {
+	if len(versionSplit) > 2 && versionSplit[2] > 0 || (versionSplit[2] == 0 && isPreRelease) {
 		return version, nil
 	}
 	return availableUpgrades[0], nil


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-7758

# What
Check if it is a pre release version

# Why
Version was defaulting to the first available upgrade in slice