### PR TITLE
Add support for labels and taints to HostedCP NodePools

### DIFF
--- a/cmd/create/machinepool/helper.go
+++ b/cmd/create/machinepool/helper.go
@@ -79,3 +79,53 @@ func getSubnetOptions(r *rosa.Runtime, cluster *cmv1.Cluster) ([]string, error) 
 
 	return subnetOptions, nil
 }
+
+func getTaints(cmd *cobra.Command, r *rosa.Runtime) []*cmv1.TaintBuilder {
+	taints := args.taints
+	if interactive.Enabled() {
+		var err error
+		taints, err = interactive.GetString(interactive.Input{
+			Question: "Taints",
+			Help:     cmd.Flags().Lookup("taints").Usage,
+			Default:  taints,
+			Validators: []interactive.Validator{
+				taintValidator,
+			},
+		})
+		if err != nil {
+			r.Reporter.Errorf("Expected a valid comma-separated list of attributes: %s", err)
+			os.Exit(1)
+		}
+	}
+	taintBuilders, err := parseTaints(taints)
+	if err != nil {
+		r.Reporter.Errorf("%s", err)
+		os.Exit(1)
+	}
+	return taintBuilders
+}
+
+func getLabelMap(cmd *cobra.Command, r *rosa.Runtime) map[string]string {
+	labels := args.labels
+	if interactive.Enabled() {
+		var err error
+		labels, err = interactive.GetString(interactive.Input{
+			Question: "Labels",
+			Help:     cmd.Flags().Lookup("labels").Usage,
+			Default:  labels,
+			Validators: []interactive.Validator{
+				LabelValidator,
+			},
+		})
+		if err != nil {
+			r.Reporter.Errorf("Expected a valid comma-separated list of attributes: %s", err)
+			os.Exit(1)
+		}
+	}
+	labelMap, err := ParseLabels(labels)
+	if err != nil {
+		r.Reporter.Errorf("%s", err)
+		os.Exit(1)
+	}
+	return labelMap
+}

--- a/cmd/create/machinepool/machinepool.go
+++ b/cmd/create/machinepool/machinepool.go
@@ -304,47 +304,9 @@ func addMachinePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster
 		os.Exit(1)
 	}
 
-	labels := args.labels
-	if interactive.Enabled() {
-		labels, err = interactive.GetString(interactive.Input{
-			Question: "Labels",
-			Help:     cmd.Flags().Lookup("labels").Usage,
-			Default:  labels,
-			Validators: []interactive.Validator{
-				LabelValidator,
-			},
-		})
-		if err != nil {
-			r.Reporter.Errorf("Expected a valid comma-separated list of attributes: %s", err)
-			os.Exit(1)
-		}
-	}
-	labelMap, err := ParseLabels(labels)
-	if err != nil {
-		r.Reporter.Errorf("%s", err)
-		os.Exit(1)
-	}
+	labelMap := getLabelMap(cmd, r)
 
-	taints := args.taints
-	if interactive.Enabled() {
-		taints, err = interactive.GetString(interactive.Input{
-			Question: "Taints",
-			Help:     cmd.Flags().Lookup("taints").Usage,
-			Default:  taints,
-			Validators: []interactive.Validator{
-				taintValidator,
-			},
-		})
-		if err != nil {
-			r.Reporter.Errorf("Expected a valid comma-separated list of attributes: %s", err)
-			os.Exit(1)
-		}
-	}
-	taintBuilders, err := parseTaints(taints)
-	if err != nil {
-		r.Reporter.Errorf("%s", err)
-		os.Exit(1)
-	}
+	taintBuilders := getTaints(cmd, r)
 
 	// Spot instances
 	isSpotSet := cmd.Flags().Changed("use-spot-instances")

--- a/cmd/create/machinepool/nodepool.go
+++ b/cmd/create/machinepool/nodepool.go
@@ -139,8 +139,13 @@ func addNodePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster, r
 		}
 	}
 
+	labelMap := getLabelMap(cmd, r)
+
+	taintBuilders := getTaints(cmd, r)
+
 	npBuilder := cmv1.NewNodePool()
-	npBuilder.ID(name)
+	npBuilder.ID(name).Labels(labelMap).
+		Taints(taintBuilders...)
 
 	if autoscaling {
 		npBuilder = npBuilder.Autoscaling(

--- a/cmd/edit/machinepool/helper.go
+++ b/cmd/edit/machinepool/helper.go
@@ -1,0 +1,93 @@
+package machinepool
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/rosa/pkg/interactive"
+	rprtr "github.com/openshift/rosa/pkg/reporter"
+	"github.com/openshift/rosa/pkg/rosa"
+	"github.com/spf13/cobra"
+)
+
+func getTaints(cmd *cobra.Command, r *rosa.Runtime, inputTaints []*cmv1.Taint) []*cmv1.TaintBuilder {
+	taintBuilders := []*cmv1.TaintBuilder{}
+	taints := args.taints
+	var err error
+	if interactive.Enabled() {
+		if taints == "" {
+			for _, taint := range inputTaints {
+				if taint == nil {
+					continue
+				}
+				if taints != "" {
+					taints += ","
+				}
+				taints += fmt.Sprintf("%s=%s:%s", taint.Key(), taint.Value(), taint.Effect())
+			}
+		}
+		taints, err = interactive.GetString(interactive.Input{
+			Question: "Taints",
+			Help:     cmd.Flags().Lookup("taints").Usage,
+			Default:  taints,
+		})
+		if err != nil {
+			r.Reporter.Errorf("Expected a valid comma-separated list of attributes: %s", err)
+			os.Exit(1)
+		}
+	}
+	taints = strings.Trim(taints, " ")
+	if taints != "" {
+		for _, taint := range strings.Split(taints, ",") {
+			if !strings.Contains(taint, "=") || !strings.Contains(taint, ":") {
+				r.Reporter.Errorf("Expected key=value:scheduleType format for taints")
+				os.Exit(1)
+			}
+			tokens := strings.FieldsFunc(taint, Split)
+			taintBuilders = append(taintBuilders, cmv1.NewTaint().Key(tokens[0]).Value(tokens[1]).Effect(tokens[2]))
+		}
+	}
+	return taintBuilders
+}
+
+func getLabels(cmd *cobra.Command,
+	reporter *rprtr.Object,
+	existingLabels map[string]string) map[string]string {
+	var err error
+	labels := args.labels
+	labelMap := make(map[string]string)
+	if interactive.Enabled() {
+		if labels == "" {
+			for lk, lv := range existingLabels {
+				if labels != "" {
+					labels += ","
+				}
+				labels += fmt.Sprintf("%s=%s", lk, lv)
+			}
+		}
+		labels, err = interactive.GetString(interactive.Input{
+			Question: "Labels",
+			Help:     cmd.Flags().Lookup("labels").Usage,
+			Default:  labels,
+		})
+		if err != nil {
+			reporter.Errorf("Expected a valid comma-separated list of attributes: %s", err)
+			os.Exit(1)
+		}
+	}
+
+	labels = strings.Trim(labels, " ")
+	if labels != "" {
+		for _, label := range strings.Split(labels, ",") {
+			if !strings.Contains(label, "=") {
+				reporter.Errorf("Expected key=value format for labels")
+				os.Exit(1)
+			}
+			tokens := strings.Split(label, "=")
+			labelMap[strings.TrimSpace(tokens[0])] = strings.TrimSpace(tokens[1])
+		}
+	}
+	return labelMap
+}


### PR DESCRIPTION
This covers both creation and modification. The UX should be the same as Classic ROSA.

Related: [SDA-8219](https://issues.redhat.com//browse/SDA-8219)