### PR TITLE
SDA-7708 | fix: remove --tags param from example for usage

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -280,7 +280,7 @@ func init() {
 		"tags",
 		nil,
 		"Apply user defined tags to all resources created by ROSA in AWS."+
-			"Tags are comma separated, for example: --tags=foo:bar,bar:baz",
+			"Tags are comma separated, for example: 'foo:bar,bar:baz'",
 	)
 
 	flags.BoolVar(

--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -246,11 +246,11 @@ func UserTagValidator(input interface{}) error {
 		tags := strings.Split(str, ",")
 		for _, t := range tags {
 			if !strings.Contains(t, ":") {
-				return fmt.Errorf("invalid tag format, Tags are comma separated, for example: --tags=foo:bar,bar:baz")
+				return fmt.Errorf("invalid tag format, Tags are comma separated, for example: 'foo:bar,bar:baz'")
 			}
 			tag := strings.Split(t, ":")
 			if len(tag) != 2 {
-				return fmt.Errorf("invalid tag format. Expected tag format: --tags=key:value")
+				return fmt.Errorf("invalid tag format. Expected tag format: 'key:value'")
 			}
 			if !UserTagKeyRE.MatchString(tag[0]) {
 				return fmt.Errorf("expected a valid user tag key '%s' matching %s", tag[0], UserTagKeyRE.String())


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-7708
# What
Removes the actual param when exemplifying tags usage

# Why
Easier for user to understand