### PR TITLE
fedramp: Remove config flag

### DIFF
--- a/cmd/login/cmd.go
+++ b/cmd/login/cmd.go
@@ -149,7 +149,7 @@ func run(cmd *cobra.Command, argv []string) {
 
 	// Determine if we should be using the FedRAMP environment:
 	if fedramp.HasFlag(cmd) ||
-		(cfg.FedRAMP && token == "") ||
+		fedramp.Enabled() ||
 		fedramp.IsGovRegion(arguments.GetRegion()) ||
 		config.IsEncryptedToken(token) {
 		fedramp.Enable()
@@ -244,7 +244,6 @@ func run(cmd *cobra.Command, argv []string) {
 	cfg.Scopes = args.scopes
 	cfg.URL = gatewayURL
 	cfg.Insecure = args.insecure
-	cfg.FedRAMP = fedramp.Enabled()
 
 	if token != "" {
 		if config.IsEncryptedToken(token) {

--- a/pkg/fedramp/config.go
+++ b/pkg/fedramp/config.go
@@ -19,13 +19,31 @@ limitations under the License.
 
 package fedramp
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/openshift/rosa/pkg/config"
+)
 
 var regions = []string{"us-gov-west-1", "us-gov-east-1"}
 
+// Verifies if configured region is GovCloud
 func IsGovRegion(region string) bool {
 	for _, r := range regions {
 		if r == region {
+			return true
+		}
+	}
+	return false
+}
+
+// Verifies if API URL in config is for FedRAMP
+func IsFedRAMP(cfg *config.Config) bool {
+	if cfg == nil {
+		return false
+	}
+	for _, api := range URLAliases {
+		if api == cfg.URL {
 			return true
 		}
 	}

--- a/pkg/fedramp/flag.go
+++ b/pkg/fedramp/flag.go
@@ -52,7 +52,7 @@ func Enabled() bool {
 	if err != nil {
 		return false
 	}
-	if cfg != nil && cfg.FedRAMP {
+	if IsFedRAMP(cfg) {
 		Enable()
 	}
 	return enabled
@@ -65,12 +65,6 @@ func Enable() {
 
 func Disable() {
 	enabled = false
-	cfg, err := config.Load()
-	if err != nil || cfg == nil {
-		return
-	}
-	cfg.FedRAMP = false
-	config.Save(cfg)
 }
 
 // enabled is a boolean flag that indicates that the govcloud mode is enabled.

--- a/pkg/ocm/client.go
+++ b/pkg/ocm/client.go
@@ -89,7 +89,7 @@ func (b *ClientBuilder) Build() (result *Client, err error) {
 	}
 
 	// Enable the FedRAMP flag globally
-	if b.cfg.FedRAMP {
+	if fedramp.IsFedRAMP(b.cfg) {
 		fedramp.Enable()
 	}
 

--- a/pkg/ocm/config.go
+++ b/pkg/ocm/config.go
@@ -44,12 +44,13 @@ func GetEnv() (string, error) {
 		return "", err
 	}
 
-	urlAliases := URLAliases
-	if cfg.FedRAMP {
-		urlAliases = fedramp.URLAliases
+	for env, api := range URLAliases {
+		if api == cfg.URL {
+			return env, nil
+		}
 	}
 
-	for env, api := range urlAliases {
+	for env, api := range fedramp.URLAliases {
 		if api == cfg.URL {
 			return env, nil
 		}


### PR DESCRIPTION
Storing a FedRAMP flag in the OCM token configuration is an unreliable indicator of whether the client is connected to the GovCloud environment. Instead, we check whether the URL matches the known GovCloud APIs and set a runtime flag.