### PR TITLE
fix: remidiating gramatical typo in hibernation help messages

### DIFF
--- a/cmd/hibernate/cmd.go
+++ b/cmd/hibernate/cmd.go
@@ -27,7 +27,7 @@ func GenerateCommand() *cobra.Command {
 	var Cmd = &cobra.Command{
 		Use:    "hibernate",
 		Short:  "Hibernate cluster",
-		Long:   "Hibernate Ready cluster",
+		Long:   "Hibernate a ready cluster",
 		Hidden: true,
 	}
 	Cmd.AddCommand(cluster.GenerateCommand())

--- a/cmd/resume/cmd.go
+++ b/cmd/resume/cmd.go
@@ -27,7 +27,7 @@ func GenerateCommand() *cobra.Command {
 	var Cmd = &cobra.Command{
 		Use:    "resume",
 		Short:  "Resume cluster",
-		Long:   "Resume Hibernate cluster",
+		Long:   "Resume a hibernating cluster",
 		Hidden: true,
 	}
 	Cmd.AddCommand(cluster.GenerateCommand())


### PR DESCRIPTION
My dear colleagues, I must confess to a grave mistake in the form of a grammatical error which had crept into our code's help message. It was a flaw that marred the very fabric of our work and tarnished our reputation as meticulous developers. But fear not, for I have undertaken the noble task of rectifying this grammatical oversight with all the fervor and passion of a true grammarian. Let it be known that this error shall plague us no more, and our help message shall now read with the grace and fluidity befitting of our esteemed profession.

https://issues.redhat.com/browse/SDA-9101