### PR TITLE
SDA-8325 Add subnets field for Default Worker

### DIFF
--- a/cmd/list/machinepool/machinepool.go
+++ b/cmd/list/machinepool/machinepool.go
@@ -33,6 +33,12 @@ func listMachinePools(r *rosa.Runtime, clusterKey string, cluster *cmv1.Cluster)
 				MaxReplicas(cluster.Nodes().AutoscaleCompute().MaxReplicas()),
 		)
 	}
+
+	// In case of AWS clusters we can query the subnbets
+	if cluster.AWS() != nil && len(cluster.AWS().SubnetIDs()) > 0 {
+		defaultMachinePoolBuilder.Subnets(cluster.AWS().SubnetIDs()...)
+	}
+
 	defaultMachinePool, _ := defaultMachinePoolBuilder.Build()
 
 	machinePools = append([]*cmv1.MachinePool{defaultMachinePool}, machinePools...)


### PR DESCRIPTION
A minimal PR to fix https://issues.redhat.com/browse/SDA-8325
As the "Default" machinepool for Hive clusters is built in the rosa side, it requires logic to populate the subnets from the cluster.

Please @oriAdler @zgalor @gdbranco take a look; feel free to suggest if there is a better way to patch this. 
I don't usually work on hive clusters, and I may miss some context.

Thanks