### PR TITLE
[SDA-7984] Add region when creating manual s3 bucket for oidc config

### DIFF
--- a/cmd/create/oidcconfig/cmd.go
+++ b/cmd/create/oidcconfig/cmd.go
@@ -303,6 +303,7 @@ func (s *CreateOidcConfigManualStrategy) execute(r *rosa.Runtime) {
 		SetCommand(awscb.CreateBucket).
 		AddParam(awscb.Bucket, bucketName).
 		AddParam(awscb.CreateBucketConfiguration, createBucketConfig).
+		AddParam(awscb.Region, args.region).
 		Build()
 	commands = append(commands, createS3BucketCommand)
 	discoveryDocumentFilename := fmt.Sprintf("discovery-document-%s.json", bucketName)


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-7984
# What
Adds regions param when user specifies a different region then default

# Why
Manual command failed if region param is not specified