### PR TITLE
OCM-842|Feat: Accept multiple users for htpasswd IDP

### DIFF
--- a/cmd/create/idp/cmd.go
+++ b/cmd/create/idp/cmd.go
@@ -78,6 +78,7 @@ var args struct {
 	// HTPasswd
 	htpasswdUsername string
 	htpasswdPassword string
+	htpasswdUsers    []string
 }
 
 var validIdps = []string{"github", "gitlab", "google", "htpasswd", "ldap", "openid"}
@@ -289,6 +290,16 @@ func init() {
 			"The password must\n"+
 			"- Be at least 14 characters (ASCII-standard) without whitespaces\n"+
 			"- Include uppercase letters, lowercase letters, and numbers or symbols (ASCII-standard characters only)",
+	)
+
+	// HTPasswd
+	flags.StringSliceVarP(
+		&args.htpasswdUsers,
+		"users",
+		"u",
+		[]string{},
+		"HTPasswd: List of users to add to the IDP. \n"+
+			"It must be a comma separate list of  username:password, i.e user1:password,user2:password",
 	)
 
 	interactive.AddFlag(flags)

--- a/pkg/ocm/idps.go
+++ b/pkg/ocm/idps.go
@@ -83,6 +83,15 @@ func (c *Client) AddHTPasswdUser(username, password, clusterID, idpID string) er
 	return nil
 }
 
+func (c *Client) AddHTPasswdUsers(userList *cmv1.HTPasswdUserList, clusterID, idpID string) error {
+	response, err := c.ocm.ClustersMgmt().V1().Clusters().Cluster(clusterID).
+		IdentityProviders().IdentityProvider(idpID).HtpasswdUsers().Import().Items(userList.Slice()).Send()
+	if err != nil {
+		return handleErr(response.Error(), err)
+	}
+	return nil
+}
+
 func (c *Client) DeleteHTPasswdUser(username, clusterID string, htpasswdIDP *cmv1.IdentityProvider) error {
 	var userID string
 


### PR DESCRIPTION
-- Currently, ROSACLI for htpasswd idp, accepts only one username and password to add to the IDP 
-- the changes in this PR allow user to input multiple users at a time through the -users flag 
-- the old flags of username/password will continue to be supported for backward comptability 
-- and so as not to break existing automation

Refers to https://issues.redhat.com/browse/OCM-842