### PR TITLE
SDA-8718 Update rosa create message for hosted cluster

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2697,7 +2697,7 @@ func buildCommand(spec ocm.Spec, operatorRolesPrefix string,
 		}
 		command += fmt.Sprintf(" --tags %s", strings.Join(tags, ","))
 	}
-	if spec.MultiAZ {
+	if spec.MultiAZ && !spec.Hypershift.Enabled {
 		command += " --multi-az"
 	}
 	if spec.Region != "" {


### PR DESCRIPTION
Minor one, as "multi-az" flag is deprecated for hosted clusters.