### PR TITLE
SDA-8538 | fix: create hcp account roles in interactive mode

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -332,7 +332,23 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
-	rolesCreator := initCreator(managedPolicies, args.hostedCP)
+	createHostedCP := args.hostedCP
+	if env != ocm.Production { // TODO: remove env check once AWS publishes all the hcp Managed Policies
+		if interactive.Enabled() && !cmd.Flags().Changed("hosted-cp") {
+			createHostedCP, err = interactive.GetBool(interactive.Input{
+				Question: "Create Hosted CP account roles",
+				Help:     cmd.Flags().Lookup("hosted-cp").Usage,
+				Default:  false,
+				Required: false,
+			})
+			if err != nil {
+				r.Reporter.Errorf("Expected a valid value: %s", err)
+				os.Exit(1)
+			}
+		}
+	}
+
+	rolesCreator := initCreator(managedPolicies, createHostedCP)
 	input := buildRolesCreationInput(prefix, permissionsBoundary, r.Creator.AccountID, env, policies,
 		policyVersion, path)
 


### PR DESCRIPTION
**Note:** this change will be available in prod once all managed policies are published.

Example:
```
oadler@fedora:rosa (SDA-8538)$ ./rosa create account-roles -i
I: Logged in as 'oadler.openshift' on 'https://api.stage.openshift.com'
I: Validating AWS credentials...
I: AWS credentials are valid!
I: Validating AWS quota...
I: AWS quota ok. If cluster installation fails, validate actual AWS resource usage against https://docs.openshift.com/rosa/rosa_getting_started/rosa-required-aws-service-quotas.html
I: Verifying whether OpenShift command-line tool is available...
I: Current OpenShift Client Version: 4.11.0
I: Creating account roles
? Role prefix: oadler
? Permissions boundary ARN (optional): 
? Path (optional): 
? Role creation mode: auto
? Create hosted CP account roles: Yes
I: Creating roles using 'arn:aws:iam::765374464689:user/oadler'
I: Created role 'oadler-HCP-Support-Role' with ARN 'arn:aws:iam::765374464689:role/oadler-HCP-Support-Role'
I: Created role 'oadler-HCP-Worker-Role' with ARN 'arn:aws:iam::765374464689:role/oadler-HCP-Worker-Role'
I: Created role 'oadler-HCP-Installer-Role' with ARN 'arn:aws:iam::765374464689:role/oadler-HCP-Installer-Role'
I: To create an OIDC Config, run the following command:
	rosa create oidc-config
I: To create a cluster with these roles, run the following command:
	rosa create cluster --sts
```
