### PR TITLE
[SDA-7879] Incorrect flags in message and hidden for upgrade roles

### DIFF
--- a/cmd/upgrade/cluster/cmd.go
+++ b/cmd/upgrade/cluster/cmd.go
@@ -203,7 +203,7 @@ func run(cmd *cobra.Command, _ []string) {
 			" are compatible with upgrade.", cluster.ID())
 		err = roles.Cmd.RunE(roles.Cmd, []string{mode, cluster.ID(), version, cluster.Version().ChannelGroup()})
 		if err != nil {
-			rolesStr := fmt.Sprintf("rosa upgrade roles -c %s --version=%s --mode=%s", clusterKey, version, mode)
+			rolesStr := fmt.Sprintf("rosa upgrade roles -c %s --cluster-version=%s --mode=%s", clusterKey, version, mode)
 			upgradeClusterStr := fmt.Sprintf("rosa upgrade cluster -c %s", clusterKey)
 
 			r.Reporter.Infof("Account/Operator Role policies are not valid with upgrade version %s. "+

--- a/cmd/upgrade/roles/cmd.go
+++ b/cmd/upgrade/roles/cmd.go
@@ -59,6 +59,12 @@ var Cmd = &cobra.Command{
 	RunE: run,
 }
 
+const (
+	clusterVersionFlag = "cluster-version"
+	policyVersionFlag  = "policy-version"
+	channelGroupFlag   = "channel-group"
+)
+
 func init() {
 	flags := Cmd.Flags()
 
@@ -68,28 +74,27 @@ func init() {
 
 	flags.StringVar(
 		&args.clusterUpgradeVersion,
-		"cluster-version",
+		clusterVersionFlag,
 		"",
 		"Version of OpenShift that the cluster will be upgraded to",
 	)
-
-	Cmd.MarkFlagRequired("cluster-version")
+	Cmd.MarkFlagRequired(clusterVersionFlag)
 
 	flags.StringVar(
 		&args.policyUpgradeversion,
-		"policy-version",
+		policyVersionFlag,
 		"",
 		"Version of OpenShift that will be used to setup policy tag, for example \"4.11\"",
 	)
-	flags.MarkHidden("version")
+	flags.MarkHidden(policyVersionFlag)
 
 	flags.StringVar(
 		&args.channelGroup,
-		"channel-group",
+		channelGroupFlag,
 		ocm.DefaultChannelGroup,
 		"Channel group is the name of the channel where this image belongs, for example \"stable\" or \"fast\".",
 	)
-	flags.MarkHidden("channel-group")
+	flags.MarkHidden(channelGroupFlag)
 
 	confirm.AddFlag(flags)
 	interactive.AddFlag(flags)


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-7879

# What
The correct flags should be prompted

# Why
User was prompted with incorrect flag