### PR TITLE
SDA-6451/Fix: Improve error msg when deletion of admin user fails

### DIFF
--- a/cmd/dlt/admin/cmd.go
+++ b/cmd/dlt/admin/cmd.go
@@ -131,8 +131,7 @@ func run(cmd *cobra.Command, _ []string) {
 			idp.ClusterAdminUsername, r.ClusterKey)
 		err = r.OCMClient.DeleteUser(clusterID, "cluster-admins", idp.ClusterAdminUsername)
 		if err != nil {
-			r.Reporter.Errorf("Failed to delete '%s' user from cluster-admins groups of cluster '%s': %s",
-				idp.ClusterAdminUsername, r.ClusterKey, err)
+			r.Reporter.Errorf("%s", err)
 			os.Exit(1)
 		}
 


### PR DESCRIPTION

When there is a failure deleting the admin user, currently, the Error from target OCP is being wrapped twice with the user friendly "Failed to delete.." msg, once in ClusterService and again in ROSA CLI.

Following the precedent of similar cases. e.g. deleteCluster,   Not wrapping in rosa if its already wrapped by CS.

Refs: https://issues.redhat.com/browse/SDA-6451