### PR TITLE
SDA-7767 Let user define machinepool name on hosted cluster

### DIFF
--- a/cmd/list/machinepool/nodepool.go
+++ b/cmd/list/machinepool/nodepool.go
@@ -21,16 +21,15 @@ func listNodePools(r *rosa.Runtime, clusterKey string, cluster *cmv1.Cluster) {
 	// Create the writer that will be used to print the tabulated results:
 	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 
-	fmt.Fprintf(writer, "ID\tAUTOSCALING\tREPLICAS\tINSTANCE TYPE\tAVAILABILITY ZONE\tSUBNET\tINSTANCE PREFIX\t\n")
+	fmt.Fprintf(writer, "ID\tAUTOSCALING\tREPLICAS\tINSTANCE TYPE\tAVAILABILITY ZONE\tSUBNET\t\n")
 	for _, nodePool := range nodePools {
-		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t\n",
+		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\t%s\t\n",
 			nodePool.ID(),
 			printNodePoolAutoscaling(nodePool.Autoscaling()),
 			printNodePoolReplicas(nodePool.Autoscaling(), nodePool.Replicas()),
 			printNodePoolInstanceType(nodePool.AWSNodePool()),
 			nodePool.AvailabilityZone(),
 			nodePool.Subnet(),
-			printNodePoolName(nodePool.AWSNodePool()),
 		)
 	}
 	writer.Flush()
@@ -57,15 +56,4 @@ func printNodePoolInstanceType(aws *cmv1.AWSNodePool) string {
 		return ""
 	}
 	return aws.InstanceType()
-}
-
-func printNodePoolName(aws *cmv1.AWSNodePool) string {
-	if aws == nil || aws.Tags() == nil {
-		return ""
-	}
-	tags := aws.Tags()
-	if nodePoolName, ok := tags["api.openshift.com/nodepool"]; ok {
-		return nodePoolName
-	}
-	return ""
 }


### PR DESCRIPTION
Follow-up work for [SDA-7767](https://issues.redhat.com//browse/SDA-7767), is needed when the backend MR is merged.

Summary of changes:
- Removing the "INSTANCE-PREFIX" column (as now the machinepool is properly identify by the ID).
- Allow to use "--name" parameter for specifying the name of a MachinePool for hosted clusters.



Use cases, test scenarios covered with this work:

```
# List existing machinepools for a cluster
$ rosa list machinepools -c lponce-local-02
ID       AUTOSCALING  REPLICAS  INSTANCE TYPE  AVAILABILITY ZONE  SUBNET                    
workers  No           2         m5.xlarge      us-west-2a         subnet-0e3a4046c1c2f1078  
test1    No           2         m5.xlarge      us-west-2a         subnet-0e3a4046c1c2f1078  
test3    No           3         m5.xlarge      us-west-2a         subnet-0e3a4046c1c2f1078  
test4    No           2         m5.xlarge      us-west-2a         subnet-0e3a4046c1c2f1078  

# Create a new machinepool using --name param
uhc-clusters-service(nodepool-name) L  $ rosa create machinepool -c lponce-local-02 --name other-1
? Replicas: 2
I: Fetching instance types
I: Machine pool 'other-1' created successfully on hosted cluster 'lponce-local-02'
I: To view all machine pools, run 'rosa list machinepools -c lponce-local-02'

# Validate a name is already used for a cluster
uhc-clusters-service(nodepool-name) L  $ rosa create machinepool -c lponce-local-02
I: Enabling interactive mode
? Machine pool name: other-1
? Enable autoscaling (optional): No
X Sorry, your reply was invalid: Value is required
? Replicas: 2
I: Fetching instance types
? Instance type: m5.xlarge
E: Failed to add machine pool to hosted cluster 'lponce-local-02': NodePool 'other-1' exists for cluster '21a1olhmroh6ds6scsh69bf10be92om6'
uhc-clusters-service(nodepool-name) L  $ rosa create machinepool -c lponce-local-02
I: Enabling interactive mode
? Machine pool name: other-2
? Enable autoscaling (optional): No
? Replicas: 2
I: Fetching instance types
? Instance type: m5.xlarge
I: Machine pool 'other-2' created successfully on hosted cluster 'lponce-local-02'
I: To view all machine pools, run 'rosa list machinepools -c lponce-local-02'

# Final list, INSTANCE-PREFIX is outdated and now it doesn't add value so, saving space in the table for state info
uhc-clusters-service(nodepool-name) L  $ rosa list machinepools -c lponce-local-02
ID       AUTOSCALING  REPLICAS  INSTANCE TYPE  AVAILABILITY ZONE  SUBNET                    
workers  No           2         m5.xlarge      us-west-2a         subnet-0e3a4046c1c2f1078  
test1    No           2         m5.xlarge      us-west-2a         subnet-0e3a4046c1c2f1078  
test3    No           3         m5.xlarge      us-west-2a         subnet-0e3a4046c1c2f1078  
test4    No           2         m5.xlarge      us-west-2a         subnet-0e3a4046c1c2f1078  
other-1  No           2         m5.xlarge      us-west-2a         subnet-0e3a4046c1c2f1078  
other-2  No           2         m5.xlarge      us-west-2a         subnet-0e3a4046c1c2f1078  

```