### PR TITLE
Fix inconsistencies across commands providing a watch flag

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -527,9 +527,10 @@ func init() {
 			"platform metrics.",
 	)
 
-	flags.BoolVar(
+	flags.BoolVarP(
 		&args.watch,
 		"watch",
+		"w",
 		false,
 		"Watch cluster installation logs.",
 	)

--- a/cmd/dlt/cluster/cmd.go
+++ b/cmd/dlt/cluster/cmd.go
@@ -53,9 +53,10 @@ func init() {
 
 	ocm.AddClusterFlag(Cmd)
 
-	flags.BoolVar(
+	flags.BoolVarP(
 		&args.watch,
 		"watch",
+		"w",
 		false,
 		"Watch cluster uninstallation logs.",
 	)


### PR DESCRIPTION
# Change
This change keeps the watch flag consistent across rosa commands. Previously some commands (e.g. rosa logs <install|uninstall>) provided both long/short form for the flag while others (e.g. rosa <create|delete> cluster) provided only long form for the flag.

It adds the short form `-w` for rosa <create|delete> clusters.