### PR TITLE
SDA-8770 | fix: accept only official default prefix when selecting default prefix

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -833,7 +833,11 @@ func run(cmd *cobra.Command, _ []string) {
 			defaultRoleARN := roleARNs[0]
 			// Prioritize roles with the default prefix
 			for _, rARN := range roleARNs {
-				if strings.Contains(rARN, fmt.Sprintf("%s-%s-Role", aws.DefaultPrefix, role.Name)) {
+				roleName, err := aws.GetResourceIdFromARN(rARN)
+				if err != nil {
+					continue
+				}
+				if roleName == fmt.Sprintf("%s-%s-Role", aws.DefaultPrefix, role.Name) {
 					defaultRoleARN = rARN
 				}
 			}

--- a/pkg/interactive/helper.go
+++ b/pkg/interactive/helper.go
@@ -61,7 +61,11 @@ func GetInstallerRoleArn(r *rosa.Runtime, cmd *cobra.Command,
 		defaultRoleARN := roleARNs[0]
 		// Prioritize roles with the default prefix
 		for _, rARN := range roleARNs {
-			if strings.Contains(rARN, fmt.Sprintf("%s-%s-Role", aws.DefaultPrefix, role.Name)) {
+			roleName, err := aws.GetResourceIdFromARN(rARN)
+			if err != nil {
+				continue
+			}
+			if roleName == fmt.Sprintf("%s-%s-Role", aws.DefaultPrefix, role.Name) {
 				defaultRoleARN = rARN
 			}
 		}


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-8770
# What
Selects only official default prefix when selecting as part of auto confirm mode

# Why
Non official default prefix shouldn't be selected without args being supplied