### PR TITLE
Create Hypershift dedicated account roles

### DIFF
--- a/cmd/create/accountroles/creators.go
+++ b/cmd/create/accountroles/creators.go
@@ -13,21 +13,31 @@ import (
 type creator interface {
 	createRoles(*rosa.Runtime, *accountRolesCreationInput) error
 	getRoleTags(string, *accountRolesCreationInput) map[string]string
-	buildCommands(*accountRolesCreationInput) (string, error)
+	printCommands(*rosa.Runtime, *accountRolesCreationInput) error
 }
 
-func initCreator(managedPolicies bool, hostedCP bool) creator {
-	// Hypershift policies are managed policies by default
+func initCreator(managedPolicies bool, classic bool, hostedCP bool, isClassicValueSet bool,
+	isHostedCPValueSet bool) (creator, bool) {
+	// Classic ROSA managed policies
+	if managedPolicies && !hostedCP {
+		return &managedPoliciesCreator{}, true
+	}
+
+	// If the user didn't select topologies (default flow creates both), or selected both topologies
+	if !isClassicValueSet && !isHostedCPValueSet || hostedCP && classic {
+		return &doubleRolesCreator{}, true
+	}
+
 	if hostedCP {
-		return &hcpManagedPoliciesCreator{}
+		return &hcpManagedPoliciesCreator{}, true
 	}
 
-	if managedPolicies {
-		return &managedPoliciesCreator{}
+	// Classic ROSA unmanaged policies
+	if classic {
+		return &unmanagedPoliciesCreator{}, true
 	}
 
-	// Default flow creates a set of roles with unmanaged policies
-	return &unmanagedPoliciesCreator{}
+	return nil, false
 }
 
 type accountRolesCreationInput struct {
@@ -57,6 +67,8 @@ func buildRolesCreationInput(prefix, permissionsBoundary, accountID, env string,
 type managedPoliciesCreator struct{}
 
 func (mp *managedPoliciesCreator) createRoles(r *rosa.Runtime, input *accountRolesCreationInput) error {
+	r.Reporter.Infof("Creating classic account roles using '%s'", r.Creator.ARN)
+
 	for file, role := range aws.AccountRoles {
 		accRoleName := aws.GetRoleName(input.prefix, role.Name)
 		assumeRolePolicy := getAssumeRolePolicy(file, input)
@@ -75,6 +87,9 @@ func (mp *managedPoliciesCreator) createRoles(r *rosa.Runtime, input *accountRol
 			return err
 		}
 	}
+
+	r.Reporter.Infof("To create a cluster with these roles, run the following command:\n" +
+		"rosa create cluster --sts")
 
 	return nil
 }
@@ -99,7 +114,7 @@ func attachManagedPolicies(r *rosa.Runtime, input *accountRolesCreationInput, ro
 	return nil
 }
 
-func (mp *managedPoliciesCreator) buildCommands(input *accountRolesCreationInput) (string, error) {
+func (mp *managedPoliciesCreator) printCommands(r *rosa.Runtime, input *accountRolesCreationInput) error {
 	commands := []string{}
 	for file, role := range aws.AccountRoles {
 		accRoleName := aws.GetRoleName(input.prefix, role.Name)
@@ -112,7 +127,7 @@ func (mp *managedPoliciesCreator) buildCommands(input *accountRolesCreationInput
 		for _, policyKey := range policyKeys {
 			policyARN, err := aws.GetManagedPolicyARN(input.policies, policyKey)
 			if err != nil {
-				return "", err
+				return err
 			}
 
 			attachRolePolicy := buildAttachRolePolicyCommand(accRoleName, policyARN)
@@ -120,7 +135,10 @@ func (mp *managedPoliciesCreator) buildCommands(input *accountRolesCreationInput
 		}
 	}
 
-	return awscb.JoinCommands(commands), nil
+	r.Reporter.Infof("Run the following commands to create the classic account roles and policies:\n")
+	fmt.Println(awscb.JoinCommands(commands) + "\n")
+
+	return nil
 }
 
 func (mp *managedPoliciesCreator) getRoleTags(roleType string, input *accountRolesCreationInput) map[string]string {
@@ -133,47 +151,27 @@ func (mp *managedPoliciesCreator) getRoleTags(roleType string, input *accountRol
 type unmanagedPoliciesCreator struct{}
 
 func (up *unmanagedPoliciesCreator) createRoles(r *rosa.Runtime, input *accountRolesCreationInput) error {
+	r.Reporter.Infof("Creating classic account roles using '%s'", r.Creator.ARN)
+
 	for file, role := range aws.AccountRoles {
 		accRoleName := aws.GetRoleName(input.prefix, role.Name)
 		assumeRolePolicy := getAssumeRolePolicy(file, input)
-
-		r.Reporter.Debugf("Creating role '%s'", accRoleName)
 		tagsList := up.getRoleTags(file, input)
-		roleARN, err := r.AWSClient.EnsureRole(accRoleName, assumeRolePolicy, input.permissionsBoundary,
-			input.defaultPolicyVersion, tagsList, input.path, false)
-		if err != nil {
-			return err
-		}
-		r.Reporter.Infof("Created role '%s' with ARN '%s'", accRoleName, roleARN)
-
 		filename := fmt.Sprintf("sts_%s_permission_policy", file)
-		policyPermissionDetail := aws.GetPolicyDetails(input.policies, filename)
 
-		policyARN := aws.GetPolicyARN(r.Creator.AccountID, accRoleName, input.path)
-
-		r.Reporter.Debugf("Creating permission policy '%s'", policyARN)
-		if args.forcePolicyCreation {
-			policyARN, err = r.AWSClient.ForceEnsurePolicy(policyARN, policyPermissionDetail,
-				input.defaultPolicyVersion, tagsList, input.path)
-		} else {
-			policyARN, err = r.AWSClient.EnsurePolicy(policyARN, policyPermissionDetail,
-				input.defaultPolicyVersion, tagsList, input.path)
-		}
-		if err != nil {
-			return err
-		}
-
-		r.Reporter.Debugf("Attaching permission policy to role '%s'", filename)
-		err = r.AWSClient.AttachRolePolicy(accRoleName, policyARN)
+		err := createRoleUnmanagedPolicy(r, input, accRoleName, assumeRolePolicy, tagsList, filename)
 		if err != nil {
 			return err
 		}
 	}
 
+	r.Reporter.Infof("To create a cluster with these roles, run the following command:\n" +
+		"rosa create cluster --sts")
+
 	return nil
 }
 
-func (up *unmanagedPoliciesCreator) buildCommands(input *accountRolesCreationInput) (string, error) {
+func (up *unmanagedPoliciesCreator) printCommands(r *rosa.Runtime, input *accountRolesCreationInput) error {
 	commands := []string{}
 	for file, role := range aws.AccountRoles {
 		accRoleName := aws.GetRoleName(input.prefix, role.Name)
@@ -182,13 +180,9 @@ func (up *unmanagedPoliciesCreator) buildCommands(input *accountRolesCreationInp
 		createRole := buildCreateRoleCommand(accRoleName, file, iamTags, input)
 
 		policyName := aws.GetPolicyName(accRoleName)
-		createPolicy := awscb.NewIAMCommandBuilder().
-			SetCommand(awscb.CreatePolicy).
-			AddParam(awscb.PolicyName, policyName).
-			AddParam(awscb.PolicyDocument, fmt.Sprintf("file://sts_%s_permission_policy.json", file)).
-			AddTags(iamTags).
-			AddParam(awscb.Path, input.path).
-			Build()
+		policyDocument := fmt.Sprintf("file://sts_%s_permission_policy.json", file)
+
+		createPolicy := buildCreatePolicyCommand(policyName, policyDocument, iamTags, input.path)
 
 		policyARN := aws.GetPolicyARN(input.accountID, accRoleName, input.path)
 
@@ -197,11 +191,77 @@ func (up *unmanagedPoliciesCreator) buildCommands(input *accountRolesCreationInp
 		commands = append(commands, createRole, createPolicy, attachRolePolicy)
 	}
 
-	return awscb.JoinCommands(commands), nil
+	r.Reporter.Infof("Run the following commands to create the classic account roles and policies:\n")
+	fmt.Println(awscb.JoinCommands(commands) + "\n")
+
+	return nil
 }
 
 func (up *unmanagedPoliciesCreator) getRoleTags(roleType string, input *accountRolesCreationInput) map[string]string {
 	return getBaseRoleTags(roleType, input)
+}
+
+type doubleRolesCreator struct{}
+
+func (db *doubleRolesCreator) createRoles(r *rosa.Runtime, input *accountRolesCreationInput) error {
+	// Create classic account roles
+	unmanagedCreator := unmanagedPoliciesCreator{}
+	err := unmanagedCreator.createRoles(r, input)
+	if err != nil {
+		return err
+	}
+
+	// Create Hypershift account roles
+	hcpCreator := hcpManagedPoliciesCreator{}
+	return hcpCreator.createRoles(r, input)
+}
+
+func (db *doubleRolesCreator) printCommands(r *rosa.Runtime, input *accountRolesCreationInput) error {
+	// Build classic account roles command
+	unmanagedCreator := unmanagedPoliciesCreator{}
+	err := unmanagedCreator.printCommands(r, input)
+	if err != nil {
+		return err
+	}
+
+	// Build Hypershift account roles command
+	hcpCreator := hcpManagedPoliciesCreator{}
+	return hcpCreator.printCommands(r, input)
+}
+
+// getRoleTags is not needed, but here to satisfy the interface
+func (db *doubleRolesCreator) getRoleTags(roleType string, input *accountRolesCreationInput) map[string]string {
+	return nil
+}
+
+func createRoleUnmanagedPolicy(r *rosa.Runtime, input *accountRolesCreationInput, accRoleName string,
+	assumeRolePolicy string, tagsList map[string]string, filename string) error {
+	r.Reporter.Debugf("Creating role '%s'", accRoleName)
+	roleARN, err := r.AWSClient.EnsureRole(accRoleName, assumeRolePolicy, input.permissionsBoundary,
+		input.defaultPolicyVersion, tagsList, input.path, false)
+	if err != nil {
+		return err
+	}
+	r.Reporter.Infof("Created role '%s' with ARN '%s'", accRoleName, roleARN)
+
+	policyPermissionDetail := aws.GetPolicyDetails(input.policies, filename)
+
+	policyARN := aws.GetPolicyARN(r.Creator.AccountID, accRoleName, input.path)
+
+	r.Reporter.Debugf("Creating permission policy '%s'", policyARN)
+	if args.forcePolicyCreation {
+		policyARN, err = r.AWSClient.ForceEnsurePolicy(policyARN, policyPermissionDetail,
+			input.defaultPolicyVersion, tagsList, input.path)
+	} else {
+		policyARN, err = r.AWSClient.EnsurePolicy(policyARN, policyPermissionDetail,
+			input.defaultPolicyVersion, tagsList, input.path)
+	}
+	if err != nil {
+		return err
+	}
+
+	r.Reporter.Debugf("Attaching permission policy to role '%s'", filename)
+	return r.AWSClient.AttachRolePolicy(accRoleName, policyARN)
 }
 
 func getAssumeRolePolicy(file string, input *accountRolesCreationInput) string {
@@ -217,6 +277,8 @@ func getAssumeRolePolicy(file string, input *accountRolesCreationInput) string {
 type hcpManagedPoliciesCreator struct{}
 
 func (hcp *hcpManagedPoliciesCreator) createRoles(r *rosa.Runtime, input *accountRolesCreationInput) error {
+	r.Reporter.Infof("Creating hosted CP account roles using '%s'", r.Creator.ARN)
+
 	for file, role := range aws.HCPAccountRoles {
 		accRoleName := aws.GetRoleName(input.prefix, role.Name)
 		assumeRolePolicy := getAssumeRolePolicy(file, input)
@@ -243,10 +305,13 @@ func (hcp *hcpManagedPoliciesCreator) createRoles(r *rosa.Runtime, input *accoun
 		}
 	}
 
+	r.Reporter.Infof("To create a cluster with these roles, run the following command:\n" +
+		"rosa create cluster --hosted-cp")
+
 	return nil
 }
 
-func (hcp *hcpManagedPoliciesCreator) buildCommands(input *accountRolesCreationInput) (string, error) {
+func (hcp *hcpManagedPoliciesCreator) printCommands(r *rosa.Runtime, input *accountRolesCreationInput) error {
 	commands := []string{}
 	for file, role := range aws.HCPAccountRoles {
 		accRoleName := aws.GetRoleName(input.prefix, role.Name)
@@ -257,14 +322,17 @@ func (hcp *hcpManagedPoliciesCreator) buildCommands(input *accountRolesCreationI
 		policyKey := fmt.Sprintf("sts_hcp_%s_permission_policy", file)
 		policyARN, err := aws.GetManagedPolicyARN(input.policies, policyKey)
 		if err != nil {
-			return "", err
+			return err
 		}
 
 		attachRolePolicy := buildAttachRolePolicyCommand(accRoleName, policyARN)
 		commands = append(commands, createRole, attachRolePolicy)
 	}
 
-	return awscb.JoinCommands(commands), nil
+	r.Reporter.Infof("Run the following commands to create the hosted CP account roles and policies:\n")
+	fmt.Println(awscb.JoinCommands(commands) + "\n")
+
+	return nil
 }
 
 func (hcp *hcpManagedPoliciesCreator) getRoleTags(roleType string, input *accountRolesCreationInput) map[string]string {
@@ -293,6 +361,16 @@ func buildCreateRoleCommand(accRoleName string, file string, iamTags map[string]
 		AddParam(awscb.PermissionsBoundary, input.permissionsBoundary).
 		AddTags(iamTags).
 		AddParam(awscb.Path, input.path).
+		Build()
+}
+
+func buildCreatePolicyCommand(policyName string, policyDocument string, iamTags map[string]string, path string) string {
+	return awscb.NewIAMCommandBuilder().
+		SetCommand(awscb.CreatePolicy).
+		AddParam(awscb.PolicyName, policyName).
+		AddParam(awscb.PolicyDocument, policyDocument).
+		AddTags(iamTags).
+		AddParam(awscb.Path, path).
 		Build()
 }
 

--- a/cmd/dlt/accountroles/cmd.go
+++ b/cmd/dlt/accountroles/cmd.go
@@ -73,7 +73,6 @@ func init() {
 		false,
 		"Delete classic account roles",
 	)
-	flags.MarkHidden("classic")
 
 	aws.AddModeFlag(Cmd)
 	confirm.AddFlag(flags)


### PR DESCRIPTION
1. The default flow creates two sets of roles: 3 for Hypershift and 4 for Hive.
2. Passing the `classic` flag will create only 4 roles for Hive.
3. Passing the `hosted-cp` flag will create only 3 roles for Hypershift.

Related: [[SDA-8665](https://issues.redhat.com/browse/SDA-8665)]

Default flow creates double sets:
![image](https://user-images.githubusercontent.com/57869309/228807412-033025a9-b4b8-44d2-80e4-a58e1a9e80de.png)

Passing the `hosted-cp` flag creates one set:
![image](https://user-images.githubusercontent.com/57869309/228807449-de68fd6f-10c9-424c-9457-babb3788055c.png)

