### PR TITLE
SDA-8880 | Fix: implement list upgrades for Hypershift

### DIFF
--- a/cmd/describe/upgrade/cmd.go
+++ b/cmd/describe/upgrade/cmd.go
@@ -48,7 +48,7 @@ func run(cmd *cobra.Command, argv []string) {
 
 	// Try to find the cluster:
 	r.Reporter.Debugf("Loading upgrade with id '%s'", cluster.ID())
-	if cluster.Hypershift().Enabled() {
+	if ocm.IsHyperShiftCluster(cluster) {
 		returnHypershiftUpgrades(r, cluster.ID())
 	} else {
 		returnClassicUpgrades(r, cluster.ID())

--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -911,3 +911,7 @@ func (c *Client) ResumeCluster(clusterID string) error {
 func IsConsoleAvailable(cluster *cmv1.Cluster) bool {
 	return cluster.Console() != nil && cluster.Console().URL() != ""
 }
+
+func IsHyperShiftCluster(cluster *cmv1.Cluster) bool {
+	return cluster != nil && cluster.Hypershift() != nil && cluster.Hypershift().Enabled()
+}


### PR DESCRIPTION
This implements `rosa list upgrade` command for Hypershift clusters

Example
```
rosa list upgrade -c 2380giimi8ahlqk4g6af942749u9o9p4
VERSION      NOTES
4.13.0-rc.4  recommended
4.13.0-rc.3
4.13.0-rc.2
4.12.14      recommended
4.12.13      scheduled for 2023-04-21 09:47 UTC
4.12.11
4.12.10
```
It is now aligned with `rosa describe upgrade`
```
rosa describe upgrade -c 2380giimi8ahlqk4g6af942749u9o9p4
                ID:                         1c000386-e028-11ed-b02d-0a580a800b63
		Cluster ID:                 2380giimi8ahlqk4g6af942749u9o9p4
		Next Run:                   2023-04-21 09:47:00 +0000 UTC
		Upgrade State:              scheduled
                Version:                    4.12.13
```

Related: [SDA-8880](https://issues.redhat.com//browse/SDA-8880)