### PR TITLE
Release v1.2.15

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -2,6 +2,18 @@
 
 This document describes the relevant changes between releases of the `rosa` command line tool.
 
+== 1.2.15 Feb 13 2023
+
+- fix: improve error messages for deleting oidc-config
+- fix: adding some validations to bucket name
+- fix: allow empty label match editing ingress interactive
+- aws: Ensure ARNs have the correct partition
+- Attach three policies to the installer role - managed policies
+- to fix empty DNS domain when DNS not ready: SDA-7418
+- fix: add a few more validations to bucket/folder name
+- Add a `AWS managed` column to list role commands
+- Add etcd encyprtion kms arn support
+
 == 1.2.14 Feb 8 2023
 
 - minor refactor to improve code clarity wrt addons

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,6 +18,6 @@ limitations under the License.
 
 package info
 
-const Version = "1.2.14"
+const Version = "1.2.15"
 
 const UserAgent = "ROSACLI"


### PR DESCRIPTION
- fix: improve error messages for deleting oidc-config
- fix: adding some validations to bucket name
- fix: allow empty label match editing ingress interactive
- aws: Ensure ARNs have the correct partition
- Attach three policies to the installer role - managed policies
- to fix empty DNS domain when DNS not ready: [SDA-7418](https://issues.redhat.com//browse/SDA-7418)
- fix: add a few more validations to bucket/folder name
- Add a `AWS managed` column to list role commands
- Add etcd encyprtion kms arn support