### PR TITLE
Use latest OCP version instead of the default version

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -86,7 +86,6 @@ func init() {
 		"",
 		"Version of OpenShift that will be used to setup policy tag, for example \"4.11\"",
 	)
-	flags.MarkHidden("version")
 
 	flags.StringVar(
 		&args.channelGroup,

--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -74,7 +74,6 @@ func init() {
 		"",
 		"Version of OpenShift that will be used to setup policy tag, for example \"4.11\"",
 	)
-	flags.MarkHidden("version")
 
 	flags.StringVar(
 		&args.channelGroup,

--- a/pkg/ocm/versions.go
+++ b/pkg/ocm/versions.go
@@ -45,7 +45,6 @@ func (c *Client) GetVersions(channelGroup string) (versions []*cmv1.Version, err
 		var response *cmv1.VersionsListResponse
 		response, err = collection.List().
 			Search(filter).
-			Order("default desc, id desc").
 			Page(page).
 			Size(size).
 			Send()
@@ -59,14 +58,8 @@ func (c *Client) GetVersions(channelGroup string) (versions []*cmv1.Version, err
 		page++
 	}
 
-	// Sort list in descending order, ensuring the 'default' version at the top
+	// Sort list in descending order
 	sort.Slice(versions, func(i, j int) bool {
-		if versions[i].Default() {
-			return true
-		}
-		if versions[j].Default() {
-			return false
-		}
 		a, erra := ver.NewVersion(versions[i].RawID())
 		b, errb := ver.NewVersion(versions[j].RawID())
 		if erra != nil || errb != nil {


### PR DESCRIPTION
1. Modify the call to the backend to get the latest version first.
2. Unhide the `version` flag for creating and upgrading account roles.

Related: [SDA-8123](https://issues.redhat.com/browse/SDA-8123)

![image](https://user-images.githubusercontent.com/57869309/220332734-8ecf2170-a6c4-427d-88e8-78af2ffa155d.png)

![image](https://user-images.githubusercontent.com/57869309/220332711-b736c5a4-76df-4b2d-9805-96de5b7319e2.png)

![image](https://user-images.githubusercontent.com/57869309/218407792-ff462510-754f-4ddf-a1ba-5396d1bbee9b.png)
