### PR TITLE
OCM-766 | feat: Filter roles by infix

### DIFF
--- a/cmd/create/oidcconfig/cmd.go
+++ b/cmd/create/oidcconfig/cmd.go
@@ -220,7 +220,8 @@ func run(cmd *cobra.Command, argv []string) {
 					"to be compliant with OIDC protocol. It will also create a Secret in Secrets Manager containing the private key")
 			}
 			if mode == aws.ModeAuto && (interactive.Enabled() || (confirm.Yes() && args.installerRoleArn == "")) {
-				args.installerRoleArn = interactive.GetInstallerRoleArn(r, cmd, args.installerRoleArn, minorVersionForGetSecret)
+				args.installerRoleArn = interactive.GetInstallerRoleArn(r, cmd, args.installerRoleArn,
+					minorVersionForGetSecret, false, false)
 			}
 			if interactive.Enabled() {
 				prefix, err := interactive.GetString(interactive.Input{

--- a/cmd/create/operatorroles/by_prefix.go
+++ b/cmd/create/operatorroles/by_prefix.go
@@ -55,7 +55,8 @@ func handleOperatorRolesPrefixOptions(r *rosa.Runtime, cmd *cobra.Command) {
 		os.Exit(1)
 	}
 	args.hostedCp = isHostedCP
-	args.installerRoleArn = interactive.GetInstallerRoleArn(r, cmd, args.installerRoleArn, "")
+	args.installerRoleArn = interactive.GetInstallerRoleArn(r, cmd, args.installerRoleArn, "",
+		true, args.hostedCp)
 }
 
 func handleOperatorRoleCreationByPrefix(r *rosa.Runtime, env string,

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -117,6 +117,7 @@ type Client interface {
 	DeleteOpenIDConnectProvider(providerURL string) error
 	HasOpenIDConnectProvider(issuerURL string, accountID string) (bool, error)
 	FindRoleARNs(roleType string, version string) ([]string, error)
+	FindRoleARNsByInfix(roleType string, version string, hostedCP bool) ([]string, error)
 	FindPolicyARN(operator Operator, version string) (string, error)
 	ListUserRoles() ([]Role, error)
 	ListOCMRoles() ([]Role, error)

--- a/pkg/interactive/helper.go
+++ b/pkg/interactive/helper.go
@@ -43,14 +43,20 @@ func GetOidcConfigID(r *rosa.Runtime, cmd *cobra.Command) string {
 }
 
 func GetInstallerRoleArn(r *rosa.Runtime, cmd *cobra.Command,
-	defaultInstallerRoleArn string, minMinorVersion string) string {
+	defaultInstallerRoleArn string, minMinorVersion string, filterByInfix bool, isHostedCP bool) string {
 	spin := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
 	spin.Start()
 	awsClient := r.AWSClient
 	role := aws.AccountRoles[aws.InstallerAccountRole]
 	roleARN := defaultInstallerRoleArn
 	// Find all installer roles in the current account using AWS resource tags
-	roleARNs, err := awsClient.FindRoleARNs(aws.InstallerAccountRole, minMinorVersion)
+	var roleARNs []string
+	var err error
+	if filterByInfix {
+		roleARNs, err = awsClient.FindRoleARNsByInfix(aws.InstallerAccountRole, minMinorVersion, isHostedCP)
+	} else {
+		roleARNs, err = awsClient.FindRoleARNs(aws.InstallerAccountRole, minMinorVersion)
+	}
 	if err != nil {
 		r.Reporter.Errorf("Failed to find %s role: %s", role.Name, err)
 		os.Exit(1)


### PR DESCRIPTION
Filter roles using infix according to the cluster topology.

**create cluster --hosted-cp**
```
oadler@fedora:rosa (OCM-766)$ ./rosa create cluster --hosted-cp
I: Enabling interactive mode
? Cluster name: oadler-test
? Deploy cluster with Hosted Control Plane: Yes
I: NOTE: Hosted control planes are currently in Technology Preview (https://access.redhat.com/support/offerings/techpreview). Any Technology Preview clusters will need to be destroyed and recreated prior to general availability.
? OpenShift version: 4.13.1
W: More than one Installer role found
? Installer role ARN:  [Use arrows to move, type to filter, ? for more help]
> arn:aws:iam::765374464689:role/dle-both-HCP-ROSA-Installer-Role
  arn:aws:iam::765374464689:role/dle-dual-HCP-ROSA-Installer-Role
  arn:aws:iam::765374464689:role/dle-p-HCP-ROSA-Installer-Role
  arn:aws:iam::765374464689:role/ManagedOpenShift-HCP-ROSA-Installer-Role
  arn:aws:iam::765374464689:role/oadler-HCP-ROSA-Installer-Role
  arn:aws:iam::765374464689:role/oadler-jun-11-HCP-ROSA-Installer-Role
```

**create cluster (classic)**
```
oadler@fedora:rosa (OCM-766)$ ./rosa create cluster
I: Enabling interactive mode
? Cluster name: oadler-test
? Deploy cluster with Hosted Control Plane (optional): No
? Deploy cluster using AWS STS: Yes
W: In a future release STS will be the default mode.
W: --sts flag won't be necessary if you wish to use STS.
W: --non-sts/--mint-mode flag will be necessary if you do not wish to use STS.
? OpenShift version: 4.13.1
? Configure the use of IMDSv2 for ec2 instances optional/required (optional): 
W: More than one Installer role found
? Installer role ARN:  [Use arrows to move, type to filter, ? for more help]
  arn:aws:iam::765374464689:role/lponce-local-Installer-Role
  arn:aws:iam::765374464689:role/lponce-prod-Installer-Role
  arn:aws:iam::765374464689:role/ManagedOpenShift-HCP-Installer-Role
> arn:aws:iam::765374464689:role/ManagedOpenShift-Installer-Role
  arn:aws:iam::765374464689:role/marco-Installer-Role
  arn:aws:iam::765374464689:role/nargaman-tf-Installer-Role
  arn:aws:iam::765374464689:role/oadler-classic-Installer-Role
```

