### PR TITLE
OCM-1013 | fix: remove dial issuer url when creating operator roles by prefix

### DIFF
--- a/cmd/create/operatorroles/by_prefix.go
+++ b/cmd/create/operatorroles/by_prefix.go
@@ -261,11 +261,6 @@ func validateArgumentsOperatorRolesCreationByPrefix(r *rosa.Runtime, operatorRol
 		r.Reporter.Errorf("Expected OIDC endpoint URL '%s' to use an https:// scheme", oidcEndpointUrl)
 		os.Exit(1)
 	}
-	err = helper.IsURLReachable(fmt.Sprintf("%s:%s", parsedURI.Host, parsedURI.Scheme))
-	if err != nil {
-		r.Reporter.Errorf("URL '%s' is not reachable.", oidcEndpointUrl)
-		os.Exit(1)
-	}
 	err = aws.ARNValidator(installerRoleArn)
 	if err != nil {
 		r.Reporter.Errorf("%s", err)

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -3,7 +3,6 @@ package helper
 import (
 	"math"
 	"math/rand"
-	"net"
 	"os"
 	"sort"
 	"strings"
@@ -202,16 +201,4 @@ func LongestCommonPrefixBySorting(stringSlice []string) string {
 	}
 
 	return first[:i]
-}
-
-func IsURLReachable(apiURL string) error {
-	dialer := &net.Dialer{
-		Timeout: time.Second,
-	}
-	externalConnection, err := dialer.Dial("tcp", apiURL)
-	if err != nil {
-		return err
-	}
-	defer externalConnection.Close()
-	return nil
 }


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/OCM-1013
# What
Removes dial call, trusting OCM registered configuration