### PR TITLE
OCM-300 | feat: remove environment check for managed policies

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -101,14 +101,14 @@ func init() {
 		&args.managed,
 		"managed-policies",
 		false,
-		"Attach AWS managed policies to the account roles",
+		"Attach Classic ROSA AWS managed policies to the account roles",
 	)
 	flags.MarkHidden("managed-policies")
 	flags.BoolVar(
 		&args.managed,
 		"mp",
 		false,
-		"Attach AWS managed policies to the account roles. This is an alias for --managed-policies")
+		"Attach Classic ROSA AWS managed policies to the account roles. This is an alias for --managed-policies")
 	flags.MarkHidden("mp")
 
 	flags.BoolVarP(
@@ -165,10 +165,10 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
-	// Determine if managed policies are enabled
+	// Determine if Classic ROSA managed policies are enabled
 	isManagedSet := cmd.Flags().Changed("managed-policies") || cmd.Flags().Changed("mp")
 	if isManagedSet && env == ocm.Production {
-		r.Reporter.Errorf("Managed policies are not supported in this environment")
+		r.Reporter.Errorf("Classic ROSA managed policies are not supported in this environment")
 		os.Exit(1)
 	}
 	managedPolicies := args.managed

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1159,19 +1159,9 @@ func run(cmd *cobra.Command, _ []string) {
 		workerRoleARN,
 	}
 
-	env, err := ocm.GetEnv()
-	if err != nil {
-		r.Reporter.Errorf("Failed to determine OCM environment: %v", err)
-		os.Exit(1)
-	}
 	managedPolicies, err := awsClient.HasManagedPolicies(roleARN)
 	if err != nil {
 		r.Reporter.Errorf("Failed to determine if cluster has managed policies: %v", err)
-		os.Exit(1)
-	}
-	// TODO: remove once AWS managed policies are in place
-	if managedPolicies && env == ocm.Production {
-		r.Reporter.Errorf("Managed policies are not supported in this environment")
 		os.Exit(1)
 	}
 

--- a/cmd/create/ocmrole/cmd.go
+++ b/cmd/create/ocmrole/cmd.go
@@ -91,14 +91,14 @@ func init() {
 		&args.managed,
 		"managed-policies",
 		false,
-		"Attach AWS managed policies to the account roles",
+		"Attach Classic ROSA AWS managed policies to the account roles",
 	)
 	flags.MarkHidden("managed-policies")
 	flags.BoolVar(
 		&args.managed,
 		"mp",
 		false,
-		"Attach AWS managed policies to the account roles. This is an alias for --managed-policies")
+		"Attach Classic ROSA AWS managed policies to the account roles. This is an alias for --managed-policies")
 	flags.MarkHidden("mp")
 
 	aws.AddModeFlag(Cmd)
@@ -123,10 +123,10 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
-	// Determine if managed policies are enabled
+	// Determine if Classic ROSA managed policies are enabled
 	isManagedSet := cmd.Flags().Changed("managed-policies") || cmd.Flags().Changed("mp")
 	if isManagedSet && env == ocm.Production {
-		r.Reporter.Errorf("Managed policies are not supported in this environment")
+		r.Reporter.Errorf("Classic ROSA managed policies are not supported in this environment")
 		os.Exit(1)
 	}
 	managedPolicies := args.managed

--- a/cmd/create/operatorroles/by_clusterkey.go
+++ b/cmd/create/operatorroles/by_clusterkey.go
@@ -80,11 +80,6 @@ func handleOperatorRoleCreationByClusterKey(r *rosa.Runtime, env string,
 		r.Reporter.Warnf("Forcing creation of policies only works for unmanaged policies")
 		os.Exit(1)
 	}
-	// TODO: remove once AWS managed policies are in place
-	if managedPolicies && env == ocm.Production {
-		r.Reporter.Errorf("Managed policies are not supported in this environment")
-		os.Exit(1)
-	}
 	credRequests, err := r.OCMClient.GetCredRequests(cluster.Hypershift().Enabled())
 	if err != nil {
 		r.Reporter.Errorf("Error getting operator credential request from OCM %s", err)

--- a/cmd/create/operatorroles/by_prefix.go
+++ b/cmd/create/operatorroles/by_prefix.go
@@ -107,11 +107,6 @@ func handleOperatorRoleCreationByPrefix(r *rosa.Runtime, env string,
 		r.Reporter.Errorf("Failed to determine if cluster has managed policies: %v", err)
 		os.Exit(1)
 	}
-	// TODO: remove once AWS managed policies are in place
-	if managedPolicies && env == ocm.Production {
-		r.Reporter.Errorf("Managed policies are not supported in this environment")
-		os.Exit(1)
-	}
 	awsCreator, err := r.AWSClient.GetCreator()
 	if err != nil {
 		r.Reporter.Errorf("Unable to get IAM credentials: %v", err)

--- a/cmd/dlt/accountroles/cmd.go
+++ b/cmd/dlt/accountroles/cmd.go
@@ -284,10 +284,6 @@ func getRoleListForDeletion(r *rosa.Runtime, env string, prefix string, clusters
 	if err != nil {
 		return finalRoleList, false, fmt.Errorf("Failed to determine if cluster has managed policies: %v", err)
 	}
-	// TODO: remove once AWS managed policies are in place
-	if managedPolicies && env == ocm.Production {
-		return finalRoleList, false, fmt.Errorf("Managed policies are not supported in this environment")
-	}
 
 	return finalRoleList, managedPolicies, nil
 }

--- a/cmd/dlt/operatorrole/cmd.go
+++ b/cmd/dlt/operatorrole/cmd.go
@@ -91,12 +91,6 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
-	env, err := ocm.GetEnv()
-	if err != nil {
-		r.Reporter.Errorf("Error getting environment %s", err)
-		os.Exit(1)
-	}
-
 	if interactive.Enabled() {
 		mode, err = interactive.GetOption(interactive.Input{
 			Question: "Operator roles deletion mode",
@@ -224,11 +218,6 @@ func run(cmd *cobra.Command, argv []string) {
 	managedPolicies, err := r.AWSClient.HasManagedPolicies(roleARN)
 	if err != nil {
 		r.Reporter.Errorf("Failed to determine if cluster has managed policies: %v", err)
-		os.Exit(1)
-	}
-	// TODO: remove once AWS managed policies are in place
-	if managedPolicies && env == ocm.Production {
-		r.Reporter.Errorf("Managed policies are not supported in this environment")
 		os.Exit(1)
 	}
 

--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -143,11 +143,6 @@ func run(cmd *cobra.Command, argv []string) error {
 		r.Reporter.Errorf("Failed to determine if the role has managed policies: %v", err)
 		os.Exit(1)
 	}
-	// TODO: remove once AWS managed policies are in place
-	if managedPolicies && env == ocm.Production {
-		r.Reporter.Errorf("Managed policies are not supported in this environment")
-		os.Exit(1)
-	}
 
 	if managedPolicies {
 		hostedCPPolicies, err := awsClient.HasHostedCPPolicies(roleARN)

--- a/cmd/upgrade/operatorroles/cmd.go
+++ b/cmd/upgrade/operatorroles/cmd.go
@@ -135,11 +135,6 @@ func run(cmd *cobra.Command, argv []string) error {
 	}
 
 	managedPolicies := cluster.AWS().STS().ManagedPolicies()
-	// TODO: remove once AWS managed policies are in place
-	if managedPolicies && env == ocm.Production {
-		r.Reporter.Errorf("Managed policies are not supported in this environment")
-		os.Exit(1)
-	}
 
 	credRequests, err := r.OCMClient.GetCredRequests(cluster.Hypershift().Enabled())
 	if err != nil {

--- a/cmd/upgrade/roles/cmd.go
+++ b/cmd/upgrade/roles/cmd.go
@@ -153,11 +153,6 @@ func run(cmd *cobra.Command, argv []string) error {
 	}
 
 	managedPolicies := cluster.AWS().STS().ManagedPolicies()
-	// TODO: remove once AWS managed policies are in place
-	if managedPolicies && env == ocm.Production {
-		r.Reporter.Errorf("Managed policies are not supported in this environment")
-		os.Exit(1)
-	}
 
 	unifiedPath, err := aws.GetPathFromAccountRole(cluster, aws.AccountRoles[aws.InstallerAccountRole].Name)
 	if err != nil {


### PR DESCRIPTION
1. Remove the check for HCP-managed policies in production.
2. Leave the check for Classic ROSA managed policies in the commands: `create account-roles`, and `create ocm-role`.

**Note:** The `--managed-policies` flag applies to classic ROSA.
Unblock the path for `--hosted-cp` in production, which comes along the HCP AWS managed policies.

Related: [OCM-300](https://issues.redhat.com/browse/OCM-300)