### PR TITLE
SDA-6239 | fix: Add message to helper --delete param on init cmd

### DIFF
--- a/cmd/initialize/cmd.go
+++ b/cmd/initialize/cmd.go
@@ -65,7 +65,7 @@ func init() {
 		&args.dlt,
 		"delete-stack",
 		false,
-		"Deletes stack template applied to your AWS account during the 'init' command.\n",
+		"Deletes stack template applied to your AWS account during the 'init' command.",
 	)
 	flags.MarkDeprecated("delete-stack", "use --delete instead")
 
@@ -73,7 +73,7 @@ func init() {
 		&args.dlt,
 		"delete",
 		false,
-		"",
+		"Deletes stack template applied to your AWS account during the 'init' command.",
 	)
 
 	flags.BoolVar(


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-6239
# What
Adds message from the deprecated value this substituted

# Why
There was no helper message