### PR TITLE
[SDA-8059] Add command delete oidc-config and minor fixes

### DIFF
--- a/cmd/dlt/cmd.go
+++ b/cmd/dlt/cmd.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift/rosa/cmd/dlt/ingress"
 	"github.com/openshift/rosa/cmd/dlt/machinepool"
 	"github.com/openshift/rosa/cmd/dlt/ocmrole"
+	"github.com/openshift/rosa/cmd/dlt/oidcconfig"
 	"github.com/openshift/rosa/cmd/dlt/oidcprovider"
 	"github.com/openshift/rosa/cmd/dlt/operatorrole"
 	"github.com/openshift/rosa/cmd/dlt/service"
@@ -49,6 +50,7 @@ func init() {
 	Cmd.AddCommand(ingress.Cmd)
 	Cmd.AddCommand(machinepool.Cmd)
 	Cmd.AddCommand(upgrade.Cmd)
+	Cmd.AddCommand(oidcconfig.Cmd)
 	Cmd.AddCommand(oidcprovider.Cmd)
 	Cmd.AddCommand(operatorrole.Cmd)
 	Cmd.AddCommand(accountroles.Cmd)

--- a/cmd/dlt/oidcconfig/cmd.go
+++ b/cmd/dlt/oidcconfig/cmd.go
@@ -1,0 +1,230 @@
+/*
+Copyright (c) 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oidcconfig
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/briandowns/spinner"
+	"github.com/spf13/cobra"
+	"github.com/zgalor/weberr"
+
+	"github.com/openshift/rosa/pkg/arguments"
+	"github.com/openshift/rosa/pkg/aws"
+	awscb "github.com/openshift/rosa/pkg/aws/commandbuilder"
+	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/interactive/confirm"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+var Cmd = &cobra.Command{
+	Use:     "oidc-config",
+	Aliases: []string{"oidconfig, oidcconfig"},
+	Short:   "Delete OIDC Config",
+	Long:    "Cleans up OIDC config based on secret ARN.",
+	Example: `  # Delete OIDC config based on secret ARN that has been supplied
+	rosa delete oidc-config --oidc-private-key-secret-arn <oidc_private_key_secret_arn>`,
+	Hidden: true,
+	Run:    run,
+}
+
+const (
+	//nolint
+	OidcPrivateKeySecretArnFlag = "oidc-private-key-secret-arn"
+
+	prefixForPrivateKeySecret = "rosa-private-key-"
+)
+
+var args struct {
+	oidcPrivateKeySecretArn string
+	region                  string
+}
+
+func init() {
+	flags := Cmd.Flags()
+
+	flags.StringVar(
+		&args.oidcPrivateKeySecretArn,
+		OidcPrivateKeySecretArnFlag,
+		"",
+		"AWS Secrets Manager ARN for identification of config",
+	)
+
+	aws.AddModeFlag(Cmd)
+
+	interactive.AddFlag(flags)
+	confirm.AddFlag(flags)
+}
+
+func run(cmd *cobra.Command, argv []string) {
+	r := rosa.NewRuntime().WithAWS()
+	defer r.Cleanup()
+
+	mode, err := aws.GetMode()
+	if err != nil {
+		r.Reporter.Errorf("%s", err)
+		os.Exit(1)
+	}
+
+	// Get AWS region
+	region, err := aws.GetRegion(arguments.GetRegion())
+	if err != nil {
+		r.Reporter.Errorf("Error getting region: %v", err)
+		os.Exit(1)
+	}
+	args.region = region
+
+	// Determine if interactive mode is needed
+	if !interactive.Enabled() && !cmd.Flags().Changed("mode") {
+		interactive.Enable()
+	}
+
+	if interactive.Enabled() {
+		mode, err = interactive.GetOption(interactive.Input{
+			Question: "OIDC config creation mode",
+			Help:     cmd.Flags().Lookup("mode").Usage,
+			Default:  aws.ModeAuto,
+			Options:  aws.Modes,
+			Required: true,
+		})
+		if err != nil {
+			r.Reporter.Errorf("Expected a valid OIDC provider creation mode: %s", err)
+			os.Exit(1)
+		}
+	}
+
+	oidcConfigInput := buildOidcConfigInput(r)
+	oidcConfigStrategy, err := getOidcConfigStrategy(mode, oidcConfigInput)
+	if err != nil {
+		r.Reporter.Errorf("%s", err)
+		os.Exit(1)
+	}
+	oidcConfigStrategy.execute(r)
+}
+
+type OidcConfigInput struct {
+	PrivateKeySecretArn string
+	BucketName          string
+}
+
+func buildOidcConfigInput(r *rosa.Runtime) OidcConfigInput {
+	parsedSecretArn, err := arn.Parse(args.oidcPrivateKeySecretArn)
+	if err != nil {
+		r.Reporter.Errorf("There was a problem parsing secret ARN '%s' : %v", args.oidcPrivateKeySecretArn, err)
+		os.Exit(1)
+	}
+	if args.region != parsedSecretArn.Region {
+		r.Reporter.Errorf("Secret region '%s' differs from chosen region '%s', "+
+			"please run the command supplying region parameter.", parsedSecretArn.Region, args.region)
+		os.Exit(1)
+	}
+	secretResourceName, err := aws.GetResourceIdFromSecretArn(args.oidcPrivateKeySecretArn)
+	if err != nil {
+		r.Reporter.Errorf("There was a problem parsing secret ARN '%s' : %v", args.oidcPrivateKeySecretArn, err)
+		os.Exit(1)
+	}
+	bucketName := strings.TrimPrefix(secretResourceName, prefixForPrivateKeySecret)
+	index := strings.LastIndex(bucketName, "-")
+	if index != -1 {
+		bucketName = bucketName[:index]
+	}
+	return OidcConfigInput{
+		BucketName:          bucketName,
+		PrivateKeySecretArn: args.oidcPrivateKeySecretArn,
+	}
+}
+
+type DeleteOidcConfigStrategy interface {
+	execute(r *rosa.Runtime)
+}
+
+type DeleteOidcConfigAutoStrategy struct {
+	oidcConfig OidcConfigInput
+}
+
+func (s *DeleteOidcConfigAutoStrategy) execute(r *rosa.Runtime) {
+	bucketName := s.oidcConfig.BucketName
+	privateKeySecretArn := s.oidcConfig.PrivateKeySecretArn
+	var spin *spinner.Spinner
+	if r.Reporter.IsTerminal() {
+		spin = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+		r.Reporter.Infof("Deleting OIDC configuration '%s'", bucketName)
+	}
+	if spin != nil {
+		spin.Start()
+	}
+	err := r.AWSClient.DeleteSecretInSecretsManager(privateKeySecretArn)
+	if err != nil {
+		r.Reporter.Errorf("There was a problem deleting private key from secrets manager: %s", err)
+		os.Exit(1)
+	}
+	err = r.AWSClient.DeleteS3Bucket(bucketName)
+	if err != nil {
+		r.Reporter.Errorf("There was a problem deleting S3 bucket '%s': %s", bucketName, err)
+		os.Exit(1)
+	}
+	if spin != nil {
+		spin.Stop()
+	}
+	if r.Reporter.IsTerminal() {
+		r.Reporter.Infof("Deleted OIDC configuration")
+	}
+
+}
+
+type DeleteOidcConfigManualStrategy struct {
+	oidcConfig OidcConfigInput
+}
+
+func (s *DeleteOidcConfigManualStrategy) execute(r *rosa.Runtime) {
+	commands := []string{}
+	bucketName := s.oidcConfig.BucketName
+	privateKeySecretArn := s.oidcConfig.PrivateKeySecretArn
+	deleteSecretCommand := awscb.NewSecretsManagerCommandBuilder().
+		SetCommand(awscb.DeleteSecret).
+		AddParam(awscb.SecretID, privateKeySecretArn).
+		AddParam(awscb.Region, args.region).
+		Build()
+	commands = append(commands, deleteSecretCommand)
+	emptyS3BucketCommand := awscb.NewS3CommandBuilder().
+		SetCommand(awscb.Remove).
+		AddValueNoParam(fmt.Sprintf("s3://%s", bucketName)).
+		AddParamNoValue(awscb.Recursive).
+		Build()
+	commands = append(commands, emptyS3BucketCommand)
+	deleteS3BucketCommand := awscb.NewS3CommandBuilder().
+		SetCommand(awscb.RemoveBucket).
+		AddValueNoParam(fmt.Sprintf("s3://%s", bucketName)).
+		Build()
+	commands = append(commands, deleteS3BucketCommand)
+	fmt.Println(awscb.JoinCommands(commands))
+}
+
+func getOidcConfigStrategy(mode string, input OidcConfigInput) (DeleteOidcConfigStrategy, error) {
+	switch mode {
+	case aws.ModeAuto:
+		return &DeleteOidcConfigAutoStrategy{oidcConfig: input}, nil
+	case aws.ModeManual:
+		return &DeleteOidcConfigManualStrategy{oidcConfig: input}, nil
+	default:
+		return nil, weberr.Errorf("Invalid mode. Allowed values are %s", aws.Modes)
+	}
+}

--- a/pkg/aws/commandbuilder/commandbuilder.go
+++ b/pkg/aws/commandbuilder/commandbuilder.go
@@ -11,9 +11,10 @@ const ParamNewLineSeparator = " \\\n"
 type Service string
 
 const (
-	IAM Service = "iam"
-	S3  Service = "s3api"
-	SM  Service = "secretsmanager"
+	IAM   Service = "iam"
+	S3Api Service = "s3api"
+	S3    Service = "s3"
+	SM    Service = "secretsmanager"
 )
 
 type Command string
@@ -33,11 +34,15 @@ const (
 	CreateOpenIdConnectProvider   Command = "create-open-id-connect-provider"
 	DeleteOpenIdConnectProvider   Command = "delete-open-id-connect-provider"
 	DeleteRolePermissionsBoundary Command = "delete-role-permissions-boundary"
-	//S3
+	//S3Api
 	CreateBucket Command = "create-bucket"
 	PutObject    Command = "put-object"
+	//S3
+	Remove       Command = "rm"
+	RemoveBucket Command = "rb"
 	//SecretsManager
 	CreateSecret Command = "create-secret"
+	DeleteSecret Command = "delete-secret"
 )
 
 type Param string
@@ -70,6 +75,8 @@ const (
 	Name         Param = "name"
 	SecretString Param = "secret-string"
 	Description  Param = "description"
+	SecretID     Param = "secret-id"
+	Recursive    Param = "recursive"
 )
 
 type Redirect string
@@ -110,6 +117,11 @@ func (b *CommandBuilder) AddTags(value map[string]string) *CommandBuilder {
 	for k, v := range value {
 		b.tags[k] = v
 	}
+	return b
+}
+
+func (b *CommandBuilder) AddValueNoParam(value string) *CommandBuilder {
+	b.params = append(b.params, fmt.Sprintf("\t%s", value))
 	return b
 }
 
@@ -159,6 +171,10 @@ func (b *CommandBuilder) Build() string {
 
 func NewIAMCommandBuilder() *CommandBuilder {
 	return &CommandBuilder{service: IAM}
+}
+
+func NewS3ApiCommandBuilder() *CommandBuilder {
+	return &CommandBuilder{service: S3Api}
 }
 
 func NewS3CommandBuilder() *CommandBuilder {

--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"github.com/zgalor/weberr"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
@@ -757,6 +758,21 @@ func GetResourceIdFromARN(stringARN string) (string, error) {
 	index := strings.LastIndex(parsedARN.Resource, "/")
 	if index == -1 || index == len(parsedARN.Resource)-1 {
 		return "", fmt.Errorf("can't find resource-id in ARN '%s'", stringARN)
+	}
+
+	return parsedARN.Resource[index+1:], nil
+}
+
+func GetResourceIdFromSecretArn(secretArn string) (string, error) {
+	parsedARN, err := arn.Parse(secretArn)
+
+	if err != nil {
+		return "", err
+	}
+
+	index := strings.LastIndex(parsedARN.Resource, ":")
+	if index == -1 || index == len(parsedARN.Resource)-1 {
+		return "", weberr.Errorf("can't find resource-id in ARN '%s'", secretArn)
 	}
 
 	return parsedARN.Resource[index+1:], nil


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-8059
# What
ROSA needs to support deleting oidc configs

# Why
Currently the client needs to go to aws to remove the configs that were created within ROSA