### PR TITLE
Add labels and taints to the list machinepools command

### DIFF
--- a/cmd/list/machinepool/helper.go
+++ b/cmd/list/machinepool/helper.go
@@ -1,0 +1,39 @@
+package machinepool
+
+import (
+	"fmt"
+	"strings"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+)
+
+func printStringSlice(in []string) string {
+	if len(in) == 0 {
+		return ""
+	}
+	return strings.Join(in, ", ")
+}
+
+func printLabels(labels map[string]string) string {
+	if len(labels) == 0 {
+		return ""
+	}
+	output := []string{}
+	for k, v := range labels {
+		output = append(output, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	return strings.Join(output, ", ")
+}
+
+func printTaints(taints []*cmv1.Taint) string {
+	if len(taints) == 0 {
+		return ""
+	}
+	output := []string{}
+	for _, taint := range taints {
+		output = append(output, fmt.Sprintf("%s=%s:%s", taint.Key(), taint.Value(), taint.Effect()))
+	}
+
+	return strings.Join(output, ", ")
+}

--- a/cmd/list/machinepool/machinepool.go
+++ b/cmd/list/machinepool/machinepool.go
@@ -3,7 +3,6 @@ package machinepool
 import (
 	"fmt"
 	"os"
-	"strings"
 	"text/tabwriter"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -82,37 +81,6 @@ func printMachinePoolReplicas(autoscaling *cmv1.MachinePoolAutoscaling, replicas
 			autoscaling.MaxReplicas())
 	}
 	return fmt.Sprintf("%d", replicas)
-}
-
-func printLabels(labels map[string]string) string {
-	if len(labels) == 0 {
-		return ""
-	}
-	output := []string{}
-	for k, v := range labels {
-		output = append(output, fmt.Sprintf("%s=%s", k, v))
-	}
-
-	return strings.Join(output, ", ")
-}
-
-func printTaints(taints []*cmv1.Taint) string {
-	if len(taints) == 0 {
-		return ""
-	}
-	output := []string{}
-	for _, taint := range taints {
-		output = append(output, fmt.Sprintf("%s=%s:%s", taint.Key(), taint.Value(), taint.Effect()))
-	}
-
-	return strings.Join(output, ", ")
-}
-
-func printStringSlice(in []string) string {
-	if len(in) == 0 {
-		return ""
-	}
-	return strings.Join(in, ", ")
 }
 
 func printSpot(mp *cmv1.MachinePool) string {

--- a/cmd/list/machinepool/nodepool.go
+++ b/cmd/list/machinepool/nodepool.go
@@ -22,14 +22,16 @@ func listNodePools(r *rosa.Runtime, clusterKey string, cluster *cmv1.Cluster) {
 	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 
 	fmt.Fprintf(writer, "ID\tAUTOSCALING\tDESIRED REPLICAS\tCURRENT REPLICAS\t"+
-		"INSTANCE TYPE\tAVAILABILITY ZONE\tSUBNET\tMESSAGE\t\n")
+		"INSTANCE TYPE\tLABELS\t\tTAINTS\t\tAVAILABILITY ZONE\tSUBNET\tMESSAGE\t\n")
 	for _, nodePool := range nodePools {
-		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t\n",
+		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\t%s\t\t%s\t\t%s\t%s\t%s\t\n",
 			nodePool.ID(),
 			printNodePoolAutoscaling(nodePool.Autoscaling()),
 			printNodePoolReplicas(nodePool.Autoscaling(), nodePool.Replicas()),
 			printNodePoolCurrentReplicas(nodePool.Status()),
 			printNodePoolInstanceType(nodePool.AWSNodePool()),
+			printLabels(nodePool.Labels()),
+			printTaints(nodePool.Taints()),
 			nodePool.AvailabilityZone(),
 			nodePool.Subnet(),
 			printNodePoolMessage(nodePool.Status()),


### PR DESCRIPTION
Align the output with classic machinepools
```
rosa list machinepool -c ad2
ID        AUTOSCALING  DESIRED REPLICAS  CURRENT REPLICAS  INSTANCE TYPE  LABELS          TAINTS                  AVAILABILITY ZONE  SUBNET                    MESSAGE
workers   No           2                 2                 m5.xlarge                                              us-west-2a         subnet-0e3a4046c1c2f1078
workers3  No           1                 2                 m5.xlarge      aa=bb, cc=dd    key2=val2:NoSchedule    us-west-2a         subnet-0e3a4046c1c2f1078
```

Related: [SDA-8219](https://issues.redhat.com//browse/SDA-8219)