### PR TITLE
OCM-285 | feat: unhide hcp params

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -123,9 +123,8 @@ func init() {
 		&args.hostedCP,
 		"hosted-cp",
 		false,
-		"Enable the use of hosted control planes (HyperShift)",
+		"Enable the use of Hosted Control Planes",
 	)
-	flags.MarkHidden("hosted-cp")
 
 	aws.AddModeFlag(Cmd)
 

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -589,9 +589,8 @@ func init() {
 		&args.hostedClusterEnabled,
 		"hosted-cp",
 		false,
-		"Enable the use of hosted control planes (HyperShift)",
+		"Enable the use of Hosted Control Planes",
 	)
-	flags.MarkHidden("hosted-cp")
 
 	flags.StringVar(
 		&args.billingAccount,
@@ -690,9 +689,9 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	isHostedCP := args.hostedClusterEnabled
-	if interactive.Enabled() && cmd.Flags().Changed("hosted-cp") {
+	if interactive.Enabled() {
 		isHostedCP, err = interactive.GetBool(interactive.Input{
-			Question: "Deploy cluster with hosted control plane",
+			Question: "Deploy cluster with Hosted Control Plane",
 			Help:     cmd.Flags().Lookup("hosted-cp").Usage,
 			Default:  isHostedCP,
 			Required: false,
@@ -701,6 +700,13 @@ func run(cmd *cobra.Command, _ []string) {
 			r.Reporter.Errorf("Expected a valid --hosted-cp value: %s", err)
 			os.Exit(1)
 		}
+	}
+
+	// FIXME: Remove before GA
+	if isHostedCP && r.Reporter.IsTerminal() {
+		//nolint
+		r.Reporter.Infof("NOTE: Hosted control planes are currently in Technology Preview (https://access.redhat.com/support/offerings/techpreview)." +
+			" Any Technology Preview clusters will need to be destroyed and recreated prior to general availability.")
 	}
 
 	if isHostedCP && args.httpTokens != "" {

--- a/cmd/dlt/accountroles/cmd.go
+++ b/cmd/dlt/accountroles/cmd.go
@@ -63,9 +63,8 @@ func init() {
 		&args.hostedCP,
 		"hosted-cp",
 		false,
-		"Delete hosted control planes roles (HyperShift)",
+		"Delete Hosted Control Planes roles",
 	)
-	flags.MarkHidden("hosted-cp")
 
 	flags.BoolVar(
 		&args.classic,
@@ -73,7 +72,6 @@ func init() {
 		false,
 		"Delete classic account roles",
 	)
-	flags.MarkHidden("classic")
 
 	aws.AddModeFlag(Cmd)
 	confirm.AddFlag(flags)

--- a/cmd/list/region/cmd.go
+++ b/cmd/list/region/cmd.go
@@ -69,9 +69,8 @@ func init() {
 		&args.hostedCluster,
 		"hosted-cp",
 		false,
-		"List only regions with support for hosted control planes (HyperShift)",
+		"List only regions with support for Hosted Control Planes",
 	)
-	flags.MarkHidden("hosted-cp")
 
 	output.AddFlag(Cmd)
 }

--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -88,9 +88,8 @@ func init() {
 		&args.hostedCP,
 		"hosted-cp",
 		false,
-		"Enable the use of hosted control planes (HyperShift)",
+		"Enable the use of Hosted Control Planes",
 	)
-	flags.MarkHidden("hosted-cp")
 
 	confirm.AddFlag(flags)
 	interactive.AddFlag(flags)


### PR DESCRIPTION
- Remove the `Hypershift` from the help messages.
- Unhide the `--classic` flag.

Related: [OCM-285](https://issues.redhat.com/browse/OCM-285)