### PR TITLE
feat: Create cluster - filter roles by policy type

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -892,7 +892,7 @@ func run(cmd *cobra.Command, _ []string) {
 		role := aws.AccountRoles[aws.InstallerAccountRole]
 
 		// Find all installer roles in the current account using AWS resource tags
-		roleARNs, err := awsClient.FindRoleARNs(aws.InstallerAccountRole, minor)
+		roleARNs, err := awsClient.FindRoleARNsByPolicyType(aws.InstallerAccountRole, minor, isHostedCP)
 		if err != nil {
 			r.Reporter.Errorf("Failed to find %s role: %s", role.Name, err)
 			os.Exit(1)
@@ -959,7 +959,7 @@ func run(cmd *cobra.Command, _ []string) {
 					// Not needed for Hypershift clusters
 					continue
 				}
-				roleARNs, err := awsClient.FindRoleARNs(roleType, minor)
+				roleARNs, err := awsClient.FindRoleARNsByPolicyType(roleType, minor, isHostedCP)
 				if err != nil {
 					r.Reporter.Errorf("Failed to find %s role: %s", role.Name, err)
 					os.Exit(1)

--- a/cmd/create/oidcconfig/cmd.go
+++ b/cmd/create/oidcconfig/cmd.go
@@ -220,7 +220,8 @@ func run(cmd *cobra.Command, argv []string) {
 					"to be compliant with OIDC protocol. It will also create a Secret in Secrets Manager containing the private key")
 			}
 			if mode == aws.ModeAuto && (interactive.Enabled() || (confirm.Yes() && args.installerRoleArn == "")) {
-				args.installerRoleArn = interactive.GetInstallerRoleArn(r, cmd, args.installerRoleArn, minorVersionForGetSecret)
+				args.installerRoleArn = interactive.GetInstallerRoleArn(r, cmd, args.installerRoleArn,
+					minorVersionForGetSecret, false, false)
 			}
 			if interactive.Enabled() {
 				prefix, err := interactive.GetString(interactive.Input{

--- a/cmd/create/operatorroles/by_prefix.go
+++ b/cmd/create/operatorroles/by_prefix.go
@@ -55,7 +55,8 @@ func handleOperatorRolesPrefixOptions(r *rosa.Runtime, cmd *cobra.Command) {
 		os.Exit(1)
 	}
 	args.hostedCp = isHostedCP
-	args.installerRoleArn = interactive.GetInstallerRoleArn(r, cmd, args.installerRoleArn, "")
+	args.installerRoleArn = interactive.GetInstallerRoleArn(r, cmd, args.installerRoleArn, "",
+		true, args.hostedCp)
 }
 
 func handleOperatorRoleCreationByPrefix(r *rosa.Runtime, env string,

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -117,6 +117,7 @@ type Client interface {
 	DeleteOpenIDConnectProvider(providerURL string) error
 	HasOpenIDConnectProvider(issuerURL string, accountID string) (bool, error)
 	FindRoleARNs(roleType string, version string) ([]string, error)
+	FindRoleARNsByPolicyType(roleType string, version string, requireHostedCPPolicies bool) ([]string, error)
 	FindPolicyARN(operator Operator, version string) (string, error)
 	ListUserRoles() ([]Role, error)
 	ListOCMRoles() ([]Role, error)
@@ -185,6 +186,8 @@ type Client interface {
 	DeleteSecretInSecretsManager(secretArn string) error
 	ValidateAccountRoleVersionCompatibility(
 		roleName string, roleType string, minVersion string) (bool, error)
+	ValidateAccountRoleVersionCompatibilityByPolicyType(
+		roleName string, roleType string, minVersion string, requireHostedCPPolicies bool) (bool, error)
 }
 
 // ClientBuilder contains the information and logic needed to build a new AWS client.

--- a/pkg/interactive/helper.go
+++ b/pkg/interactive/helper.go
@@ -43,14 +43,20 @@ func GetOidcConfigID(r *rosa.Runtime, cmd *cobra.Command) string {
 }
 
 func GetInstallerRoleArn(r *rosa.Runtime, cmd *cobra.Command,
-	defaultInstallerRoleArn string, minMinorVersion string) string {
+	defaultInstallerRoleArn string, minMinorVersion string, filterByPolicyType bool, requireHostedCPPolicies bool) string {
 	spin := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
 	spin.Start()
 	awsClient := r.AWSClient
 	role := aws.AccountRoles[aws.InstallerAccountRole]
 	roleARN := defaultInstallerRoleArn
 	// Find all installer roles in the current account using AWS resource tags
-	roleARNs, err := awsClient.FindRoleARNs(aws.InstallerAccountRole, minMinorVersion)
+	var roleARNs []string
+	var err error
+	if filterByPolicyType {
+		roleARNs, err = awsClient.FindRoleARNsByPolicyType(aws.InstallerAccountRole, minMinorVersion, requireHostedCPPolicies)
+	} else {
+		roleARNs, err = awsClient.FindRoleARNs(aws.InstallerAccountRole, minMinorVersion)
+	}
 	if err != nil {
 		r.Reporter.Errorf("Failed to find %s role: %s", role.Name, err)
 		os.Exit(1)


### PR DESCRIPTION
For hosted CP cluster display only roles with hosted CP managed policies. 
For classic cluster display only roles with unmanaged policies.

Related: [SDA-8843](https://issues.redhat.com/browse/SDA-8843)

For hosted CP it chooses the only set with managed CP policies:
![image](https://user-images.githubusercontent.com/57869309/232806945-32266dba-49e7-4c3c-9fe1-92714bd4c1be.png)

For classic it displays all roles excluding roles with CP managed policies:
![image](https://user-images.githubusercontent.com/57869309/232807026-ea8e8749-c7e3-4053-b1fd-1c5ff94d8944.png)
