### PR TITLE
OCM-1361 | fix: Add flag to bypass confirmation on edit cluster

### DIFF
--- a/cmd/edit/cluster/cmd.go
+++ b/cmd/edit/cluster/cmd.go
@@ -234,7 +234,7 @@ func run(cmd *cobra.Command, _ []string) {
 		private = &privateValue
 	} else if privateValue {
 		r.Reporter.Warnf("You are choosing to make your cluster API private. %s", privateWarning)
-		if !confirm.Yes() && !confirm.Confirm("set cluster '%s' as private", clusterKey) {
+		if !confirm.Confirm("set cluster '%s' as private", clusterKey) {
 			os.Exit(0)
 		}
 	}
@@ -261,7 +261,7 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 		disableWorkloadMonitoring = &disableWorkloadMonitoringValue
 	} else if disableWorkloadMonitoringValue {
-		if !confirm.Yes() && !confirm.Confirm("disable workload monitoring for your cluster %s", clusterKey) {
+		if !confirm.Confirm("disable workload monitoring for your cluster %s", clusterKey) {
 			os.Exit(0)
 		}
 	}

--- a/cmd/edit/cluster/cmd.go
+++ b/cmd/edit/cluster/cmd.go
@@ -66,6 +66,7 @@ func init() {
 	flags.SortFlags = false
 
 	ocm.AddClusterFlag(Cmd)
+	confirm.AddFlag(Cmd.Flags())
 
 	// Basic options
 	flags.StringVar(
@@ -233,7 +234,7 @@ func run(cmd *cobra.Command, _ []string) {
 		private = &privateValue
 	} else if privateValue {
 		r.Reporter.Warnf("You are choosing to make your cluster API private. %s", privateWarning)
-		if !confirm.Confirm("set cluster '%s' as private", clusterKey) {
+		if !confirm.Yes() && !confirm.Confirm("set cluster '%s' as private", clusterKey) {
 			os.Exit(0)
 		}
 	}
@@ -260,7 +261,7 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 		disableWorkloadMonitoring = &disableWorkloadMonitoringValue
 	} else if disableWorkloadMonitoringValue {
-		if !confirm.Confirm("disable workload monitoring for your cluster %s", clusterKey) {
+		if !confirm.Yes() && !confirm.Confirm("disable workload monitoring for your cluster %s", clusterKey) {
 			os.Exit(0)
 		}
 	}


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/OCM-1361

This PR adds functionality to the edit cluster command to accept a "-y" flag to bypass confirmation on certain changes. Editing proxy values remains unchanged as the confirmation question was never asked on these commands