### PR TITLE
OCM-1179 | fix: act on output flag for list service command

### DIFF
--- a/cmd/list/service/cmd.go
+++ b/cmd/list/service/cmd.go
@@ -62,6 +62,20 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
+	if output.HasFlag() {
+		outList := []*msv1.ManagedService{}
+		servicesList.Each(func(srv *msv1.ManagedService) bool {
+			outList = append(outList, srv)
+			return true
+		})
+		output.Print(outList)
+		if err != nil {
+			r.Reporter.Errorf("%s", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
 	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	fmt.Fprintf(writer, "SERVICE_ID\tSERVICE\tSERVICE_STATE\tCLUSTER_NAME\n")
 	servicesList.Each(func(srv *msv1.ManagedService) bool {

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	msv1 "github.com/openshift-online/ocm-sdk-go/servicemgmt/v1"
 	"github.com/openshift/rosa/pkg/aws"
 	"gitlab.com/c0b/go-ordered-json"
 )
@@ -40,6 +41,10 @@ var emptyBuffer = []byte{91, 10, 32, 32, 10, 93}
 func Print(resource interface{}) error {
 	var b bytes.Buffer
 	switch reflect.TypeOf(resource).String() {
+	case "[]*v1.ManagedService":
+		if managedServices, ok := resource.([]*msv1.ManagedService); ok {
+			msv1.MarshalManagedServiceList(managedServices, &b)
+		}
 	case "[]*v1.CloudRegion":
 		if cloudRegions, ok := resource.([]*cmv1.CloudRegion); ok {
 			cmv1.MarshalCloudRegionList(cloudRegions, &b)


### PR DESCRIPTION
Related issue: [OCM-1179](https://issues.redhat.com/browse/OCM-1179)