### PR TITLE
Allow editing ingress privacy for private hypershift cluster

### DIFF
--- a/cmd/edit/ingress/cmd.go
+++ b/cmd/edit/ingress/cmd.go
@@ -118,10 +118,15 @@ func run(cmd *cobra.Command, argv []string) {
 		interactive.Enable()
 	}
 
+	cluster := r.FetchCluster()
 	var labelMatch *string
 	if cmd.Flags().Changed(labelMatchFlag) {
+		if ocm.IsHyperShiftCluster(cluster) {
+			r.Reporter.Errorf("Updating route selectors is not supported for hosted cp clusters")
+			os.Exit(1)
+		}
 		labelMatch = &args.labelMatch
-	} else if interactive.Enabled() {
+	} else if interactive.Enabled() && !ocm.IsHyperShiftCluster(cluster) {
 		labelMatchArg, err := interactive.GetString(interactive.Input{
 			Question: "Label match for ingress",
 			Help:     cmd.Flags().Lookup(labelMatchFlag).Usage,
@@ -150,8 +155,7 @@ func run(cmd *cobra.Command, argv []string) {
 		private = &privArg
 	}
 
-	cluster := r.FetchCluster()
-	if cluster.AWS().PrivateLink() {
+	if cluster.AWS().PrivateLink() && !ocm.IsHyperShiftCluster(cluster) {
 		r.Reporter.Errorf("Cluster '%s' is PrivateLink and does not support updating ingresses", clusterKey)
 		os.Exit(1)
 	}


### PR DESCRIPTION
Related: [SDA-8109](https://issues.redhat.com//browse/SDA-8109)