### PR TITLE
Create Hypershift operator roles

### DIFF
--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -825,6 +825,14 @@ func GetManagedPolicyARN(policies map[string]*cmv1.AWSSTSPolicy, key string) (st
 	return policy.ARN(), nil
 }
 
+func GetOperatorPolicyKey(roleType string, hostedCP bool) string {
+	if hostedCP {
+		return fmt.Sprintf("openshift_hcp_%s_policy", roleType)
+	}
+
+	return fmt.Sprintf("openshift_%s_policy", roleType)
+}
+
 // GetAccountRolePolicyKeys returns the policy key for fetching the managed policy ARN
 func GetAccountRolePolicyKeys(roleType string) []string {
 	if roleType == InstallerAccountRole {

--- a/pkg/aws/tags/tags.go
+++ b/pkg/aws/tags/tags.go
@@ -52,7 +52,7 @@ const RedHatManaged = "red-hat-managed"
 
 const ManagedPolicies = prefix + "managed_policies"
 
-const HypershiftPolicies = prefix + "hypershift_policies"
+const HypershiftPolicies = prefix + "hcp_policies"
 
 const OperatorNamespace = "operator_namespace"
 


### PR DESCRIPTION
If the account roles have Hypershift managed policies, attach the managed policies to the operator roles instead of creating policies in the user account.

Related: [SDA-8507](https://issues.redhat.com/browse/SDA-8507)

![image](https://user-images.githubusercontent.com/57869309/226344742-6b5d26c3-009d-4838-aad0-e4b12e821723.png)
