### PR TITLE
SDA-8382| Fix: delete tuning config bad definition

### DIFF
--- a/cmd/dlt/tuningconfigs/cmd.go
+++ b/cmd/dlt/tuningconfigs/cmd.go
@@ -28,7 +28,7 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:     "tuning config name",
+	Use:     "tuning-configs",
 	Aliases: []string{"tuningconfig", "tuningconfigs", "tuning-config"},
 	Short:   "Delete tuning config",
 	Long:    "Delete a tuning config for a cluster.",


### PR DESCRIPTION
Align the command to the rest of tuning config commands to accept
```
rosa delete tuning-config -c <cluster> name
```

Related: [SDA-8382](https://issues.redhat.com//browse/SDA-8382)