### PR TITLE
SDA-9087 | fix: validate installer role arn after selection

### DIFF
--- a/cmd/create/oidcconfig/cmd.go
+++ b/cmd/create/oidcconfig/cmd.go
@@ -246,6 +246,16 @@ func run(cmd *cobra.Command, argv []string) {
 					os.Exit(1)
 				}
 			}
+			isValid, err := r.AWSClient.ValidateAccountRoleVersionCompatibility(
+				roleName, aws.InstallerAccountRole, minorVersionForGetSecret)
+			if err != nil {
+				r.Reporter.Errorf("There was a problem listing role tags: %v", err)
+				os.Exit(1)
+			}
+			if !isValid {
+				r.Reporter.Errorf("Role '%s' is not of minimum version '%s'", args.installerRoleArn, minorVersionForGetSecret)
+				os.Exit(1)
+			}
 		}
 
 		args.userPrefix = strings.Trim(args.userPrefix, " \t")

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -182,6 +182,8 @@ type Client interface {
 	PutPublicReadObjectInS3Bucket(bucketName string, body io.ReadSeeker, key string) error
 	CreateSecretInSecretsManager(name string, secret string) (string, error)
 	DeleteSecretInSecretsManager(secretArn string) error
+	ValidateAccountRoleVersionCompatibility(
+		roleName string, roleType string, minVersion string) (bool, error)
 }
 
 // ClientBuilder contains the information and logic needed to build a new AWS client.


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-9087

# What
Validates version of installer role arn

# Why
When specifying the param directly version was not being validated