### PR TITLE
Use cluster attribute `ManagedPolicies` to identify policy type

### DIFF
--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -218,11 +218,7 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
-	managedPolicies, err := r.AWSClient.HasManagedPolicies(cluster.AWS().STS().RoleARN())
-	if err != nil {
-		r.Reporter.Errorf("Failed to determine if cluster has managed policies: %v", err)
-		os.Exit(1)
-	}
+	managedPolicies := cluster.AWS().STS().ManagedPolicies()
 	if args.forcePolicyCreation && managedPolicies {
 		r.Reporter.Warnf("Forcing creation of policies only works for unmanaged policies")
 		os.Exit(1)

--- a/cmd/upgrade/operatorroles/cmd.go
+++ b/cmd/upgrade/operatorroles/cmd.go
@@ -134,11 +134,7 @@ func run(cmd *cobra.Command, argv []string) error {
 		os.Exit(1)
 	}
 
-	managedPolicies, err := r.AWSClient.HasManagedPolicies(cluster.AWS().STS().RoleARN())
-	if err != nil {
-		r.Reporter.Errorf("Failed to determine if cluster has managed policies: %v", err)
-		os.Exit(1)
-	}
+	managedPolicies := cluster.AWS().STS().ManagedPolicies()
 	// TODO: remove once AWS managed policies are in place
 	if managedPolicies && env == ocm.Production {
 		r.Reporter.Errorf("Managed policies are not supported in this environment")

--- a/cmd/upgrade/roles/cmd.go
+++ b/cmd/upgrade/roles/cmd.go
@@ -152,11 +152,7 @@ func run(cmd *cobra.Command, argv []string) error {
 		os.Exit(1)
 	}
 
-	managedPolicies, err := awsClient.HasManagedPolicies(cluster.AWS().STS().RoleARN())
-	if err != nil {
-		r.Reporter.Errorf("Failed to determine if cluster has managed policies: %v", err)
-		os.Exit(1)
-	}
+	managedPolicies := cluster.AWS().STS().ManagedPolicies()
 	// TODO: remove once AWS managed policies are in place
 	if managedPolicies && env == ocm.Production {
 		r.Reporter.Errorf("Managed policies are not supported in this environment")


### PR DESCRIPTION
Since we are now persisting this information upon cluster creation, use the attribute to reduce API calls to AWS.

Related: [SDA-8278](https://issues.redhat.com/browse/SDA-8278)