### PR TITLE
fix: small issue when customer sets up oidc provider with issuer url '/' at the end

### DIFF
--- a/cmd/dlt/oidcprovider/cmd.go
+++ b/cmd/dlt/oidcprovider/cmd.go
@@ -150,7 +150,7 @@ func run(cmd *cobra.Command, argv []string) {
 		}
 		providerArn, err = r.AWSClient.GetOpenIDConnectProviderByOidcEndpointUrl(oidcEndpointUrl)
 		if err != nil {
-			r.Reporter.Errorf("Failed to get the OIDC provider for cluster '%s'.", clusterKey)
+			r.Reporter.Errorf("Failed to get the OIDC provider for endpoint URL '%s': %v", oidcEndpointUrl, err)
 			os.Exit(1)
 		}
 		hasClusterUsingOidcProvider, err := r.OCMClient.HasAClusterUsingOidcEndpointUrl(oidcEndpointUrl)

--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -765,12 +765,17 @@ func GetResourceIdFromARN(stringARN string) (string, error) {
 	parsedARN, err := arn.Parse(stringARN)
 
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("couldn't parse arn '%s': %v", stringARN, err)
 	}
 
 	index := strings.LastIndex(parsedARN.Resource, "/")
-	if index == -1 || index == len(parsedARN.Resource)-1 {
+	if index == -1 {
 		return "", fmt.Errorf("can't find resource-id in ARN '%s'", stringARN)
+	}
+
+	// If the customer has created the provider using a / at the end of the URL for some reason
+	if index == len(parsedARN.Resource)-1 {
+		return GetResourceIdFromARN(stringARN[:index])
 	}
 
 	return parsedARN.Resource[index+1:], nil


### PR DESCRIPTION
# What
When customer sets up oidc provider using '/' at the end of the URL the deletion process fails

# Why
Fixes a flow issue