### PR TITLE
SDA-9085 | Fix: enable interactive mode if missing name or spec path for tuning configs

### DIFF
--- a/cmd/create/tuningconfigs/cmd.go
+++ b/cmd/create/tuningconfigs/cmd.go
@@ -75,6 +75,11 @@ func run(cmd *cobra.Command, _ []string) {
 
 	var err error
 	name := args.name
+	if name == "" && !interactive.Enabled() {
+		interactive.Enable()
+		r.Reporter.Infof("Enabling interactive mode")
+	}
+
 	if interactive.Enabled() {
 		name, err = interactive.GetString(interactive.Input{
 			Question: "Name of the tuning config",
@@ -89,6 +94,10 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	specPath := args.specPath
+	if specPath == "" && !interactive.Enabled() {
+		interactive.Enable()
+		r.Reporter.Infof("Enabling interactive mode")
+	}
 	if interactive.Enabled() {
 		specPath, err = interactive.GetString(interactive.Input{
 			Question: "Path of the file containing the spec of the tuning config",

--- a/cmd/edit/tuningconfigs/cmd.go
+++ b/cmd/edit/tuningconfigs/cmd.go
@@ -84,6 +84,10 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	specPath := args.specPath
+	if specPath == "" && !interactive.Enabled() {
+		interactive.Enable()
+		r.Reporter.Infof("Enabling interactive mode")
+	}
 	if interactive.Enabled() {
 		specPath, err = interactive.GetString(interactive.Input{
 			Question: "Path of the file containing the spec of the tuning config",


### PR DESCRIPTION
Related: SDA-9077 SDA-9085