### PR TITLE
aws: Ensure ARNs have the correct partition

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2335,7 +2335,7 @@ func getOperatorRoleArn(prefix string, operator *cmv1.STSOperator, creator *aws.
 	if len(role) > 64 {
 		role = role[0:64]
 	}
-	str := fmt.Sprintf("arn:aws:iam::%s:role", creator.AccountID)
+	str := fmt.Sprintf("arn:%s:iam::%s:role", aws.GetPartition(), creator.AccountID)
 	if path != "" {
 		str = fmt.Sprintf("%s%s", str, path)
 		return fmt.Sprintf("%s%s", str, role)

--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -515,9 +515,9 @@ func getPolicyARN(accountID string, prefix string, namespace string, name string
 		policy = policy[0:64]
 	}
 	if path != "" {
-		return fmt.Sprintf("arn:aws:iam::%s:policy%s%s", accountID, path, policy)
+		return fmt.Sprintf("arn:%s:iam::%s:policy%s%s", aws.GetPartition(), accountID, path, policy)
 	}
-	return fmt.Sprintf("arn:aws:iam::%s:policy/%s", accountID, policy)
+	return fmt.Sprintf("arn:%s:iam::%s:policy/%s", aws.GetPartition(), accountID, policy)
 }
 
 func validateOperatorRoles(r *rosa.Runtime, cluster *cmv1.Cluster) ([]string, error) {

--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -409,7 +409,8 @@ func GetPolicyARN(accountID string, name string, path string) string {
 }
 
 func getPolicyARN(accountID string, name string, path string) string {
-	str := fmt.Sprintf("arn:aws:iam::%s:policy", accountID)
+	partition := GetPartition()
+	str := fmt.Sprintf("arn:%s:iam::%s:policy", partition, accountID)
 	if path != "" {
 		str = fmt.Sprintf("%s%s", str, path)
 		return fmt.Sprintf("%s%s", str, name)


### PR DESCRIPTION
Not all ARNs belong to the 'aws' partition based on their region. This ensures that all ARNs have the correct one.