### PR TITLE
[SDA-8092] Add a few more validations to bucket/folder name

### DIFF
--- a/cmd/create/oidcconfig/cmd.go
+++ b/cmd/create/oidcconfig/cmd.go
@@ -202,6 +202,12 @@ func isValidBucketName(bucketName string) bool {
 	if bucketName[0] == '.' || bucketName[len(bucketName)-1] == '.' {
 		return false
 	}
+	if strings.HasPrefix(bucketName, "xn--") {
+		return false
+	}
+	if strings.HasSuffix(bucketName, "-s3alias") {
+		return false
+	}
 	if match, _ := regexp.MatchString("\\.\\.", bucketName); match {
 		return false
 	}


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-8092

# What
https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
Prefixed with `xn--` or suffixed with `-s3alias` are considered invalid

# Why
Invalid for aws 