### PR TITLE
Add a `AWS managed` column to list role commands

### DIFF
--- a/cmd/list/accountroles/cmd.go
+++ b/cmd/list/accountroles/cmd.go
@@ -107,15 +107,22 @@ func run(_ *cobra.Command, _ []string) {
 
 	// Create the writer that will be used to print the tabulated results:
 	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintf(writer, "ROLE NAME\tROLE TYPE\tROLE ARN\tOPENSHIFT VERSION\n")
-	for _, accountRoles := range accountRoles {
+	fmt.Fprintf(writer, "ROLE NAME\tROLE TYPE\tROLE ARN\tOPENSHIFT VERSION\tAWS Managed\n")
+	for _, accountRole := range accountRoles {
+		var awsManaged string
+		if accountRole.ManagedPolicy {
+			awsManaged = "Yes"
+		} else {
+			awsManaged = "No"
+		}
 		fmt.Fprintf(
 			writer,
-			"%s\t%s\t%s\t%s\n",
-			accountRoles.RoleName,
-			accountRoles.RoleType,
-			accountRoles.RoleARN,
-			accountRoles.Version,
+			"%s\t%s\t%s\t%s\t%s\n",
+			accountRole.RoleName,
+			accountRole.RoleType,
+			accountRole.RoleARN,
+			accountRole.Version,
+			awsManaged,
 		)
 	}
 	writer.Flush()

--- a/cmd/list/ocmroles/cmd.go
+++ b/cmd/list/ocmroles/cmd.go
@@ -84,9 +84,16 @@ func run(_ *cobra.Command, _ []string) {
 
 	// Create the writer that will be used to print the tabulated results:
 	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprint(writer, "ROLE NAME\tROLE ARN\tLINKED\tADMIN\n")
+	fmt.Fprint(writer, "ROLE NAME\tROLE ARN\tLINKED\tADMIN\tAWS Managed\n")
 	for _, ocmRole := range ocmRoles {
-		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\n", ocmRole.RoleName, ocmRole.RoleARN, ocmRole.Linked, ocmRole.Admin)
+		var awsManaged string
+		if ocmRole.ManagedPolicy {
+			awsManaged = "Yes"
+		} else {
+			awsManaged = "No"
+		}
+		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\n", ocmRole.RoleName, ocmRole.RoleARN, ocmRole.Linked, ocmRole.Admin,
+			awsManaged)
 	}
 	writer.Flush()
 }

--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -46,14 +46,15 @@ type AccountRole struct {
 }
 
 type Role struct {
-	RoleType   string   `json:"RoleType,omitempty"`
-	Version    string   `json:"Version,omitempty"`
-	RolePrefix string   `json:"RolePrefix,omitempty"`
-	RoleName   string   `json:"RoleName,omitempty"`
-	RoleARN    string   `json:"RoleARN,omitempty"`
-	Linked     string   `json:"Linked,omitempty"`
-	Admin      string   `json:"Admin,omitempty"`
-	Policy     []Policy `json:"Policy,omitempty"`
+	RoleType      string   `json:"RoleType,omitempty"`
+	Version       string   `json:"Version,omitempty"`
+	RolePrefix    string   `json:"RolePrefix,omitempty"`
+	RoleName      string   `json:"RoleName,omitempty"`
+	RoleARN       string   `json:"RoleARN,omitempty"`
+	Linked        string   `json:"Linked,omitempty"`
+	Admin         string   `json:"Admin,omitempty"`
+	Policy        []Policy `json:"Policy,omitempty"`
+	ManagedPolicy bool     `json:"ManagedPolicy,omitempty"`
 }
 
 type PolicyDetail struct {
@@ -648,10 +649,13 @@ func (c *awsClient) ListOCMRoles() ([]Role, error) {
 			if err != nil {
 				return nil, err
 			}
-			if roleHasTag(roleTags.Tags, tags.AdminRole, "true") {
+			if roleHasTag(roleTags.Tags, tags.AdminRole, tags.True) {
 				ocmRole.Admin = "Yes"
 			} else {
 				ocmRole.Admin = "No"
+			}
+			if roleHasTag(roleTags.Tags, tags.ManagedPolicies, tags.True) {
+				ocmRole.ManagedPolicy = true
 			}
 
 			ocmRoles = append(ocmRoles, ocmRole)
@@ -725,6 +729,10 @@ func (c *awsClient) ListAccountRoles(version string) ([]Role, error) {
 				}
 				isTagged = true
 				accountRole.Version = tagValue
+			case tags.ManagedPolicies:
+				if aws.StringValue(tag.Value) == tags.True {
+					accountRole.ManagedPolicy = true
+				}
 			}
 		}
 		if isTagged && !skip {


### PR DESCRIPTION
Display a new column with info about the role's policies.

Related: [SDA-7969](https://issues.redhat.com/browse/SDA-7969)

![image](https://user-images.githubusercontent.com/57869309/218423732-3270682c-ca97-4eb3-825a-538ffd0021cb.png)

![image](https://user-images.githubusercontent.com/57869309/218423756-201b761e-0a22-47be-b7ea-93d4b214443c.png)
