### PR TITLE
Create Hypershift account roles with managed policies

### DIFF
--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -74,8 +74,13 @@ const (
 	ControlPlaneAccountRole = "instance_controlplane"
 	WorkerAccountRole       = "instance_worker"
 	SupportAccountRole      = "support"
-	OCMRole                 = "OCM"
-	OCMUserRole             = "User"
+
+	HCPInstallerRole = "installer"
+	HCPWorkerRole    = "instance_worker"
+	HCPSupportRole   = "support"
+
+	OCMRole     = "OCM"
+	OCMUserRole = "User"
 )
 
 const (
@@ -89,6 +94,12 @@ var AccountRoles map[string]AccountRole = map[string]AccountRole{
 	ControlPlaneAccountRole: {Name: "ControlPlane", Flag: "controlplane-iam-role"},
 	WorkerAccountRole:       {Name: "Worker", Flag: "worker-iam-role"},
 	SupportAccountRole:      {Name: "Support", Flag: "support-role-arn"},
+}
+
+var HCPAccountRoles = map[string]AccountRole{
+	HCPInstallerRole: {Name: "HCP-Installer", Flag: "role-arn"},
+	HCPSupportRole:   {Name: "HCP-Support", Flag: "support-role-arn"},
+	HCPWorkerRole:    {Name: "HCP-Worker", Flag: "worker-iam-role"},
 }
 
 var OCMUserRolePolicyFile = "ocm_user"

--- a/pkg/aws/tags/tags.go
+++ b/pkg/aws/tags/tags.go
@@ -52,6 +52,8 @@ const RedHatManaged = "red-hat-managed"
 
 const ManagedPolicies = prefix + "managed_policies"
 
+const HypershiftPolicies = prefix + "hypershift_policies"
+
 const OperatorNamespace = "operator_namespace"
 
 const OperatorName = "operator_name"


### PR DESCRIPTION
Run `rosa create account-roles --hosted-cp` to get a set of Hypershift roles.

**Note:** The default flow for Hypershift is going to be managed policies.

Related: [SDA-8494](https://issues.redhat.com/browse/SDA-8498)

Auto mode:
![image](https://user-images.githubusercontent.com/57869309/225033995-b25e3f63-066f-4af7-9487-848842475d14.png)

Manual mode:
![image](https://user-images.githubusercontent.com/57869309/225021942-2f751058-19da-4209-95e4-1987571009b6.png)
