### PR TITLE
SDA-8777 | feat: check if there are clusters using operator roles prefix

### DIFF
--- a/cmd/dlt/oidcconfig/cmd.go
+++ b/cmd/dlt/oidcconfig/cmd.go
@@ -169,7 +169,7 @@ func buildOidcConfigInput(r *rosa.Runtime) OidcConfigInput {
 	}
 
 	issuerUrl := oidcConfig.IssuerUrl()
-	hasClusterUsingOidcConfig, err := r.OCMClient.HasAClusterUsingOidcConfig(issuerUrl)
+	hasClusterUsingOidcConfig, err := r.OCMClient.HasAClusterUsingOidcEndpointUrl(issuerUrl)
 	if err != nil {
 		r.Reporter.Errorf("There was a problem checking if any clusters are using OIDC config '%s' : %v", issuerUrl, err)
 		os.Exit(1)

--- a/cmd/dlt/oidcprovider/cmd.go
+++ b/cmd/dlt/oidcprovider/cmd.go
@@ -153,7 +153,7 @@ func run(cmd *cobra.Command, argv []string) {
 			r.Reporter.Errorf("Failed to get the OIDC provider for cluster '%s'.", clusterKey)
 			os.Exit(1)
 		}
-		hasClusterUsingOidcProvider, err := r.OCMClient.HasAClusterUsingOidcProvider(oidcEndpointUrl)
+		hasClusterUsingOidcProvider, err := r.OCMClient.HasAClusterUsingOidcEndpointUrl(oidcEndpointUrl)
 		if err != nil {
 			r.Reporter.Errorf("There was a problem checking if any clusters are using OIDC provider '%s' : %v",
 				oidcEndpointUrl, err)

--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -379,9 +379,9 @@ func (c *Client) GetPendingClusterForARN(creator *aws.Creator) (cluster *cmv1.Cl
 	return response.Items().Get(0), nil
 }
 
-func (c *Client) HasAClusterUsingOidcConfig(issuerUrl string) (bool, error) {
+func (c *Client) HasAClusterUsingOperatorRolesPrefix(prefix string) (bool, error) {
 	query := fmt.Sprintf(
-		"aws.sts.oidc_endpoint_url = '%s'", issuerUrl,
+		"aws.sts.operator_iam_roles.role_arn like '%%/%s-%%'", prefix,
 	)
 	request := c.ocm.ClustersMgmt().V1().Clusters().List().Search(query)
 	page := 1
@@ -395,9 +395,9 @@ func (c *Client) HasAClusterUsingOidcConfig(issuerUrl string) (bool, error) {
 	return false, nil
 }
 
-func (c *Client) HasAClusterUsingOidcProvider(oidcEndpointURL string) (bool, error) {
+func (c *Client) HasAClusterUsingOidcEndpointUrl(issuerUrl string) (bool, error) {
 	query := fmt.Sprintf(
-		"aws.sts.oidc_endpoint_url = '%s'", oidcEndpointURL,
+		"aws.sts.oidc_endpoint_url = '%s'", issuerUrl,
 	)
 	request := c.ocm.ClustersMgmt().V1().Clusters().List().Search(query)
 	page := 1


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-8777
# What
Check if clusters are using operator roles prefix before removing roles

# Why
Ensures roles are not removed from working clusters