### PR TITLE
oc client version local check only

### DIFF
--- a/cmd/verify/oc/cmd.go
+++ b/cmd/verify/oc/cmd.go
@@ -44,7 +44,7 @@ func run(_ *cobra.Command, _ []string) {
 		reporter.Infof("Verifying whether OpenShift command-line tool is available...")
 	}
 
-	output, err := exec.Command("oc", "version").Output()
+	output, err := exec.Command("oc", "version", "--client").Output()
 	if output == nil && err != nil {
 		reporter.Warnf("OpenShift command-line tool is not installed.\n" +
 			"Run 'rosa download oc' to download the latest version, then add it to your PATH.")


### PR DESCRIPTION
We are using only the local oc client version.
By passing the --client flag we can avoid any remote call making the call faster.