### PR TITLE
[SDA-8354] Allow creating operator roles prior to cluster spec

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -29,7 +29,6 @@ import (
 
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
-	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/rosa/cmd/create/machinepool"
 	"github.com/openshift/rosa/pkg/helper/roles"
 	"github.com/spf13/cobra"
@@ -1170,7 +1169,8 @@ func run(cmd *cobra.Command, _ []string) {
 			operatorIAMRoleList = append(operatorIAMRoleList, ocm.OperatorIAMRole{
 				Name:      operator.Name(),
 				Namespace: operator.Namespace(),
-				RoleARN:   getOperatorRoleArn(operatorRolesPrefix, operator, awsCreator, operatorRolePath),
+				RoleARN: aws.ComputeOperatorRoleArn(operatorRolesPrefix, operator,
+					awsCreator, operatorRolePath),
 			})
 
 		}
@@ -2398,19 +2398,6 @@ func hostPrefixValidator(val interface{}) error {
 			hostPrefix, HostPrefixMin, HostPrefixMax)
 	}
 	return nil
-}
-
-func getOperatorRoleArn(prefix string, operator *cmv1.STSOperator, creator *aws.Creator, path string) string {
-	role := fmt.Sprintf("%s-%s-%s", prefix, operator.Namespace(), operator.Name())
-	if len(role) > 64 {
-		role = role[0:64]
-	}
-	str := fmt.Sprintf("arn:%s:iam::%s:role", aws.GetPartition(), creator.AccountID)
-	if path != "" {
-		str = fmt.Sprintf("%s%s", str, path)
-		return fmt.Sprintf("%s%s", str, role)
-	}
-	return fmt.Sprintf("%s/%s", str, role)
 }
 
 func getAccountRolePrefix(roleARN string, role aws.AccountRole) (string, error) {

--- a/cmd/create/operatorroles/by_clusterkey.go
+++ b/cmd/create/operatorroles/by_clusterkey.go
@@ -1,0 +1,392 @@
+package operatorroles
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/rosa/pkg/aws"
+	awscb "github.com/openshift/rosa/pkg/aws/commandbuilder"
+	"github.com/openshift/rosa/pkg/aws/tags"
+	"github.com/openshift/rosa/pkg/helper"
+	"github.com/openshift/rosa/pkg/interactive/confirm"
+	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/output"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+func handleOperatorRoleCreationByClusterKey(r *rosa.Runtime, env string,
+	permissionsBoundary string, mode string,
+	policies map[string]*cmv1.AWSSTSPolicy,
+	defaultPolicyVersion string) error {
+	clusterKey := r.GetClusterKey()
+	cluster := r.FetchCluster()
+	if cluster.AWS().STS().RoleARN() == "" {
+		r.Reporter.Errorf("Cluster '%s' is not an STS cluster.", clusterKey)
+		os.Exit(1)
+	}
+	// Check to see if IAM operator roles have already created
+	missingRoles, err := validateOperatorRoles(r, cluster)
+	if err != nil {
+		if strings.Contains(err.Error(), "AccessDenied") {
+			r.Reporter.Debugf("Failed to verify if operator roles exist: %s", err)
+		} else {
+			r.Reporter.Errorf("Failed to verify if operator roles exist: %s", err)
+			os.Exit(1)
+		}
+	}
+
+	if isByoOidcSet(cluster) && len(missingRoles) == 0 {
+		err := validateOperatorRolesMatchOidcProvider(r, cluster)
+		if err != nil {
+			return err
+		}
+		r.Reporter.Warnf("Cluster '%s' is using BYO OIDC and operator roles already exist.", clusterKey)
+		return nil
+	}
+
+	if len(missingRoles) == 0 &&
+		cluster.State() != cmv1.ClusterStateWaiting && cluster.State() != cmv1.ClusterStatePending &&
+		!args.forcePolicyCreation {
+		r.Reporter.Infof("Cluster '%s' is %s and does not need additional configuration.",
+			clusterKey, cluster.State())
+		os.Exit(0)
+	}
+	roleName, err := aws.GetInstallerAccountRoleName(cluster)
+	if err != nil {
+		r.Reporter.Errorf("Expected parsing role account role '%s': %v", cluster.AWS().STS().RoleARN(), err)
+		os.Exit(1)
+	}
+
+	path, err := aws.GetPathFromAccountRole(cluster, aws.AccountRoles[aws.InstallerAccountRole].Name)
+	if err != nil {
+		r.Reporter.Errorf("Expected a valid path for '%s': %v", cluster.AWS().STS().RoleARN(), err)
+		os.Exit(1)
+	}
+	if path != "" && !output.HasFlag() && r.Reporter.IsTerminal() {
+		r.Reporter.Infof("ARN path '%s' detected in installer role '%s'. "+
+			"This ARN path will be used for subsequent created operator roles and policies.",
+			path, cluster.AWS().STS().RoleARN())
+	}
+	accountRoleVersion, err := r.AWSClient.GetAccountRoleVersion(roleName)
+	if err != nil {
+		r.Reporter.Errorf("Error getting account role version %s", err)
+		os.Exit(1)
+	}
+	managedPolicies := cluster.AWS().STS().ManagedPolicies()
+	if args.forcePolicyCreation && managedPolicies {
+		r.Reporter.Warnf("Forcing creation of policies only works for unmanaged policies")
+		os.Exit(1)
+	}
+	// TODO: remove once AWS managed policies are in place
+	if managedPolicies && env == ocm.Production {
+		r.Reporter.Errorf("Managed policies are not supported in this environment")
+		os.Exit(1)
+	}
+	credRequests, err := r.OCMClient.GetCredRequests(cluster.Hypershift().Enabled())
+	if err != nil {
+		r.Reporter.Errorf("Error getting operator credential request from OCM %s", err)
+		os.Exit(1)
+	}
+
+	operatorRolePolicyPrefix, err := aws.GetOperatorRolePolicyPrefixFromCluster(cluster, r.AWSClient)
+	if err != nil {
+		r.Reporter.Errorf("%s", err)
+	}
+	switch mode {
+	case aws.ModeAuto:
+		if !output.HasFlag() || r.Reporter.IsTerminal() {
+			r.Reporter.Infof("Creating roles using '%s'", r.Creator.ARN)
+		}
+		err = createRoles(r, operatorRolePolicyPrefix, permissionsBoundary, cluster,
+			accountRoleVersion, policies, defaultPolicyVersion, credRequests, managedPolicies)
+		if err != nil {
+			r.Reporter.Errorf("There was an error creating the operator roles: %s", err)
+			isThrottle := "false"
+			if strings.Contains(err.Error(), "Throttling") {
+				isThrottle = helper.True
+			}
+			r.OCMClient.LogEvent("ROSACreateOperatorRolesModeAuto", map[string]string{
+				ocm.ClusterID:  clusterKey,
+				ocm.Response:   ocm.Failure,
+				ocm.IsThrottle: isThrottle,
+			})
+			os.Exit(1)
+		}
+		r.OCMClient.LogEvent("ROSACreateOperatorRolesModeAuto", map[string]string{
+			ocm.ClusterID: clusterKey,
+			ocm.Response:  ocm.Success,
+		})
+	case aws.ModeManual:
+		commands, err := buildCommands(r, env, operatorRolePolicyPrefix, permissionsBoundary, defaultPolicyVersion,
+			cluster, policies, credRequests, managedPolicies)
+		if err != nil {
+			r.Reporter.Errorf("There was an error building the list of resources: %s", err)
+			os.Exit(1)
+			r.OCMClient.LogEvent("ROSACreateOperatorRolesModeManual", map[string]string{
+				ocm.ClusterID: clusterKey,
+				ocm.Response:  ocm.Failure,
+			})
+		}
+		if r.Reporter.IsTerminal() {
+			r.Reporter.Infof("All policy files saved to the current directory")
+			r.Reporter.Infof("Run the following commands to create the operator roles:\n")
+		}
+		r.OCMClient.LogEvent("ROSACreateOperatorRolesModeManual", map[string]string{
+			ocm.ClusterID: clusterKey,
+		})
+		fmt.Println(commands)
+
+	default:
+		r.Reporter.Errorf("Invalid mode. Allowed values are %s", aws.Modes)
+		os.Exit(1)
+	}
+	return nil
+}
+
+func createRoles(r *rosa.Runtime,
+	prefix string, permissionsBoundary string,
+	cluster *cmv1.Cluster, accountRoleVersion string, policies map[string]*cmv1.AWSSTSPolicy,
+	defaultVersion string, credRequests map[string]*cmv1.STSOperator, managedPolicies bool) error {
+	for credrequest, operator := range credRequests {
+		ver := cluster.Version()
+		if ver != nil && operator.MinVersion() != "" {
+			isSupported, err := ocm.CheckSupportedVersion(ocm.GetVersionMinor(ver.ID()), operator.MinVersion())
+			if err != nil {
+				r.Reporter.Errorf("Error validating operator role '%s' version %s", operator.Name(), err)
+				os.Exit(1)
+			}
+			if !isSupported {
+				continue
+			}
+		}
+		roleName, _ := aws.FindOperatorRoleNameBySTSOperator(cluster, operator)
+		if roleName == "" {
+			return fmt.Errorf("Failed to find operator IAM role")
+		}
+		if !confirm.Prompt(true, "Create the '%s' role?", roleName) {
+			continue
+		}
+
+		path, err := aws.GetPathFromAccountRole(cluster, aws.AccountRoles[aws.InstallerAccountRole].Name)
+		if err != nil {
+			return err
+		}
+
+		var policyARN string
+		filename := fmt.Sprintf("openshift_%s_policy", credrequest)
+		if managedPolicies {
+			policyARN, err = aws.GetManagedPolicyARN(policies, filename)
+			if err != nil {
+				return err
+			}
+		} else {
+			policyARN = aws.GetOperatorPolicyARN(r.Creator.AccountID, prefix, operator.Namespace(),
+				operator.Name(), path)
+			policyDetails := aws.GetPolicyDetails(policies, filename)
+
+			operatorPolicyTags := map[string]string{
+				tags.OpenShiftVersion:  accountRoleVersion,
+				tags.RolePrefix:        prefix,
+				tags.RedHatManaged:     helper.True,
+				tags.OperatorNamespace: operator.Namespace(),
+				tags.OperatorName:      operator.Name(),
+			}
+
+			if args.forcePolicyCreation {
+				policyARN, err = r.AWSClient.ForceEnsurePolicy(policyARN, policyDetails,
+					defaultVersion, operatorPolicyTags, path)
+				if err != nil {
+					return err
+				}
+			} else {
+				policyARN, err = r.AWSClient.EnsurePolicy(policyARN, policyDetails,
+					defaultVersion, operatorPolicyTags, path)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		policyDetails := aws.GetPolicyDetails(policies, "operator_iam_role_policy")
+		policy, err := aws.GenerateOperatorRolePolicyDoc(cluster, r.Creator.AccountID, operator, policyDetails)
+		if err != nil {
+			return err
+		}
+
+		r.Reporter.Debugf("Creating role '%s'", roleName)
+		tagsList := map[string]string{
+			tags.OperatorNamespace: operator.Namespace(),
+			tags.OperatorName:      operator.Name(),
+			tags.RedHatManaged:     helper.True,
+		}
+		if !isByoOidcSet(cluster) {
+			tagsList[tags.ClusterID] = cluster.ID()
+		}
+		if managedPolicies {
+			tagsList[tags.ManagedPolicies] = helper.True
+		}
+
+		roleARN, err := r.AWSClient.EnsureRole(roleName, policy, permissionsBoundary, accountRoleVersion,
+			tagsList, path, managedPolicies)
+		if err != nil {
+			return err
+		}
+		if !output.HasFlag() || r.Reporter.IsTerminal() {
+			r.Reporter.Infof("Created role '%s' with ARN '%s'", roleName, roleARN)
+		}
+
+		r.Reporter.Debugf("Attaching permission policy '%s' to role '%s'", policyARN, roleName)
+		err = r.AWSClient.AttachRolePolicy(roleName, policyARN)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func buildCommands(r *rosa.Runtime, env string,
+	prefix string, permissionsBoundary string, defaultPolicyVersion string, cluster *cmv1.Cluster,
+	policies map[string]*cmv1.AWSSTSPolicy, credRequests map[string]*cmv1.STSOperator,
+	managedPolicies bool) (string, error) {
+	err := aws.GeneratePolicyFiles(r.Reporter, env, false,
+		true, policies, credRequests, managedPolicies)
+	if err != nil {
+		r.Reporter.Errorf("There was an error generating the policy files: %s", err)
+		os.Exit(1)
+	}
+
+	commands := []string{}
+
+	for credrequest, operator := range credRequests {
+		ver := cluster.Version()
+		if ver != nil && operator.MinVersion() != "" {
+			isSupported, err := ocm.CheckSupportedVersion(ocm.GetVersionMinor(ver.ID()), operator.MinVersion())
+			if err != nil {
+				r.Reporter.Errorf("Error validating operator role '%s' version %s", operator.Name(), err)
+				os.Exit(1)
+			}
+			if !isSupported {
+				continue
+			}
+		}
+		roleName, _ := aws.FindOperatorRoleNameBySTSOperator(cluster, operator)
+		path, err := aws.GetPathFromAccountRole(cluster, aws.AccountRoles[aws.InstallerAccountRole].Name)
+		if err != nil {
+			return "", err
+		}
+
+		var policyARN string
+		if managedPolicies {
+			policyARN, err = aws.GetManagedPolicyARN(policies, fmt.Sprintf("openshift_%s_policy", credrequest))
+			if err != nil {
+				return "", err
+			}
+		} else {
+			policyARN = computePolicyARN(r.Creator.AccountID, prefix, operator.Namespace(), operator.Name(), path)
+			name := aws.GetOperatorPolicyName(prefix, operator.Namespace(), operator.Name())
+			_, err = r.AWSClient.IsPolicyExists(policyARN)
+			if err != nil {
+				iamTags := map[string]string{
+					tags.OpenShiftVersion:  defaultPolicyVersion,
+					tags.RolePrefix:        prefix,
+					tags.OperatorNamespace: operator.Namespace(),
+					tags.OperatorName:      operator.Name(),
+					tags.RedHatManaged:     helper.True,
+				}
+				createPolicy := awscb.NewIAMCommandBuilder().
+					SetCommand(awscb.CreatePolicy).
+					AddParam(awscb.PolicyName, name).
+					AddParam(awscb.PolicyDocument, fmt.Sprintf("file://openshift_%s_policy.json", credrequest)).
+					AddTags(iamTags).
+					AddParam(awscb.Path, path).
+					Build()
+				commands = append(commands, createPolicy)
+			}
+		}
+
+		policyDetail := aws.GetPolicyDetails(policies, "operator_iam_role_policy")
+		policy, err := aws.GenerateOperatorRolePolicyDoc(cluster, r.Creator.AccountID, operator, policyDetail)
+		if err != nil {
+			return "", err
+		}
+
+		filename := fmt.Sprintf("operator_%s_policy", credrequest)
+		filename = aws.GetFormattedFileName(filename)
+		r.Reporter.Debugf("Saving '%s' to the current directory", filename)
+		err = helper.SaveDocument(policy, filename)
+		if err != nil {
+			return "", err
+		}
+		iamTags := map[string]string{
+			tags.OperatorNamespace: operator.Namespace(),
+			tags.OperatorName:      operator.Name(),
+			tags.RedHatManaged:     helper.True,
+		}
+		if !isByoOidcSet(cluster) {
+			iamTags[tags.ClusterID] = cluster.ID()
+		}
+		if managedPolicies {
+			iamTags[tags.ManagedPolicies] = helper.True
+		}
+		createRole := awscb.NewIAMCommandBuilder().
+			SetCommand(awscb.CreateRole).
+			AddParam(awscb.RoleName, roleName).
+			AddParam(awscb.AssumeRolePolicyDocument, fmt.Sprintf("file://%s", filename)).
+			AddParam(awscb.PermissionsBoundary, permissionsBoundary).
+			AddTags(iamTags).
+			AddParam(awscb.Path, path).
+			Build()
+
+		attachRolePolicy := awscb.NewIAMCommandBuilder().
+			SetCommand(awscb.AttachRolePolicy).
+			AddParam(awscb.RoleName, roleName).
+			AddParam(awscb.PolicyArn, policyARN).
+			Build()
+		commands = append(commands, createRole, attachRolePolicy)
+	}
+	return awscb.JoinCommands(commands), nil
+}
+
+func validateOperatorRoles(r *rosa.Runtime, cluster *cmv1.Cluster) ([]string, error) {
+	var missingRoles []string
+	operatorIAMRoles := cluster.AWS().STS().OperatorIAMRoles()
+	if len(operatorIAMRoles) == 0 {
+		return missingRoles, fmt.Errorf("No Operator IAM roles found for cluster %s", cluster.Name())
+	}
+	for _, operatorIAMRole := range operatorIAMRoles {
+		roleARN := operatorIAMRole.RoleARN()
+		roleName, err := aws.GetResourceIdFromARN(roleARN)
+		if err != nil {
+			return missingRoles, err
+		}
+		exists, _, err := r.AWSClient.CheckRoleExists(roleName)
+		if err != nil {
+			return missingRoles, err
+		}
+		if !exists {
+			missingRoles = append(missingRoles, roleName)
+		}
+	}
+	return missingRoles, nil
+}
+
+func validateOperatorRolesMatchOidcProvider(r *rosa.Runtime, cluster *cmv1.Cluster) error {
+	operatorRolesList := []ocm.OperatorIAMRole{}
+	for _, operatorIAMRole := range cluster.AWS().STS().OperatorIAMRoles() {
+		path, err := aws.GetPathFromARN(operatorIAMRole.RoleARN())
+		if err != nil {
+			return err
+		}
+		operatorRolesList = append(operatorRolesList, ocm.OperatorIAMRole{
+			Name:      operatorIAMRole.Name(),
+			Namespace: operatorIAMRole.Namespace(),
+			RoleARN:   operatorIAMRole.RoleARN(),
+			Path:      path,
+		})
+	}
+	return ocm.ValidateOperatorRolesMatchOidcProvider(r.AWSClient, operatorRolesList,
+		cluster.AWS().STS().OIDCEndpointURL())
+}

--- a/cmd/create/operatorroles/by_prefix.go
+++ b/cmd/create/operatorroles/by_prefix.go
@@ -1,0 +1,427 @@
+package operatorroles
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/aws"
+	awscb "github.com/openshift/rosa/pkg/aws/commandbuilder"
+	"github.com/openshift/rosa/pkg/aws/tags"
+	"github.com/openshift/rosa/pkg/helper"
+	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/interactive/confirm"
+	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/output"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+func handleOperatorRolesPrefixOptions(r *rosa.Runtime, cmd *cobra.Command) {
+	operatorRolesPrefix := args.prefix
+	operatorRolesPrefix, err := interactive.GetString(interactive.Input{
+		Question: "Operator roles prefix",
+		Help:     cmd.Flags().Lookup(PrefixFlag).Usage,
+		Required: true,
+		Default:  operatorRolesPrefix,
+		Validators: []interactive.Validator{
+			interactive.RegExp(aws.RoleNameRE.String()),
+			interactive.MaxLength(32),
+		},
+	})
+	if err != nil {
+		r.Reporter.Errorf("Expected a prefix for the operator IAM roles: %s", err)
+		os.Exit(1)
+	}
+	args.prefix = operatorRolesPrefix
+	oidcEndpointUrl := args.oidcEndpointUrl
+	oidcEndpointUrl, err = interactive.GetString(
+		interactive.Input{
+			Question:   "OIDC Endpoint URL",
+			Help:       cmd.Flags().Lookup(OidcEndpointUrlFlag).Usage,
+			Required:   true,
+			Default:    oidcEndpointUrl,
+			Validators: []interactive.Validator{interactive.IsURL},
+		})
+	if err != nil {
+		r.Reporter.Errorf("Expected a valid OIDC Endpoint Url: %s", err)
+		os.Exit(1)
+	}
+	args.oidcEndpointUrl = oidcEndpointUrl
+	isHostedCP := args.hostedCp
+	isHostedCP, err = interactive.GetBool(interactive.Input{
+		Question: "Create hosted control plane operator roles",
+		Help:     cmd.Flags().Lookup("hosted-cp").Usage,
+		Default:  isHostedCP,
+		Required: false,
+	})
+	if err != nil {
+		r.Reporter.Errorf("Expected a valid --hosted-cp value: %s", err)
+		os.Exit(1)
+	}
+	args.hostedCp = isHostedCP
+	installerRoleArn := args.installerRoleArn
+	installerRoleArn, err = interactive.GetString(interactive.Input{
+		Question: "Installer Role ARN",
+		Help:     cmd.Flags().Lookup(InstallerRoleArnFlag).Usage,
+		Default:  installerRoleArn,
+		Required: true,
+		Validators: []interactive.Validator{
+			aws.ARNValidator,
+		},
+	})
+	if err != nil {
+		r.Reporter.Errorf("Expected a valid ARN: %s", err)
+		os.Exit(1)
+	}
+	args.installerRoleArn = installerRoleArn
+}
+
+func handleOperatorRoleCreationByPrefix(r *rosa.Runtime, env string,
+	permissionsBoundary string, mode string,
+	policies map[string]*cmv1.AWSSTSPolicy,
+	defaultPolicyVersion string) error {
+	includeHostedCpSet := args.hostedCp
+	operatorRolesPrefix := args.prefix
+	oidcEndpointUrl := args.oidcEndpointUrl
+	installerRoleArn := args.installerRoleArn
+
+	validateArgumentsOperatorRolesCreationByPrefix(r, operatorRolesPrefix, oidcEndpointUrl, installerRoleArn)
+
+	installerRoleName, err := aws.GetResourceIdFromARN(installerRoleArn)
+	if err != nil {
+		r.Reporter.Errorf("%s", err)
+		os.Exit(1)
+	}
+	path, err := aws.GetPathFromARN(installerRoleArn)
+	if err != nil {
+		r.Reporter.Errorf("Expected a valid path for '%s': %v", installerRoleArn, err)
+		os.Exit(1)
+	}
+	if path != "" && !output.HasFlag() && r.Reporter.IsTerminal() {
+		r.Reporter.Infof("ARN path '%s' detected in installer role '%s'. "+
+			"This ARN path will be used for subsequent created operator roles and policies.",
+			path, installerRoleArn)
+	}
+
+	hasStandardNamedInstallerRole, installerRolePrefix := aws.IsStandardNamedAccountRole(installerRoleName,
+		aws.AccountRoles[aws.InstallerAccountRole].Name)
+	if !hasStandardNamedInstallerRole {
+		r.Reporter.Infof("Can only use installer roles created through ROSA CLI for this flow.")
+		os.Exit(1)
+	}
+	operatorRolePolicyPrefix := installerRolePrefix
+	credRequests, err := r.OCMClient.GetCredRequests(includeHostedCpSet)
+	if err != nil {
+		r.Reporter.Errorf("Error getting operator credential request from OCM %s", err)
+		os.Exit(1)
+	}
+	managedPolicies, err := r.AWSClient.HasManagedPolicies(installerRoleArn)
+	if err != nil {
+		r.Reporter.Errorf("Failed to determine if cluster has managed policies: %v", err)
+		os.Exit(1)
+	}
+	// TODO: remove once AWS managed policies are in place
+	if managedPolicies && env == ocm.Production {
+		r.Reporter.Errorf("Managed policies are not supported in this environment")
+		os.Exit(1)
+	}
+	awsCreator, err := r.AWSClient.GetCreator()
+	if err != nil {
+		r.Reporter.Errorf("Unable to get IAM credentials: %v", err)
+		os.Exit(1)
+	}
+
+	operatorIAMRoleList, err := convertCredRequestsOperatorRolesIntoV1OperatorIAMRole(credRequests,
+		args.prefix, awsCreator, path)
+	if err != nil {
+		r.Reporter.Errorf("%s", err)
+		os.Exit(1)
+	}
+
+	switch mode {
+	case aws.ModeAuto:
+		if !output.HasFlag() || r.Reporter.IsTerminal() {
+			r.Reporter.Infof("Creating roles using '%s'", r.Creator.ARN)
+		}
+		err = createRolesByPrefix(r, env,
+			operatorRolePolicyPrefix, permissionsBoundary,
+			defaultPolicyVersion, policies,
+			credRequests, managedPolicies,
+			path, operatorIAMRoleList,
+			oidcEndpointUrl)
+		if err != nil {
+			r.Reporter.Errorf("There was an error creating the operator roles: %s", err)
+			isThrottle := "false"
+			if strings.Contains(err.Error(), "Throttling") {
+				isThrottle = helper.True
+			}
+			r.OCMClient.LogEvent("ROSACreateOperatorRolesModeAuto", map[string]string{
+				ocm.OperatorRolesPrefix: operatorRolesPrefix,
+				ocm.Response:            ocm.Failure,
+				ocm.IsThrottle:          isThrottle,
+			})
+			os.Exit(1)
+		}
+		r.OCMClient.LogEvent("ROSACreateOperatorRolesModeAuto", map[string]string{
+			ocm.OperatorRolesPrefix: operatorRolesPrefix,
+			ocm.Response:            ocm.Success,
+		})
+	case aws.ModeManual:
+		commands, err := buildCommandsFromPrefix(r, env,
+			operatorRolePolicyPrefix, permissionsBoundary,
+			defaultPolicyVersion, policies,
+			credRequests, managedPolicies,
+			path, operatorIAMRoleList,
+			oidcEndpointUrl)
+		if err != nil {
+			r.Reporter.Errorf("There was an error building the list of resources: %s", err)
+			os.Exit(1)
+			r.OCMClient.LogEvent("ROSACreateOperatorRolesModeManual", map[string]string{
+				ocm.OperatorRolesPrefix: operatorRolesPrefix,
+				ocm.Response:            ocm.Failure,
+			})
+		}
+		if r.Reporter.IsTerminal() {
+			r.Reporter.Infof("All policy files saved to the current directory")
+			r.Reporter.Infof("Run the following commands to create the operator roles:\n")
+		}
+		r.OCMClient.LogEvent("ROSACreateOperatorRolesModeManual", map[string]string{
+			ocm.OperatorRolesPrefix: operatorRolesPrefix,
+		})
+		fmt.Println(commands)
+	default:
+		r.Reporter.Errorf("Invalid mode. Allowed values are %s", aws.Modes)
+		os.Exit(1)
+	}
+	return nil
+}
+
+func convertCredRequestsOperatorRolesIntoV1OperatorIAMRole(credRequests map[string]*cmv1.STSOperator,
+	operatorRolesPrefix string, awsCreator *aws.Creator, path string) ([]*cmv1.OperatorIAMRole, error) {
+	operatorIAMRoleList := []*cmv1.OperatorIAMRole{}
+	for _, operator := range credRequests {
+		operatorIamRole, err := cmv1.NewOperatorIAMRole().
+			Name(operator.Name()).
+			Namespace(operator.Namespace()).
+			RoleARN(aws.ComputeOperatorRoleArn(operatorRolesPrefix, operator,
+				awsCreator, path)).
+			Build()
+		if err != nil {
+			return operatorIAMRoleList, err
+		}
+		operatorIAMRoleList = append(operatorIAMRoleList, operatorIamRole)
+	}
+	return operatorIAMRoleList, nil
+}
+
+func validateArgumentsOperatorRolesCreationByPrefix(r *rosa.Runtime, operatorRolesPrefix string,
+	oidcEndpointUrl string, installerRoleArn string) {
+	if len(operatorRolesPrefix) == 0 {
+		r.Reporter.Errorf("Expected a prefix for the operator IAM roles")
+		os.Exit(1)
+	}
+	if len(operatorRolesPrefix) > 32 {
+		r.Reporter.Errorf("Expected a prefix with no more than 32 characters")
+		os.Exit(1)
+	}
+	if !aws.RoleNameRE.MatchString(operatorRolesPrefix) {
+		r.Reporter.Errorf("Expected valid operator roles prefix matching %s", aws.RoleNameRE.String())
+		os.Exit(1)
+	}
+	parsedURI, err := url.ParseRequestURI(oidcEndpointUrl)
+	if err != nil {
+		r.Reporter.Errorf("%s", err)
+		os.Exit(1)
+	}
+	if parsedURI.Scheme != helper.ProtocolHttps {
+		r.Reporter.Errorf("Expected OIDC endpoint URL '%s' to use an https:// scheme", oidcEndpointUrl)
+		os.Exit(1)
+	}
+	err = aws.ARNValidator(installerRoleArn)
+	if err != nil {
+		r.Reporter.Errorf("%s", err)
+		os.Exit(1)
+	}
+}
+
+func createRolesByPrefix(r *rosa.Runtime, env string,
+	prefix string, permissionsBoundary string, defaultPolicyVersion string,
+	policies map[string]*cmv1.AWSSTSPolicy, credRequests map[string]*cmv1.STSOperator,
+	managedPolicies bool, path string,
+	operatorIAMRoleList []*cmv1.OperatorIAMRole,
+	oidcEndpointUrl string) error {
+	for credrequest, operator := range credRequests {
+		roleArn := aws.FindOperatorRoleBySTSOperator(operatorIAMRoleList, operator)
+		roleName, err := aws.GetResourceIdFromARN(roleArn)
+		if err != nil {
+			return err
+		}
+		if roleName == "" {
+			return fmt.Errorf("Failed to find operator IAM role")
+		}
+		if !confirm.Prompt(true, "Create the '%s' role?", roleName) {
+			continue
+		}
+
+		var policyArn string
+		filename := fmt.Sprintf("openshift_%s_policy", credrequest)
+		if managedPolicies {
+			policyArn, err = aws.GetManagedPolicyARN(policies, filename)
+			if err != nil {
+				return err
+			}
+		} else {
+			policyArn = aws.GetOperatorPolicyARN(r.Creator.AccountID, prefix, operator.Namespace(),
+				operator.Name(), path)
+			policyDetails := aws.GetPolicyDetails(policies, filename)
+
+			operatorPolicyTags := map[string]string{
+				tags.OpenShiftVersion:  defaultPolicyVersion,
+				tags.RolePrefix:        prefix,
+				tags.RedHatManaged:     helper.True,
+				tags.OperatorNamespace: operator.Namespace(),
+				tags.OperatorName:      operator.Name(),
+			}
+
+			if args.forcePolicyCreation {
+				_, err := r.AWSClient.ForceEnsurePolicy(policyArn, policyDetails,
+					defaultPolicyVersion, operatorPolicyTags, path)
+				if err != nil {
+					return err
+				}
+			} else {
+				_, err := r.AWSClient.EnsurePolicy(policyArn, policyDetails,
+					defaultPolicyVersion, operatorPolicyTags, path)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		policyDetails := aws.GetPolicyDetails(policies, "operator_iam_role_policy")
+		policy, err := aws.GenerateOperatorRolePolicyDocByOidcEndpointUrl(oidcEndpointUrl,
+			r.Creator.AccountID, operator, policyDetails)
+		if err != nil {
+			return err
+		}
+
+		r.Reporter.Debugf("Creating role '%s'", roleName)
+		tagsList := map[string]string{
+			tags.OperatorNamespace: operator.Namespace(),
+			tags.OperatorName:      operator.Name(),
+			tags.RedHatManaged:     helper.True,
+		}
+		if managedPolicies {
+			tagsList[tags.ManagedPolicies] = helper.True
+		}
+
+		roleARN, err := r.AWSClient.EnsureRole(roleName, policy, permissionsBoundary, defaultPolicyVersion,
+			tagsList, path, managedPolicies)
+		if err != nil {
+			return err
+		}
+		if !output.HasFlag() || r.Reporter.IsTerminal() {
+			r.Reporter.Infof("Created role '%s' with ARN '%s'", roleName, roleARN)
+		}
+
+		r.Reporter.Debugf("Attaching permission policy '%s' to role '%s'", policyArn, roleName)
+		err = r.AWSClient.AttachRolePolicy(roleName, policyArn)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func buildCommandsFromPrefix(r *rosa.Runtime, env string,
+	prefix string, permissionsBoundary string, defaultPolicyVersion string,
+	policies map[string]*cmv1.AWSSTSPolicy, credRequests map[string]*cmv1.STSOperator,
+	managedPolicies bool, path string,
+	operatorIAMRoleList []*cmv1.OperatorIAMRole,
+	oidcEndpointUrl string) (string, error) {
+	err := aws.GeneratePolicyFiles(r.Reporter, env, false,
+		true, policies, credRequests, managedPolicies)
+	if err != nil {
+		r.Reporter.Errorf("There was an error generating the policy files: %s", err)
+		os.Exit(1)
+	}
+
+	commands := []string{}
+
+	for credrequest, operator := range credRequests {
+		roleName := aws.FindOperatorRoleBySTSOperator(operatorIAMRoleList, operator)
+
+		var policyARN string
+		if managedPolicies {
+			policyARN, err = aws.GetManagedPolicyARN(policies, fmt.Sprintf("openshift_%s_policy", credrequest))
+			if err != nil {
+				return "", err
+			}
+		} else {
+			policyARN = computePolicyARN(r.Creator.AccountID, prefix, operator.Namespace(), operator.Name(), path)
+			name := aws.GetOperatorPolicyName(prefix, operator.Namespace(), operator.Name())
+			_, err = r.AWSClient.IsPolicyExists(policyARN)
+			if err != nil {
+				iamTags := map[string]string{
+					tags.OpenShiftVersion:  defaultPolicyVersion,
+					tags.RolePrefix:        prefix,
+					tags.OperatorNamespace: operator.Namespace(),
+					tags.OperatorName:      operator.Name(),
+					tags.RedHatManaged:     helper.True,
+				}
+				createPolicy := awscb.NewIAMCommandBuilder().
+					SetCommand(awscb.CreatePolicy).
+					AddParam(awscb.PolicyName, name).
+					AddParam(awscb.PolicyDocument, fmt.Sprintf("file://openshift_%s_policy.json", credrequest)).
+					AddTags(iamTags).
+					AddParam(awscb.Path, path).
+					Build()
+				commands = append(commands, createPolicy)
+			}
+		}
+
+		policyDetail := aws.GetPolicyDetails(policies, "operator_iam_role_policy")
+		policy, err := aws.GenerateOperatorRolePolicyDocByOidcEndpointUrl(oidcEndpointUrl,
+			r.Creator.AccountID, operator, policyDetail)
+		if err != nil {
+			return "", err
+		}
+
+		filename := fmt.Sprintf("operator_%s_policy", credrequest)
+		filename = aws.GetFormattedFileName(filename)
+		r.Reporter.Debugf("Saving '%s' to the current directory", filename)
+		err = helper.SaveDocument(policy, filename)
+		if err != nil {
+			return "", err
+		}
+		iamTags := map[string]string{
+			tags.OperatorNamespace: operator.Namespace(),
+			tags.OperatorName:      operator.Name(),
+			tags.RedHatManaged:     helper.True,
+		}
+		if managedPolicies {
+			iamTags[tags.ManagedPolicies] = helper.True
+		}
+		createRole := awscb.NewIAMCommandBuilder().
+			SetCommand(awscb.CreateRole).
+			AddParam(awscb.RoleName, roleName).
+			AddParam(awscb.AssumeRolePolicyDocument, fmt.Sprintf("file://%s", filename)).
+			AddParam(awscb.PermissionsBoundary, permissionsBoundary).
+			AddTags(iamTags).
+			AddParam(awscb.Path, path).
+			Build()
+
+		attachRolePolicy := awscb.NewIAMCommandBuilder().
+			SetCommand(awscb.AttachRolePolicy).
+			AddParam(awscb.RoleName, roleName).
+			AddParam(awscb.PolicyArn, policyARN).
+			Build()
+		commands = append(commands, createRole, attachRolePolicy)
+	}
+	return awscb.JoinCommands(commands), nil
+}

--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -17,7 +17,6 @@ limitations under the License.
 package operatorroles
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -25,20 +24,26 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/pkg/aws"
-	awscb "github.com/openshift/rosa/pkg/aws/commandbuilder"
-	"github.com/openshift/rosa/pkg/aws/tags"
-	"github.com/openshift/rosa/pkg/helper"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/ocm"
-	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/rosa"
+)
+
+const (
+	PrefixFlag           = "prefix"
+	HostedCpFlag         = "hosted-cp"
+	OidcEndpointUrlFlag  = "oidc-endpoint-url"
+	InstallerRoleArnFlag = "installer-role-arn"
 )
 
 var args struct {
 	prefix              string
+	hostedCp            bool
+	installerRoleArn    string
 	permissionsBoundary string
 	forcePolicyCreation bool
+	oidcEndpointUrl     string
 }
 
 var Cmd = &cobra.Command{
@@ -57,15 +62,35 @@ var Cmd = &cobra.Command{
 func init() {
 	flags := Cmd.Flags()
 
-	ocm.AddClusterFlag(Cmd)
+	ocm.AddOptionalClusterFlag(Cmd)
 
 	flags.StringVar(
 		&args.prefix,
-		"prefix",
+		PrefixFlag,
 		"",
-		"User-defined prefix for generated AWS operator policies. Leave empty to attempt to find them automatically.",
+		"User-defined prefix for generated AWS operator policies. Not to be used alongside --cluster flag.",
 	)
-	flags.MarkDeprecated("prefix", "skip --prefix;rosa auto-detects prefix")
+
+	flags.StringVar(
+		&args.oidcEndpointUrl,
+		OidcEndpointUrlFlag,
+		"",
+		"Oidc endpoint URL to add as the trusted relationship to the operator roles.",
+	)
+
+	flags.StringVar(
+		&args.installerRoleArn,
+		InstallerRoleArnFlag,
+		"",
+		"Installer role ARN supplied to retrieve operator policy prefix and path.",
+	)
+
+	flags.BoolVar(
+		&args.hostedCp,
+		HostedCpFlag,
+		false,
+		"Indicates whether to create the hosted control planes operator roles when using --prefix option.",
+	)
 
 	flags.StringVar(
 		&args.permissionsBoundary,
@@ -108,7 +133,11 @@ func run(cmd *cobra.Command, argv []string) error {
 		}
 	}
 
-	clusterKey := r.GetClusterKey()
+	env, err := ocm.GetEnv()
+	if err != nil {
+		r.Reporter.Errorf("Failed to determine OCM environment: %v", err)
+		os.Exit(1)
+	}
 
 	mode, err := aws.GetMode()
 	if err != nil {
@@ -121,43 +150,37 @@ func run(cmd *cobra.Command, argv []string) error {
 		interactive.Enable()
 	}
 
-	cluster := r.FetchCluster()
-	if cluster.AWS().STS().RoleARN() == "" {
-		r.Reporter.Errorf("Cluster '%s' is not an STS cluster.", clusterKey)
+	if !cmd.Flag("cluster").Changed && !cmd.Flag(PrefixFlag).Changed {
+		r.Reporter.Errorf("Either a cluster key for STS cluster or an operator roles prefix must be specified.")
 		os.Exit(1)
 	}
 
-	// Check to see if IAM operator roles have already created
-	missingRoles, err := validateOperatorRoles(r, cluster)
-	if err != nil {
-		if strings.Contains(err.Error(), "AccessDenied") {
-			r.Reporter.Debugf("Failed to verify if operator roles exist: %s", err)
-		} else {
-			r.Reporter.Errorf("Failed to verify if operator roles exist: %s", err)
-			os.Exit(1)
-		}
-	}
-
-	if isByoOidcSet(cluster) && len(missingRoles) == 0 {
-		err := validateOperatorRolesMatchOidcProvider(r, cluster)
-		if err != nil {
-			return err
-		}
-		r.Reporter.Warnf("Cluster '%s' is using BYO OIDC and operator roles already exist.", clusterKey)
-		return nil
-	}
-
-	if len(missingRoles) == 0 &&
-		cluster.State() != cmv1.ClusterStateWaiting && cluster.State() != cmv1.ClusterStatePending &&
-		!args.forcePolicyCreation {
-		r.Reporter.Infof("Cluster '%s' is %s and does not need additional configuration.",
-			clusterKey, cluster.State())
-		os.Exit(0)
+	var cluster *cmv1.Cluster
+	if args.prefix == "" {
+		cluster = r.FetchCluster()
 	}
 
 	if args.forcePolicyCreation && mode != aws.ModeAuto {
 		r.Reporter.Warnf("Forcing creation of policies only works in auto mode")
 		os.Exit(1)
+	}
+
+	if interactive.Enabled() && !skipInteractive {
+		mode, err = interactive.GetOption(interactive.Input{
+			Question: "Role creation mode",
+			Help:     cmd.Flags().Lookup("mode").Usage,
+			Default:  aws.ModeAuto,
+			Options:  aws.Modes,
+			Required: true,
+		})
+		if err != nil {
+			r.Reporter.Errorf("Expected a valid role creation mode: %s", err)
+			os.Exit(1)
+		}
+	}
+
+	if cluster == nil && interactive.Enabled() && !skipInteractive {
+		handleOperatorRolesPrefixOptions(r, cmd)
 	}
 
 	permissionsBoundary := args.permissionsBoundary
@@ -184,61 +207,9 @@ func run(cmd *cobra.Command, argv []string) error {
 		}
 	}
 
-	if interactive.Enabled() && !skipInteractive {
-		mode, err = interactive.GetOption(interactive.Input{
-			Question: "Role creation mode",
-			Help:     cmd.Flags().Lookup("mode").Usage,
-			Default:  aws.ModeAuto,
-			Options:  aws.Modes,
-			Required: true,
-		})
-		if err != nil {
-			r.Reporter.Errorf("Expected a valid role creation mode: %s", err)
-			os.Exit(1)
-		}
-	}
-
-	roleName, err := aws.GetInstallerAccountRoleName(cluster)
-	if err != nil {
-		r.Reporter.Errorf("Expected parsing role account role '%s': %v", cluster.AWS().STS().RoleARN(), err)
-		os.Exit(1)
-	}
-
-	path, err := getPathFromInstallerRole(cluster)
-	if err != nil {
-		r.Reporter.Errorf("Expected a valid path for '%s': %v", cluster.AWS().STS().RoleARN(), err)
-		os.Exit(1)
-	}
-	if path != "" && !output.HasFlag() && r.Reporter.IsTerminal() {
-		r.Reporter.Infof("ARN path '%s' detected in installer role '%s'. "+
-			"This ARN path will be used for subsequent created operator roles and policies.",
-			path, cluster.AWS().STS().RoleARN())
-	}
-	accountRoleVersion, err := r.AWSClient.GetAccountRoleVersion(roleName)
-	if err != nil {
-		r.Reporter.Errorf("Error getting account role version %s", err)
-		os.Exit(1)
-	}
 	policies, err := r.OCMClient.GetPolicies("OperatorRole")
 	if err != nil {
 		r.Reporter.Errorf("Expected a valid role creation mode: %s", err)
-		os.Exit(1)
-	}
-
-	env, err := ocm.GetEnv()
-	if err != nil {
-		r.Reporter.Errorf("Failed to determine OCM environment: %v", err)
-		os.Exit(1)
-	}
-
-	managedPolicies := cluster.AWS().STS().ManagedPolicies()
-	if args.forcePolicyCreation && managedPolicies {
-		r.Reporter.Warnf("Forcing creation of policies only works for unmanaged policies")
-		os.Exit(1)
-	}
-	// TODO: remove once AWS managed policies are in place
-	if managedPolicies && env == ocm.Production {
-		r.Reporter.Errorf("Managed policies are not supported in this environment")
 		os.Exit(1)
 	}
 
@@ -248,328 +219,19 @@ func run(cmd *cobra.Command, argv []string) error {
 		os.Exit(1)
 	}
 
-	credRequests, err := r.OCMClient.GetCredRequests(cluster.Hypershift().Enabled())
-	if err != nil {
-		r.Reporter.Errorf("Error getting operator credential request from OCM %s", err)
-		os.Exit(1)
-	}
-
-	operatorRolePolicyPrefix, err := aws.GetOperatorRolePolicyPrefixFromCluster(cluster, r.AWSClient)
-	if err != nil {
-		r.Reporter.Errorf("%s", err)
-	}
-
-	switch mode {
-	case aws.ModeAuto:
-		if !output.HasFlag() || r.Reporter.IsTerminal() {
-			r.Reporter.Infof("Creating roles using '%s'", r.Creator.ARN)
-		}
-		err = createRoles(r, operatorRolePolicyPrefix, permissionsBoundary, cluster,
-			accountRoleVersion, policies, defaultPolicyVersion, credRequests, managedPolicies)
-		if err != nil {
-			r.Reporter.Errorf("There was an error creating the operator roles: %s", err)
-			isThrottle := "false"
-			if strings.Contains(err.Error(), "Throttling") {
-				isThrottle = helper.True
-			}
-			r.OCMClient.LogEvent("ROSACreateOperatorRolesModeAuto", map[string]string{
-				ocm.ClusterID:  clusterKey,
-				ocm.Response:   ocm.Failure,
-				ocm.IsThrottle: isThrottle,
-			})
+	if args.prefix != "" {
+		if args.oidcEndpointUrl == "" {
+			r.Reporter.Errorf("%s is mandatory for %s param flow.", OidcEndpointUrlFlag, PrefixFlag)
 			os.Exit(1)
 		}
-		r.OCMClient.LogEvent("ROSACreateOperatorRolesModeAuto", map[string]string{
-			ocm.ClusterID: clusterKey,
-			ocm.Response:  ocm.Success,
-		})
-	case aws.ModeManual:
-		commands, err := buildCommands(r, env, operatorRolePolicyPrefix, permissionsBoundary, defaultPolicyVersion,
-			cluster, policies, credRequests, managedPolicies)
-		if err != nil {
-			r.Reporter.Errorf("There was an error building the list of resources: %s", err)
+
+		if args.installerRoleArn == "" {
+			r.Reporter.Errorf("%s is mandatory for %s param flow.", InstallerRoleArnFlag, PrefixFlag)
 			os.Exit(1)
-			r.OCMClient.LogEvent("ROSACreateOperatorRolesModeManual", map[string]string{
-				ocm.ClusterID: clusterKey,
-				ocm.Response:  ocm.Failure,
-			})
 		}
-		if r.Reporter.IsTerminal() {
-			r.Reporter.Infof("All policy files saved to the current directory")
-			r.Reporter.Infof("Run the following commands to create the operator roles:\n")
-		}
-		r.OCMClient.LogEvent("ROSACreateOperatorRolesModeManual", map[string]string{
-			ocm.ClusterID: clusterKey,
-		})
-		fmt.Println(commands)
-
-	default:
-		r.Reporter.Errorf("Invalid mode. Allowed values are %s", aws.Modes)
-		os.Exit(1)
+		return handleOperatorRoleCreationByPrefix(r, env, permissionsBoundary,
+			mode, policies, defaultPolicyVersion)
 	}
-	return nil
-}
-
-func createRoles(r *rosa.Runtime,
-	prefix string, permissionsBoundary string,
-	cluster *cmv1.Cluster, accountRoleVersion string, policies map[string]*cmv1.AWSSTSPolicy,
-	defaultVersion string, credRequests map[string]*cmv1.STSOperator, managedPolicies bool) error {
-	for credrequest, operator := range credRequests {
-		ver := cluster.Version()
-		if ver != nil && operator.MinVersion() != "" {
-			isSupported, err := ocm.CheckSupportedVersion(ocm.GetVersionMinor(ver.ID()), operator.MinVersion())
-			if err != nil {
-				r.Reporter.Errorf("Error validating operator role '%s' version %s", operator.Name(), err)
-				os.Exit(1)
-			}
-			if !isSupported {
-				continue
-			}
-		}
-		roleName, _ := aws.FindOperatorRoleNameBySTSOperator(cluster, operator)
-		if roleName == "" {
-			return fmt.Errorf("Failed to find operator IAM role")
-		}
-		if !confirm.Prompt(true, "Create the '%s' role?", roleName) {
-			continue
-		}
-
-		path, err := getPathFromInstallerRole(cluster)
-		if err != nil {
-			return err
-		}
-
-		var policyARN string
-		filename := fmt.Sprintf("openshift_%s_policy", credrequest)
-		if managedPolicies {
-			policyARN, err = aws.GetManagedPolicyARN(policies, filename)
-			if err != nil {
-				return err
-			}
-		} else {
-			policyARN = aws.GetOperatorPolicyARN(r.Creator.AccountID, prefix, operator.Namespace(),
-				operator.Name(), path)
-			policyDetails := aws.GetPolicyDetails(policies, filename)
-
-			operatorPolicyTags := map[string]string{
-				tags.OpenShiftVersion:  accountRoleVersion,
-				tags.RolePrefix:        prefix,
-				tags.RedHatManaged:     helper.True,
-				tags.OperatorNamespace: operator.Namespace(),
-				tags.OperatorName:      operator.Name(),
-			}
-
-			if args.forcePolicyCreation {
-				policyARN, err = r.AWSClient.ForceEnsurePolicy(policyARN, policyDetails,
-					defaultVersion, operatorPolicyTags, path)
-				if err != nil {
-					return err
-				}
-			} else {
-				policyARN, err = r.AWSClient.EnsurePolicy(policyARN, policyDetails,
-					defaultVersion, operatorPolicyTags, path)
-				if err != nil {
-					return err
-				}
-			}
-		}
-
-		policyDetails := aws.GetPolicyDetails(policies, "operator_iam_role_policy")
-		policy, err := aws.GenerateOperatorRolePolicyDoc(cluster, r.Creator.AccountID, operator, policyDetails)
-		if err != nil {
-			return err
-		}
-
-		r.Reporter.Debugf("Creating role '%s'", roleName)
-		tagsList := map[string]string{
-			tags.OperatorNamespace: operator.Namespace(),
-			tags.OperatorName:      operator.Name(),
-			tags.RedHatManaged:     helper.True,
-		}
-		if !isByoOidcSet(cluster) {
-			tagsList[tags.ClusterID] = cluster.ID()
-		}
-		if managedPolicies {
-			tagsList[tags.ManagedPolicies] = helper.True
-		}
-
-		roleARN, err := r.AWSClient.EnsureRole(roleName, policy, permissionsBoundary, accountRoleVersion,
-			tagsList, path, managedPolicies)
-		if err != nil {
-			return err
-		}
-		if !output.HasFlag() || r.Reporter.IsTerminal() {
-			r.Reporter.Infof("Created role '%s' with ARN '%s'", roleName, roleARN)
-		}
-
-		r.Reporter.Debugf("Attaching permission policy '%s' to role '%s'", policyARN, roleName)
-		err = r.AWSClient.AttachRolePolicy(roleName, policyARN)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func buildCommands(r *rosa.Runtime, env string,
-	prefix string, permissionsBoundary string, defaultPolicyVersion string, cluster *cmv1.Cluster,
-	policies map[string]*cmv1.AWSSTSPolicy, credRequests map[string]*cmv1.STSOperator,
-	managedPolicies bool) (string, error) {
-	err := aws.GeneratePolicyFiles(r.Reporter, env, false,
-		true, policies, credRequests, managedPolicies)
-	if err != nil {
-		r.Reporter.Errorf("There was an error generating the policy files: %s", err)
-		os.Exit(1)
-	}
-
-	commands := []string{}
-
-	for credrequest, operator := range credRequests {
-		ver := cluster.Version()
-		if ver != nil && operator.MinVersion() != "" {
-			isSupported, err := ocm.CheckSupportedVersion(ocm.GetVersionMinor(ver.ID()), operator.MinVersion())
-			if err != nil {
-				r.Reporter.Errorf("Error validating operator role '%s' version %s", operator.Name(), err)
-				os.Exit(1)
-			}
-			if !isSupported {
-				continue
-			}
-		}
-		roleName, _ := aws.FindOperatorRoleNameBySTSOperator(cluster, operator)
-		path, err := getPathFromInstallerRole(cluster)
-		if err != nil {
-			return "", err
-		}
-
-		var policyARN string
-		if managedPolicies {
-			policyARN, err = aws.GetManagedPolicyARN(policies, fmt.Sprintf("openshift_%s_policy", credrequest))
-			if err != nil {
-				return "", err
-			}
-		} else {
-			policyARN = getPolicyARN(r.Creator.AccountID, prefix, operator.Namespace(), operator.Name(), path)
-			name := aws.GetOperatorPolicyName(prefix, operator.Namespace(), operator.Name())
-			_, err = r.AWSClient.IsPolicyExists(policyARN)
-			if err != nil {
-				iamTags := map[string]string{
-					tags.OpenShiftVersion:  defaultPolicyVersion,
-					tags.RolePrefix:        prefix,
-					tags.OperatorNamespace: operator.Namespace(),
-					tags.OperatorName:      operator.Name(),
-					tags.RedHatManaged:     helper.True,
-				}
-				createPolicy := awscb.NewIAMCommandBuilder().
-					SetCommand(awscb.CreatePolicy).
-					AddParam(awscb.PolicyName, name).
-					AddParam(awscb.PolicyDocument, fmt.Sprintf("file://openshift_%s_policy.json", credrequest)).
-					AddTags(iamTags).
-					AddParam(awscb.Path, path).
-					Build()
-				commands = append(commands, createPolicy)
-			}
-		}
-
-		policyDetail := aws.GetPolicyDetails(policies, "operator_iam_role_policy")
-		policy, err := aws.GenerateOperatorRolePolicyDoc(cluster, r.Creator.AccountID, operator, policyDetail)
-		if err != nil {
-			return "", err
-		}
-
-		filename := fmt.Sprintf("operator_%s_policy", credrequest)
-		filename = aws.GetFormattedFileName(filename)
-		r.Reporter.Debugf("Saving '%s' to the current directory", filename)
-		err = helper.SaveDocument(policy, filename)
-		if err != nil {
-			return "", err
-		}
-		iamTags := map[string]string{
-			tags.OperatorNamespace: operator.Namespace(),
-			tags.OperatorName:      operator.Name(),
-			tags.RedHatManaged:     helper.True,
-		}
-		if !isByoOidcSet(cluster) {
-			iamTags[tags.ClusterID] = cluster.ID()
-		}
-		if managedPolicies {
-			iamTags[tags.ManagedPolicies] = helper.True
-		}
-		createRole := awscb.NewIAMCommandBuilder().
-			SetCommand(awscb.CreateRole).
-			AddParam(awscb.RoleName, roleName).
-			AddParam(awscb.AssumeRolePolicyDocument, fmt.Sprintf("file://%s", filename)).
-			AddParam(awscb.PermissionsBoundary, permissionsBoundary).
-			AddTags(iamTags).
-			AddParam(awscb.Path, path).
-			Build()
-
-		attachRolePolicy := awscb.NewIAMCommandBuilder().
-			SetCommand(awscb.AttachRolePolicy).
-			AddParam(awscb.RoleName, roleName).
-			AddParam(awscb.PolicyArn, policyARN).
-			Build()
-		commands = append(commands, createRole, attachRolePolicy)
-	}
-	return awscb.JoinCommands(commands), nil
-}
-
-func getPathFromInstallerRole(cluster *cmv1.Cluster) (string, error) {
-	return aws.GetPathFromARN(cluster.AWS().STS().RoleARN())
-}
-
-func getPolicyARN(accountID string, prefix string, namespace string, name string, path string) string {
-	if prefix == "" {
-		prefix = aws.DefaultPrefix
-	}
-	policy := fmt.Sprintf("%s-%s-%s", prefix, namespace, name)
-	if len(policy) > 64 {
-		policy = policy[0:64]
-	}
-	if path != "" {
-		return fmt.Sprintf("arn:%s:iam::%s:policy%s%s", aws.GetPartition(), accountID, path, policy)
-	}
-	return fmt.Sprintf("arn:%s:iam::%s:policy/%s", aws.GetPartition(), accountID, policy)
-}
-
-func validateOperatorRoles(r *rosa.Runtime, cluster *cmv1.Cluster) ([]string, error) {
-	var missingRoles []string
-	operatorIAMRoles := cluster.AWS().STS().OperatorIAMRoles()
-	if len(operatorIAMRoles) == 0 {
-		return missingRoles, fmt.Errorf("No Operator IAM roles found for cluster %s", cluster.Name())
-	}
-	for _, operatorIAMRole := range operatorIAMRoles {
-		roleARN := operatorIAMRole.RoleARN()
-		roleName, err := aws.GetResourceIdFromARN(roleARN)
-		if err != nil {
-			return missingRoles, err
-		}
-		exists, _, err := r.AWSClient.CheckRoleExists(roleName)
-		if err != nil {
-			return missingRoles, err
-		}
-		if !exists {
-			missingRoles = append(missingRoles, roleName)
-		}
-	}
-	return missingRoles, nil
-}
-
-func validateOperatorRolesMatchOidcProvider(r *rosa.Runtime, cluster *cmv1.Cluster) error {
-	operatorRolesList := []ocm.OperatorIAMRole{}
-	for _, operatorIAMRole := range cluster.AWS().STS().OperatorIAMRoles() {
-		path, err := aws.GetPathFromARN(operatorIAMRole.RoleARN())
-		if err != nil {
-			return err
-		}
-		operatorRolesList = append(operatorRolesList, ocm.OperatorIAMRole{
-			Name:      operatorIAMRole.Name(),
-			Namespace: operatorIAMRole.Namespace(),
-			RoleARN:   operatorIAMRole.RoleARN(),
-			Path:      path,
-		})
-	}
-	return ocm.ValidateOperatorRolesMatchOidcProvider(r.AWSClient, operatorRolesList,
-		cluster.AWS().STS().OIDCEndpointURL())
+	return handleOperatorRoleCreationByClusterKey(r, env, permissionsBoundary,
+		mode, policies, defaultPolicyVersion)
 }

--- a/cmd/create/operatorroles/common_utils.go
+++ b/cmd/create/operatorroles/common_utils.go
@@ -1,0 +1,21 @@
+package operatorroles
+
+import (
+	"fmt"
+
+	"github.com/openshift/rosa/pkg/aws"
+)
+
+func computePolicyARN(accountID string, prefix string, namespace string, name string, path string) string {
+	if prefix == "" {
+		prefix = aws.DefaultPrefix
+	}
+	policy := fmt.Sprintf("%s-%s-%s", prefix, namespace, name)
+	if len(policy) > 64 {
+		policy = policy[0:64]
+	}
+	if path != "" {
+		return fmt.Sprintf("arn:%s:iam::%s:policy%s%s", aws.GetPartition(), accountID, path, policy)
+	}
+	return fmt.Sprintf("arn:%s:iam::%s:policy/%s", aws.GetPartition(), accountID, policy)
+}

--- a/cmd/create/service/cmd.go
+++ b/cmd/create/service/cmd.go
@@ -426,7 +426,8 @@ func run(cmd *cobra.Command, argv []string) {
 		operatorIAMRoleList = append(operatorIAMRoleList, ocm.OperatorIAMRole{
 			Name:      operator.Name(),
 			Namespace: operator.Namespace(),
-			RoleARN:   getOperatorRoleArn(operatorRolesPrefix, operator, r.Creator, path),
+			RoleARN: aws.ComputeOperatorRoleArn(operatorRolesPrefix, operator,
+				r.Creator, path),
 		})
 	}
 
@@ -499,12 +500,4 @@ func getAccountRolePrefix(roleARN string, role aws.AccountRole) (string, error) 
 
 func getRolePrefix(clusterName string) string {
 	return fmt.Sprintf("%s-%s", clusterName, helper.RandomLabel(4))
-}
-
-func getOperatorRoleArn(prefix string, operator *cmv1.STSOperator, creator *aws.Creator, path string) string {
-	role := fmt.Sprintf("%s-%s-%s", prefix, operator.Namespace(), operator.Name())
-	if len(role) > 64 {
-		role = role[0:64]
-	}
-	return aws.GetRoleARN(creator.AccountID, role, path)
 }

--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -837,3 +837,21 @@ func GetAccountRolePolicyKeys(roleType string) []string {
 
 	return []string{fmt.Sprintf("sts_%s_permission_policy", roleType)}
 }
+
+func ComputeOperatorRoleArn(prefix string, operator *cmv1.STSOperator, creator *Creator, path string) string {
+	role := fmt.Sprintf("%s-%s-%s", prefix, operator.Namespace(), operator.Name())
+	if len(role) > 64 {
+		role = role[0:64]
+	}
+	str := fmt.Sprintf("arn:%s:iam::%s:role", GetPartition(), creator.AccountID)
+	if path != "" {
+		str = fmt.Sprintf("%s%s", str, path)
+		return fmt.Sprintf("%s%s", str, role)
+	}
+	return fmt.Sprintf("%s/%s", str, role)
+}
+
+func IsStandardNamedAccountRole(accountRoleName, roleSuffix string) (bool, string) {
+	accountRolePrefix := TrimRoleSuffix(accountRoleName, fmt.Sprintf("-%s-Role", roleSuffix))
+	return accountRolePrefix != accountRoleName, accountRolePrefix
+}

--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -44,14 +44,15 @@ const (
 	HibernateCapability  = "capability.organization.hibernate_cluster"
 	HypershiftCapability = "capability.organization.hypershift"
 	//Pendo Events
-	Success    = "Success"
-	Failure    = "Failure"
-	Response   = "Response"
-	ClusterID  = "ClusterID"
-	Version    = "Version"
-	Username   = "Username"
-	URL        = "URL"
-	IsThrottle = "IsThrottle"
+	Success             = "Success"
+	Failure             = "Failure"
+	Response            = "Response"
+	ClusterID           = "ClusterID"
+	OperatorRolesPrefix = "OperatorRolePrefix"
+	Version             = "Version"
+	Username            = "Username"
+	URL                 = "URL"
+	IsThrottle          = "IsThrottle"
 
 	OCMRoleLabel  = "sts_ocm_role"
 	USERRoleLabel = "sts_user_role"
@@ -763,7 +764,8 @@ func ValidateOperatorRolesMatchOidcProvider(awsClient aws.Client,
 			return err
 		}
 		if !strings.Contains(*roleObject.AssumeRolePolicyDocument, parsedUrl.Host) {
-			return weberr.Errorf("Operator role '%s' does not have trusted relationship to '%s' issuer URL", roleARN, parsedUrl)
+			return weberr.Errorf("Operator role '%s' does not have trusted relationship to '%s' issuer URL",
+				roleARN, parsedUrl.Host)
 		}
 	}
 	return nil


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-8354
# What
Allow creating operator roles prior to cluster spec

# Why
Ensures full BYO OIDC flow creating all needed resources prior to cluster spec