### PR TITLE
SDA-8538 | fix: create account-roles remove environment check

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -333,18 +333,16 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	createHostedCP := args.hostedCP
-	if env != ocm.Production { // TODO: remove env check once AWS publishes all the hcp Managed Policies
-		if interactive.Enabled() && !cmd.Flags().Changed("hosted-cp") {
-			createHostedCP, err = interactive.GetBool(interactive.Input{
-				Question: "Create Hosted CP account roles",
-				Help:     cmd.Flags().Lookup("hosted-cp").Usage,
-				Default:  false,
-				Required: false,
-			})
-			if err != nil {
-				r.Reporter.Errorf("Expected a valid value: %s", err)
-				os.Exit(1)
-			}
+	if interactive.Enabled() && !cmd.Flags().Changed("hosted-cp") {
+		createHostedCP, err = interactive.GetBool(interactive.Input{
+			Question: "Create Hosted CP account roles",
+			Help:     cmd.Flags().Lookup("hosted-cp").Usage,
+			Default:  false,
+			Required: false,
+		})
+		if err != nil {
+			r.Reporter.Errorf("Expected a valid value: %s", err)
+			os.Exit(1)
 		}
 	}
 


### PR DESCRIPTION
Remove environment check for managed policies in interactive mode.

Related: [SDA-8538](https://issues.redhat.com/browse/SDA-8538)