### PR TITLE
[SDA-8587] Favoring regex when deleting operator roles by prefix

### DIFF
--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -18,6 +18,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -1117,14 +1118,12 @@ func (c *awsClient) GetOperatorRolesFromAccountByPrefix(prefix string,
 	if err != nil {
 		return roleList, err
 	}
-	// An extra '-' is needed to end the prefix where the suffixes for openshift/kube starts
-	// This ensures other similar prefixes will not be deleted
-	prefix = prefix + "-"
+	prefixOperatorRoleRE := regexp.MustCompile(("(?i)" + fmt.Sprintf("(%s)-(openshift|kube)", prefix)))
 	for _, role := range roles {
 		if !checkIfROSAOperatorRole(role.RoleName, credRequest) {
 			continue
 		}
-		if strings.HasPrefix(*role.RoleName, prefix) {
+		if prefixOperatorRoleRE.MatchString(*role.RoleName) {
 			roleList = append(roleList, aws.StringValue(role.RoleName))
 		}
 	}


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-8587
# What
Favors regex when deleting operator roles by prefix

# Why
There was still an edge case that was not accommodated by the last mechanism

# How it was tested
Created two sets of operator roles, gdb and gdb-, deleted each individually making sure the other was not taken into account by current mechanism