### PR TITLE
SDA-9086 | fix: check error when retrieving operator-roles

### DIFF
--- a/cmd/dlt/operatorrole/cmd.go
+++ b/cmd/dlt/operatorrole/cmd.go
@@ -189,10 +189,14 @@ func run(cmd *cobra.Command, argv []string) {
 		}
 		credRequests, err := r.OCMClient.GetCredRequests(true)
 		if err != nil {
-			r.Reporter.Errorf("Error getting operator credential request from OCM %s", err)
+			r.Reporter.Errorf("Error getting operator credential request from OCM %v", err)
 			os.Exit(1)
 		}
-		foundOperatorRoles, _ = r.AWSClient.GetOperatorRolesFromAccountByPrefix(args.prefix, credRequests)
+		foundOperatorRoles, err = r.AWSClient.GetOperatorRolesFromAccountByPrefix(args.prefix, credRequests)
+		if err != nil {
+			r.Reporter.Errorf("There was a problem retrieving the Operator Roles from AWS: %v", err)
+			os.Exit(1)
+		}
 	}
 
 	if len(foundOperatorRoles) == 0 {


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-9086

# What
Check aws errors before moving flow forward when deleting roles by prefix

# Why
Was not being checked