### PR TITLE
SDA-8914 | fix: rosa upgrade hcp account roles - handle edge cases

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -256,6 +256,10 @@ func run(cmd *cobra.Command, argv []string) {
 		r.Reporter.Errorf("Expected a valid role prefix matching %s", aws.RoleNameRE.String())
 		os.Exit(1)
 	}
+	if !args.hostedCP && strings.HasSuffix(prefix, "-HCP") {
+		r.Reporter.Errorf("The '-HCP' suffix is reserved for hosted CP managed policies")
+		os.Exit(1)
+	}
 
 	permissionsBoundary := args.permissionsBoundary
 	if interactive.Enabled() {


### PR DESCRIPTION
1. Prevent creating classic account roles with prefixes ending with `-HCP`.
2. Improve the error message for `rosa upgrade account-roles`.

Prevent `-HCP` for classic account roles:
![image](https://user-images.githubusercontent.com/57869309/234022927-666c8a78-872c-449a-8363-50005e4330ff.png)

Improve `upgrade account roles` error messages:
![image](https://user-images.githubusercontent.com/57869309/234023042-4a484b7a-00f3-473e-8f07-9b117c0d8cc9.png)
![image](https://user-images.githubusercontent.com/57869309/234023077-1b6b68a8-3c53-4840-8185-0579be887967.png)
