### PR TITLE
[SDA-8445] Add check for cluster version compatibility when reusing the operator roles

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1206,7 +1206,8 @@ func run(cmd *cobra.Command, _ []string) {
 				r.Reporter.Errorf("%v", err)
 				os.Exit(1)
 			} else {
-				err = ocm.ValidateOperatorRolesMatchOidcProvider(awsClient, operatorIAMRoleList, oidcEndpointUrl)
+				err = ocm.ValidateOperatorRolesMatchOidcProvider(awsClient, operatorIAMRoleList, oidcEndpointUrl,
+					ocm.GetVersionMinor(version))
 				if err != nil {
 					r.Reporter.Errorf("%v", err)
 					os.Exit(1)

--- a/cmd/create/operatorroles/by_clusterkey.go
+++ b/cmd/create/operatorroles/by_clusterkey.go
@@ -388,5 +388,5 @@ func validateOperatorRolesMatchOidcProvider(r *rosa.Runtime, cluster *cmv1.Clust
 		})
 	}
 	return ocm.ValidateOperatorRolesMatchOidcProvider(r.AWSClient, operatorRolesList,
-		cluster.AWS().STS().OIDCEndpointURL())
+		cluster.AWS().STS().OIDCEndpointURL(), ocm.GetVersionMinor(cluster.Version().RawID()))
 }


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-8445
# Why
Extra check to make sure operator roles are ok to be reused