### PR TITLE
SDA-4652 | feat: add list oidc providers command

### DIFF
--- a/cmd/list/cmd.go
+++ b/cmd/list/cmd.go
@@ -29,6 +29,7 @@ import (
 	"github.com/openshift/rosa/cmd/list/machinepool"
 	"github.com/openshift/rosa/cmd/list/ocmroles"
 	"github.com/openshift/rosa/cmd/list/oidcconfig"
+	"github.com/openshift/rosa/cmd/list/oidcprovider"
 	"github.com/openshift/rosa/cmd/list/operatorroles"
 	"github.com/openshift/rosa/cmd/list/region"
 	"github.com/openshift/rosa/cmd/list/service"
@@ -65,6 +66,7 @@ func init() {
 	Cmd.AddCommand(service.Cmd)
 	Cmd.AddCommand(oidcconfig.Cmd)
 	Cmd.AddCommand(tuningconfigs.Cmd)
+	Cmd.AddCommand(oidcprovider.Cmd)
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)
 	arguments.AddRegionFlag(flags)
@@ -72,6 +74,7 @@ func init() {
 	globallyAvailableCommands := []*cobra.Command{
 		accountroles.Cmd, userroles.Cmd,
 		ocmroles.Cmd, oidcconfig.Cmd,
+		oidcprovider.Cmd,
 	}
 	arguments.MarkRegionHidden(Cmd, globallyAvailableCommands)
 }

--- a/cmd/list/oidcprovider/cmd.go
+++ b/cmd/list/oidcprovider/cmd.go
@@ -1,0 +1,107 @@
+/*
+Copyright (c) 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oidcprovider
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/briandowns/spinner"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/output"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+var Cmd = &cobra.Command{
+	Use:     "oidc-providers",
+	Aliases: []string{"oidcprovider", "oidc-provider", "oidcproviders"},
+	Short:   "List OIDC providers",
+	Long:    "List OIDC providers for the current AWS account.",
+	Example: `  # List all oidc providers
+  rosa list oidc-providers`,
+	Run: run,
+}
+
+func init() {
+	flags := Cmd.Flags()
+	flags.SortFlags = false
+	output.AddFlag(Cmd)
+	ocm.AddOptionalClusterFlag(Cmd)
+}
+
+func run(cmd *cobra.Command, _ []string) {
+	r := rosa.NewRuntime().WithAWS()
+	defer r.Cleanup()
+
+	var spin *spinner.Spinner
+	if r.Reporter.IsTerminal() {
+		spin = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+	}
+	if spin != nil {
+		r.Reporter.Infof("Fetching OIDC providers")
+		spin.Start()
+	}
+
+	clusterId := ""
+	if cmd.Flags().Changed("cluster") {
+		clusterKey := r.GetClusterKey()
+		clusterId = clusterKey
+	}
+
+	providers, err := r.AWSClient.ListOidcProviders(clusterId)
+	if spin != nil {
+		spin.Stop()
+	}
+	if err != nil {
+		r.Reporter.Errorf("Failed to get OIDC providers: %v", err)
+		os.Exit(1)
+	}
+
+	if len(providers) == 0 {
+		r.Reporter.Infof("No OIDC providers available")
+		os.Exit(0)
+	}
+	if output.HasFlag() {
+		outList := []map[string]interface{}{}
+		for _, provider := range providers {
+			outList = append(outList, map[string]interface{}{"arn": provider.Arn, "cluster_id": provider.ClusterId})
+		}
+		err = output.Print(outList)
+		if err != nil {
+			r.Reporter.Errorf("%s", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
+	// Create the writer that will be used to print the tabulated results:
+	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(writer, "OIDC PROVIDER ARN\tCluster ID\n")
+	for _, oidcProvider := range providers {
+		fmt.Fprintf(
+			writer,
+			"%s\t%s\n",
+			oidcProvider.Arn,
+			oidcProvider.ClusterId,
+		)
+	}
+	writer.Flush()
+}

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -122,6 +122,7 @@ type Client interface {
 	ListOCMRoles() ([]Role, error)
 	ListAccountRoles(version string) ([]Role, error)
 	ListOperatorRoles(version string) (map[string][]Role, error)
+	ListOidcProviders(targetClusterId string) ([]OidcProviderOutput, error)
 	GetRoleByARN(roleARN string) (*iam.Role, error)
 	HasCompatibleVersionTags(iamTags []*iam.Tag, version string) (bool, error)
 	DeleteOperatorRole(roles string, managedPolicies bool) error

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -118,7 +118,7 @@ func Print(resource interface{}) error {
 				}
 			}
 		}
-	case "object.Object", "map[string]interface {}":
+	case "object.Object", "map[string]interface {}", "[]map[string]interface {}":
 		{
 			reqBodyBytes := new(bytes.Buffer)
 			json.NewEncoder(reqBodyBytes).Encode(resource)


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-4652
# What
Adds listing of identity providers in current AWS account filtering `red-hat-managed:true` tags

For the identity providers which are created through an OIDC configuration is shows the cluster ID as empty ("") and the OIDC configuration ID is not yet retrieved. This will be part of second PR 

```
./rosa list oidc-provider                                    
I: Fetching OIDC providers
/ time=2023-05-29T09:04:19-03:00 level=warning msg=Throttling Rate limit exceeded. Retrying the request again
OIDC PROVIDER ARN                                                                                                Cluster ID
arn:aws:iam::xxx:oidc-provider/d1b0cha94ris3q.cloudfront.net/xxx           
arn:aws:iam::xxx:oidc-provider/d3gt1gce2zmg3d.cloudfront.net/xxx           
arn:aws:iam::xxx:oidc-provider/d3gt1gce2zmg3d.cloudfront.net/xxx           
arn:aws:iam::xxx:oidc-provider/d3gt1gce2zmg3d.cloudfront.net/xxx           xxx
arn:aws:iam::xxx:oidc-provider/d3gt1gce2zmg3d.cloudfront.net/xxx           xxx
arn:aws:iam::xxx:oidc-provider/d3gt1gce2zmg3d.cloudfront.net/xxx           xxx
arn:aws:iam::xxx:oidc-provider/xxx.s3.us-east-1.amazonaws.com                             
arn:aws:iam::xxx:oidc-provider/xxx.s3.us-east-1.amazonaws.com                        
arn:aws:iam::xxx:oidc-provider/xxx.s3.us-east-1.amazonaws.com                              
arn:aws:iam::xxx:oidc-provider/rh-oidc-dev.s3.us-east-1.amazonaws.com/xxx  xxx
arn:aws:iam::xxx:oidc-provider/rh-oidc-dev.s3.us-east-1.amazonaws.com/xxx  
arn:aws:iam::xxx:oidc-provider/rh-oidc-dev.s3.us-east-1.amazonaws.com/xxx  
arn:aws:iam::xxx:oidc-provider/rh-oidc-dev.s3.us-east-1.amazonaws.com/xxx  
```