### PR TITLE
SDA-8808 | feat: add aws account ID to filter unmanaged OIDC configs

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -590,7 +590,7 @@ func networkTypeCompletion(cmd *cobra.Command, args []string, toComplete string)
 }
 
 func run(cmd *cobra.Command, _ []string) {
-	r := rosa.NewRuntime().WithOCM()
+	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
 
 	supportedRegions, err := r.OCMClient.GetDatabaseRegionList()

--- a/cmd/list/oidcconfig/cmd.go
+++ b/cmd/list/oidcconfig/cmd.go
@@ -42,12 +42,12 @@ func init() {
 }
 
 func run(_ *cobra.Command, _ []string) {
-	r := rosa.NewRuntime().WithOCM()
+	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
 
 	// Load any existing ingresses for this cluster
 	r.Reporter.Debugf("Loading oidc configs for current org id")
-	oidcConfigs, err := r.OCMClient.ListOidcConfigs()
+	oidcConfigs, err := r.OCMClient.ListOidcConfigs(r.Creator.AccountID)
 	if err != nil {
 		r.Reporter.Errorf("Failed to list OIDC Configurations: %v", err)
 		os.Exit(1)

--- a/pkg/interactive/helper.go
+++ b/pkg/interactive/helper.go
@@ -15,7 +15,7 @@ import (
 )
 
 func GetOidcConfigID(r *rosa.Runtime, cmd *cobra.Command) string {
-	oidcConfigs, err := r.OCMClient.ListOidcConfigs()
+	oidcConfigs, err := r.OCMClient.ListOidcConfigs(r.Creator.AccountID)
 	if err != nil {
 		r.Reporter.Warnf("There was a problem retrieving OIDC Configurations "+
 			"for your organization: %v", err)

--- a/pkg/ocm/oidc_config.go
+++ b/pkg/ocm/oidc_config.go
@@ -14,6 +14,8 @@ limitations under the License.
 package ocm
 
 import (
+	"fmt"
+
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
@@ -28,10 +30,11 @@ func (c *Client) GetOidcConfig(id string) (*cmv1.OidcConfig, error) {
 	return response.Body(), nil
 }
 
-func (c *Client) ListOidcConfigs() ([]*cmv1.OidcConfig, error) {
+func (c *Client) ListOidcConfigs(awsAccountId string) ([]*cmv1.OidcConfig, error) {
 	response, err := c.ocm.ClustersMgmt().V1().
 		OidcConfigs().
 		List().Page(1).Size(-1).
+		Parameter("search", fmt.Sprintf("aws.account_id='%s' or aws.account_id=''", awsAccountId)).
 		Send()
 	if err != nil {
 		return nil, handleErr(response.Error(), err)


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-8808
# What
Filters unmanaged OIDC configs by aws account ID

# Why
When customer selects a config from a different account cluster install will fail