### PR TITLE
SDA-8551 Sync replicas validation for hosted clusters

### DIFF
--- a/cmd/create/machinepool/nodepool.go
+++ b/cmd/create/machinepool/nodepool.go
@@ -10,6 +10,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/rosa/pkg/helper/machinepools"
 	"github.com/openshift/rosa/pkg/helper/versions"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/output"
@@ -151,11 +152,19 @@ func addNodePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster, r
 				Help:     cmd.Flags().Lookup("min-replicas").Usage,
 				Default:  minReplicas,
 				Required: true,
+				Validators: []interactive.Validator{
+					machinepools.MinNodePoolReplicaValidator(),
+				},
 			})
 			if err != nil {
 				r.Reporter.Errorf("Expected a valid number of min replicas: %s", err)
 				os.Exit(1)
 			}
+		}
+		err = machinepools.MinNodePoolReplicaValidator()(minReplicas)
+		if err != nil {
+			r.Reporter.Errorf("%s", err)
+			os.Exit(1)
 		}
 
 		if interactive.Enabled() || !isMaxReplicasSet {
@@ -164,11 +173,19 @@ func addNodePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster, r
 				Help:     cmd.Flags().Lookup("max-replicas").Usage,
 				Default:  maxReplicas,
 				Required: true,
+				Validators: []interactive.Validator{
+					machinepools.MaxNodePoolReplicaValidator(minReplicas),
+				},
 			})
 			if err != nil {
 				r.Reporter.Errorf("Expected a valid number of max replicas: %s", err)
 				os.Exit(1)
 			}
+		}
+		err = machinepools.MaxNodePoolReplicaValidator(minReplicas)(maxReplicas)
+		if err != nil {
+			r.Reporter.Errorf("%s", err)
+			os.Exit(1)
 		}
 	} else {
 		// if the user set min/max replicas and hasn't enabled autoscaling
@@ -182,11 +199,19 @@ func addNodePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster, r
 				Help:     cmd.Flags().Lookup("replicas").Usage,
 				Default:  replicas,
 				Required: true,
+				Validators: []interactive.Validator{
+					machinepools.MinNodePoolReplicaValidator(),
+				},
 			})
 			if err != nil {
 				r.Reporter.Errorf("Expected a valid number of replicas: %s", err)
 				os.Exit(1)
 			}
+		}
+		err = machinepools.MinNodePoolReplicaValidator()(replicas)
+		if err != nil {
+			r.Reporter.Errorf("%s", err)
+			os.Exit(1)
 		}
 	}
 

--- a/pkg/helper/machinepools/helpers.go
+++ b/pkg/helper/machinepools/helpers.go
@@ -1,0 +1,34 @@
+package machinepools
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/openshift/rosa/pkg/interactive"
+)
+
+func MinNodePoolReplicaValidator() interactive.Validator {
+	return func(val interface{}) error {
+		minReplicas, err := strconv.Atoi(fmt.Sprintf("%v", val))
+		if err != nil {
+			return err
+		}
+		if minReplicas < 1 {
+			return fmt.Errorf("min-replicas must be greater than zero")
+		}
+		return nil
+	}
+}
+
+func MaxNodePoolReplicaValidator(minReplicas int) interactive.Validator {
+	return func(val interface{}) error {
+		maxReplicas, err := strconv.Atoi(fmt.Sprintf("%v", val))
+		if err != nil {
+			return err
+		}
+		if minReplicas > maxReplicas {
+			return fmt.Errorf("max-replicas must be greater or equal to min-replicas")
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
This ticket is a follow-up of https://issues.redhat.com/browse/SDA-7929 for ROSA CLI.

Hypershift Operator updated the minimal replica validation, and those changes have been propagated into the backend ([SDA-7929](https://issues.redhat.com//browse/SDA-7929)) and frontend ([SDA-8551](https://issues.redhat.com//browse/SDA-8551)).

cc @oriAdler @gdbranco 