### PR TITLE
Permissions boundary shouldn't be asked if supposed to skip interactive

### DIFF
--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -139,7 +139,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	permissionsBoundary := args.permissionsBoundary
-	if interactive.Enabled() {
+	if interactive.Enabled() && !skipInteractive {
 		permissionsBoundary, err = interactive.GetString(interactive.Input{
 			Question: "Permissions boundary ARN",
 			Help:     cmd.Flags().Lookup("permissions-boundary").Usage,


### PR DESCRIPTION
# What
Asks for permissions boundaries for operator roles during the cluster creation. If supplied consider we can skip interactive on creation of operator roles

# Why
Some automations may get interactive question during creation operator roles