### PR TITLE
SDA-8963 Improve machine type not found message

### DIFF
--- a/cmd/create/machinepool/machinepool.go
+++ b/cmd/create/machinepool/machinepool.go
@@ -283,7 +283,7 @@ func addMachinePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster
 
 	if interactive.Enabled() {
 		if instanceType == "" {
-			instanceType = instanceTypeList[0].MachineType.ID()
+			instanceType = instanceTypeList.Items[0].MachineType.ID()
 		}
 		instanceType, err = interactive.GetOption(interactive.Input{
 			Question: "Instance type",

--- a/cmd/list/instancetypes/cmd.go
+++ b/cmd/list/instancetypes/cmd.go
@@ -54,14 +54,14 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
-	if len(machineTypes) == 0 {
+	if len(machineTypes.Items) == 0 {
 		r.Reporter.Warnf("There are no machine types supported for your account. Contact Red Hat support.")
 		os.Exit(1)
 	}
 
 	if output.HasFlag() {
 		var instanceTypes []*cmv1.MachineType
-		for _, machine := range machineTypes {
+		for _, machine := range machineTypes.Items {
 			instanceTypes = append(instanceTypes, machine.MachineType)
 		}
 		err = output.Print(instanceTypes)
@@ -76,7 +76,7 @@ func run(cmd *cobra.Command, _ []string) {
 	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	fmt.Fprintf(writer, "ID\tCATEGORY\tCPU_CORES\tMEMORY\t\n")
 
-	for _, machine := range machineTypes {
+	for _, machine := range machineTypes.Items {
 		if !machine.Available {
 			continue
 		}


### PR DESCRIPTION
~~Minimal change to improve the wording of the machine type not found error.~~

I've prepared a patch for two similar issues (I see more complexity in splitting the patch, and I think it makes sense to put it together)

https://issues.redhat.com/browse/SDA-8963
https://issues.redhat.com/browse/SDA-9075

This PR will cover the following:
- A minimal refactoring to include the region and the availability zones in the MachineTypeList object.
- Improve the validation message when an instance type is not found in a given AZ.
- Fix a situation where the user may select a new subnet/AZ that is not part of day 1, and in the new AZ, there are different machine types.

Please, @andreadecorte @ciaranRoche @gregsheremeta, feel free to review. 

Thanks



