### PR TITLE
[SDA-8078] Check if any clusters are using the oidc config

### DIFF
--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -379,6 +379,22 @@ func (c *Client) GetPendingClusterForARN(creator *aws.Creator) (cluster *cmv1.Cl
 	return response.Items().Get(0), nil
 }
 
+func (c *Client) HasAClusterUsingOidcConfig(bucketName string) (bool, error) {
+	query := fmt.Sprintf(
+		"aws.sts.oidc_endpoint_url like '%%%s%%'", bucketName,
+	)
+	request := c.ocm.ClustersMgmt().V1().Clusters().List().Search(query)
+	page := 1
+	response, err := request.Page(page).Send()
+	if err != nil {
+		return false, err
+	}
+	if response.Total() > 0 {
+		return true, nil
+	}
+	return false, nil
+}
+
 func (c *Client) IsSTSClusterExists(creator *aws.Creator, count int, roleARN string) (exists bool, err error) {
 	if count < 1 {
 		err = errors.Errorf("Cannot fetch fewer than 1 cluster")


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-8078
# What
Checks if there are any clusters using the oidc config

# Why
Safer flow for client

# Changes
`./rosa delete oidc-config --mode auto`
```
? OIDC Private Key Secret ARN: xxx
E: There are clusters using OIDC config 'xxx', can't delete the configuration
```