### PR TITLE
Delete account-roles - handle Hypershift roles

### DIFF
--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -128,7 +128,8 @@ type Client interface {
 	GetPolicies(roles []string) (map[string][]string, error)
 	GetAccountRolesForCurrentEnv(env string, accountID string) ([]Role, error)
 	GetAccountRoleForCurrentEnv(env string, roleName string) (Role, error)
-	GetAccountRoleForCurrentEnvWithPrefix(env string, rolePrefix string) ([]Role, error)
+	GetAccountRoleForCurrentEnvWithPrefix(env string, rolePrefix string,
+		accountRolesMap map[string]AccountRole) ([]Role, error)
 	DeleteAccountRole(roleName string, managedPolicies bool) error
 	DeleteOCMRole(roleARN string, managedPolicies bool) error
 	DeleteUserRole(roleName string) error

--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -89,7 +89,7 @@ const (
 	InstallerPrivateLinkKey = "sts_installer_privatelink_permission_policy"
 )
 
-var AccountRoles map[string]AccountRole = map[string]AccountRole{
+var AccountRoles = map[string]AccountRole{
 	InstallerAccountRole:    {Name: "Installer", Flag: "role-arn"},
 	ControlPlaneAccountRole: {Name: "ControlPlane", Flag: "controlplane-iam-role"},
 	WorkerAccountRole:       {Name: "Worker", Flag: "worker-iam-role"},
@@ -1270,9 +1270,10 @@ func (c *awsClient) checkInstallerRoleExists(roleName string) (*iam.Role, error)
 	return installerRoleResponse.Role, nil
 }
 
-func (c *awsClient) GetAccountRoleForCurrentEnvWithPrefix(env string, rolePrefix string) ([]Role, error) {
+func (c *awsClient) GetAccountRoleForCurrentEnvWithPrefix(env string, rolePrefix string,
+	accountRolesMap map[string]AccountRole) ([]Role, error) {
 	roleList := []Role{}
-	for _, prefix := range AccountRoles {
+	for _, prefix := range accountRolesMap {
 		role, err := c.GetAccountRoleForCurrentEnv(env, fmt.Sprintf("%s-%s-Role", rolePrefix, prefix.Name))
 		if err != nil {
 			if errors.GetType(err) != errors.NotFound {


### PR DESCRIPTION
1. Default flow deletes classic ROSA roles.
2. If "--hosted-cp" is specified, delete the Hypershift roles (same behavior as `create account roles`).

**TODO:** we can delete both by default once we have the managed policies in place. 
Otherwise, deleting the Hypershift roles for users is meaningless.

Related: [SDA-8565](https://issues.redhat.com/browse/SDA-8565)

By default delete classic ROSA account roles:
![image](https://user-images.githubusercontent.com/57869309/226596280-37b82e65-536e-4721-9bba-6861a13409ba.png)

When the **--hosted-cp** flag is provided, delete the Hypershift account roles:
![image](https://user-images.githubusercontent.com/57869309/226596398-812d90b2-7f90-4666-93dd-1063c6622fa2.png)
