### PR TITLE
SDA-9048 | feat: add messages and checks to ensure a better flow UX wise

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -362,8 +362,12 @@ func run(cmd *cobra.Command, argv []string) {
 		} else {
 			createClusterFlag = "--sts"
 		}
-		r.Reporter.Infof(fmt.Sprintf("To create a cluster with these roles, run the following command:\n"+
-			"rosa create cluster %s", createClusterFlag))
+		if r.Reporter.IsTerminal() {
+			r.Reporter.Infof("To create an OIDC Config, run the following command:\n" +
+				"\trosa create oidc-config")
+			r.Reporter.Infof(fmt.Sprintf("To create a cluster with these roles, run the following command:\n"+
+				"\trosa create cluster %s", createClusterFlag))
+		}
 		r.OCMClient.LogEvent("ROSACreateAccountRolesModeAuto", map[string]string{
 			ocm.Response: ocm.Success,
 			ocm.Version:  policyVersion,

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1195,9 +1195,9 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	operatorRolesPrefix := args.operatorRolesPrefix
-	operatorRolePath, _ := aws.GetPathFromARN(roleARN)
+	expectedOperatorRolePath, _ := aws.GetPathFromARN(roleARN)
 	operatorIAMRoles := args.operatorIAMRoles
-	operatorIAMRoleList := []ocm.OperatorIAMRole{}
+	computedOperatorIamRoleList := []ocm.OperatorIAMRole{}
 	if isSTS {
 		if operatorRolesPrefix == "" {
 			operatorRolesPrefix = getRolePrefix(clusterName)
@@ -1250,9 +1250,10 @@ func run(cmd *cobra.Command, _ []string) {
 			r.Reporter.Errorf("Failed to find prefix from %s account role", installerRole.Name)
 			os.Exit(1)
 		}
-		if operatorRolePath != "" && !output.HasFlag() && r.Reporter.IsTerminal() {
+		if expectedOperatorRolePath != "" && !output.HasFlag() && r.Reporter.IsTerminal() {
 			r.Reporter.Infof("ARN path '%s' detected. This ARN path will be used for subsequent"+
-				" created operator roles and policies, for the account roles with prefix '%s'", operatorRolePath, accRolesPrefix)
+				" created operator roles and policies, for the account roles with prefix '%s'",
+				expectedOperatorRolePath, accRolesPrefix)
 		}
 		for _, operator := range credRequests {
 			//If the cluster version is less than the supported operator version
@@ -1266,18 +1267,17 @@ func run(cmd *cobra.Command, _ []string) {
 					continue
 				}
 			}
-			operatorIAMRoleList = append(operatorIAMRoleList, ocm.OperatorIAMRole{
+			computedOperatorIamRoleList = append(computedOperatorIamRoleList, ocm.OperatorIAMRole{
 				Name:      operator.Name(),
 				Namespace: operator.Namespace(),
 				RoleARN: aws.ComputeOperatorRoleArn(operatorRolesPrefix, operator,
-					awsCreator, operatorRolePath),
+					awsCreator, expectedOperatorRolePath),
 			})
-
 		}
 		// If user insists on using the deprecated --operator-iam-roles
 		// override the values to support the legacy documentation
 		if cmd.Flags().Changed("operator-iam-roles") {
-			operatorIAMRoleList = []ocm.OperatorIAMRole{}
+			computedOperatorIamRoleList = []ocm.OperatorIAMRole{}
 			for _, role := range operatorIAMRoles {
 				if !strings.Contains(role, ",") {
 					r.Reporter.Errorf("Expected operator IAM roles to be a comma-separated " +
@@ -1290,7 +1290,7 @@ func run(cmd *cobra.Command, _ []string) {
 						"list of name,namespace,role_arn")
 					os.Exit(1)
 				}
-				operatorIAMRoleList = append(operatorIAMRoleList, ocm.OperatorIAMRole{
+				computedOperatorIamRoleList = append(computedOperatorIamRoleList, ocm.OperatorIAMRole{
 					Name:      roleData[0],
 					Namespace: roleData[1],
 					RoleARN:   roleData[2],
@@ -1298,14 +1298,14 @@ func run(cmd *cobra.Command, _ []string) {
 			}
 		}
 		oidcConfig = handleOidcConfigOptions(r, cmd, isSTS, isHostedCP)
-		err = validateOperatorRolesAvailabilityUnderUserAwsAccount(awsClient, operatorIAMRoleList)
+		err = validateOperatorRolesAvailabilityUnderUserAwsAccount(awsClient, computedOperatorIamRoleList)
 		if err != nil {
 			if !oidcConfig.Reusable() {
 				r.Reporter.Errorf("%v", err)
 				os.Exit(1)
 			} else {
-				err = ocm.ValidateOperatorRolesMatchOidcProvider(awsClient, operatorIAMRoleList, oidcConfig.IssuerUrl(),
-					ocm.GetVersionMinor(version))
+				err = ocm.ValidateOperatorRolesMatchOidcProvider(r.Reporter, awsClient, computedOperatorIamRoleList,
+					oidcConfig.IssuerUrl(), ocm.GetVersionMinor(version), expectedOperatorRolePath)
 				if err != nil {
 					r.Reporter.Errorf("%v", err)
 					os.Exit(1)
@@ -2237,7 +2237,7 @@ func run(cmd *cobra.Command, _ []string) {
 		RoleARN:                   roleARN,
 		ExternalID:                externalID,
 		SupportRoleARN:            supportRoleARN,
-		OperatorIAMRoles:          operatorIAMRoleList,
+		OperatorIAMRoles:          computedOperatorIamRoleList,
 		ControlPlaneRoleARN:       controlPlaneRoleARN,
 		WorkerRoleARN:             workerRoleARN,
 		Mode:                      mode,
@@ -2295,7 +2295,7 @@ func run(cmd *cobra.Command, _ []string) {
 	if !output.HasFlag() || r.Reporter.IsTerminal() {
 		r.Reporter.Infof("Creating cluster '%s'", clusterName)
 		if interactive.Enabled() {
-			command := buildCommand(clusterConfig, operatorRolesPrefix, operatorRolePath,
+			command := buildCommand(clusterConfig, operatorRolesPrefix, expectedOperatorRolePath,
 				isAvailabilityZonesSet || selectAvailabilityZones, labels)
 			r.Reporter.Infof("To create this cluster again in the future, you can run:\n   %s", command)
 		}
@@ -2344,13 +2344,18 @@ func run(cmd *cobra.Command, _ []string) {
 			}
 			oidcprovider.Cmd.Run(oidcprovider.Cmd, []string{clusterName, mode, ""})
 		} else {
+			output := ""
+			if cluster.AWS().STS().OidcConfig().Reusable() {
+				output = "When using reusable OIDC Config and resources have been created " +
+					"prior to cluster specification, this step is not required."
+			}
 			rolesCMD := fmt.Sprintf("rosa create operator-roles --cluster %s", clusterName)
 			if permissionsBoundary != "" {
 				rolesCMD = fmt.Sprintf("%s --permissions-boundary %s", rolesCMD, permissionsBoundary)
 			}
 			oidcCMD := "rosa create oidc-provider"
 			oidcCMD = fmt.Sprintf("%s --cluster %s", oidcCMD, clusterName)
-			output := "Run the following commands to continue the cluster creation:\n\n"
+			output += "\nRun the following commands to continue the cluster creation:\n\n"
 			output = fmt.Sprintf("%s\t%s\n", output, rolesCMD)
 			output = fmt.Sprintf("%s\t%s\n", output, oidcCMD)
 			r.Reporter.Infof(output)
@@ -2369,6 +2374,7 @@ func run(cmd *cobra.Command, _ []string) {
 			clusterName,
 		)
 	}
+	os.Exit(0)
 }
 
 func validateOperatorRolesAvailabilityUnderUserAwsAccount(awsClient aws.Client,

--- a/cmd/create/oidcconfig/cmd.go
+++ b/cmd/create/oidcconfig/cmd.go
@@ -74,6 +74,10 @@ const (
 
 	prefixForPrivateKeySecret = "rosa-private-key"
 	minorVersionForGetSecret  = "4.12"
+	informOperatorRolesOutput = "To create Operator Roles for this OIDC Configuration, " +
+		"run the following command and remember to replace <user-defined> with a prefix of your choice:\n" +
+		"\trosa create operator-roles --prefix <user-defined> --oidc-config-id %s\n" +
+		"If you are going to create a Hosted Control Plane cluster please include '--hosted-cp'"
 )
 
 func init() {
@@ -390,8 +394,7 @@ func (s *CreateUnmanagedOidcConfigAutoStrategy) execute(r *rosa.Runtime) {
 		if spin != nil {
 			spin.Stop()
 		}
-		output := "Please run the following command to create a cluster with this oidc config"
-		output = fmt.Sprintf("%s\nrosa create cluster --sts --oidc-config-id %s", output, oidcConfig.ID())
+		output := fmt.Sprintf(informOperatorRolesOutput, oidcConfig.ID())
 		r.Reporter.Infof(output)
 	}
 }
@@ -543,8 +546,7 @@ func (s *CreateManagedOidcConfigAutoStrategy) execute(r *rosa.Runtime) {
 		if spin != nil {
 			spin.Stop()
 		}
-		output := "Please run the following command to create a cluster with this oidc config"
-		output = fmt.Sprintf("%s\nrosa create cluster --sts --oidc-config-id %s", output, oidcConfig.ID())
+		output := fmt.Sprintf(informOperatorRolesOutput, oidcConfig.ID())
 		r.Reporter.Infof(output)
 	}
 }

--- a/cmd/create/oidcprovider/cmd.go
+++ b/cmd/create/oidcprovider/cmd.go
@@ -182,13 +182,14 @@ func run(cmd *cobra.Command, argv []string) {
 			}
 		}
 		if oidcProviderExists {
-			if cluster != nil {
+			if cluster != nil &&
+				cluster.AWS().STS().OidcConfig() != nil && !cluster.AWS().STS().OidcConfig().Reusable() {
 				r.Reporter.Warnf("Cluster '%s' already has OIDC provider but has not yet started installation. "+
 					"Verify that the cluster operator roles exist and are configured correctly.", clusterKey)
 				os.Exit(1)
 			}
 			// Returns so that when called from create cluster does not interrupt flow
-			r.Reporter.Warnf("OIDC provider already exists.")
+			r.Reporter.Infof("OIDC provider already exists.")
 			return
 		}
 		if !output.HasFlag() || r.Reporter.IsTerminal() {

--- a/cmd/create/operatorroles/by_clusterkey.go
+++ b/cmd/create/operatorroles/by_clusterkey.go
@@ -41,7 +41,7 @@ func handleOperatorRoleCreationByClusterKey(r *rosa.Runtime, env string,
 		if err != nil {
 			return err
 		}
-		r.Reporter.Warnf("Cluster '%s' is using reusable OIDC Config and operator roles already exist.", clusterKey)
+		r.Reporter.Infof("Cluster '%s' is using reusable OIDC Config and operator roles already exist.", clusterKey)
 		return nil
 	}
 
@@ -392,6 +392,11 @@ func validateOperatorRolesMatchOidcProvider(r *rosa.Runtime, cluster *cmv1.Clust
 			Path:      path,
 		})
 	}
-	return ocm.ValidateOperatorRolesMatchOidcProvider(r.AWSClient, operatorRolesList,
-		cluster.AWS().STS().OidcConfig().IssuerUrl(), ocm.GetVersionMinor(cluster.Version().RawID()))
+	expectedPath, err := aws.GetPathFromARN(cluster.AWS().STS().RoleARN())
+	if err != nil {
+		return err
+	}
+	return ocm.ValidateOperatorRolesMatchOidcProvider(r.Reporter, r.AWSClient,
+		operatorRolesList, cluster.AWS().STS().OidcConfig().IssuerUrl(),
+		ocm.GetVersionMinor(cluster.Version().RawID()), expectedPath)
 }

--- a/cmd/create/operatorroles/by_prefix.go
+++ b/cmd/create/operatorroles/by_prefix.go
@@ -156,6 +156,15 @@ func handleOperatorRoleCreationByPrefix(r *rosa.Runtime, env string,
 			})
 			os.Exit(1)
 		}
+		if r.Reporter.IsTerminal() {
+			hostedCpOutputParam := ""
+			if args.hostedCp {
+				hostedCpOutputParam = fmt.Sprintf(" --%s", HostedCpFlag)
+			}
+			r.Reporter.Infof(fmt.Sprintf("To create a cluster with these roles, run the following command:\n"+
+				"\trosa create cluster --sts --oidc-config-id %s --operator-roles-prefix %s%s",
+				args.oidcConfigId, args.prefix, hostedCpOutputParam))
+		}
 		r.OCMClient.LogEvent("ROSACreateOperatorRolesModeAuto", map[string]string{
 			ocm.OperatorRolesPrefix: operatorRolesPrefix,
 			ocm.Response:            ocm.Success,

--- a/cmd/verify/rosa/cmd.go
+++ b/cmd/verify/rosa/cmd.go
@@ -58,13 +58,14 @@ func run(_ *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 	if currVersion.LessThan(latestVersionFromMirror) {
-		rprtr.Warnf(
+		rprtr.Infof(
 			"There is a newer release version '%s', please consider updating: %s",
 			latestVersionFromMirror, DownloadLatestMirrorFolder,
 		)
 	} else if rprtr.IsTerminal() {
 		rprtr.Infof("Your ROSA CLI is up to date.")
 	}
+	os.Exit(0)
 }
 
 func retrievePossibleVersionsFromMirror() ([]string, error) {


### PR DESCRIPTION
Related issues:
* https://issues.redhat.com/browse/SDA-9048
* https://issues.redhat.com/browse/SDA-9053
# What
Helps customer to be more aware of the flow through each step prior to creating the cluster
Also adds a check for the path between installer role and operator roles

# Why
Makes the flow less confusing