### PR TITLE
[SDA-8587] Check specific prefix instead of all op roles that start with prefix

### DIFF
--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -1114,6 +1114,9 @@ func (c *awsClient) GetOperatorRolesFromAccountByPrefix(prefix string,
 	if err != nil {
 		return roleList, err
 	}
+	// An extra '-' is needed to end the prefix where the suffixes for openshift/kube starts
+	// This ensures other similar prefixes will not be deleted
+	prefix = prefix + "-"
 	for _, role := range roles {
 		if !checkIfROSAOperatorRole(role.RoleName, credRequest) {
 			continue


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-8587
# What
Given prefix was deleting extra roles that started with prefix however didn't completely match it

# Why
Should only match a specific prefix