### PR TITLE
remove os.Exit in cluster creation cmd

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2379,7 +2379,6 @@ func run(cmd *cobra.Command, _ []string) {
 			clusterName,
 		)
 	}
-	os.Exit(0)
 }
 
 func validateOperatorRolesAvailabilityUnderUserAwsAccount(awsClient aws.Client,


### PR DESCRIPTION
this causes osde2e to exit before running the test suite due our usage of rosa (imported)

closes #1238

Signed-off-by: Brady Pratt <bpratt@redhat.com>
