### PR TITLE
SDA-8716 | Fix: provide warning message when no OIDC config is found

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2369,6 +2369,7 @@ func handleOidcConfigOptions(r *rosa.Runtime, cmd *cobra.Command, isSTS bool, is
 	}
 	if oidcConfigId == "" {
 		if !isHostedCP {
+			r.Reporter.Warnf("No OIDC Configuration found; will continue with the classic flow.")
 			return nil
 		}
 		if args.classicOidcConfig {


### PR DESCRIPTION
ref: https://issues.redhat.com/browse/SDA-8716?filter=-1