### PR TITLE
SDA-8861 | feat: add --etcd-encryption-kms-arn to cluster build command when in use

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2734,6 +2734,9 @@ func buildCommand(spec ocm.Spec, operatorRolesPrefix string,
 	if spec.Hypershift.Enabled {
 		command += " --hosted-cp"
 	}
+	if spec.EtcdEncryptionKMSArn != "" {
+		command += fmt.Sprintf(" --etcd-encryption-kms-arn %s", spec.EtcdEncryptionKMSArn)
+	}
 
 	return command
 }


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-8861
# What
Add param when building commands for creating cluster

# Why
Currently missing param