### PR TITLE
cmd/dlt/machinepool: add confirm flag

### DIFF
--- a/cmd/dlt/machinepool/cmd.go
+++ b/cmd/dlt/machinepool/cmd.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
 )
@@ -45,6 +46,7 @@ var Cmd = &cobra.Command{
 
 func init() {
 	ocm.AddClusterFlag(Cmd)
+	confirm.AddFlag(Cmd.Flags())
 }
 
 func run(_ *cobra.Command, argv []string) {


### PR DESCRIPTION
the flag is a global flag but is not picked up when programmatically
calling `cmd.SetFlags` with `--yes` which is done in osde2e. This aligns
the behavior to match `create cluster --yes`.

Signed-off-by: Brady Pratt <bpratt@redhat.com>

In `osde2e`, we programmatically execute the cobra commands which requires the
flags to be configured locally, not globally. An example of this is:

```go
import machinepooldelete "github.com/openshift/rosa/cmd/dlt/machinepool"

cmd := machinepooldelete.Cmd
cmd.SetArgs([]string{"--yes", fmt.Sprintf("--cluster=%s", clusterName), machinePoolName})
_ = cmd.Execute()
```

The create cluster command is set up the same which works in `osde2e`:

https://github.com/openshift/rosa/blob/2215aeffc61c48d03c1bb4d926e1d22367d7aa5e/cmd/create/cluster/cmd.go#L580

https://github.com/openshift/osde2e/blob/3715eb8a0d8e4d3c6ef70c10e36b4b7cf098d884/pkg/common/providers/rosaprovider/cluster.go#L113

Prior to the change:

```
Error: unknown flag: --yes
Usage:
  machinepool ID [flags]

Aliases:
  machinepool, machinepools, machine-pool, machine-pools

Examples:
  # Delete machine pool with ID mp-1 from a cluster named 'mycluster'
  rosa delete machinepool --cluster=mycluster mp-1

Flags:
  -c, --cluster string   Name or ID of the cluster.
  -h, --help             help for machinepool

  [FAILED] in [It] - /var/home/bpratt/git/openshift/osde2e/pkg/e2e/rosa/machinepools/machinepools.go:85 @ 02/06/23 08:04:59.671
• [FAILED] [0.618 seconds]
ROSA Machine Pools [It] can be deleted [ROSA, HyperShift]
/var/home/bpratt/git/openshift/osde2e/pkg/e2e/rosa/machinepools/machinepools.go:82

  [FAILED] failed to delete machinepool
  Unexpected error:
      <*errors.errorString | 0xc000b3ef60>: {
          s: "unknown flag: --yes",
      }
      unknown flag: --yes
  occurred
  In [It] at: /var/home/bpratt/git/openshift/osde2e/pkg/e2e/rosa/machinepools/machinepools.go:85 @ 02/06/23 08:04:59.671
------------------------------

Summarizing 1 Failure:
  [FAIL] ROSA Machine Pools [It] can be deleted [ROSA, HyperShift]
```

After the change:

```
ROSA Machine Pools can be deleted [ROSA, HyperShift]
/var/home/bpratt/git/openshift/osde2e/pkg/e2e/rosa/machinepools/machinepools.go:82
I: Successfully deleted machine pool 'majora-test' from hosted cluster 'majora'
• [111.318 seconds]
------------------------------
```

https://github.com/openshift/osde2e/pull/1506
