### PR TITLE
Add control plane upgrades for Hypershift cluster

### DIFF
--- a/cmd/list/gates/cmd.go
+++ b/cmd/list/gates/cmd.go
@@ -129,7 +129,7 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 
 		// check if the cluster upgrade requires gate agreements
-		versionGates, err = r.OCMClient.GetMissingGateAgreements(cluster.ID(), upgradePolicy)
+		versionGates, err = r.OCMClient.GetMissingGateAgreementsClassic(cluster.ID(), upgradePolicy)
 		if err != nil {
 			r.Reporter.Errorf("Failed to check for missing gate agreements upgrade for "+
 				"cluster '%s': %v", clusterKey, err)

--- a/pkg/ocm/upgrades.go
+++ b/pkg/ocm/upgrades.go
@@ -18,6 +18,7 @@ package ocm
 
 import (
 	"encoding/json"
+
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
@@ -37,6 +38,33 @@ func (c *Client) GetUpgradePolicies(clusterID string) (upgradePolicies []*cmv1.U
 			return nil, handleErr(response.Error(), err)
 		}
 		upgradePolicies = append(upgradePolicies, response.Items().Slice()...)
+		if response.Size() < size {
+			break
+		}
+		page++
+	}
+	return
+}
+
+func (c *Client) GetControlPlaneUpgradePolicies(clusterID string) (
+	controlPlaneUpgradePolicies []*cmv1.ControlPlaneUpgradePolicy,
+	err error) {
+	collection := c.ocm.ClustersMgmt().V1().
+		Clusters().
+		Cluster(clusterID).
+		ControlPlane().
+		UpgradePolicies()
+	page := 1
+	size := 100
+	for {
+		response, err := collection.List().
+			Page(page).
+			Size(size).
+			Send()
+		if err != nil {
+			return nil, handleErr(response.Error(), err)
+		}
+		controlPlaneUpgradePolicies = append(controlPlaneUpgradePolicies, response.Items().Slice()...)
 		if response.Size() < size {
 			break
 		}
@@ -69,9 +97,36 @@ func (c *Client) GetScheduledUpgrade(clusterID string) (*cmv1.UpgradePolicy, *cm
 	return nil, nil, nil
 }
 
+func (c *Client) GetControlPlaneScheduledUpgrade(clusterID string) (*cmv1.ControlPlaneUpgradePolicy, error) {
+	upgradePolicies, err := c.GetControlPlaneUpgradePolicies(clusterID)
+	if err != nil {
+		return nil, err
+	}
+	for _, upgradePolicy := range upgradePolicies {
+		if upgradePolicy.UpgradeType() == "ControlPlane" {
+			return upgradePolicy, nil
+		}
+	}
+
+	return nil, nil
+}
+
 func (c *Client) ScheduleUpgrade(clusterID string, upgradePolicy *cmv1.UpgradePolicy) error {
 	response, err := c.ocm.ClustersMgmt().V1().
 		Clusters().Cluster(clusterID).
+		UpgradePolicies().
+		Add().Body(upgradePolicy).
+		Send()
+	if err != nil {
+		return handleErr(response.Error(), err)
+	}
+	return nil
+}
+
+func (c *Client) ScheduleHypershiftControlPlaneUpgrade(clusterID string,
+	upgradePolicy *cmv1.ControlPlaneUpgradePolicy) error {
+	response, err := c.ocm.ClustersMgmt().V1().
+		Clusters().Cluster(clusterID).ControlPlane().
 		UpgradePolicies().
 		Add().Body(upgradePolicy).
 		Send()
@@ -97,7 +152,34 @@ func (c *Client) CancelUpgrade(clusterID string) (bool, error) {
 	return true, nil
 }
 
-func (c *Client) GetMissingGateAgreements(
+func (c *Client) GetMissingGateAgreementsHypershift(
+	clusterID string,
+	upgradePolicy *cmv1.ControlPlaneUpgradePolicy) ([]*cmv1.VersionGate, error) {
+	response, err := c.ocm.ClustersMgmt().V1().Clusters().
+		Cluster(clusterID).ControlPlane().UpgradePolicies().Add().Parameter("dryRun", true).Body(upgradePolicy).Send()
+
+	if err != nil {
+		if response.Error() != nil {
+			// parse gates list
+			errorDetails, ok := response.Error().GetDetails()
+			if !ok {
+				return []*cmv1.VersionGate{}, handleErr(response.Error(), err)
+			}
+			data, err := json.Marshal(errorDetails)
+			if err != nil {
+				return []*cmv1.VersionGate{}, handleErr(response.Error(), err)
+			}
+			gates, err := cmv1.UnmarshalVersionGateList(data)
+			if err != nil {
+				return []*cmv1.VersionGate{}, handleErr(response.Error(), err)
+			}
+			return gates, nil
+		}
+	}
+	return []*cmv1.VersionGate{}, nil
+}
+
+func (c *Client) GetMissingGateAgreementsClassic(
 	clusterID string,
 	upgradePolicy *cmv1.UpgradePolicy) ([]*cmv1.VersionGate, error) {
 	response, err := c.ocm.ClustersMgmt().V1().Clusters().


### PR DESCRIPTION
This is the only supported mode for Hypershift cluster at the moment. We also enforce that upgrades will start immediately, no scheduling possible in the first phase.

Examples:
```
rosa upgrade cluster -c ad3 --control-plane
? Version: 4.12.8
? IAM Roles/Policies upgrade mode: auto
I: Ensuring account and operator role policies for cluster '22oaveu9j278qh79814p2aug5ahtvl2h' are compatible with upgrade.
I: Account roles/policies for cluster '22oaveu9j278qh79814p2aug5ahtvl2h' are already up-to-date.
I: Operator roles/policies associated with the cluster '22oaveu9j278qh79814p2aug5ahtvl2h' are already up-to-date.
I: Account and operator roles for cluster 'ad3' are compatible with upgrade
? Are you sure you want to upgrade cluster to version '4.12.8'? Yes
? Node draining: 1 hour
I: Upgrade successfully scheduled for cluster 'ad3'

rosa describe upgrade -c ad3
                ID:                         5cbfc13c-ce36-11ed-9dda-0a580a8308f5
		Cluster ID:                 22oaveu9j278qh79814p2aug5ahtvl2h
		Next Run:                   2023-03-29 13:43:00 +0000 UTC
		Upgrade State:              started
                Version:                    4.12.8
```

Related: [SDA-8472](https://issues.redhat.com//browse/SDA-8472)