### PR TITLE
OCM-213 | ci : skip tests that can not be run in prow

### DIFF
--- a/cmd/create/cluster/cmd_test.go
+++ b/cmd/create/cluster/cmd_test.go
@@ -19,6 +19,9 @@ var _ = Describe("Validates OCP version", func() {
 	)
 	var client *ocm.Client
 	BeforeEach(func() {
+		// todo this test expects and uses a real ocm client
+		// disabling the test until we can mock this to run in prow
+		Skip("disabling test until ocm client is mocked")
 		c, err := ocm.NewClient().Logger(logging.NewLogger()).Build()
 		Expect(err).NotTo(HaveOccurred())
 		client = c


### PR DESCRIPTION
JIRA - https://issues.redhat.com/browse/OCM-213

Skips tests that require the ocm client. These currently can not be run in prow.