### PR TITLE
OCM-264 | fix: Properly checks the path when validating trusted relationship

### DIFF
--- a/cmd/create/operatorroles/by_clusterkey.go
+++ b/cmd/create/operatorroles/by_clusterkey.go
@@ -381,18 +381,10 @@ func validateOperatorRoles(r *rosa.Runtime, cluster *cmv1.Cluster) ([]string, er
 }
 
 func validateOperatorRolesMatchOidcProvider(r *rosa.Runtime, cluster *cmv1.Cluster) error {
-	operatorRolesList := []ocm.OperatorIAMRole{}
-	for _, operatorIAMRole := range cluster.AWS().STS().OperatorIAMRoles() {
-		path, err := aws.GetPathFromARN(operatorIAMRole.RoleARN())
-		if err != nil {
-			return err
-		}
-		operatorRolesList = append(operatorRolesList, ocm.OperatorIAMRole{
-			Name:      operatorIAMRole.Name(),
-			Namespace: operatorIAMRole.Namespace(),
-			RoleARN:   operatorIAMRole.RoleARN(),
-			Path:      path,
-		})
+	operatorRolesList, err := convertV1OperatorIAMRoleIntoOcmOperatorIamRole(
+		cluster.AWS().STS().OperatorIAMRoles())
+	if err != nil {
+		return err
 	}
 	expectedPath, err := aws.GetPathFromARN(cluster.AWS().STS().RoleARN())
 	if err != nil {

--- a/cmd/create/operatorroles/by_prefix.go
+++ b/cmd/create/operatorroles/by_prefix.go
@@ -132,6 +132,18 @@ func handleOperatorRoleCreationByPrefix(r *rosa.Runtime, env string,
 		}
 	}
 
+	operatorRolesList, err := convertV1OperatorIAMRoleIntoOcmOperatorIamRole(operatorIAMRoleList)
+	if err != nil {
+		r.Reporter.Errorf("%v", err)
+		os.Exit(1)
+	}
+	err = ocm.ValidateOperatorRolesMatchOidcProvider(r.Reporter, r.AWSClient,
+		operatorRolesList, oidcConfig.IssuerUrl(), "4.0", path)
+	if err != nil {
+		r.Reporter.Errorf("%v", err)
+		os.Exit(1)
+	}
+
 	switch mode {
 	case aws.ModeAuto:
 		if !output.HasFlag() || r.Reporter.IsTerminal() {

--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -237,3 +237,16 @@ func run(cmd *cobra.Command, argv []string) error {
 	return handleOperatorRoleCreationByClusterKey(r, env, permissionsBoundary,
 		mode, policies, defaultPolicyVersion)
 }
+
+func convertV1OperatorIAMRoleIntoOcmOperatorIamRole(
+	operatorIAMRoleList []*cmv1.OperatorIAMRole) ([]ocm.OperatorIAMRole, error) {
+	operatorRolesList := []ocm.OperatorIAMRole{}
+	for _, operatorIAMRole := range operatorIAMRoleList {
+		newRole, err := ocm.NewOperatorIamRoleFromCmv1(operatorIAMRole)
+		if err != nil {
+			return operatorRolesList, err
+		}
+		operatorRolesList = append(operatorRolesList, *newRole)
+	}
+	return operatorRolesList, nil
+}

--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -123,6 +123,19 @@ type OperatorIAMRole struct {
 	Path      string
 }
 
+func NewOperatorIamRoleFromCmv1(operatorIAMRole *cmv1.OperatorIAMRole) (*OperatorIAMRole, error) {
+	path, err := aws.GetPathFromARN(operatorIAMRole.RoleARN())
+	if err != nil {
+		return nil, err
+	}
+	return &OperatorIAMRole{
+		Name:      operatorIAMRole.Name(),
+		Namespace: operatorIAMRole.Namespace(),
+		RoleARN:   operatorIAMRole.RoleARN(),
+		Path:      path,
+	}, nil
+}
+
 type Hypershift struct {
 	Enabled bool
 }

--- a/pkg/ocm/clusters_test.go
+++ b/pkg/ocm/clusters_test.go
@@ -1,0 +1,27 @@
+package ocm
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/rosa/pkg/aws"
+)
+
+var _ = Describe("New Operator Iam Role From Cmv1", func() {
+	const (
+		fakeOperatorRoleArn = "arn:aws:iam::765374464689:role/fake-arn-openshift-cluster-csi-drivers-ebs-cloud-credentials"
+	)
+	It("OK: Converts cmv1 operator iam role", func() {
+		cmv1OperatorIamRole, err := cmv1.NewOperatorIAMRole().
+			Name("openshift").Namespace("operator").RoleARN(fakeOperatorRoleArn).Build()
+		Expect(err).NotTo(HaveOccurred())
+		ocmOperatorIamRole, err := NewOperatorIamRoleFromCmv1(cmv1OperatorIamRole)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ocmOperatorIamRole.Name).To(Equal(cmv1OperatorIamRole.Name()))
+		Expect(ocmOperatorIamRole.Namespace).To(Equal(cmv1OperatorIamRole.Namespace()))
+		Expect(ocmOperatorIamRole.RoleARN).To(Equal(cmv1OperatorIamRole.RoleARN()))
+		path, err := aws.GetPathFromARN(cmv1OperatorIamRole.RoleARN())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ocmOperatorIamRole.Path).To(Equal(path))
+	})
+})

--- a/pkg/ocm/helpers_test.go
+++ b/pkg/ocm/helpers_test.go
@@ -2,6 +2,8 @@ package ocm
 
 import (
 	"fmt"
+	"net/url"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -28,5 +30,48 @@ var _ = Describe("Http tokens", func() {
 				cmv1.HttpTokenStateRequired, cmv1.HttpTokenStateOptional)))
 		})
 	})
+})
 
+var _ = Describe("Validate Issuer Url Matches Assume Policy Document", func() {
+	const (
+		fakeOperatorRoleArn = "arn:aws:iam::765374464689:role/fake-arn-openshift-cluster-csi-drivers-ebs-cloud-credentials"
+	)
+	It("OK: Matching", func() {
+		//nolint
+		fakeAssumePolicyDocument := `%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Federated%22%3A%22arn%3Aaws%3Aiam%3A%3A765374464689%3Aoidc-provider%2Ffake-oidc.s3.us-east-1.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRoleWithWebIdentity%22%2C%22Condition%22%3A%7B%22StringEquals%22%3A%7B%22fake.s3.us-east-1.amazonaws.com%3Asub%22%3A%5B%22system%3Aserviceaccount%3Aopenshift-image-registry%3Acluster-image-registry-operator%22%2C%22system%3Aserviceaccount%3Aopenshift-image-registry%3Aregistry%22%5D%7D%7D%7D%5D%7D`
+		parsedUrl, _ := url.Parse("https://fake-oidc.s3.us-east-1.amazonaws.com")
+		err := validateIssuerUrlMatchesAssumePolicyDocument(
+			fakeOperatorRoleArn, parsedUrl, fakeAssumePolicyDocument)
+		Expect(err).NotTo(HaveOccurred())
+	})
+	It("OK: Matching with path", func() {
+		//nolint
+		fakeAssumePolicyDocument := `%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Federated%22%3A%22arn%3Aaws%3Aiam%3A%3A765374464689%3Aoidc-provider%2Ffake-oidc.s3.us-east-1.amazonaws.com%2F23g84jr4cdfpej0ghlr4teqiog8747gt%22%7D%2C%22Action%22%3A%22sts%3AAssumeRoleWithWebIdentity%22%2C%22Condition%22%3A%7B%22StringEquals%22%3A%7B%22fake.s3.us-east-1.amazonaws.com%2F23g84jr4cdfpej0ghlr4teqiog8747gt%3Asub%22%3A%5B%22system%3Aserviceaccount%3Aopenshift-image-registry%3Acluster-image-registry-operator%22%2C%22system%3Aserviceaccount%3Aopenshift-image-registry%3Aregistry%22%5D%7D%7D%7D%5D%7D`
+		parsedUrl, _ := url.Parse("https://fake-oidc.s3.us-east-1.amazonaws.com/23g84jr4cdfpej0ghlr4teqiog8747gt")
+		err := validateIssuerUrlMatchesAssumePolicyDocument(
+			fakeOperatorRoleArn, parsedUrl, fakeAssumePolicyDocument)
+		Expect(err).NotTo(HaveOccurred())
+	})
+	It("KO: Not matching", func() {
+		//nolint
+		fakeAssumePolicyDocument := `%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Federated%22%3A%22arn%3Aaws%3Aiam%3A%3A765374464689%3Aoidc-provider%2Ffake-oidc.s3.us-east-1.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRoleWithWebIdentity%22%2C%22Condition%22%3A%7B%22StringEquals%22%3A%7B%22fake.s3.us-east-1.amazonaws.com%3Asub%22%3A%5B%22system%3Aserviceaccount%3Aopenshift-image-registry%3Acluster-image-registry-operator%22%2C%22system%3Aserviceaccount%3Aopenshift-image-registry%3Aregistry%22%5D%7D%7D%7D%5D%7D`
+		fakeIssuerUrl := "https://fake-oidc-2.s3.us-east-1.amazonaws.com"
+		parsedUrl, _ := url.Parse(fakeIssuerUrl)
+		err := validateIssuerUrlMatchesAssumePolicyDocument(
+			fakeOperatorRoleArn, parsedUrl, fakeAssumePolicyDocument)
+		Expect(err).To(HaveOccurred())
+		//nolint
+		Expect(fmt.Sprintf("Operator role '%s' does not have trusted relationship to '%s' issuer URL", fakeOperatorRoleArn, parsedUrl.Host)).To(Equal(err.Error()))
+	})
+	It("KO: Not matching with path", func() {
+		//nolint
+		fakeAssumePolicyDocument := `%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Federated%22%3A%22arn%3Aaws%3Aiam%3A%3A765374464689%3Aoidc-provider%2Ffake-oidc.s3.us-east-1.amazonaws.com%2F23g84jr4cdfpej0ghlr4teqiog8747gt%22%7D%2C%22Action%22%3A%22sts%3AAssumeRoleWithWebIdentity%22%2C%22Condition%22%3A%7B%22StringEquals%22%3A%7B%22fake.s3.us-east-1.amazonaws.com%2F23g84jr4cdfpej0ghlr4teqiog8747gt%3Asub%22%3A%5B%22system%3Aserviceaccount%3Aopenshift-image-registry%3Acluster-image-registry-operator%22%2C%22system%3Aserviceaccount%3Aopenshift-image-registry%3Aregistry%22%5D%7D%7D%7D%5D%7D`
+		fakeIssuerUrl := "https://fake-oidc-2.s3.us-east-1.amazonaws.com/23g84jr4cdfpej0ghlr4teqiog8747g"
+		parsedUrl, _ := url.Parse(fakeIssuerUrl)
+		err := validateIssuerUrlMatchesAssumePolicyDocument(
+			fakeOperatorRoleArn, parsedUrl, fakeAssumePolicyDocument)
+		Expect(err).To(HaveOccurred())
+		//nolint
+		Expect(fmt.Sprintf("Operator role '%s' does not have trusted relationship to '%s' issuer URL", fakeOperatorRoleArn, parsedUrl.Host+parsedUrl.Path)).To(Equal(err.Error()))
+	})
 })


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/OCM-264
# What
Properly checks the path when validating trusted relationship

# Why
Customer shouldn't be able to change the trusted relationship of existing roles