### PR TITLE
SDA-8534 | fix : update tag format to all `:` be a valid value

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -295,8 +295,8 @@ func init() {
 		&args.tags,
 		"tags",
 		nil,
-		"Apply user defined tags to all resources created by ROSA in AWS."+
-			"Tags are comma separated, for example: 'foo:bar,bar:baz'",
+		"Apply user defined tags to all resources created by ROSA in AWS. "+
+			"Tags are comma separated, for example: 'key value, foo bar'",
 	)
 
 	flags.BoolVar(
@@ -1402,6 +1402,7 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 	}
 	if len(tags) > 0 {
+		delim := aws.GetTagsDelimiter(tags)
 		duplicate, found := aws.HasDuplicateTagKey(tags)
 		if found {
 			r.Reporter.Errorf("Invalid tags, user tag keys must be unique, duplicate key '%s' found", duplicate)
@@ -1413,7 +1414,7 @@ func run(cmd *cobra.Command, _ []string) {
 				r.Reporter.Errorf("%s", err)
 				os.Exit(1)
 			}
-			t := strings.Split(tag, ":")
+			t := strings.Split(tag, delim)
 			tagsList[t[0]] = strings.TrimSpace(t[1])
 		}
 	}
@@ -2810,11 +2811,7 @@ func buildCommand(spec ocm.Spec, operatorRolesPrefix string,
 		command += fmt.Sprintf(" --%s", ClassicOidcConfigFlag)
 	}
 	if len(spec.Tags) > 0 {
-		tags := []string{}
-		for k, v := range spec.Tags {
-			tags = append(tags, fmt.Sprintf("%s:%s", k, v))
-		}
-		command += fmt.Sprintf(" --tags %s", strings.Join(tags, ","))
+		command += fmt.Sprintf(" --tags \"%s\"", strings.Join(buildTagsCommand(spec.Tags), ","))
 	}
 	if spec.MultiAZ && !spec.Hypershift.Enabled {
 		command += " --multi-az"
@@ -2924,6 +2921,24 @@ func buildCommand(spec ocm.Spec, operatorRolesPrefix string,
 	}
 
 	return command
+}
+
+func buildTagsCommand(tags map[string]string) []string {
+	// set correct delim, if a key or value contains `:` the delim should be " "
+	delim := ":"
+	for k, v := range tags {
+		if strings.Contains(k, ":") || strings.Contains(v, ":") {
+			delim = " "
+			break
+		}
+	}
+
+	// build list of formatted tags to return in command
+	var formattedTags []string
+	for k, v := range tags {
+		formattedTags = append(formattedTags, fmt.Sprintf("%s%s%s", k, delim, v))
+	}
+	return formattedTags
 }
 
 func getRolePrefix(clusterName string) string {

--- a/cmd/create/cluster/cmd_test.go
+++ b/cmd/create/cluster/cmd_test.go
@@ -2,12 +2,65 @@ package cluster
 
 import (
 	"fmt"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/rosa/pkg/logging"
 	"github.com/openshift/rosa/pkg/ocm"
 )
+
+var _ = Describe("Validate build command", func() {
+	Context("build tags command", func() {
+		When("tag key or values DO contain a colon", func() {
+			It("should build tags command with a space as a delimiter", func() {
+				tags := map[string]string{
+					"key1":   "value1",
+					"key2":   "value2",
+					"key3:4": "value3:4",
+					"key5":   "value5:6",
+				}
+
+				formattedTags := buildTagsCommand(tags)
+
+				Expect(len(formattedTags)).To(Equal(len(tags)),
+					"expected not to lose any tags while formatting")
+				for _, tag := range formattedTags {
+					if strings.Contains(tag, "key3") {
+						Expect(strings.Contains(tag, ":")).To(Equal(true),
+							"expected `:` to not be removed from key/value")
+					}
+
+					Expect(strings.Contains(tag, " ")).To(Equal(true),
+						"expected delim to be ' '")
+
+				}
+			})
+		})
+
+		When("tag key or values DO NOT contain a colon", func() {
+			It("should build tags command with default delimiter", func() {
+				tags := map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+					"key3": "value3",
+					"key4": "value4",
+					"key5": "value5",
+				}
+
+				formattedTags := buildTagsCommand(tags)
+
+				Expect(len(formattedTags)).To(Equal(len(tags)),
+					"expected not to lose any tags while formatting")
+				for _, tag := range formattedTags {
+					Expect(strings.Contains(tag, ":")).To(Equal(true),
+						"expected delim to be ':'")
+
+				}
+			})
+		})
+	})
+})
 
 var _ = Describe("Validates OCP version", func() {
 

--- a/pkg/aws/helpers_test.go
+++ b/pkg/aws/helpers_test.go
@@ -1,0 +1,176 @@
+package aws
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("UserTagValidator", func() {
+	When("given a string input", func() {
+		When("input is empty", func() {
+			It("should return nil", func() {
+				err := UserTagValidator("")
+				Expect(err).To(BeNil())
+			})
+		})
+
+		When("the input contains valid tags", func() {
+			It("should return nil", func() {
+				err := UserTagValidator("tag1 value1, tag2 value2")
+				Expect(err).To(BeNil())
+			})
+		})
+
+		When("the input contains legacy tags format", func() {
+			It("should return nil", func() {
+				err := UserTagValidator("tag1:value1,tag2:value2")
+				Expect(err).To(BeNil())
+			})
+		})
+
+		When("the input contains invalid tags", func() {
+			It("should return an error", func() {
+				err := UserTagValidator("foo bar,tag2=value2")
+				Expect(err).To(MatchError("invalid tag format. Expected tag format: 'key value'"))
+			})
+
+			It("should return an error if a tag is missing a key", func() {
+				err := UserTagValidator(":value1,tag2:value2")
+				Expect(err).To(MatchError("invalid tag format, tag key and tag value can not be empty"))
+			})
+
+			It("should return an error if a tag is missing a key", func() {
+				err := UserTagValidator("tag1:,tag2:value2")
+				Expect(err).To(MatchError("invalid tag format, tag key and tag value can not be empty"))
+			})
+
+			It("should return an error if a tag key contains invalid characters", func() {
+				err := UserTagValidator("tag1$:value1,tag2:value2")
+				Expect(err).To(MatchError(fmt.Sprintf("expected a valid user tag key 'tag1$' matching %s",
+					UserTagKeyRE.String())))
+			})
+
+			It("should return an error if a tag value contains invalid characters", func() {
+				err := UserTagValidator("tag1:value$1,tag2:value2")
+				Expect(err).To(MatchError(fmt.Sprintf("expected a valid user tag value 'value$1' matching %s",
+					UserTagValueRE.String())))
+			})
+
+			When("the input contains tags with colon or equals signs in the value", func() {
+				It("should not return an error if the tag is properly formatted", func() {
+					err := UserTagValidator("tag1 value:1,tag:2 value2")
+					Expect(err).To(BeNil())
+				})
+			})
+		})
+	})
+
+	Describe("when given a non-string input", func() {
+		It("should return an error", func() {
+			err := UserTagValidator(42)
+			Expect(err).To(MatchError("can only validate strings, got 42"))
+		})
+	})
+})
+
+var _ = Describe("GetTagsDelimiter", func() {
+	When("tag contains ' '", func() {
+		It("should return ' '", func() {
+			Expect(GetTagsDelimiter([]string{"key value", "foo bar"})).To(Equal(" "))
+			Expect(GetTagsDelimiter([]string{"foo bar baz", "key value"})).To(Equal(" "))
+		})
+	})
+
+	When("tag contains :", func() {
+		It("should return :", func() {
+			Expect(GetTagsDelimiter([]string{"key:value", "foo:bar"})).To(Equal(":"))
+			Expect(GetTagsDelimiter([]string{"foo:bar:baz", "key:value"})).To(Equal(":"))
+		})
+	})
+
+	When("tag does not contain either ' ' or :", func() {
+		It("should default to ':'", func() {
+			Expect(GetTagsDelimiter([]string{"keyvalue", "foobar"})).To(Equal(":"))
+			Expect(GetTagsDelimiter([]string{"foo=bar", "key=value"})).To(Equal(":"))
+			Expect(GetTagsDelimiter([]string{""})).To(Equal(":"))
+		})
+	})
+})
+
+var _ = Describe("UserTagDuplicateValidator", func() {
+	When("given an empty string", func() {
+		It("should return nil", func() {
+			err := UserTagDuplicateValidator("")
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Context("when given a non-string input", func() {
+		It("should return an error", func() {
+			err := UserTagDuplicateValidator(123)
+			Expect(err).To(MatchError("can only validate strings, got 123"))
+		})
+	})
+
+	Context("space separated", func() {
+		When("given a string with unique tags", func() {
+			It("should return nil", func() {
+				err := UserTagDuplicateValidator("key1 value1,key2 value2,key3 value3")
+				Expect(err).To(BeNil())
+			})
+		})
+
+		When("given a string with duplicate tags", func() {
+			It("should return an error", func() {
+				err := UserTagDuplicateValidator("key1 value1,key2 value2,key1 value3")
+				Expect(err).To(MatchError("user tag keys must be unique, duplicate key 'key1' found"))
+			})
+		})
+
+		When("given a string with a space prefix with unique tags", func() {
+			It("should return nil", func() {
+				err := UserTagDuplicateValidator(" key1 value1, key2 value2, key3 value3")
+				Expect(err).To(BeNil())
+			})
+		})
+
+		When("given a string with a space prefix with duplicate tags", func() {
+			It("should return an error", func() {
+				err := UserTagDuplicateValidator(" key1 value1, key2 value2, key1 value3")
+				Expect(err).To(MatchError("user tag keys must be unique, duplicate key 'key1' found"))
+			})
+		})
+	})
+
+	Context("colon separated", func() {
+		When("given a string with unique tags", func() {
+			It("should return nil", func() {
+				err := UserTagDuplicateValidator("key1:value1,key2:value2,key3:value3")
+				Expect(err).To(BeNil())
+			})
+		})
+
+		When("given a string with duplicate tags", func() {
+			It("should return an error", func() {
+				err := UserTagDuplicateValidator("key1:value1,key2:value2,key1:value3")
+				Expect(err).To(MatchError("user tag keys must be unique, duplicate key 'key1' found"))
+			})
+		})
+
+		When("given a string with a space prefix with unique tags", func() {
+			It("should return nil", func() {
+				err := UserTagDuplicateValidator(" key1:value1, key2:value2, key3:value3")
+				Expect(err).To(BeNil())
+			})
+		})
+
+		When("given a string with a space prefix with duplicate tags colon separated", func() {
+			It("should return an error", func() {
+				err := UserTagDuplicateValidator(" key1:value1, key2:value2, key1:value3")
+				Expect(err).To(MatchError("user tag keys must be unique, duplicate key 'key1' found"))
+			})
+		})
+	})
+})


### PR DESCRIPTION
JIRA - https://issues.redhat.com/browse/SDA-8534

This change enabled using tags with a `:` value in either key or value. 

To support backwards compatibility we still support the `:` delim between the key value pairs. To pass a key or value with the `:` value a user can use a whitespace as a delim 

## Verification
### Create tags with `:` value and space seperated key values in interactive mode
```
rosa create cluster           
I: Enabling interactive mode
? Cluster name: croche1
? Deploy cluster with Hosted Control Plane (optional): No
? Create cluster admin user: No
? Deploy cluster using AWS STS: Yes
W: In a future release STS will be the default mode.
W: --sts flag won't be necessary if you wish to use STS.
W: --non-sts/--mint-mode flag will be necessary if you do not wish to use STS.
? OpenShift version: 4.12.22
? Configure the use of IMDSv2 for ec2 instances optional/required (optional): 
W: More than one Installer role found
? Installer role ARN: arn:aws:iam::765374464689:role/ManagedOpenShift-Installer-Role
I: Using arn:aws:iam::765374464689:role/ManagedOpenShift-ControlPlane-Role for the ControlPlane role
I: Using arn:aws:iam::765374464689:role/ManagedOpenShift-Worker-Role for the Worker role
I: Using arn:aws:iam::765374464689:role/ManagedOpenShift-Support-Role for the Support role
? External ID (optional): 
? Operator roles prefix: croche1-p0s3
? Deploy cluster using pre registered OIDC Configuration ID: No
W: No OIDC Configuration found; will continue with the classic flow.
? Tags (optional): key value, foo:bar buzz, foo bar
...
```
Verify values in OCM 
```
 ocm get cluster 24snjpt22jussg979kgbm7gahqbc45th | jq .aws.tags
{
  "foo": "bar",
  "foo:bar": "buzz",
  "key": "value",
  "red-hat-clustertype": "rosa",
  "red-hat-managed": "true"
}

```
### Create tags with no colon, but colon seperated key values in interactive mode
```
rosa create cluster
I: Enabling interactive mode
? Cluster name: croche2
? Deploy cluster with Hosted Control Plane (optional): No
? Create cluster admin user: No
? Deploy cluster using AWS STS: Yes
W: In a future release STS will be the default mode.
W: --sts flag won't be necessary if you wish to use STS.
W: --non-sts/--mint-mode flag will be necessary if you do not wish to use STS.
? OpenShift version: 4.12.22
? Configure the use of IMDSv2 for ec2 instances optional/required (optional): 
W: More than one Installer role found
? Installer role ARN: arn:aws:iam::765374464689:role/ManagedOpenShift-Installer-Role
I: Using arn:aws:iam::765374464689:role/ManagedOpenShift-ControlPlane-Role for the ControlPlane role
I: Using arn:aws:iam::765374464689:role/ManagedOpenShift-Worker-Role for the Worker role
I: Using arn:aws:iam::765374464689:role/ManagedOpenShift-Support-Role for the Support role
? External ID (optional): 
? Operator roles prefix: croche2-a4g3
? Deploy cluster using pre registered OIDC Configuration ID: No
W: No OIDC Configuration found; will continue with the classic flow.
? Tags (optional): foo:bar, key:value, foobar:buzz
...
```
Verify values in OCM 
```
ocm get cluster 24snmbi8iqramjbtohu06g3hb4clm16q | jq .aws.tags
{
  "foo": "bar",
  "foobar": "buzz",
  "key": "value",
  "red-hat-clustertype": "rosa",
  "red-hat-managed": "true"
}
```

### Colon seperated key values passed as parameter
```
rosa create cluster --tags foo:bar,key:value,foobar:buzz       
I: Enabling interactive mode
? Cluster name: croche3
? Deploy cluster with Hosted Control Plane (optional): No
? Create cluster admin user: No
? Deploy cluster using AWS STS: Yes
W: In a future release STS will be the default mode.
W: --sts flag won't be necessary if you wish to use STS.
W: --non-sts/--mint-mode flag will be necessary if you do not wish to use STS.
? OpenShift version: 4.12.22
? Configure the use of IMDSv2 for ec2 instances optional/required (optional): 
W: More than one Installer role found
? Installer role ARN: arn:aws:iam::765374464689:role/ManagedOpenShift-Installer-Role
I: Using arn:aws:iam::765374464689:role/ManagedOpenShift-ControlPlane-Role for the ControlPlane role
I: Using arn:aws:iam::765374464689:role/ManagedOpenShift-Worker-Role for the Worker role
I: Using arn:aws:iam::765374464689:role/ManagedOpenShift-Support-Role for the Support role
? External ID (optional): 
? Operator roles prefix: croche3-v0g5
? Deploy cluster using pre registered OIDC Configuration ID: No
W: No OIDC Configuration found; will continue with the classic flow.
? Tags: foo:bar,key:value,foobar:buzz
...
```
Verify values in OCM 
```
ocm get cluster 24snnpnf3smvkpepal80mqjeogdf5jst | jq .aws.tags
{
  "foo": "bar",
  "foobar": "buzz",
  "key": "value",
  "red-hat-clustertype": "rosa",
  "red-hat-managed": "true"
}
```

### Space seperated key value pairs passed as a parameter 
```
rosa create cluster --tags "foo bar,key value,foo:bar buzz"                                                                                                                                                                           1 ↵
I: Enabling interactive mode
? Cluster name: croche4
? Deploy cluster with Hosted Control Plane (optional): No
? Create cluster admin user: No
? Deploy cluster using AWS STS: Yes
W: In a future release STS will be the default mode.
W: --sts flag won't be necessary if you wish to use STS.
W: --non-sts/--mint-mode flag will be necessary if you do not wish to use STS.
? OpenShift version: 4.12.22
? Configure the use of IMDSv2 for ec2 instances optional/required (optional): 
W: More than one Installer role found
? Installer role ARN: arn:aws:iam::765374464689:role/ManagedOpenShift-Installer-Role
I: Using arn:aws:iam::765374464689:role/ManagedOpenShift-ControlPlane-Role for the ControlPlane role
I: Using arn:aws:iam::765374464689:role/ManagedOpenShift-Worker-Role for the Worker role
I: Using arn:aws:iam::765374464689:role/ManagedOpenShift-Support-Role for the Support role
? External ID (optional): 
? Operator roles prefix: croche4-u5n7
? Deploy cluster using pre registered OIDC Configuration ID: No
W: No OIDC Configuration found; will continue with the classic flow.
? Tags: foo bar,key value,foo:bar buzz
```
Verify values in OCM 
```
ocm get cluster 24snr3slvcmvbkq2cnpjj73o5f96lb60 | jq .aws.tags
{
  "foo": "bar",
  "foo:bar": "buzz",
  "key": "value",
  "red-hat-clustertype": "rosa",
  "red-hat-managed": "true"
}
```


### Example formatting 
Because we can now pass space seperated key value pairs we need to ensure we wrap the `--tags` parameter in quotes when passing it. This change updates the output run again command with the tags wrapped in quotes 
```
I: Creating cluster 'croche6'
I: To create this cluster again in the future, you can run:
   rosa create cluster --cluster-name croche6 --sts --role-arn arn:aws:iam::765374464689:role/ManagedOpenShift-Installer-Role --support-role-arn arn:aws:iam::765374464689:role/ManagedOpenShift-Support-Role --controlplane-iam-role arn:aws:iam::765374464689:role/ManagedOpenShift-ControlPlane-Role --worker-iam-role arn:aws:iam::765374464689:role/ManagedOpenShift-Worker-Role --operator-roles-prefix croche6-c0f8 --tags "foo bar,key value,foo:bar buzz" --region eu-west-1 --version 4.12.22 --replicas 2 --compute-machine-type m5.xlarge --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23
I: To view a list of clusters and their status, run 'rosa list clusters'
```