### PR TITLE
Release v1.2.13

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -2,6 +2,20 @@
 
 This document describes the relevant changes between releases of the `rosa` command line tool.
 
+== 1.2.13 Jan 24 2023
+
+- Skip region check if we use shard pinning
+- Remove GitHub IDP dependency to console availability
+- Bump ocm-sdk-go to v0.1.310
+- Fix managed policies cluster upgrade path
+- Delete roles with managed policies
+- feat: store private key for byo oidc in secrets manager
+- [SDA-7757] byo OIDC secret arn support (#1018)
+- feat: add download rosa option
+- Create OCM role with managed policies
+- Upgrade to Go 1.19
+- Delete OCM role with managed policies
+
 == 1.2.12 Jan 18 2023
 
 - fix: Incorrect OIDC Provider Sometimes Targeted for Deletion

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,6 +18,6 @@ limitations under the License.
 
 package info
 
-const Version = "1.2.12"
+const Version = "1.2.13"
 
 const UserAgent = "ROSACLI"


### PR DESCRIPTION
- Skip region check if we use shard pinning
- Remove GitHub IDP dependency to console availability
- Bump ocm-sdk-go to v0.1.310
- Fix managed policies cluster upgrade path
- Delete roles with managed policies
- feat: store private key for byo oidc in secrets manager
- [SDA-7757] byo OIDC secret arn support (#1018)
- feat: add download rosa option
- Create OCM role with managed policies
- Upgrade to Go 1.19
- Delete OCM role with managed policies