### PR TITLE
Create OCM role with managed policies

### DIFF
--- a/pkg/aws/tags/tags.go
+++ b/pkg/aws/tags/tags.go
@@ -55,3 +55,5 @@ const ManagedPolicies = prefix + "managed_policies"
 const OperatorNamespace = "operator_namespace"
 
 const OperatorName = "operator_name"
+
+const True = "true"


### PR DESCRIPTION
Attach existing policy instead of creating a new one.

Related: [SDA-7864](https://issues.redhat.com/browse/SDA-7864)

![image](https://user-images.githubusercontent.com/57869309/214241000-8228d25d-6b90-4ea0-a404-f451544dc958.png)
