### PR TITLE
SDA-8897 | fix: shared operator roles with managed policies

### DIFF
--- a/cmd/upgrade/roles/cmd.go
+++ b/cmd/upgrade/roles/cmd.go
@@ -301,7 +301,7 @@ func run(cmd *cobra.Command, argv []string) error {
 					if args.isInvokedFromClusterUpgrade {
 						return err
 					}
-					reporter.Errorf("Error upgrading the account role polices: %s", err)
+					reporter.Errorf("Error upgrading the account role policies: %s", err)
 					os.Exit(1)
 				}
 			}

--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -1703,7 +1703,7 @@ func (c *awsClient) checkPolicyExistsAndUpToDate(policyARN string, policyVersion
 func (c *awsClient) isRolePolicyUpToDate(policyARN string, policyVersion string) (bool, error) {
 	isCompatible, err := c.isRolePoliciesCompatibleForUpgrade(policyARN, policyVersion)
 	if err != nil {
-		return false, errors.Errorf("Failed to validate role polices : %v", err)
+		return false, errors.Errorf("Failed to validate role policies : %v", err)
 	}
 	if !isCompatible {
 		return false, nil

--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -813,6 +813,14 @@ func ValidateOperatorRolesMatchOidcProvider(awsClient aws.Client,
 			return weberr.Errorf("Operator role '%s' does not have trusted relationship to '%s' issuer URL",
 				roleARN, parsedUrl.Host)
 		}
+		hasManagedPolicies, err := awsClient.HasManagedPolicies(roleARN)
+		if err != nil {
+			return err
+		}
+		if hasManagedPolicies {
+			// Managed policies should be compatible with all versions
+			continue
+		}
 		policiesDetails, err := awsClient.GetAttachedPolicy(roleObject.RoleName)
 		if err != nil {
 			return err


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-8897
# What
When using shared operator roles with managed policies the validation does not need to consider the policies version

# Why
Managed policies are compatible with all cluster versions