### PR TITLE
Hypershift - create cluster

### DIFF
--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -135,7 +135,8 @@ func run(cmd *cobra.Command, argv []string) error {
 	}
 
 	if managedPolicies {
-		err = roles.ValidateAccountRolesManagedPolicies(r, prefix)
+		// TODO: handle Hypershift account roles
+		err = roles.ValidateAccountRolesManagedPolicies(r, prefix, false)
 		if err != nil {
 			r.Reporter.Errorf("Failed while validating managed policies: %v", err)
 			os.Exit(1)

--- a/cmd/upgrade/roles/cmd.go
+++ b/cmd/upgrade/roles/cmd.go
@@ -199,7 +199,8 @@ func run(cmd *cobra.Command, argv []string) error {
 			r.Reporter.Errorf("Failed while trying to get account role prefix: '%v'", err)
 			os.Exit(1)
 		}
-		err = roles.ValidateAccountRolesManagedPolicies(r, accountRolePrefix)
+		// TODO: handle Hypershift account roles
+		err = roles.ValidateAccountRolesManagedPolicies(r, accountRolePrefix, false)
 		if err != nil {
 			r.Reporter.Errorf("Failed while validating managed policies: %v", err)
 			os.Exit(1)

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -168,8 +168,10 @@ type Client interface {
 	IsLocalAvailabilityZone(availabilityZoneName string) (bool, error)
 	DetachRolePolicies(roleName string) error
 	HasManagedPolicies(roleARN string) (bool, error)
+	HasHostedCPPolicies(roleARN string) (bool, error)
 	GetAccountRoleARN(prefix string, roleType string) (string, error)
 	ValidateAccountRolesManagedPolicies(prefix string, policies map[string]*cmv1.AWSSTSPolicy) error
+	ValidateHCPAccountRolesManagedPolicies(prefix string, policies map[string]*cmv1.AWSSTSPolicy) error
 	ValidateOperatorRolesManagedPolicies(cluster *cmv1.Cluster, operatorRoles map[string]*cmv1.STSOperator,
 		policies map[string]*cmv1.AWSSTSPolicy) error
 	CreateS3Bucket(bucketName string, region string) error

--- a/pkg/helper/roles/helpers.go
+++ b/pkg/helper/roles/helpers.go
@@ -89,10 +89,14 @@ func BuildMissingOperatorRoleCommand(
 	return awscb.JoinCommands(commands), nil
 }
 
-func ValidateAccountRolesManagedPolicies(r *rosa.Runtime, prefix string) error {
+func ValidateAccountRolesManagedPolicies(r *rosa.Runtime, prefix string, hostedCPPolicies bool) error {
 	policies, err := r.OCMClient.GetPolicies("")
 	if err != nil {
 		return fmt.Errorf("Failed to fetch policies: %v", err)
+	}
+
+	if hostedCPPolicies {
+		return r.AWSClient.ValidateHCPAccountRolesManagedPolicies(prefix, policies)
 	}
 
 	return r.AWSClient.ValidateAccountRolesManagedPolicies(prefix, policies)


### PR DESCRIPTION
Omit the control plane role when creating a Hypershift cluster.

**Note:** a follow-up PR will ensure the set of account roles is a Hypershift set.

Related: [SDA-8454](https://issues.redhat.com/browse/SDA-8454)

Only three account roles are required from the user:
![image](https://user-images.githubusercontent.com/57869309/224991927-ba090867-aff4-490a-8472-eab11bb3aaad.png)
