### PR TITLE
SDA-8690 Update replicas help message for hosted-cp cluster

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -436,7 +436,8 @@ func init() {
 		"replicas",
 		2,
 		"Number of worker nodes to provision. Single zone clusters need at least 2 nodes, "+
-			"multizone clusters need at least 3 nodes.",
+			"multizone clusters need at least 3 nodes. Hosted clusters require that the number of worker nodes be a "+
+			"multiple of the number of private subnets.",
 	)
 
 	flags.BoolVar(


### PR DESCRIPTION
Update the help message to include the hosted cluster case.