### PR TITLE
[SDA-8450] Use role name instead of role arn for manual creation by prefix

### DIFF
--- a/cmd/create/operatorroles/by_prefix.go
+++ b/cmd/create/operatorroles/by_prefix.go
@@ -354,7 +354,11 @@ func buildCommandsFromPrefix(r *rosa.Runtime, env string,
 	commands := []string{}
 
 	for credrequest, operator := range credRequests {
-		roleName := aws.FindOperatorRoleBySTSOperator(operatorIAMRoleList, operator)
+		roleArn := aws.FindOperatorRoleBySTSOperator(operatorIAMRoleList, operator)
+		roleName, err := aws.GetResourceIdFromARN(roleArn)
+		if err != nil {
+			return "", err
+		}
 
 		var policyARN string
 		if managedPolicies {


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-8450
# Why
AWS does not accept role arn, should have been role name