### PR TITLE
[SDA-8387] Add possibility to delete operator roles from prefix

### DIFF
--- a/cmd/dlt/cluster/cmd.go
+++ b/cmd/dlt/cluster/cmd.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/cmd/dlt/oidcprovider"
+	"github.com/openshift/rosa/cmd/dlt/operatorrole"
 	uninstallLogs "github.com/openshift/rosa/cmd/logs/uninstall"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
@@ -113,6 +114,8 @@ func buildCommands(cluster *cmv1.Cluster) string {
 	deleteOperatorRole := fmt.Sprintf("\trosa delete operator-roles -c %s", cluster.ID())
 	deleteOIDCProvider := fmt.Sprintf("\trosa delete oidc-provider -c %s", cluster.ID())
 	if cluster.ByoOidc().Enabled() {
+		deleteOperatorRole = fmt.Sprintf("\trosa delete operator-roles --%s %s",
+			operatorrole.PrefixFlag, cluster.AWS().STS().OperatorRolePrefix())
 		deleteOIDCProvider = fmt.Sprintf("\trosa delete oidc-provider --%s %s",
 			oidcprovider.OidcEndpointUrlFlag, cluster.AWS().STS().OIDCEndpointURL())
 	}

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -123,7 +123,8 @@ type Client interface {
 	GetRoleByARN(roleARN string) (*iam.Role, error)
 	HasCompatibleVersionTags(iamTags []*iam.Tag, version string) (bool, error)
 	DeleteOperatorRole(roles string, managedPolicies bool) error
-	GetOperatorRolesFromAccount(clusterID string, credRequests map[string]*cmv1.STSOperator) ([]string, error)
+	GetOperatorRolesFromAccountByClusterID(clusterID string, credRequests map[string]*cmv1.STSOperator) ([]string, error)
+	GetOperatorRolesFromAccountByPrefix(prefix string, credRequest map[string]*cmv1.STSOperator) ([]string, error)
 	GetPolicies(roles []string) (map[string][]string, error)
 	GetAccountRolesForCurrentEnv(env string, accountID string) ([]Role, error)
 	GetAccountRoleForCurrentEnv(env string, roleName string) (Role, error)

--- a/pkg/aws/sts.go
+++ b/pkg/aws/sts.go
@@ -42,7 +42,7 @@ func (c *awsClient) DeleteUserRole(roleName string) error {
 		return err
 	}
 
-	return c.DeleteRole(roleName, aws.String(roleName))
+	return c.DeleteRole(roleName)
 }
 
 func (c *awsClient) DeleteOCMRole(roleName string, managedPolicies bool) error {
@@ -56,7 +56,7 @@ func (c *awsClient) DeleteOCMRole(roleName string, managedPolicies bool) error {
 		return err
 	}
 
-	return c.DeleteRole(roleName, aws.String(roleName))
+	return c.DeleteRole(roleName)
 }
 
 func (c *awsClient) ValidateRoleARNAccountIDMatchCallerAccountID(roleARN string) error {


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-8387
# What
Operator roles created from/for BYO OIDC clusters do not have cluster ID tag, so it is required to provide a different way of deleting them

# Why
Facilitates flow for customers so they don't need to deal directly with aws console/cli