### PR TITLE
SDA-8636 | fix: OIDC provider behavior when calling internally from oidc config flow

### DIFF
--- a/cmd/create/oidcprovider/cmd.go
+++ b/cmd/create/oidcprovider/cmd.go
@@ -83,6 +83,7 @@ func run(cmd *cobra.Command, argv []string) {
 
 	// Allow the command to be called programmatically
 	isProgmaticallyCalled := false
+	shouldUseClusterKey := true
 	if len(argv) == 3 && !cmd.Flag("cluster").Changed {
 		ocm.SetClusterKey(argv[0])
 		aws.SetModeKey(argv[1])
@@ -93,6 +94,7 @@ func run(cmd *cobra.Command, argv []string) {
 
 		if argv[2] != "" {
 			args.oidcEndpointUrl = argv[2]
+			shouldUseClusterKey = false
 		}
 	}
 
@@ -116,7 +118,7 @@ func run(cmd *cobra.Command, argv []string) {
 
 	var cluster *cmv1.Cluster
 	clusterKey := ""
-	if cmd.Flags().Changed("cluster") || isProgmaticallyCalled {
+	if cmd.Flags().Changed("cluster") || (isProgmaticallyCalled && shouldUseClusterKey) {
 		clusterKey = r.GetClusterKey()
 		cluster = r.FetchCluster()
 		if !ocm.IsSts(cluster) {


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-8636
# What
When calling from oidc config flow the cluster ID is unknow

# Why
Was failing to create the oidc provider from oidc config flow