### PR TITLE
OCM-342 | feat: add a default value when selecting oidc configs

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2464,7 +2464,7 @@ func handleOidcConfigOptions(r *rosa.Runtime, cmd *cobra.Command, isSTS bool, is
 			isOidcConfig = _isOidcConfig
 		}
 		if isOidcConfig {
-			oidcConfigId = interactive.GetOidcConfigID(r, cmd)
+			oidcConfigId = interactive.GetOidcConfigID(r, cmd, oidcConfigId)
 		}
 	}
 	if oidcConfigId == "" {

--- a/cmd/create/oidcprovider/cmd.go
+++ b/cmd/create/oidcprovider/cmd.go
@@ -148,9 +148,7 @@ func run(cmd *cobra.Command, argv []string) {
 		if isProgmaticallyCalled && args.oidcEndpointUrl != "" {
 			oidcEndpointURL = args.oidcEndpointUrl
 		} else {
-			if args.oidcConfigId == "" {
-				args.oidcConfigId = interactive.GetOidcConfigID(r, cmd)
-			}
+			args.oidcConfigId = interactive.GetOidcConfigID(r, cmd, args.oidcConfigId)
 			oidcConfig, err := r.OCMClient.GetOidcConfig(args.oidcConfigId)
 			if err != nil {
 				r.Reporter.Errorf("There was a problem retrieving OIDC Config '%s': %v", args.oidcConfigId, err)

--- a/cmd/create/operatorroles/by_prefix.go
+++ b/cmd/create/operatorroles/by_prefix.go
@@ -39,13 +39,15 @@ func handleOperatorRolesPrefixOptions(r *rosa.Runtime, cmd *cobra.Command) {
 	}
 	args.prefix = operatorRolesPrefix
 
+	args.oidcConfigId = interactive.GetOidcConfigID(r, cmd, args.oidcConfigId)
 	if args.oidcConfigId == "" {
-		args.oidcConfigId = interactive.GetOidcConfigID(r, cmd)
+		r.Reporter.Errorf("No OIDC configuration available, please create one first.")
+		os.Exit(1)
 	}
 
 	isHostedCP := args.hostedCp
 	isHostedCP, err = interactive.GetBool(interactive.Input{
-		Question: "Create hosted control plane operator roles",
+		Question: "Create Hosted Control Plane operator roles",
 		Help:     cmd.Flags().Lookup("hosted-cp").Usage,
 		Default:  isHostedCP,
 		Required: false,

--- a/cmd/dlt/oidcconfig/cmd.go
+++ b/cmd/dlt/oidcconfig/cmd.go
@@ -110,9 +110,7 @@ func run(cmd *cobra.Command, argv []string) {
 		}
 	}
 
-	if args.oidcConfigId == "" || interactive.Enabled() {
-		args.oidcConfigId = interactive.GetOidcConfigID(r, cmd)
-	}
+	args.oidcConfigId = interactive.GetOidcConfigID(r, cmd, args.oidcConfigId)
 
 	oidcConfigInput := buildOidcConfigInput(r)
 	oidcConfigStrategy, err := getOidcConfigStrategy(mode, oidcConfigInput)

--- a/cmd/dlt/oidcprovider/cmd.go
+++ b/cmd/dlt/oidcprovider/cmd.go
@@ -163,9 +163,7 @@ func run(cmd *cobra.Command, argv []string) {
 		if isProgmaticallyCalled && args.oidcEndpointUrl != "" {
 			oidcEndpointUrl = args.oidcEndpointUrl
 		} else {
-			if args.oidcConfigId == "" {
-				args.oidcConfigId = interactive.GetOidcConfigID(r, cmd)
-			}
+			args.oidcConfigId = interactive.GetOidcConfigID(r, cmd, args.oidcConfigId)
 			oidcConfig, err := r.OCMClient.GetOidcConfig(args.oidcConfigId)
 			if err != nil {
 				r.Reporter.Errorf("There was a problem retrieving OIDC Config '%s': %v", args.oidcConfigId, err)


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/OCM-342
# What
Adds a default value and if no value is selectable a message indicating to create a new one

# Why
Clearer flow