### PR TITLE
Create cluster - fix error messages

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -897,9 +897,6 @@ func run(cmd *cobra.Command, _ []string) {
 			roleARN = roleARNs[0]
 		} else {
 			createAccountRolesCommand := "rosa create account-roles"
-			if isHostedCP {
-				createAccountRolesCommand = createAccountRolesCommand + " --hosted-cp"
-			}
 			r.Reporter.Warnf(fmt.Sprintf("No account roles found. You will need to manually set them in the "+
 				"next steps or run '%s' to create them first.", createAccountRolesCommand))
 			interactive.Enable()
@@ -945,12 +942,9 @@ func run(cmd *cobra.Command, _ []string) {
 				}
 				if selectedARN == "" {
 					createAccountRolesCommand := "rosa create account-roles"
-					if isHostedCP {
-						createAccountRolesCommand = createAccountRolesCommand + " --hosted-cp"
-					}
 					r.Reporter.Warnf(fmt.Sprintf("No %s account roles found. You will need to manually set "+
 						"them in the next steps or run '%s' to create "+
-						"them first.", createAccountRolesCommand, role.Name))
+						"them first.", role.Name, createAccountRolesCommand))
 					interactive.Enable()
 					hasRoles = false
 					break

--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -135,12 +135,7 @@ func run(cmd *cobra.Command, argv []string) error {
 
 	roleARN, err := awsClient.GetAccountRoleARN(prefix, role.Name)
 	if err != nil {
-		if args.hostedCP {
-			reporter.Errorf("Failed to get hosted CP account roles ARN: %v", err)
-		} else {
-			reporter.Errorf("Failed to get classic account role ARN: %v. "+
-				"To upgrade hosted CP account roles use the '--hosted-cp' flag", err)
-		}
+		r.Reporter.Errorf("Failed to get account roles ARN: %v", err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Omit the `--hosted-cp` flag from the error message and fix the string formatting.

```
oadler@fedora:rosa (create-cluster-fix-warning-message)$ ./rosa create cluster --cluster-name zg-may18 --sts --region us-west-2 --replicas 2 --compute-machine-type m5.xlarge --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23 --subnet-ids subnet-0d65e2465258986db,subnet-0cbc29215162f7548 --hosted-cp --yes --mode=auto --oidc-config-id 23ihr0nit0krcdvt4v8qtjltkptj2947 --dry-run true
I: NOTE: Hosted control planes are currently in Technology Preview (https://access.redhat.com/support/offerings/techpreview). Any Technology Preview clusters will need to be destroyed and recreated prior to general availability.
W: In a future release STS will be the default mode.
W: --sts flag won't be necessary if you wish to use STS.
W: --non-sts/--mint-mode flag will be necessary if you do not wish to use STS.
W: More than one Installer role found
I: Using arn:aws:iam::765374464689:role/ManagedOpenShift-Installer-Role for the Installer role
I: Using arn:aws:iam::765374464689:role/ManagedOpenShift-Worker-Role for the Worker role
W: No Support account roles found. You will need to manually set them in the next steps or run 'rosa create account-roles' to create them first.
? Role ARN: [? for help] (arn:aws:iam::765374464689:role/ManagedOpenShift-Installer-Role) 
```

```
oadler@fedora:rosa (create-cluster-fix-warning-message)$ ./rosa upgrade account-roles --prefix oriadler
E: Failed to get account roles ARN: Role with the prefix 'oriadler' not found
```