### PR TITLE
SDA-7895 Enable editing subnet in machinepools for hosted clusters

### DIFF
--- a/cmd/create/machinepool/helper.go
+++ b/cmd/create/machinepool/helper.go
@@ -1,0 +1,81 @@
+package machinepool
+
+import (
+	"os"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/rosa"
+	"github.com/spf13/cobra"
+)
+
+func getSubnetFromUser(cmd *cobra.Command, r *rosa.Runtime, isSubnetSet bool,
+	cluster *cmv1.Cluster) string {
+	var selectSubnet bool
+	var subnet string
+	var err error
+
+	question := "Select subnet for a single AZ machine pool"
+	questionError := "Expected a valid value for subnet for a single AZ machine pool"
+
+	if cluster.Hypershift().Enabled() {
+		question = "Select subnet for a hosted machine pool"
+		questionError = "Expected a valid value for subnet for a hosted machine pool"
+	}
+
+	if !isSubnetSet && interactive.Enabled() {
+		selectSubnet, err = interactive.GetBool(interactive.Input{
+			Question: question,
+			Help:     cmd.Flags().Lookup("subnet").Usage,
+			Default:  false,
+			Required: false,
+		})
+		if err != nil {
+			r.Reporter.Errorf(questionError)
+			os.Exit(1)
+		}
+	} else {
+		subnet = args.subnet
+	}
+
+	if selectSubnet {
+		subnetOptions, err := getSubnetOptions(r, cluster)
+		if err != nil {
+			r.Reporter.Errorf("%s", err)
+			os.Exit(1)
+		}
+
+		subnetOption, err := interactive.GetOption(interactive.Input{
+			Question: "Subnet ID",
+			Help:     cmd.Flags().Lookup("subnet").Usage,
+			Options:  subnetOptions,
+			Default:  subnetOptions[0],
+			Required: true,
+		})
+		if err != nil {
+			r.Reporter.Errorf("Expected a valid AWS subnet: %s", err)
+			os.Exit(1)
+		}
+		subnet = aws.ParseSubnet(subnetOption)
+	}
+
+	return subnet
+}
+
+// getSubnetOptions gets one of the cluster subnets and returns a slice of formatted VPC's private subnets.
+func getSubnetOptions(r *rosa.Runtime, cluster *cmv1.Cluster) ([]string, error) {
+	// Fetch VPC's subnets
+	privateSubnets, err := r.AWSClient.GetVPCPrivateSubnets(cluster.AWS().SubnetIDs()[0])
+	if err != nil {
+		return nil, err
+	}
+
+	// Format subnet options
+	var subnetOptions []string
+	for _, subnet := range privateSubnets {
+		subnetOptions = append(subnetOptions, aws.SetSubnetOption(*subnet.SubnetId, *subnet.AvailabilityZone))
+	}
+
+	return subnetOptions, nil
+}


### PR DESCRIPTION
ROSA CLI UX for
https://issues.redhat.com/browse/SDA-7895

It requires backend MR 
https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/5154

it will enable using "subnet" parameter for creating a machine-pool for a hosted cluster.
Additionally, it will allow the user to resolve the "subnet" from an "availability zone."

ROSA CLI UX:

```

## Non interactive tests

# It will work; "subnet-06023544bf8e5b199" is PRIVATE, and it belongs to the VPC where the cluster was created
rosa create machinepool -c lponce-local-02 --name mp-2c --subnet subnet-06023544bf8e5b199 --replicas 2

# It will fail; "subnet-0fd5b560cd0518bb9" is PUBLIC
rosa create machinepool -c lponce-local-02 --name mp-2c-public --subnet subnet-0fd5b560cd0518bb9 --replicas 2

# It will fail; "subnet-bad" doesn't exist
rosa create machinepool -c lponce-local-02 --name mp-2c --subnet subnet-bad --replicas 2

# It will work; there is a private subnet under the "us-west-2b" AZ in the VPC that cluster was created
rosa create machinepool -c lponce-local-02 --name mp-2b --availability-zone us-west-2b

# It will fail; there is no a private subnet under the "bad-az" AZ
rosa create machinepool -c lponce-local-02 --name mp-2b --availability-zone bad-az --replicas 2

# It will move to interactive mode where there are several subnets for a given availability zone
rosa create machinepool -c lponce-local-03 --name mp-2d --availability-zone us-west-2d
I: There are several subnets for availability zone 'us-west-2d'
? Select subnet for a hosted machine pool (optional): Yes
? Subnet ID: subnet-00afcc1145d04b345 (us-west-2d)
? Enable autoscaling (optional): No
? Replicas: 2
I: Fetching instance types
? Instance type: m5.xlarge
I: Machine pool 'mp-2d' created successfully on hosted cluster 'lponce-local-03'
I: To view all machine pools, run 'rosa list machinepools -c lponce-local-03'



## Interactive tests:

# Select subnet
 rosa create machinepool -c lponce-local-02 --name mp-2b --interactive
? Machine pool name: mp-2b
? Select subnet for a single AZ machine pool (optional): Yes
? Subnet ID:  [Use arrows to move, type to filter, ? for more help]
> subnet-06023544bf8e5b199 (us-west-2c)
  subnet-0310ceb7c0094e92a (us-west-2b)
  subnet-0d65e2465258986db (us-west-2a)
  subnet-00afcc1145d04b345 (us-west-2d)

# Select AZ
$ rosa create machinepool -c lponce-local-02 --name mp-2b --interactive
? Machine pool name: mp-2b
? Select subnet for a single AZ machine pool (optional): No
? AWS availability zone:  [Use arrows to move, type to filter, ? for more help]
  us-west-2c
  us-west-2b
> us-west-2a
  us-west-2d
```

Please @gdbranco @wgordon17 @pvasant take a look if the UX is addressed as expected.
Thanks

