### PR TITLE
[SDA-9078] fix: only ask mode if flag is not changed

### DIFF
--- a/cmd/create/oidcprovider/cmd.go
+++ b/cmd/create/oidcprovider/cmd.go
@@ -127,7 +127,7 @@ func run(cmd *cobra.Command, argv []string) {
 		}
 	}
 
-	if interactive.Enabled() && !isProgmaticallyCalled {
+	if !cmd.Flags().Changed("mode") && interactive.Enabled() && !isProgmaticallyCalled {
 		mode, err = interactive.GetOption(interactive.Input{
 			Question: "OIDC provider creation mode",
 			Help:     cmd.Flags().Lookup("mode").Usage,

--- a/cmd/dlt/oidcprovider/cmd.go
+++ b/cmd/dlt/oidcprovider/cmd.go
@@ -97,7 +97,7 @@ func run(cmd *cobra.Command, argv []string) {
 		interactive.Enable()
 	}
 
-	if interactive.Enabled() && !isProgmaticallyCalled {
+	if !cmd.Flags().Changed("mode") && interactive.Enabled() && !isProgmaticallyCalled {
 		mode, err = interactive.GetOption(interactive.Input{
 			Question: "OIDC provider deletion mode",
 			Help:     cmd.Flags().Lookup("mode").Usage,


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-9078
# What
Only asks for aws mode if flag is not changed

# Why
No reason to ask for mode if user already requested it