### PR TITLE
SDA-8790 | fix: use parameter installer role arn when passed

### DIFF
--- a/cmd/create/oidcconfig/cmd.go
+++ b/cmd/create/oidcconfig/cmd.go
@@ -207,10 +207,15 @@ func run(cmd *cobra.Command, argv []string) {
 
 	if !args.managed {
 		if !args.rawFiles {
-			r.Reporter.Infof("This command will create a S3 bucket populating it with documents " +
-				"to be compliant with OIDC protocol. It will also create a Secret in Secrets Manager containing the private key")
-			if mode == aws.ModeAuto && (interactive.Enabled() || confirm.Yes()) {
+			if r.Reporter.IsTerminal() {
+				r.Reporter.Infof("This command will create a S3 bucket populating it with documents " +
+					"to be compliant with OIDC protocol. It will also create a Secret in Secrets Manager containing the private key")
+			}
+			if mode == aws.ModeAuto && (interactive.Enabled() || (confirm.Yes() && args.installerRoleArn == "")) {
 				args.installerRoleArn = interactive.GetInstallerRoleArn(r, cmd, args.installerRoleArn, minorVersionForGetSecret)
+			}
+			if r.Reporter.IsTerminal() {
+				r.Reporter.Infof("Using %s for the installer role", args.installerRoleArn)
 			}
 			if interactive.Enabled() {
 				prefix, err := interactive.GetString(interactive.Input{

--- a/pkg/interactive/helper.go
+++ b/pkg/interactive/helper.go
@@ -67,7 +67,6 @@ func GetInstallerRoleArn(r *rosa.Runtime, cmd *cobra.Command,
 		}
 		r.Reporter.Warnf("More than one %s role found", role.Name)
 		if !Enabled() && confirm.Yes() {
-			r.Reporter.Infof("Using %s for the %s role", defaultRoleARN, role.Name)
 			roleARN = defaultRoleARN
 		} else {
 			if roleARN != "" {


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-8790
# What
Should use passed role arn when creating the oidc config

# Why
Role ARN from arguments was being overwritten