### PR TITLE
[OHSS-18020] Improve logging so that it's more obvious what is wrong

### DIFF
--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -849,7 +849,7 @@ func (c *awsClient) GetRoleByARN(roleARN string) (*iam.Role, error) {
 	// validate arn
 	parsedARN, err := arn.Parse(roleARN)
 	if err != nil {
-		return nil, fmt.Errorf("expected a valid IAM role ARN: %s", err)
+		return nil, fmt.Errorf("expected '%s' to be a valid IAM role ARN: %s", roleARN, err)
 	}
 
 	// validate arn is for a role resource


### PR DESCRIPTION
Customers can get this log when attempting to upgrade account and operator roles, but it's not immediately obvious what the problem is from the existing logs:

```
I: Ensuring account and operator role policies for cluster 'REDACTED' are compatible with upgrade.
E: expected a valid IAM role ARN: arn: invalid prefix
```

[OHSS-18020](https://issues.redhat.com//browse/OHSS-18020)