### PR TITLE
Create cluster - roles with managed policies

### DIFF
--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -482,6 +482,12 @@ func (c *awsClient) FindRoleARNs(roleType string, version string) ([]string, err
 				}
 			case tags.OpenShiftVersion:
 				isTagged = true
+
+				if roleHasTag(listRoleTagsOutput.Tags, tags.ManagedPolicies, tags.True) {
+					// Managed policies will be up-to-date no need to check version tags
+					break
+				}
+
 				clusterVersion, err := semver.NewVersion(version)
 				if err != nil {
 					skip = true


### PR DESCRIPTION
Since managed policies are always going to be up-to-date, 
skip the `rosa_openshift_version` tag check for roles with managed policies.

Related: [SDA-8328](https://issues.redhat.com/browse/SDA-8328)

![image](https://user-images.githubusercontent.com/57869309/221864980-4bf845c9-3bed-4d40-b70d-2954bcd1c816.png)
