### PR TITLE
OCM-263 | fix: behavior when creating operator-roles

### DIFF
--- a/cmd/create/operatorroles/by_clusterkey.go
+++ b/cmd/create/operatorroles/by_clusterkey.go
@@ -41,8 +41,10 @@ func handleOperatorRoleCreationByClusterKey(r *rosa.Runtime, env string,
 		if err != nil {
 			return err
 		}
-		r.Reporter.Infof("Cluster '%s' is using reusable OIDC Config and operator roles already exist.", clusterKey)
-		return nil
+		if !args.forcePolicyCreation {
+			r.Reporter.Infof("Cluster '%s' is using reusable OIDC Config and operator roles already exist.", clusterKey)
+			return nil
+		}
 	}
 
 	if len(missingRoles) == 0 &&

--- a/cmd/create/operatorroles/by_prefix.go
+++ b/cmd/create/operatorroles/by_prefix.go
@@ -1,7 +1,6 @@
 package operatorroles
 
 import (
-	"context"
 	"fmt"
 	"net/url"
 	"os"
@@ -244,13 +243,6 @@ func validateArgumentsOperatorRolesCreationByPrefix(r *rosa.Runtime, operatorRol
 	if err != nil {
 		r.Reporter.Errorf("URL '%s' is not reachable.", oidcEndpointUrl)
 		os.Exit(1)
-	}
-	if strings.Contains(oidcEndpointUrl, ".s3.") {
-		err = helper.IsBucketReacheable(context.Background(), oidcEndpointUrl)
-		if err != nil {
-			r.Reporter.Errorf("%v", err)
-			os.Exit(1)
-		}
 	}
 	err = aws.ARNValidator(installerRoleArn)
 	if err != nil {

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -1,11 +1,9 @@
 package helper
 
 import (
-	"context"
 	"math"
 	"math/rand"
 	"net"
-	"net/http"
 	"os"
 	"sort"
 	"strings"
@@ -14,7 +12,6 @@ import (
 	"github.com/briandowns/spinner"
 	"github.com/google/uuid"
 	"github.com/openshift/rosa/pkg/reporter"
-	"github.com/zgalor/weberr"
 )
 
 func init() {
@@ -205,23 +202,6 @@ func LongestCommonPrefixBySorting(stringSlice []string) string {
 	}
 
 	return first[:i]
-}
-
-func IsBucketReacheable(ctx context.Context, bucketUrl string) error {
-	req, err := http.NewRequestWithContext(ctx, "HEAD", bucketUrl, nil)
-	if err != nil {
-		return err
-	}
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode == http.StatusNotFound {
-		return weberr.BadRequest.Errorf("Bucket '%s' not found.", bucketUrl)
-	}
-	return nil
 }
 
 func IsURLReachable(apiURL string) error {


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/OCM-263
# What
Adjusts behavior when creating operator-roles with `-f` param

# Why
No need to check s3 bucket as we can trust oidc-config spec, if something wrong happens will be caught creating the cluster

When using `-f` it should bypass validation that the operator already exist