### PR TITLE
Fix managed policies cluster upgrade path

### DIFF
--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -144,7 +144,7 @@ func run(cmd *cobra.Command, argv []string) error {
 
 		r.Reporter.Infof("Account roles with the prefix '%s' have attached managed policies. "+
 			"An upgrade isn't needed", prefix)
-		os.Exit(0)
+		return nil
 	}
 
 	creator, err := awsClient.GetCreator()

--- a/cmd/upgrade/operatorroles/cmd.go
+++ b/cmd/upgrade/operatorroles/cmd.go
@@ -172,7 +172,7 @@ func run(cmd *cobra.Command, argv []string) error {
 		}
 
 		r.Reporter.Infof("Cluster '%s' operator roles have attached managed policies", cluster.Name())
-		os.Exit(0)
+		return nil
 	}
 
 	isAccountRoleUpgradeNeed := false

--- a/cmd/upgrade/roles/cmd.go
+++ b/cmd/upgrade/roles/cmd.go
@@ -217,7 +217,7 @@ func run(cmd *cobra.Command, argv []string) error {
 			os.Exit(1)
 		}
 		r.Reporter.Infof("Cluster '%s' operator roles have attached managed policies", cluster.Name())
-		os.Exit(0)
+		return nil
 	}
 
 	policyVersion := args.policyUpgradeversion


### PR DESCRIPTION
In case of success in the upgrade roles command, return nil instead of exit. 
This change is required since we trigger the upgrade roles command from the upgrade cluster command.

Related: [SDA-7761](https://issues.redhat.com/browse/SDA-7761)

![image](https://user-images.githubusercontent.com/57869309/213996550-39613ea3-fd81-4f21-b796-edc5d5c5155a.png)
