### PR TITLE
Attach three policies to the installer role - managed policies

### DIFF
--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -819,3 +819,16 @@ func GetManagedPolicyARN(policies map[string]*cmv1.AWSSTSPolicy, key string) (st
 
 	return policy.ARN(), nil
 }
+
+// GetAccountRolePolicyKeys returns the policy key for fetching the managed policy ARN
+func GetAccountRolePolicyKeys(roleType string) []string {
+	if roleType == InstallerAccountRole {
+		return []string{
+			InstallerCoreKey,
+			InstallerVPCKey,
+			InstallerPrivateLinkKey,
+		}
+	}
+
+	return []string{fmt.Sprintf("sts_%s_permission_policy", roleType)}
+}


### PR DESCRIPTION
For managed policies, attach `core`, `vpc`, and `private link` installer policies.
Validate three policies are in place upon cluster creation and cluster upgrade.

Related: [SDA-7941](https://issues.redhat.com/browse/SDA-7941)

Create a role with managed policies (manual mode):
![image](https://user-images.githubusercontent.com/57869309/216972074-bce7fabf-5686-4a71-a730-74e85e5987d9.png)

Three policies are attached to the installer role:
![image](https://user-images.githubusercontent.com/57869309/216972140-97ab3b5e-23cd-4c38-971e-a1576912e74c.png)

Validating all three policies are attached to the installer role:
![image](https://user-images.githubusercontent.com/57869309/216972201-1af0d881-f523-4e37-b194-c1089d5e89a3.png)
