### PR TITLE
[WIP] Add hosted-cp flag to account roles

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -41,6 +41,9 @@ var args struct {
 	channelGroup        string
 	managed             bool
 	forcePolicyCreation bool
+
+	// Hypershift options:
+	hostedCPEnabled bool
 }
 
 var Cmd = &cobra.Command{
@@ -113,6 +116,16 @@ func init() {
 		"Forces creation of policies skipping compatibility check",
 	)
 
+	// Options releated to HyperShift:
+	flags.BoolVar(
+		&args.hostedCPEnabled,
+		"hosted-cp",
+		false,
+		"Enable the use of hosted control planes (HyperShift)",
+	)
+
+	flags.MarkHidden("hosted-cp")
+
 	aws.AddModeFlag(Cmd)
 
 	confirm.AddFlag(flags)
@@ -143,6 +156,12 @@ func run(cmd *cobra.Command, argv []string) {
 	if err != nil {
 		r.Reporter.Errorf("Failed to determine OCM environment: %v", err)
 		os.Exit(1)
+	}
+
+	// Set HostedCP for Runtime if we are creating HostedCP roles and policies
+	isHostedCP := cmd.Flags().Changed("hosted-cp")
+	if isHostedCP {
+		r.IsHostedCP()
 	}
 
 	// Determine if managed policies are enabled

--- a/cmd/create/accountroles/creators.go
+++ b/cmd/create/accountroles/creators.go
@@ -118,6 +118,13 @@ type unmanagedPoliciesCreator struct{}
 
 func (up *unmanagedPoliciesCreator) createRoles(r *rosa.Runtime, input *accountRolesCreationInput) error {
 	for file, role := range aws.AccountRoles {
+		// If hosted-cp flag was passed, create only the hosted CP installer policy
+		if r.HostedCP != nil {
+			if *r.HostedCP && file == aws.InstallerAccountRole {
+				continue
+			}
+		}
+
 		accRoleName := aws.GetRoleName(input.prefix, role.Name)
 		if !confirm.Prompt(true, "Create the '%s' role?", accRoleName) {
 			continue

--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -68,19 +68,21 @@ type Policy struct {
 }
 
 const (
-	InstallerAccountRole    = "installer"
-	ControlPlaneAccountRole = "instance_controlplane"
-	WorkerAccountRole       = "instance_worker"
-	SupportAccountRole      = "support"
-	OCMRole                 = "OCM"
-	OCMUserRole             = "User"
+	InstallerAccountRole         = "installer"
+	HostedCPInstallerAccountRole = "installer_hosted_cp"
+	ControlPlaneAccountRole      = "instance_controlplane"
+	WorkerAccountRole            = "instance_worker"
+	SupportAccountRole           = "support"
+	OCMRole                      = "OCM"
+	OCMUserRole                  = "User"
 )
 
 var AccountRoles map[string]AccountRole = map[string]AccountRole{
-	InstallerAccountRole:    {Name: "Installer", Flag: "role-arn"},
-	ControlPlaneAccountRole: {Name: "ControlPlane", Flag: "controlplane-iam-role"},
-	WorkerAccountRole:       {Name: "Worker", Flag: "worker-iam-role"},
-	SupportAccountRole:      {Name: "Support", Flag: "support-role-arn"},
+	InstallerAccountRole:         {Name: "Installer", Flag: "role-arn"},
+	HostedCPInstallerAccountRole: {Name: "Installer", Flag: "role-arn"},
+	ControlPlaneAccountRole:      {Name: "ControlPlane", Flag: "controlplane-iam-role"},
+	WorkerAccountRole:            {Name: "Worker", Flag: "worker-iam-role"},
+	SupportAccountRole:           {Name: "Support", Flag: "support-role-arn"},
 }
 
 var OCMUserRolePolicyFile = "ocm_user"

--- a/pkg/rosa/runtime.go
+++ b/pkg/rosa/runtime.go
@@ -19,6 +19,7 @@ type Runtime struct {
 	Creator    *aws.Creator
 	ClusterKey string
 	Cluster    *cmv1.Cluster
+	HostedCP   *bool
 }
 
 func NewRuntime() *Runtime {
@@ -48,6 +49,16 @@ func (r *Runtime) WithAWS() *Runtime {
 			os.Exit(1)
 		}
 	}
+	return r
+}
+
+func (r *Runtime) IsHostedCP() *Runtime {
+	isHostedCP := true
+	if r.HostedCP != nil && r.HostedCP != &isHostedCP {
+		r.Reporter.Errorf("Runtime HostedCP already set to %s", r.HostedCP)
+	}
+
+	r.HostedCP = &isHostedCP
 	return r
 }
 
@@ -94,5 +105,11 @@ func (r *Runtime) FetchCluster() *cmv1.Cluster {
 		os.Exit(1)
 	}
 	r.Cluster = cluster
+
+	isHostedCP := cluster.Hypershift().Enabled()
+	if isHostedCP {
+		r.HostedCP = &isHostedCP
+	}
+
 	return cluster
 }


### PR DESCRIPTION
This PR adds the hidden flag `--hosted-cp` to the account-roles command. It should do two things

1. By default (not supplying the flag) add both the regular installer permission policy and the new `sts_installer_hosted_cp_permission_policy` policy to the installer role
2. Allow attaching just the `sts_installer_hosted_cp_permission_policy` policy to the install role when the flag is passed ie `rosa create account-roles --hosted-cp`

The new permission policy will need to be added to OCM for this to work