### PR TITLE
[SDA-8274] Missing '--' for the oidc endpoint url flag

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2227,7 +2227,7 @@ func run(cmd *cobra.Command, _ []string) {
 			if !isByoOidcSet {
 				oidcCMD = fmt.Sprintf("%s --cluster %s", oidcCMD, clusterName)
 			} else {
-				oidcCMD = fmt.Sprintf("%s %s %s", oidcCMD, OidcEndpointUrlFlag, oidcEndpointUrl)
+				oidcCMD = fmt.Sprintf("%s --%s %s", oidcCMD, OidcEndpointUrlFlag, oidcEndpointUrl)
 			}
 
 			r.Reporter.Infof("Run the following commands to continue the cluster creation:\n\n"+


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-8274