### PR TITLE
fix: Add flag to bypass confirmation for hibernate/resume

### DIFF
--- a/cmd/hibernate/cluster/cmd.go
+++ b/cmd/hibernate/cluster/cmd.go
@@ -38,6 +38,7 @@ var Cmd = &cobra.Command{
 
 func init() {
 	ocm.AddClusterFlag(Cmd)
+	confirm.AddFlag(Cmd.Flags())
 }
 
 func run(cmd *cobra.Command, _ []string) {
@@ -55,7 +56,7 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
-	if !confirm.Confirm("hibernate cluster %s", clusterKey) {
+	if !confirm.Yes() && !confirm.Confirm("hibernate cluster %s", clusterKey) {
 		os.Exit(1)
 	}
 

--- a/cmd/hibernate/cluster/cmd.go
+++ b/cmd/hibernate/cluster/cmd.go
@@ -27,18 +27,18 @@ import (
 	"github.com/openshift/rosa/pkg/rosa"
 )
 
-var Cmd = &cobra.Command{
-	Use:   "cluster",
-	Short: "Hibernate cluster",
-	Long:  "Hibernate cluster.",
-	Example: `  # Hibernate the cluster
+func GenerateCommand() *cobra.Command {
+	var Cmd = &cobra.Command{
+		Use:   "cluster",
+		Short: "Hibernate cluster",
+		Long:  "Hibernate cluster.",
+		Example: `  # Hibernate the cluster
   rosa hibernate cluster -c mycluster`,
-	Run: run,
-}
-
-func init() {
+		Run: run,
+	}
 	ocm.AddClusterFlag(Cmd)
 	confirm.AddFlag(Cmd.Flags())
+	return Cmd
 }
 
 func run(cmd *cobra.Command, _ []string) {

--- a/cmd/hibernate/cmd.go
+++ b/cmd/hibernate/cmd.go
@@ -23,16 +23,16 @@ import (
 	"github.com/openshift/rosa/pkg/arguments"
 )
 
-var Cmd = &cobra.Command{
-	Use:    "hibernate",
-	Short:  "Hibernate cluster",
-	Long:   "Hibernate Ready cluster",
-	Hidden: true,
-}
-
-func init() {
-	Cmd.AddCommand(cluster.Cmd)
+func GenerateCommand() *cobra.Command {
+	var Cmd = &cobra.Command{
+		Use:    "hibernate",
+		Short:  "Hibernate cluster",
+		Long:   "Hibernate Ready cluster",
+		Hidden: true,
+	}
+	Cmd.AddCommand(cluster.GenerateCommand())
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)
 	arguments.AddRegionFlag(flags)
+	return Cmd
 }

--- a/cmd/resume/cluster/cmd.go
+++ b/cmd/resume/cluster/cmd.go
@@ -38,6 +38,7 @@ var Cmd = &cobra.Command{
 
 func init() {
 	ocm.AddClusterFlag(Cmd)
+	confirm.AddFlag(Cmd.Flags())
 }
 
 func run(cmd *cobra.Command, _ []string) {
@@ -53,7 +54,7 @@ func run(cmd *cobra.Command, _ []string) {
 			clusterKey, cluster.State())
 		os.Exit(1)
 	}
-	if !confirm.Confirm("resume cluster %s", clusterKey) {
+	if !confirm.Yes() && !confirm.Confirm("resume cluster %s", clusterKey) {
 		os.Exit(1)
 	}
 	err := r.OCMClient.ResumeCluster(cluster.ID())

--- a/cmd/resume/cluster/cmd.go
+++ b/cmd/resume/cluster/cmd.go
@@ -27,18 +27,18 @@ import (
 	"github.com/openshift/rosa/pkg/rosa"
 )
 
-var Cmd = &cobra.Command{
-	Use:   "cluster",
-	Short: "Resume cluster",
-	Long:  "Resume cluster.",
-	Example: `  # Resume the cluster
+func GenerateCommand() *cobra.Command {
+	var Cmd = &cobra.Command{
+		Use:   "cluster",
+		Short: "Resume cluster",
+		Long:  "Resume cluster.",
+		Example: `  # Resume the cluster
   rosa resume cluster -c mycluster`,
-	Run: run,
-}
-
-func init() {
+		Run: run,
+	}
 	ocm.AddClusterFlag(Cmd)
 	confirm.AddFlag(Cmd.Flags())
+	return Cmd
 }
 
 func run(cmd *cobra.Command, _ []string) {

--- a/cmd/resume/cmd.go
+++ b/cmd/resume/cmd.go
@@ -23,16 +23,16 @@ import (
 	"github.com/openshift/rosa/pkg/arguments"
 )
 
-var Cmd = &cobra.Command{
-	Use:    "resume",
-	Short:  "Resume cluster",
-	Long:   "Resume Hibernate cluster",
-	Hidden: true,
-}
-
-func init() {
-	Cmd.AddCommand(cluster.Cmd)
+func GenerateCommand() *cobra.Command {
+	var Cmd = &cobra.Command{
+		Use:    "resume",
+		Short:  "Resume cluster",
+		Long:   "Resume Hibernate cluster",
+		Hidden: true,
+	}
+	Cmd.AddCommand(cluster.GenerateCommand())
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)
 	arguments.AddRegionFlag(flags)
+	return Cmd
 }

--- a/cmd/rosa/main.go
+++ b/cmd/rosa/main.go
@@ -86,8 +86,8 @@ func init() {
 	root.AddCommand(verify.Cmd)
 	root.AddCommand(version.Cmd)
 	root.AddCommand(whoami.Cmd)
-	root.AddCommand(hibernate.Cmd)
-	root.AddCommand(resume.Cmd)
+	root.AddCommand(hibernate.GenerateCommand())
+	root.AddCommand(resume.GenerateCommand())
 	root.AddCommand(link.Cmd)
 	root.AddCommand(unlink.Cmd)
 }


### PR DESCRIPTION
When calling `rosa hibernate|resume cluster` it always asks for a confirmation. However, the `--help` text does not show that the confirmation prompt can be bypassed with the `--yes`.

This PR adds the --yes flag to these operations.