### PR TITLE
[SDA-8452] Check if bucket page returns 404

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cluster
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -2338,6 +2339,13 @@ func handleByoOidcOptions(r *rosa.Runtime, cmd *cobra.Command, isSTS bool) (bool
 			if err != nil {
 				r.Reporter.Errorf("URL '%s' is not reachable.", oidcEndpointUrl)
 				os.Exit(1)
+			}
+			if strings.Contains(oidcEndpointUrl, ".s3.") {
+				err = helper.IsBucketReacheable(context.Background(), oidcEndpointUrl)
+				if err != nil {
+					r.Reporter.Errorf("%v", err)
+					os.Exit(1)
+				}
 			}
 			err = aws.ARNValidator(oidcPrivateKeySecretArn)
 			if err != nil {

--- a/cmd/create/operatorroles/by_prefix.go
+++ b/cmd/create/operatorroles/by_prefix.go
@@ -1,6 +1,7 @@
 package operatorroles
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"os"
@@ -245,6 +246,13 @@ func validateArgumentsOperatorRolesCreationByPrefix(r *rosa.Runtime, operatorRol
 	if err != nil {
 		r.Reporter.Errorf("URL '%s' is not reachable.", oidcEndpointUrl)
 		os.Exit(1)
+	}
+	if strings.Contains(oidcEndpointUrl, ".s3.") {
+		err = helper.IsBucketReacheable(context.Background(), oidcEndpointUrl)
+		if err != nil {
+			r.Reporter.Errorf("%v", err)
+			os.Exit(1)
+		}
 	}
 	err = aws.ARNValidator(installerRoleArn)
 	if err != nil {

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -1,9 +1,11 @@
 package helper
 
 import (
+	"context"
 	"math"
 	"math/rand"
 	"net"
+	"net/http"
 	"os"
 	"sort"
 	"strings"
@@ -12,6 +14,7 @@ import (
 	"github.com/briandowns/spinner"
 	"github.com/google/uuid"
 	"github.com/openshift/rosa/pkg/reporter"
+	"github.com/zgalor/weberr"
 )
 
 func init() {
@@ -202,6 +205,23 @@ func LongestCommonPrefixBySorting(stringSlice []string) string {
 	}
 
 	return first[:i]
+}
+
+func IsBucketReacheable(ctx context.Context, bucketUrl string) error {
+	req, err := http.NewRequestWithContext(ctx, "HEAD", bucketUrl, nil)
+	if err != nil {
+		return err
+	}
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return weberr.BadRequest.Errorf("Bucket '%s' not found.", bucketUrl)
+	}
+	return nil
 }
 
 func IsURLReachable(apiURL string) error {


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-8452
# What
Checks if bucket url 404s

# Why
Not sure when, but it looks like aws is now returning a page with 404 status code, so dialing is not enough to check if page exists.