### PR TITLE
chore: remove deprecated lib `io/ioutil`

### DIFF
--- a/cmd/create/idp/github.go
+++ b/cmd/create/idp/github.go
@@ -19,8 +19,8 @@ package idp
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"strings"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -222,7 +222,7 @@ func buildGithubIdp(cmd *cobra.Command,
 		// Get certificate contents
 		ca := ""
 		if caPath != "" {
-			cert, err := ioutil.ReadFile(caPath)
+			cert, err := os.ReadFile(caPath)
 			if err != nil {
 				return idpBuilder, fmt.Errorf("Expected a valid certificate bundle: %s", err)
 			}

--- a/cmd/create/idp/gitlab.go
+++ b/cmd/create/idp/gitlab.go
@@ -19,8 +19,8 @@ package idp
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/rosa/pkg/helper"
@@ -123,7 +123,7 @@ func buildGitlabIdp(cmd *cobra.Command,
 	// Get certificate contents
 	ca := ""
 	if caPath != "" {
-		cert, err := ioutil.ReadFile(caPath)
+		cert, err := os.ReadFile(caPath)
 		if err != nil {
 			return idpBuilder, fmt.Errorf("Expected a valid certificate bundle: %s", err)
 		}

--- a/cmd/create/idp/ldap.go
+++ b/cmd/create/idp/ldap.go
@@ -19,8 +19,8 @@ package idp
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"strings"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -109,7 +109,7 @@ func buildLdapIdp(cmd *cobra.Command,
 		if ldapInsecure {
 			return idpBuilder, fmt.Errorf("Cannot use certificate bundle with an insecure connection")
 		}
-		cert, err := ioutil.ReadFile(caPath)
+		cert, err := os.ReadFile(caPath)
 		if err != nil {
 			return idpBuilder, fmt.Errorf("Expected a valid certificate bundle: %s", err)
 		}

--- a/cmd/create/idp/openid.go
+++ b/cmd/create/idp/openid.go
@@ -19,8 +19,8 @@ package idp
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"strings"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -128,7 +128,7 @@ func buildOpenidIdp(cmd *cobra.Command,
 	// Get certificate contents
 	ca := ""
 	if caPath != "" {
-		cert, err := ioutil.ReadFile(caPath)
+		cert, err := os.ReadFile(caPath)
 		if err != nil {
 			return idpBuilder, fmt.Errorf("Expected a valid certificate bundle: %s", err)
 		}

--- a/cmd/edit/cluster/cmd.go
+++ b/cmd/edit/cluster/cmd.go
@@ -19,7 +19,6 @@ package cluster
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -497,7 +496,7 @@ func run(cmd *cobra.Command, _ []string) {
 		} else {
 			// Get certificate contents
 			if len(*additionalTrustBundleFile) > 0 {
-				cert, err := ioutil.ReadFile(*additionalTrustBundleFile)
+				cert, err := os.ReadFile(*additionalTrustBundleFile)
 				if err != nil {
 					r.Reporter.Errorf("Failed to read additional trust bundle file: %s", err)
 					os.Exit(1)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,7 +22,6 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -65,7 +64,7 @@ func Load() (cfg *Config, err error) {
 		return
 	}
 	// #nosec G304
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		err = fmt.Errorf("Failed to read config file '%s': %v", file, err)
 		return
@@ -94,7 +93,7 @@ func Save(cfg *Config) error {
 	if err != nil {
 		return fmt.Errorf("Failed to marshal config: %v", err)
 	}
-	err = ioutil.WriteFile(file, data, 0600)
+	err = os.WriteFile(file, data, 0600)
 	if err != nil {
 		return fmt.Errorf("Failed to write file '%s': %v", file, err)
 	}

--- a/pkg/logging/round_tripper.go
+++ b/pkg/logging/round_tripper.go
@@ -23,7 +23,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"mime"
 	"net/http"
 	"net/url"
@@ -118,7 +118,7 @@ func (d *RoundTripper) RoundTrip(request *http.Request) (response *http.Response
 	// reader that reads it from memory:
 	if request.Body != nil {
 		var body []byte
-		body, err = ioutil.ReadAll(request.Body)
+		body, err = io.ReadAll(request.Body)
 		if err != nil {
 			return
 		}
@@ -127,7 +127,7 @@ func (d *RoundTripper) RoundTrip(request *http.Request) (response *http.Response
 			return
 		}
 		d.dumpRequest(request, body)
-		request.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+		request.Body = io.NopCloser(bytes.NewBuffer(body))
 	} else {
 		d.dumpRequest(request, nil)
 	}
@@ -142,7 +142,7 @@ func (d *RoundTripper) RoundTrip(request *http.Request) (response *http.Response
 	// with a reader that reads it from memory:
 	if response.Body != nil {
 		var body []byte
-		body, err = ioutil.ReadAll(response.Body)
+		body, err = io.ReadAll(response.Body)
 		if err != nil {
 			return
 		}
@@ -151,7 +151,7 @@ func (d *RoundTripper) RoundTrip(request *http.Request) (response *http.Response
 			return
 		}
 		d.dumpResponse(response, body)
-		response.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+		response.Body = io.NopCloser(bytes.NewBuffer(body))
 	} else {
 		d.dumpResponse(response, nil)
 	}

--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -19,10 +19,10 @@ package ocm
 import (
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"strings"
 
@@ -115,7 +115,7 @@ func ValidateAdditionalTrustBundle(val interface{}) error {
 		if additionalTrustBundleFile == "" {
 			return nil
 		}
-		cert, err := ioutil.ReadFile(additionalTrustBundleFile)
+		cert, err := os.ReadFile(additionalTrustBundleFile)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
```
"io/ioutil" has been deprecated since Go 1.19: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.
```