### PR TITLE
Delete account roles - classic ROSA

### DIFF
--- a/cmd/dlt/accountroles/cmd.go
+++ b/cmd/dlt/accountroles/cmd.go
@@ -154,6 +154,7 @@ func deleteAccountRoles(r *rosa.Runtime, env string, prefix string, clusters []*
 		roleTypeString = "hosted CP "
 	} else {
 		accountRolesMap = aws.AccountRoles
+		roleTypeString = "classic "
 	}
 
 	finalRoleList, managedPolicies, err := getRoleListForDeletion(r, env, prefix, clusters, accountRolesMap)


### PR DESCRIPTION
Add the `classic` specification to the messages of the command.

Related: [SDA-8599](https://issues.redhat.com/browse/SDA-8599)