### PR TITLE
SDA-8600 | feat: add interactive option for delete account roles

### DIFF
--- a/cmd/dlt/accountroles/accountroles_suite_test.go
+++ b/cmd/dlt/accountroles/accountroles_suite_test.go
@@ -1,0 +1,13 @@
+package accountroles
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCluster(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Account roles Suite")
+}

--- a/cmd/dlt/accountroles/cmd_test.go
+++ b/cmd/dlt/accountroles/cmd_test.go
@@ -1,0 +1,29 @@
+package accountroles
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Delete account roles", func() {
+	It("Deletes all account-roles if the user didn't specify topology", func() {
+		deleteClassic, deleteHostedCP := setDeleteRoles(false, false)
+		Expect(deleteClassic).To(Equal(true))
+		Expect(deleteHostedCP).To(Equal(true))
+	})
+	It("Deletes only hosted CP account-roles if the user selected '--hosted-cp'", func() {
+		deleteClassic, deleteHostedCP := setDeleteRoles(false, true)
+		Expect(deleteClassic).To(Equal(false))
+		Expect(deleteHostedCP).To(Equal(true))
+	})
+	It("Deletes only classic account-roles if the user selected '--classic'", func() {
+		deleteClassic, deleteHostedCP := setDeleteRoles(true, false)
+		Expect(deleteClassic).To(Equal(true))
+		Expect(deleteHostedCP).To(Equal(false))
+	})
+	It("Deletes all account-roles if the user selected both '--classic' and '--hosted-cp'", func() {
+		deleteClassic, deleteHostedCP := setDeleteRoles(true, true)
+		Expect(deleteClassic).To(Equal(true))
+		Expect(deleteHostedCP).To(Equal(true))
+	})
+})


### PR DESCRIPTION
For the interactive mode, prompt a message for deleting hosted CP account roles.

![image](https://user-images.githubusercontent.com/57869309/235425270-d646cba3-c5fc-4e24-a193-2c5d1cd78e30.png)

