### PR TITLE
SDA-8218 Support version parameter on hosted machine pools

### DIFF
--- a/cmd/create/cluster/cmd_test.go
+++ b/cmd/create/cluster/cmd_test.go
@@ -5,6 +5,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/openshift/rosa/pkg/helper/versions"
 )
 
 var _ = Describe("Validates OCP version", func() {
@@ -17,14 +19,14 @@ var _ = Describe("Validates OCP version", func() {
 	var _ = Context("when creating a hosted cluster", func() {
 
 		It("OK: Validates successfully a cluster for hosted clusters with a supported version", func() {
-			v, err := validateVersion("4.12.0", []string{"4.12.0"}, stable, false, true)
+			v, err := versions.ValidateVersion("4.12.0", []string{"4.12.0"}, stable, false, true)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(v).To(Equal("openshift-v4.12.0"))
 		})
 
 		It("OK: Validates successfully a nightly version of OCP for hosted clusters "+
 			"with a supported version", func() {
-			v, err := validateVersion("4.12.0-0.nightly-2022-11-25-185455-nightly",
+			v, err := versions.ValidateVersion("4.12.0-0.nightly-2022-11-25-185455-nightly",
 				[]string{"4.12.0-0.nightly-2022-11-25-185455-nightly"}, nightly, false, true)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(v).To(Equal("openshift-v4.12.0-0.nightly-2022-11-25-185455-nightly-nightly"))
@@ -32,7 +34,7 @@ var _ = Describe("Validates OCP version", func() {
 
 		It("KO: Fails with a nightly version of OCP for hosted clusters "+
 			"in a not supported version", func() {
-			v, err := validateVersion("4.11.0-0.nightly-2022-10-17-040259-nightly",
+			v, err := versions.ValidateVersion("4.11.0-0.nightly-2022-10-17-040259-nightly",
 				[]string{"4.11.0-0.nightly-2022-10-17-040259-nightly"}, nightly, false, true)
 			Expect(err).To(BeEquivalentTo(
 				fmt.Errorf("version '4.11.0-0.nightly-2022-10-17-040259-nightly' " +
@@ -42,21 +44,21 @@ var _ = Describe("Validates OCP version", func() {
 
 		It("OK: Validates successfully the next major release of OCP for hosted clusters "+
 			"with a supported version", func() {
-			v, err := validateVersion("4.13.0", []string{"4.13.0"}, fast, false, true)
+			v, err := versions.ValidateVersion("4.13.0", []string{"4.13.0"}, fast, false, true)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(v).To(Equal("openshift-v4.13.0-fast"))
 		})
 
 		It(`KO: Fails to validate a cluster for a hosted
 		cluster when the user provides an unsupported version`, func() {
-			v, err := validateVersion("4.11.5", []string{"4.11.5"}, stable, false, true)
+			v, err := versions.ValidateVersion("4.11.5", []string{"4.11.5"}, stable, false, true)
 			Expect(err).To(BeEquivalentTo(fmt.Errorf("version '4.11.5' is not supported for hosted clusters")))
 			Expect(v).To(BeEmpty())
 		})
 
 		It(`KO: Fails to validate a cluster for a hosted cluster
 		when the user provides an invalid or malformed version`, func() {
-			v, err := validateVersion("foo.bar", []string{"foo.bar"}, stable, false, true)
+			v, err := versions.ValidateVersion("foo.bar", []string{"foo.bar"}, stable, false, true)
 			Expect(err).To(BeEquivalentTo(
 				fmt.Errorf("error while parsing OCP version 'foo.bar': Malformed version: foo.bar")))
 			Expect(v).To(BeEmpty())
@@ -65,7 +67,7 @@ var _ = Describe("Validates OCP version", func() {
 	var _ = Context("when creating a classic cluster", func() {
 
 		It("OK: Validates successfully a cluster with a supported version", func() {
-			v, err := validateVersion("4.11.0", []string{"4.11.0"}, stable, true, false)
+			v, err := versions.ValidateVersion("4.11.0", []string{"4.11.0"}, stable, true, false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(v).To(Equal("openshift-v4.11.0"))
 		})

--- a/cmd/create/machinepool/cmd.go
+++ b/cmd/create/machinepool/cmd.go
@@ -48,6 +48,7 @@ var args struct {
 	multiAvailabilityZone bool
 	availabilityZone      string
 	subnet                string
+	version               string
 }
 
 var Cmd = &cobra.Command{
@@ -168,6 +169,14 @@ func init() {
 		"subnet",
 		"",
 		"Select subnet to create a single AZ machine pool for BYOVPC cluster")
+
+	flags.StringVar(
+		&args.version,
+		"version",
+		"",
+		"Version of OpenShift that will be used to install a machine pool for a hosted cluster,"+
+			" for example \"4.12.4\"",
+	)
 
 	interactive.AddFlag(flags)
 	output.AddFlag(Cmd)

--- a/cmd/create/machinepool/machinepool.go
+++ b/cmd/create/machinepool/machinepool.go
@@ -22,6 +22,12 @@ import (
 func addMachinePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster, r *rosa.Runtime) {
 	var err error
 
+	isVersionSet := cmd.Flags().Changed("version")
+	if isVersionSet {
+		r.Reporter.Errorf("Setting `version` flag is not supported on classic rosa clusters")
+		os.Exit(1)
+	}
+
 	// Validate flags that are only allowed for multi-AZ clusters
 	isMultiAvailabilityZoneSet := cmd.Flags().Changed("multi-availability-zone")
 	if isMultiAvailabilityZoneSet && !cluster.MultiAZ() {

--- a/cmd/edit/machinepool/cmd.go
+++ b/cmd/edit/machinepool/cmd.go
@@ -32,6 +32,7 @@ var args struct {
 	maxReplicas        int
 	labels             string
 	taints             string
+	version            string
 }
 
 var Cmd = &cobra.Command{
@@ -101,6 +102,14 @@ func init() {
 		"",
 		"Taints for machine pool. Format should be a comma-separated list of 'key=value:ScheduleType'. "+
 			"This list will overwrite any modifications made to node taints on an ongoing basis.",
+	)
+
+	flags.StringVar(
+		&args.version,
+		"version",
+		"",
+		"Version of OpenShift that will be used to install a machine pool for a hosted cluster,"+
+			" for example \"4.12.4\"",
 	)
 }
 

--- a/cmd/edit/machinepool/machinepool.go
+++ b/cmd/edit/machinepool/machinepool.go
@@ -24,6 +24,12 @@ func editMachinePool(cmd *cobra.Command, machinePoolID string, clusterKey string
 		os.Exit(1)
 	}
 
+	isVersionSet := cmd.Flags().Changed("version")
+	if isVersionSet {
+		r.Reporter.Errorf("Setting `version` flag is not supported on classic rosa clusters")
+		os.Exit(1)
+	}
+
 	isMinReplicasSet := cmd.Flags().Changed("min-replicas")
 	isMaxReplicasSet := cmd.Flags().Changed("max-replicas")
 	isReplicasSet := cmd.Flags().Changed("replicas")

--- a/cmd/list/machinepool/nodepool.go
+++ b/cmd/list/machinepool/nodepool.go
@@ -6,6 +6,7 @@ import (
 	"text/tabwriter"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
 )
 
@@ -22,9 +23,9 @@ func listNodePools(r *rosa.Runtime, clusterKey string, cluster *cmv1.Cluster) {
 	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 
 	fmt.Fprintf(writer, "ID\tAUTOSCALING\tDESIRED REPLICAS\tCURRENT REPLICAS\t"+
-		"INSTANCE TYPE\tLABELS\t\tTAINTS\t\tAVAILABILITY ZONE\tSUBNET\tMESSAGE\t\n")
+		"INSTANCE TYPE\tLABELS\t\tTAINTS\t\tAVAILABILITY ZONE\tSUBNET\tVERSION\tMESSAGE\t\n")
 	for _, nodePool := range nodePools {
-		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\t%s\t\t%s\t\t%s\t%s\t%s\t\n",
+		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\t%s\t\t%s\t\t%s\t%s\t%s\t%s\t\n",
 			nodePool.ID(),
 			printNodePoolAutoscaling(nodePool.Autoscaling()),
 			printNodePoolReplicas(nodePool.Autoscaling(), nodePool.Replicas()),
@@ -34,6 +35,7 @@ func listNodePools(r *rosa.Runtime, clusterKey string, cluster *cmv1.Cluster) {
 			printTaints(nodePool.Taints()),
 			nodePool.AvailabilityZone(),
 			nodePool.Subnet(),
+			printNodePoolVersion(nodePool.Version()),
 			printNodePoolMessage(nodePool.Status()),
 		)
 	}
@@ -75,4 +77,8 @@ func printNodePoolMessage(status *cmv1.NodePoolStatus) string {
 		return status.Message()
 	}
 	return ""
+}
+
+func printNodePoolVersion(version *cmv1.Version) string {
+	return ocm.GetRawVersionId(version.ID())
 }

--- a/pkg/helper/versions/helpers.go
+++ b/pkg/helper/versions/helpers.go
@@ -1,0 +1,132 @@
+package versions
+
+import (
+	"fmt"
+	"strings"
+
+	ver "github.com/hashicorp/go-version"
+	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+const (
+	MinorVersionsSupported = 2
+)
+
+func GetVersionList(r *rosa.Runtime, channelGroup string, isSTS bool, isHostedCP bool) (versionList []string,
+	err error) {
+	vs, err := r.OCMClient.GetVersions(channelGroup)
+	if err != nil {
+		err = fmt.Errorf("Failed to retrieve versions: %s", err)
+		return
+	}
+
+	for _, v := range vs {
+		if isSTS && !ocm.HasSTSSupport(v.RawID(), v.ChannelGroup()) {
+			continue
+		}
+		if isHostedCP {
+			valid, err := ocm.HasHostedCPSupport(v.RawID())
+			if err != nil {
+				return versionList, fmt.Errorf("failed to check HostedCP support: %v", err)
+			}
+			if !valid {
+				continue
+			}
+		}
+		versionList = append(versionList, v.RawID())
+	}
+
+	if len(versionList) == 0 {
+		err = fmt.Errorf("Could not find versions for the provided channel-group: '%s'", channelGroup)
+		return
+	}
+
+	return
+}
+
+func GetFilteredVersionList(versionList []string, minVersion string, maxVersion string) []string {
+	var filteredVersionList []string
+
+	// Parse the versions for comparison
+	min, errmin := ver.NewVersion(minVersion)
+	max, errmax := ver.NewVersion(maxVersion)
+
+	if errmin != nil || errmax != nil {
+		return versionList
+	}
+
+	for _, version := range versionList {
+		ver, errver := ver.NewVersion(version)
+		if errver != nil {
+			continue
+		}
+		if ver.GreaterThanOrEqual(min) && ver.LessThanOrEqual(max) {
+			filteredVersionList = append(filteredVersionList, version)
+		}
+	}
+	return filteredVersionList
+}
+
+// Used for hosted machinepool minimal version
+func GetMinimalHostedMachinePoolVersion(controlPlaneVersion string) (string, error) {
+	cpVersion, errcp := ver.NewVersion(controlPlaneVersion)
+	if errcp != nil {
+		return "", errcp
+	}
+	segments := cpVersion.Segments()
+	// Hosted machinepools can be created with a minimal of two minor versions from the control plane
+	minor := segments[1] - MinorVersionsSupported
+	version := fmt.Sprintf("%d.%d.%d", segments[0], minor, 0)
+	minimalVersion, errminver := ver.NewVersion(version)
+	if errminver != nil {
+		return "", errminver
+	}
+
+	lowestHostedCPSupport, errlow := ver.NewVersion(ocm.LowestHostedCPSupport)
+	if errlow != nil {
+		return "", errlow
+	}
+
+	if minimalVersion.LessThanOrEqual(lowestHostedCPSupport) {
+		return ocm.LowestHostedCPSupport, nil
+	}
+
+	return version, nil
+}
+
+// Validate OpenShift versions
+func ValidateVersion(version string, versionList []string, channelGroup string, isSTS,
+	isHostedCP bool) (string, error) {
+	if version == "" {
+		return version, nil
+	}
+	// Check and set the cluster version
+	hasVersion := false
+	for _, v := range versionList {
+		if v == version {
+			hasVersion = true
+		}
+	}
+	if !hasVersion {
+		allVersions := strings.Join(versionList, " ")
+		err := fmt.Errorf("A valid version number must be specified\nValid versions: %s", allVersions)
+		return version, err
+	}
+
+	if isSTS && !ocm.HasSTSSupport(version, channelGroup) {
+		err := fmt.Errorf("Version '%s' is not supported for STS clusters", version)
+		return version, err
+	}
+	if isHostedCP {
+		valid, err := ocm.HasHostedCPSupport(version)
+		if err != nil {
+			return "", fmt.Errorf("error while parsing OCP version '%s': %v", version, err)
+		}
+		if !valid {
+			return "", fmt.Errorf("version '%s' is not supported for hosted clusters", version)
+		}
+	}
+
+	return ocm.CreateVersionID(version, channelGroup), nil
+}

--- a/pkg/helper/versions/helpers_test.go
+++ b/pkg/helper/versions/helpers_test.go
@@ -1,0 +1,78 @@
+package versions
+
+import (
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/ginkgo/v2/dsl/decorators"
+	. "github.com/onsi/ginkgo/v2/dsl/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Version Helpers", Ordered, func() {
+
+	Context("when creating a hosted machine pool ", func() {
+		DescribeTable("Filtered versions",
+			func(versionList []string, minVersion string, maxVersion string, expetedVersionList []string) {
+				filteredVersionList := GetFilteredVersionList(versionList, minVersion, maxVersion)
+				Expect(filteredVersionList).To(BeEquivalentTo(expetedVersionList))
+			},
+			Entry("machinepool create",
+				[]string{
+					"4.12.0-rc.8",
+					"4.12.1",
+					"4.12.2",
+					"4.12.3",
+					"4.12.4",
+					"4.12.5",
+					"4.13.0-0.nightly-2023-02-22-192922",
+				},
+				"4.12.2",
+				"4.12.5",
+				[]string{
+					"4.12.2",
+					"4.12.3",
+					"4.12.4",
+					"4.12.5",
+				},
+			),
+			Entry("machinepool update",
+				[]string{
+					"4.12.0-rc.8",
+					"4.12.1",
+					"4.12.2",
+					"4.12.3",
+					"4.12.4",
+					"4.12.5",
+					"4.13.0-0.nightly-2023-02-22-192922",
+				},
+				"4.12.4",
+				"4.12.5",
+				[]string{
+					"4.12.4",
+					"4.12.5",
+				},
+			),
+		)
+
+		DescribeTable("Minimal hosted machinepool version",
+			func(controlPlaneVersion string, expected string) {
+				minimalVersion, err := GetMinimalHostedMachinePoolVersion(controlPlaneVersion)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(minimalVersion).To(Equal(expected))
+			},
+			Entry("Future control plane",
+				"4.15.0",
+				"4.13.0",
+			),
+			Entry("Nightly control plane",
+				"4.14.0-0.nightly-2023-02-27-084419",
+				"4.12.0",
+			),
+			Entry("Current control plane",
+				"4.12.5",
+				"4.12.0-0.a",
+			),
+		)
+
+	})
+
+})

--- a/pkg/helper/versions/main_test.go
+++ b/pkg/helper/versions/main_test.go
@@ -1,0 +1,13 @@
+package versions
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestVersionHelpers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Version Helpers")
+}

--- a/pkg/ocm/versions.go
+++ b/pkg/ocm/versions.go
@@ -155,6 +155,15 @@ func CreateVersionID(version string, channelGroup string) string {
 	return versionID
 }
 
+func GetRawVersionId(versionId string) string {
+	trimmedPrefix := strings.TrimPrefix(versionId, "openshift-v")
+	channelSeparator := strings.LastIndex(trimmedPrefix, "-")
+	if channelSeparator > 0 {
+		return trimmedPrefix[:channelSeparator]
+	}
+	return trimmedPrefix
+}
+
 // Get a list of all STS-supported minor versions
 func GetVersionMinorList(ocmClient *Client) (versionList []string, err error) {
 	vs, err := ocmClient.GetVersions("")

--- a/pkg/ocm/versions_test.go
+++ b/pkg/ocm/versions_test.go
@@ -33,6 +33,27 @@ var _ = Describe("Versions", Ordered, func() {
 				func() string { return "candidate" }, true, nil),
 		)
 	})
+
+	Context("when listing machinepools versions", func() {
+		DescribeTable("Parse correctly raw versions from version id",
+			func(versionId string, expected string) {
+				rawId := GetRawVersionId(versionId)
+				Expect(rawId).To(Equal(expected))
+			},
+			Entry("stable channel",
+				"openshift-v4.10.21",
+				"4.10.21",
+			),
+			Entry("candidate channel",
+				"openshift-v4.11.0-fc.0-candidate",
+				"4.11.0-fc.0",
+			),
+			Entry("nightly channel",
+				"openshift-v4.7.0-0.nightly-2021-05-21-224816-nightly",
+				"4.7.0-0.nightly-2021-05-21-224816",
+			),
+		)
+	})
 })
 
 func validateVersion(version func() string, channelGroup func() string, expectedValidation bool, expectedErr error) {


### PR DESCRIPTION
The "hosted machinepools" can accept a "version" parameter on "create" and "edit" commands.

This PR exposes this parameter on "list" command:

```
$ rosa list machinepools -c lponce-local-01
ID       AUTOSCALING  DESIRED REPLICAS  CURRENT REPLICAS  INSTANCE TYPE  LABELS    TAINTS    AVAILABILITY ZONE  SUBNET                    VERSION  MESSAGE            
mp-02    No           2                 2                 m5.xlarge                          us-west-2a         subnet-0d65e2465258986db  4.12.2   NodeProvisioning   
workers  No           2                 2                 m5.xlarge                          us-west-2a         subnet-0d65e2465258986db  4.12.4                      
mp-01    No           1                 2                 m5.xlarge                          us-west-2a         subnet-0d65e2465258986db  4.12.1   Deleting,Deleting  
```

It adds it on "create" command, both in interactive and non-interactive modes:

```
$ rosa create machinepool -c lponce-local-01 
I: Enabling interactive mode
? Machine pool name: mp-03
? OpenShift version:  [Use arrows to move, type to filter, ? for more help]
  4.12.3
  4.12.2
  4.12.1
> 4.12.0
  4.12.0-rc.8
  4.12.0-rc.7
  4.12.0-rc.6
```

```
$ rosa create machinepool -c lponce-local-01 --name mp-04 --version 4.12.0 --replicas 1
I: Fetching instance types
I: Machine pool 'mp-04' created successfully on hosted cluster 'lponce-local-01'
I: To view all machine pools, run 'rosa list machinepools -c lponce-local-01'
```

It adds it on "edit" command, both on interactive and non-interactive modes:

```
$ rosa edit machinepool -c lponce-local-01 mp-01 --interactive
? Enable autoscaling (optional): No
? Replicas: 1
? Labels (optional): 
? Taints (optional): 
? OpenShift version (optional):  [Use arrows to move, type to filter, ? for more help]
  4.12.5
> 4.12.4
  4.12.3
  4.12.2
  4.12.1
  4.12.0
  4.12.0-rc.8
```

```
$ rosa edit machinepool -c lponce-local-01 mp-02 --replicas 2 --version 4.12.3
I: Updated machine pool 'mp-02' on hosted cluster 'lponce-local-01'
```

Please, @gdbranco @pvasant @wgordon17 
