### PR TITLE
[SDA-8752] Add type of cluster column in list clusters command

### DIFF
--- a/cmd/list/cluster/cmd.go
+++ b/cmd/list/cluster/cmd.go
@@ -72,14 +72,22 @@ func run(_ *cobra.Command, _ []string) {
 
 	// Create the writer that will be used to print the tabulated results:
 	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintf(writer, "ID\tNAME\tSTATE\n")
+	fmt.Fprintf(writer, "ID\tNAME\tSTATE\tTYPE\n")
 	for _, cluster := range clusters {
+		typeOutput := "Classic - Mint"
+		if cluster.AWS() != nil && cluster.AWS().STS() != nil && cluster.AWS().STS().Enabled() {
+			typeOutput = "Classic - STS"
+		}
+		if cluster.Hypershift().Enabled() {
+			typeOutput = "Hosted CP"
+		}
 		fmt.Fprintf(
 			writer,
-			"%s\t%s\t%s\n",
+			"%s\t%s\t%s\t%s\n",
 			cluster.ID(),
 			cluster.Name(),
 			cluster.State(),
+			typeOutput,
 		)
 	}
 	writer.Flush()


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-8752
# What
Add type of cluster column in list clusters command

# Why
Easier for customer to check