### PR TITLE
SDA-6562 | feat: skip subnet choice when AZ is supplied

### DIFF
--- a/cmd/create/machinepool/helper.go
+++ b/cmd/create/machinepool/helper.go
@@ -10,8 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func getSubnetFromUser(cmd *cobra.Command, r *rosa.Runtime, isSubnetSet bool,
-	cluster *cmv1.Cluster) string {
+func getSubnetFromUser(cmd *cobra.Command, r *rosa.Runtime, isSubnetSet bool, cluster *cmv1.Cluster) string {
 	var selectSubnet bool
 	var subnet string
 	var err error

--- a/cmd/create/machinepool/machinepool.go
+++ b/cmd/create/machinepool/machinepool.go
@@ -120,7 +120,7 @@ func addMachinePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster
 
 		if !multiAZMachinePool {
 			// Allow to create a single AZ machine pool providing the subnet
-			if isBYOVPC(cluster) {
+			if isBYOVPC(cluster) && args.availabilityZone == "" {
 				subnet = getSubnetFromUser(cmd, r, isSubnetSet, cluster)
 			}
 


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-6562
# What
Shows only subnets from supplied AZ

# Why
So as not to show user subnets he might not be interest in