### PR TITLE
[SDA-7784] Tagged current version on policy is not necessarily compatible

### DIFF
--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -384,7 +384,9 @@ func (c *awsClient) HasCompatibleVersionTags(iamTags []*iam.Tag, version string)
 			if err != nil {
 				return false, err
 			}
-			return currentVersion.GreaterThanOrEqual(wantedVersion), nil
+			// Current version equals to wanted is not necessarily compatible
+			// as actions can be altered to accommodate more permissions
+			return currentVersion.GreaterThan(wantedVersion), nil
 		}
 	}
 	return false, nil


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-7784

# What
Checks preexisting actions under a policy to check if it is needed to recreate it

# Why
If there are changes under a policy within the same version tag it is not updated