### PR TITLE
[SDA-8621] Use oidcConfigIdFlag instead of var

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2340,7 +2340,7 @@ func handleOidcConfigOptions(r *rosa.Runtime, cmd *cobra.Command, isSTS bool) *v
 			_oidcConfigId, err := interactive.GetString(
 				interactive.Input{
 					Question: "OIDC Config ID",
-					Help:     cmd.Flags().Lookup(oidcConfigId).Usage,
+					Help:     cmd.Flags().Lookup(OidcConfigIdFlag).Usage,
 					Required: false,
 					Default:  oidcConfigId,
 				})


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-8621
# What
Correctly setup usage help

# Why
Avoid segfault