### PR TITLE
[SDA-8025] Show info report when deleting operator roles

### DIFF
--- a/cmd/dlt/operatorrole/cmd.go
+++ b/cmd/dlt/operatorrole/cmd.go
@@ -211,11 +211,21 @@ func run(cmd *cobra.Command, argv []string) {
 			if !confirm.Prompt(true, "Delete the operator roles  '%s'?", role) {
 				continue
 			}
+			r.Reporter.Infof("Deleting operator role '%s'", role)
+			if spin != nil {
+				spin.Start()
+			}
 			err := r.AWSClient.DeleteOperatorRole(role, managedPolicies)
 
 			if err != nil {
+				if spin != nil {
+					spin.Stop()
+				}
 				r.Reporter.Warnf("There was an error deleting the Operator Roles or Policies: %s", err)
 				continue
+			}
+			if spin != nil {
+				spin.Stop()
 			}
 		}
 		r.Reporter.Infof("Successfully deleted the operator roles")


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-8025

# Changes
`./rosa delete operator-roles -c 21gv47khdrd9mg58igoir4kp8crg0n9f --mode=auto -y`
```
I: Fetching operator roles for the cluster: 21gv47khdrd9mg58igoir4kp8crg0n9f
I: Deleting operator role 'hs-hosted-oidc-m9c1-kube-system-capa-controller-manager'
I: Deleting operator role 'hs-hosted-oidc-m9c1-kube-system-control-plane-operator'
I: Deleting operator role 'hs-hosted-oidc-m9c1-kube-system-kube-controller-manager'
I: Deleting operator role 'hs-hosted-oidc-m9c1-openshift-image-registry-installer-cloud-cre'
I: Deleting operator role 'hs-hosted-oidc-m9c1-openshift-ingress-operator-cloud-credentials'
I: Successfully deleted the operator roles
```