### PR TITLE
OCM-301 | fix: goes through both operator roles type when deleting by prefix

### DIFF
--- a/cmd/dlt/operatorrole/cmd.go
+++ b/cmd/dlt/operatorrole/cmd.go
@@ -187,7 +187,7 @@ func run(cmd *cobra.Command, argv []string) {
 			r.Reporter.Errorf("There are clusters using Operator Roles Prefix '%s', can't delete the IAM roles", args.prefix)
 			os.Exit(1)
 		}
-		credRequests, err := r.OCMClient.GetCredRequests(true)
+		credRequests, err := r.OCMClient.GetAllCredRequests()
 		if err != nil {
 			r.Reporter.Errorf("Error getting operator credential request from OCM %v", err)
 			os.Exit(1)

--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -528,6 +528,27 @@ func (c *Client) GetPolicies(policyType string) (map[string]*cmv1.AWSSTSPolicy, 
 	return m, nil
 }
 
+// The actual values might differ from classic to hcp
+// prefer using GetCredRequests(isHypershift bool) when there is prior knowledge of the topology
+func (c *Client) GetAllCredRequests() (map[string]*cmv1.STSOperator, error) {
+	result := make(map[string]*cmv1.STSOperator)
+	classic, err := c.GetCredRequests(false)
+	if err != nil {
+		return result, err
+	}
+	hcp, err := c.GetCredRequests(true)
+	if err != nil {
+		return result, err
+	}
+	for key, value := range classic {
+		result[key] = value
+	}
+	for key, value := range hcp {
+		result[key] = value
+	}
+	return result, nil
+}
+
 func (c *Client) GetCredRequests(isHypershift bool) (map[string]*cmv1.STSOperator, error) {
 	m := make(map[string]*cmv1.STSOperator)
 	stsCredentialResponse, err := c.ocm.ClustersMgmt().


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/OCM-301
# What
Goes through both classic and hcp operator roles when deleting by prefix

# Why
At some point credential requests API changed to only return either classic or hcp and not both merged together