### PR TITLE
[SDA-8022] Forcing creation should only work for unmanaged policies

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -153,6 +153,11 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 	managedPolicies := args.managed
 
+	if args.forcePolicyCreation && managedPolicies {
+		r.Reporter.Warnf("Forcing creation of policies only works for unmanaged policies")
+		os.Exit(1)
+	}
+
 	r.WithAWS()
 	// Validate AWS credentials for current user
 	if r.Reporter.IsTerminal() {

--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -223,6 +223,10 @@ func run(cmd *cobra.Command, argv []string) {
 		r.Reporter.Errorf("Failed to determine if cluster has managed policies: %v", err)
 		os.Exit(1)
 	}
+	if args.forcePolicyCreation && managedPolicies {
+		r.Reporter.Warnf("Forcing creation of policies only works for unmanaged policies")
+		os.Exit(1)
+	}
 	// TODO: remove once AWS managed policies are in place
 	if managedPolicies && env == ocm.Production {
 		r.Reporter.Errorf("Managed policies are not supported in this environment")


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-8022
# What
When forcing creation of policies for updating actions on current version should validate if they are using managed policies first

# Why
Managed policies are always up to date and don't require forcing update

# Changes
`rosa create account-roles --mode auto -y -f --managed`
```
.
.
.
W: Forcing creation of policies only works for unmanaged policies
```