### PR TITLE
SDA-9041 | feat: defaults to managed oidc configs

### DIFF
--- a/cmd/create/oidcconfig/cmd.go
+++ b/cmd/create/oidcconfig/cmd.go
@@ -97,7 +97,7 @@ func init() {
 	flags.BoolVar(
 		&args.managed,
 		managedFlag,
-		false,
+		true,
 		"Indicates whether it is a Red Hat managed or unmanaged (Customer hosted) OIDC Configuration.",
 	)
 


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-9041

# Why
Managed configs are easier to setup and use