### PR TITLE
Warn about `version` flag in combination with HCP managed policies

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -172,6 +172,11 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
+	if args.hostedCP && cmd.Flags().Changed("version") {
+		r.Reporter.Warnf("Setting `version` flag for hosted CP managed policies has no effect, " +
+			"any supported ROSA version can be installed with managed policies")
+	}
+
 	// Hosted cluster roles always use managed policies
 	if cmd.Flags().Changed("hosted-cp") && cmd.Flags().Changed("managed-policies") && !args.managed {
 		r.Reporter.Errorf("Setting `hosted-cp` as unmanaged policies is not supported")


### PR DESCRIPTION
Related: [SDA-8842](https://issues.redhat.com/browse/SDA-8842)

![image](https://user-images.githubusercontent.com/57869309/232498158-3b618f1b-a25d-4758-a65c-5b2aee233e21.png)
