### PR TITLE
[SDA-8005] Oidc endpoint url should be of https scheme

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2249,6 +2249,10 @@ func handleByoOidcOptions(r *rosa.Runtime, cmd *cobra.Command, isSTS bool) (bool
 				os.Exit(1)
 			}
 			parsedURI, _ := url.ParseRequestURI(oidcEndpointUrl)
+			if parsedURI.Scheme != helper.ProtocolHttps {
+				r.Reporter.Errorf("Expected OIDC endpoint URL '%s' to use an https:// scheme", oidcEndpointUrl)
+				os.Exit(1)
+			}
 			err := helper.IsURLReachable(fmt.Sprintf("%s:%s", parsedURI.Host, parsedURI.Scheme))
 			if err != nil {
 				r.Reporter.Errorf("URL '%s' is not reachable.", oidcEndpointUrl)

--- a/cmd/create/idp/gitlab.go
+++ b/cmd/create/idp/gitlab.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/rosa/pkg/helper"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/spf13/cobra"
 
@@ -161,7 +162,7 @@ func validateGitlabHostURL(val interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Expected a valid GitLab provider URL: %s", err)
 	}
-	if parsedIssuerURL.Scheme != "https" {
+	if parsedIssuerURL.Scheme != helper.ProtocolHttps {
 		return errors.New("Expected GitLab provider URL to use an https:// scheme")
 	}
 	if parsedIssuerURL.RawQuery != "" {

--- a/cmd/create/idp/openid.go
+++ b/cmd/create/idp/openid.go
@@ -26,6 +26,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/rosa/pkg/helper"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/ocm"
 )
@@ -247,7 +248,7 @@ func validateOpenidIssuerURL(val interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Expected a valid OpenID issuer URL: %v", err)
 	}
-	if parsedIssuerURL.Scheme != "https" {
+	if parsedIssuerURL.Scheme != helper.ProtocolHttps {
 		return errors.New("Expected OpenID issuer URL to use an https:// scheme")
 	}
 	if parsedIssuerURL.RawQuery != "" {

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -33,6 +33,7 @@ const (
 )
 
 const True = "true"
+const ProtocolHttps = "https"
 
 func RandomLabel(size int) string {
 	value := rand.Int() // #nosec G404


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-8005
# What
Checks supplied oidc endpoint url to be HTTPS

# Why
When in waiting state the validation expects it to be HTTPS