### PR TITLE
[SDA-8074] Add description when available for error state in describe cluster

### DIFF
--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -99,16 +99,8 @@ func run(cmd *cobra.Command, argv []string) {
 	switch cluster.State() {
 	case cmv1.ClusterStateWaiting:
 		phase = "(Waiting for user action)"
-		status, _ := r.OCMClient.GetClusterStatus(cluster.ID())
-		if status.Description() != "" {
-			phase = fmt.Sprintf("(%s)", status.Description())
-		}
 	case cmv1.ClusterStatePending:
 		phase = "(Preparing account)"
-		status, _ := r.OCMClient.GetClusterStatus(cluster.ID())
-		if status.Description() != "" {
-			phase = fmt.Sprintf("(%s)", status.Description())
-		}
 	case cmv1.ClusterStateInstalling:
 		if !cluster.Status().DNSReady() {
 			phase = "(DNS setup in progress)"
@@ -120,6 +112,9 @@ func run(cmd *cobra.Command, argv []string) {
 			}
 			phase = "(" + errorCode + "Install is taking longer than expected)"
 		}
+	}
+	if cluster.Status().Description() != "" {
+		phase = fmt.Sprintf("(%s)", cluster.Status().Description())
 	}
 
 	clusterDNS := "Not ready"

--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -427,18 +427,6 @@ func (c *Client) IsSTSClusterExists(creator *aws.Creator, count int, roleARN str
 	return false, nil
 }
 
-func (c *Client) GetClusterStatus(clusterID string) (*cmv1.ClusterStatus, error) {
-	response, err := c.ocm.ClustersMgmt().V1().Clusters().
-		Cluster(clusterID).
-		Status().
-		Get().
-		Send()
-	if err != nil || response.Body() == nil {
-		return nil, err
-	}
-	return response.Body(), nil
-}
-
 func (c *Client) GetClusterState(clusterID string) (cmv1.ClusterState, error) {
 	response, err := c.ocm.ClustersMgmt().V1().Clusters().
 		Cluster(clusterID).


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-8074
# What
Add description when available for error state in describe cluster

# Why
Better info for client/SRE to understand