### PR TITLE
fix: trims trailing slash in ocm api when checking env

### DIFF
--- a/pkg/ocm/config.go
+++ b/pkg/ocm/config.go
@@ -21,6 +21,7 @@ package ocm
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/openshift/rosa/pkg/config"
 	"github.com/openshift/rosa/pkg/fedramp"
@@ -50,7 +51,7 @@ func GetEnv() (string, error) {
 	}
 
 	for env, api := range urlAliases {
-		if api == cfg.URL {
+		if api == strings.TrimSuffix(cfg.URL, "/") {
 			return env, nil
 		}
 	}


### PR DESCRIPTION
Related issue: https://github.com/openshift/rosa/issues/975