### PR TITLE
Create account roles - hide `hosted-cp` flag

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -125,6 +125,7 @@ func init() {
 		false,
 		"Enable the use of hosted control planes (HyperShift)",
 	)
+	flags.MarkHidden("hosted-cp")
 
 	aws.AddModeFlag(Cmd)
 


### PR DESCRIPTION
Hide the flag until AWS managed policies are in place.

Related: [SDA-8498](https://issues.redhat.com/browse/SDA-8498)