### PR TITLE
Upgrade cluster with hosted CP policies

### DIFF
--- a/cmd/create/operatorroles/by_clusterkey.go
+++ b/cmd/create/operatorroles/by_clusterkey.go
@@ -94,14 +94,7 @@ func handleOperatorRoleCreationByClusterKey(r *rosa.Runtime, env string,
 		r.Reporter.Errorf("%s", err)
 	}
 
-	var hostedCPPolicies bool
-	if cluster.Hypershift().Enabled() {
-		hostedCPPolicies, err = r.AWSClient.HasHostedCPPolicies(cluster.AWS().STS().RoleARN())
-		if err != nil {
-			r.Reporter.Errorf("Failed to determine if cluster has hosted CP policies: %v", err)
-			os.Exit(1)
-		}
-	}
+	hostedCPPolicies := aws.IsHostedCPManagedPolicies(cluster)
 
 	switch mode {
 	case aws.ModeAuto:

--- a/cmd/upgrade/operatorroles/cmd.go
+++ b/cmd/upgrade/operatorroles/cmd.go
@@ -160,8 +160,10 @@ func run(cmd *cobra.Command, argv []string) error {
 			os.Exit(1)
 		}
 
+		hostedCPPolicies := aws.IsHostedCPManagedPolicies(cluster)
+
 		err = roles.ValidateOperatorRolesManagedPolicies(r, cluster, credRequests, policies, mode, prefix, unifiedPath,
-			args.upgradeVersion)
+			args.upgradeVersion, hostedCPPolicies)
 		if err != nil {
 			r.Reporter.Errorf("Failed while validating managed policies: %v", err)
 			os.Exit(1)

--- a/cmd/upgrade/roles/cmd.go
+++ b/cmd/upgrade/roles/cmd.go
@@ -199,8 +199,10 @@ func run(cmd *cobra.Command, argv []string) error {
 			r.Reporter.Errorf("Failed while trying to get account role prefix: '%v'", err)
 			os.Exit(1)
 		}
-		// TODO: handle Hypershift account roles
-		err = roles.ValidateAccountRolesManagedPolicies(r, accountRolePrefix, false)
+
+		hostedCPPolicies := aws.IsHostedCPManagedPolicies(cluster)
+
+		err = roles.ValidateAccountRolesManagedPolicies(r, accountRolePrefix, hostedCPPolicies)
 		if err != nil {
 			r.Reporter.Errorf("Failed while validating managed policies: %v", err)
 			os.Exit(1)
@@ -213,7 +215,7 @@ func run(cmd *cobra.Command, argv []string) error {
 			os.Exit(1)
 		}
 		err = roles.ValidateOperatorRolesManagedPolicies(r, cluster, credRequests, policies, mode,
-			accountRolePrefix, unifiedPath, clusterUpgradeVersion)
+			accountRolePrefix, unifiedPath, clusterUpgradeVersion, hostedCPPolicies)
 		if err != nil {
 			r.Reporter.Errorf("Failed while validating managed policies: %v", err)
 			os.Exit(1)

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -175,7 +175,7 @@ type Client interface {
 	ValidateAccountRolesManagedPolicies(prefix string, policies map[string]*cmv1.AWSSTSPolicy) error
 	ValidateHCPAccountRolesManagedPolicies(prefix string, policies map[string]*cmv1.AWSSTSPolicy) error
 	ValidateOperatorRolesManagedPolicies(cluster *cmv1.Cluster, operatorRoles map[string]*cmv1.STSOperator,
-		policies map[string]*cmv1.AWSSTSPolicy) error
+		policies map[string]*cmv1.AWSSTSPolicy, hostedCPPolicies bool) error
 	CreateS3Bucket(bucketName string, region string) error
 	DeleteS3Bucket(bucketName string) error
 	PutPublicReadObjectInS3Bucket(bucketName string, body io.ReadSeeker, key string) error

--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -475,7 +475,15 @@ func GetPrefixFromAccountRole(cluster *cmv1.Cluster, roleNameSuffix string) (str
 	if err != nil {
 		return "", err
 	}
-	rolePrefix := TrimRoleSuffix(roleName, fmt.Sprintf("-%s-Role", roleNameSuffix))
+
+	var suffix string
+	if IsHostedCPManagedPolicies(cluster) {
+		suffix = fmt.Sprintf("-HCP-%s-Role", roleNameSuffix)
+	} else {
+		suffix = fmt.Sprintf("-%s-Role", roleNameSuffix)
+	}
+
+	rolePrefix := TrimRoleSuffix(roleName, suffix)
 	return rolePrefix, nil
 }
 
@@ -862,4 +870,8 @@ func ComputeOperatorRoleArn(prefix string, operator *cmv1.STSOperator, creator *
 func IsStandardNamedAccountRole(accountRoleName, roleSuffix string) (bool, string) {
 	accountRolePrefix := TrimRoleSuffix(accountRoleName, fmt.Sprintf("-%s-Role", roleSuffix))
 	return accountRolePrefix != accountRoleName, accountRolePrefix
+}
+
+func IsHostedCPManagedPolicies(cluster *cmv1.Cluster) bool {
+	return cluster.Hypershift().Enabled() && cluster.AWS().STS().ManagedPolicies()
 }

--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -1672,11 +1672,11 @@ func (c *awsClient) GetAccountRoleARN(prefix string, roleType string) (string, e
 }
 
 func (c *awsClient) ValidateOperatorRolesManagedPolicies(cluster *cmv1.Cluster,
-	operatorRoles map[string]*cmv1.STSOperator, policies map[string]*cmv1.AWSSTSPolicy) error {
+	operatorRoles map[string]*cmv1.STSOperator, policies map[string]*cmv1.AWSSTSPolicy, hostedCPPolicies bool) error {
 	for key, operatorRole := range operatorRoles {
 		roleName, exist := FindOperatorRoleNameBySTSOperator(cluster, operatorRole)
 		if exist {
-			err := c.validateManagedPolicy(policies, fmt.Sprintf("openshift_%s_policy", key), roleName)
+			err := c.validateManagedPolicy(policies, GetOperatorPolicyKey(key, hostedCPPolicies), roleName)
 			if err != nil {
 				return err
 			}

--- a/pkg/helper/roles/helpers.go
+++ b/pkg/helper/roles/helpers.go
@@ -130,7 +130,7 @@ func ValidateUnmanagedAccountRoles(roleARNs []string, awsClient aws.Client, vers
 
 func ValidateOperatorRolesManagedPolicies(r *rosa.Runtime, cluster *cmv1.Cluster,
 	operatorRoles map[string]*cmv1.STSOperator, policies map[string]*cmv1.AWSSTSPolicy, mode string, prefix string,
-	unifiedPath string, upgradeVersion string) error {
+	unifiedPath string, upgradeVersion string, hostedCPPolicies bool) error {
 	if upgradeVersion != "" {
 		missingRolesInCS, err := r.OCMClient.FindMissingOperatorRolesForUpgrade(cluster, upgradeVersion)
 		if err != nil {
@@ -145,7 +145,7 @@ func ValidateOperatorRolesManagedPolicies(r *rosa.Runtime, cluster *cmv1.Cluster
 		}
 	}
 
-	return r.AWSClient.ValidateOperatorRolesManagedPolicies(cluster, operatorRoles, policies)
+	return r.AWSClient.ValidateOperatorRolesManagedPolicies(cluster, operatorRoles, policies, hostedCPPolicies)
 }
 
 func CreateMissingRoles(r *rosa.Runtime, missingRolesInCS map[string]*cmv1.STSOperator, cluster *cmv1.Cluster,


### PR DESCRIPTION
1. Validate that managed policies are attached to the account roles.
2. Validate that managed policies are attached to the operator roles.

**Note:** Upgrade hosted control plane isn't supported yet, this PR adds validation for missing policies/roles.

Related: [SDA-8552](https://issues.redhat.com/browse/SDA-8552)

Upgrade cluster - installer role without the managed policy:
![image](https://user-images.githubusercontent.com/57869309/226946305-2e65d61e-bde3-4475-be9f-a62dd7f09fed.png)

Upgrade cluster - operator role without the managed policy:
![image](https://user-images.githubusercontent.com/57869309/226946367-cf06a76f-a7fb-4a01-8c45-68edcf4755a3.png)

Upgrade operator roles - all managed policies are attached to the roles:
![image](https://user-images.githubusercontent.com/57869309/226946480-7896058e-9f28-4952-84f4-d11836931253.png)
