### PR TITLE
OCM-285 | feat: Unhide the `--hosted-cp` flag

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -123,9 +123,8 @@ func init() {
 		&args.hostedCP,
 		"hosted-cp",
 		false,
-		"Enable the use of hosted control planes (HyperShift)",
+		"Enable the use of hosted control planes",
 	)
-	flags.MarkHidden("hosted-cp")
 
 	aws.AddModeFlag(Cmd)
 

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -589,9 +589,8 @@ func init() {
 		&args.hostedClusterEnabled,
 		"hosted-cp",
 		false,
-		"Enable the use of hosted control planes (HyperShift)",
+		"Enable the use of hosted control planes",
 	)
-	flags.MarkHidden("hosted-cp")
 
 	flags.StringVar(
 		&args.billingAccount,

--- a/cmd/dlt/accountroles/cmd.go
+++ b/cmd/dlt/accountroles/cmd.go
@@ -63,9 +63,8 @@ func init() {
 		&args.hostedCP,
 		"hosted-cp",
 		false,
-		"Delete hosted control planes roles (HyperShift)",
+		"Delete hosted control planes roles",
 	)
-	flags.MarkHidden("hosted-cp")
 
 	flags.BoolVar(
 		&args.classic,
@@ -73,7 +72,6 @@ func init() {
 		false,
 		"Delete classic account roles",
 	)
-	flags.MarkHidden("classic")
 
 	aws.AddModeFlag(Cmd)
 	confirm.AddFlag(flags)

--- a/cmd/list/region/cmd.go
+++ b/cmd/list/region/cmd.go
@@ -69,9 +69,8 @@ func init() {
 		&args.hostedCluster,
 		"hosted-cp",
 		false,
-		"List only regions with support for hosted control planes (HyperShift)",
+		"List only regions with support for hosted control planes",
 	)
-	flags.MarkHidden("hosted-cp")
 
 	output.AddFlag(Cmd)
 }

--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -88,9 +88,8 @@ func init() {
 		&args.hostedCP,
 		"hosted-cp",
 		false,
-		"Enable the use of hosted control planes (HyperShift)",
+		"Enable the use of hosted control planes",
 	)
-	flags.MarkHidden("hosted-cp")
 
 	confirm.AddFlag(flags)
 	interactive.AddFlag(flags)


### PR DESCRIPTION
- Remove the `Hypershift` from the help messages.
- Unhide the `--classic` flag.

Related: [OCM-285](https://issues.redhat.com/browse/OCM-285)