### PR TITLE
IDP related minor cleanup

### DIFF
--- a/cmd/create/admin/cmd.go
+++ b/cmd/create/admin/cmd.go
@@ -115,7 +115,7 @@ func run(cmd *cobra.Command, _ []string) {
 			idp.CreateHTPasswdUser(idp.ClusterAdminUsername, password),
 		))
 		newIDP, err := cmv1.NewIdentityProvider().
-			Type("HTPasswdIdentityProvider").
+			Type(cmv1.IdentityProviderTypeHtpasswd).
 			Name(idp.HTPasswdIDPName).
 			Htpasswd(htpasswdIDP).
 			Build()

--- a/cmd/create/idp/cmd.go
+++ b/cmd/create/idp/cmd.go
@@ -97,8 +97,6 @@ var Cmd = &cobra.Command{
 	Run: run,
 }
 
-var clusterKey string
-
 func init() {
 	flags := Cmd.Flags()
 	flags.SortFlags = false

--- a/cmd/create/idp/github.go
+++ b/cmd/create/idp/github.go
@@ -247,7 +247,7 @@ func buildGithubIdp(cmd *cobra.Command,
 
 	// Create new IDP with GitHub provider
 	idpBuilder.
-		Type("GithubIdentityProvider"). // FIXME: ocm-api-model has the wrong enum values
+		Type(cmv1.IdentityProviderTypeGithub).
 		Name(idpName).
 		MappingMethod(cmv1.IdentityProviderMappingMethod(mappingMethod)).
 		Github(githubIDP)

--- a/cmd/create/idp/gitlab.go
+++ b/cmd/create/idp/gitlab.go
@@ -146,7 +146,7 @@ func buildGitlabIdp(cmd *cobra.Command,
 
 	// Create new IDP with GitLab provider
 	idpBuilder.
-		Type("GitlabIdentityProvider"). // FIXME: ocm-api-model has the wrong enum values
+		Type(cmv1.IdentityProviderTypeGitlab).
 		Name(idpName).
 		MappingMethod(cmv1.IdentityProviderMappingMethod(mappingMethod)).
 		Gitlab(gitlabIDP)

--- a/cmd/create/idp/google.go
+++ b/cmd/create/idp/google.go
@@ -123,7 +123,7 @@ func buildGoogleIdp(cmd *cobra.Command,
 
 	// Create new IDP with Google provider
 	idpBuilder.
-		Type("GoogleIdentityProvider"). // FIXME: ocm-api-model has the wrong enum values
+		Type(cmv1.IdentityProviderTypeGoogle).
 		Name(idpName).
 		MappingMethod(cmv1.IdentityProviderMappingMethod(mappingMethod)).
 		Google(googleIDP)

--- a/cmd/create/idp/htpasswd.go
+++ b/cmd/create/idp/htpasswd.go
@@ -89,7 +89,7 @@ func createHTPasswdIDP(cmd *cobra.Command,
 		}
 
 		idpBuilder := cmv1.NewIdentityProvider().
-			Type("HTPasswdIdentityProvider").
+			Type(cmv1.IdentityProviderTypeHtpasswd).
 			Name(idpName).
 			Htpasswd(
 				cmv1.NewHTPasswdIdentityProvider().Users(
@@ -124,7 +124,7 @@ func getUserDetails(cmd *cobra.Command, r *rosa.Runtime) (string, string) {
 		},
 	})
 	if err != nil {
-		exitHTPasswdCreate("Expected a valid username: %s", clusterKey, err, r)
+		exitHTPasswdCreate("Expected a valid username: %s", r.ClusterKey, err, r)
 	}
 	password, err := interactive.GetPassword(interactive.Input{
 		Question: "Password",
@@ -136,7 +136,7 @@ func getUserDetails(cmd *cobra.Command, r *rosa.Runtime) (string, string) {
 		},
 	})
 	if err != nil {
-		exitHTPasswdCreate("Expected a valid password: %s", clusterKey, err, r)
+		exitHTPasswdCreate("Expected a valid password: %s", r.ClusterKey, err, r)
 	}
 	return username, password
 }
@@ -148,7 +148,7 @@ func shouldAddAnotherUser(r *rosa.Runtime) bool {
 		Default:  false,
 	})
 	if err != nil {
-		exitHTPasswdCreate("Expected a valid reply: %s", clusterKey, err, r)
+		exitHTPasswdCreate("Expected a valid reply: %s", r.ClusterKey, err, r)
 	}
 	return addAnother
 }
@@ -223,7 +223,7 @@ func FindExistingHTPasswdIDP(cluster *cmv1.Cluster, r *rosa.Runtime) (
 	r.Reporter.Debugf("Loading cluster's identity providers")
 	idps, err := r.OCMClient.GetIdentityProviders(cluster.ID())
 	if err != nil {
-		r.Reporter.Errorf("Failed to get identity providers for cluster '%s': %v", clusterKey, err)
+		r.Reporter.Errorf("Failed to get identity providers for cluster '%s': %v", r.ClusterKey, err)
 		os.Exit(1)
 	}
 
@@ -235,7 +235,7 @@ func FindExistingHTPasswdIDP(cluster *cmv1.Cluster, r *rosa.Runtime) (
 	if htpasswdIDP != nil {
 		userList, err = r.OCMClient.GetHTPasswdUserList(cluster.ID(), htpasswdIDP.ID())
 		if err != nil {
-			r.Reporter.Errorf("Failed to get user list of the HTPasswd IDP of '%s': %v", clusterKey, err)
+			r.Reporter.Errorf("Failed to get user list of the HTPasswd IDP of '%s': %v", r.ClusterKey, err)
 			os.Exit(1)
 		}
 	}

--- a/cmd/create/idp/ldap.go
+++ b/cmd/create/idp/ldap.go
@@ -235,7 +235,7 @@ func buildLdapIdp(cmd *cobra.Command,
 
 	// Create new IDP with LDAP provider
 	idpBuilder.
-		Type("LDAPIdentityProvider"). // FIXME: ocm-api-model has the wrong enum values
+		Type(cmv1.IdentityProviderTypeLDAP).
 		Name(idpName).
 		MappingMethod(cmv1.IdentityProviderMappingMethod(mappingMethod)).
 		LDAP(ldapIDP)

--- a/cmd/create/idp/openid.go
+++ b/cmd/create/idp/openid.go
@@ -232,7 +232,7 @@ separated by commas.`,
 
 	// Create new IDP with OpenID provider
 	idpBuilder.
-		Type("OpenIDIdentityProvider"). // FIXME: ocm-api-model has the wrong enum values
+		Type(cmv1.IdentityProviderTypeOpenID).
 		Name(idpName).
 		MappingMethod(cmv1.IdentityProviderMappingMethod(mappingMethod)).
 		OpenID(openIDIDP)

--- a/pkg/ocm/idps.go
+++ b/pkg/ocm/idps.go
@@ -126,17 +126,17 @@ func (c *Client) DeleteIdentityProvider(clusterID string, idpID string) error {
 
 func IdentityProviderType(idp *cmv1.IdentityProvider) string {
 	switch idp.Type() {
-	case "GithubIdentityProvider":
+	case cmv1.IdentityProviderTypeGithub:
 		return GithubIDPType
-	case "GitlabIdentityProvider":
+	case cmv1.IdentityProviderTypeGitlab:
 		return GitlabIDPType
-	case "GoogleIdentityProvider":
+	case cmv1.IdentityProviderTypeGoogle:
 		return GoogleIDPType
-	case "HTPasswdIdentityProvider":
+	case cmv1.IdentityProviderTypeHtpasswd:
 		return HTPasswdIDPType
-	case "LDAPIdentityProvider":
+	case cmv1.IdentityProviderTypeLDAP:
 		return LDAPIDPType
-	case "OpenIDIdentityProvider":
+	case cmv1.IdentityProviderTypeOpenID:
 		return OpenIDIDPType
 	}
 


### PR DESCRIPTION
* Use SDK enums which are now correct
* Remove a (broken) usage of a global variable to align with the rest