### PR TITLE
OCM-15 | feat: ability to set machine pool root disk size 

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2180,7 +2180,7 @@ func run(cmd *cobra.Command, _ []string) {
 		if args.machinePoolRootDiskSize == "" {
 			// We don't need to parse the default since it's returned from the OCM API and AWS
 			// always defaults to GiB
-			machinePoolRootDiskSizeStr = gigybyteStringer(defaultMachinePoolRootDiskSize)
+			machinePoolRootDiskSizeStr = helper.GigybyteStringer(defaultMachinePoolRootDiskSize)
 		} else {
 			machinePoolRootDiskSizeStr = args.machinePoolRootDiskSize
 		}
@@ -2195,7 +2195,7 @@ func run(cmd *cobra.Command, _ []string) {
 				Help:     cmd.Flags().Lookup("worker-disk-size").Usage,
 				Default:  machinePoolRootDiskSizeStr,
 				Validators: []interactive.Validator{
-					machinePoolRootDiskSizeValidator,
+					interactive.MachinePoolRootDiskSizeValidator,
 				},
 			})
 			if err != nil {
@@ -3211,26 +3211,4 @@ func getExpectedResourceIDForAccRole(hostedCPPolicies bool, roleARN string, role
 	}
 
 	return strings.ToLower(fmt.Sprintf("%s-%s-Role", rolePrefix, accountRoles[roleType].Name)), rolePrefix, nil
-}
-
-func gigybyteStringer(size int) string {
-	return fmt.Sprintf("%d GiB", size)
-}
-
-func machinePoolRootDiskSizeValidator(val interface{}) error {
-	// We expect GigiByte as the unit for the root volume size
-
-	// Validate the worker root volume size is an integer
-	machinePoolRootDiskSize, ok := val.(string)
-	if !ok {
-		return fmt.Errorf("machine pool root disk size must be an string, got %T", machinePoolRootDiskSize)
-	}
-
-	// parse it to validate it is a valid unit
-	_, err := ocm.ParseDiskSizeToGigibyte(machinePoolRootDiskSize)
-	if err != nil {
-		return fmt.Errorf("failed to parse machine pool root disk size: %v", err)
-	}
-
-	return nil
 }

--- a/cmd/create/machinepool/cmd.go
+++ b/cmd/create/machinepool/cmd.go
@@ -52,6 +52,7 @@ var args struct {
 	version               string
 	autorepair            bool
 	tuningConfigs         string
+	rootDiskSize          string
 }
 
 var Cmd = &cobra.Command{
@@ -195,6 +196,12 @@ func init() {
 		"Name of the tuning configs to be applied to the machine pool. Format should be a comma-separated list. "+
 			"Tuning config must already exist. "+
 			"This list will overwrite any modifications made to node tuning configs on an ongoing basis.",
+	)
+
+	flags.StringVar(&args.rootDiskSize,
+		"disk-size",
+		"",
+		"Root disk size with a suffix like GiB or TiB",
 	)
 
 	interactive.AddFlag(flags)

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -1,6 +1,7 @@
 package helper
 
 import (
+	"fmt"
 	"math"
 	"math/rand"
 	"os"
@@ -215,4 +216,8 @@ func LongestCommonPrefixBySorting(stringSlice []string) string {
 	}
 
 	return first[:i]
+}
+
+func GigybyteStringer(size int) string {
+	return fmt.Sprintf("%d GiB", size)
 }

--- a/pkg/interactive/validation.go
+++ b/pkg/interactive/validation.go
@@ -168,3 +168,21 @@ func AvailabilityZonesCountValidator(multiAZ bool) Validator {
 		return fmt.Errorf("can only validate a slice of string, got %v", input)
 	}
 }
+
+func MachinePoolRootDiskSizeValidator(val interface{}) error {
+	// We expect GigiByte as the unit for the root volume size
+
+	// Validate the worker root volume size is an integer
+	machinePoolRootDiskSize, ok := val.(string)
+	if !ok {
+		return fmt.Errorf("machine pool root disk size must be an string, got %T", machinePoolRootDiskSize)
+	}
+
+	// parse it to validate it is a valid unit
+	_, err := ocm.ParseDiskSizeToGigibyte(machinePoolRootDiskSize)
+	if err != nil {
+		return fmt.Errorf("failed to parse machine pool root disk size: %v", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
When creating a new machine pool (during a day 2 operation), we can now
set the size of the root disk.

```
$ rosa list machinepools -c 258idq729qn7g8ltl01vjsiopopf8lmi
ID            AUTOSCALING  REPLICAS  INSTANCE TYPE  LABELS    TAINTS    AVAILABILITY ZONES    SUBNETS    SPOT INSTANCES  DISK SIZE
Default       No           2         m5.xlarge                          us-west-2a                       N/A             256 GiB
mp-ocm-15     No           2         m5.xlarge                          us-west-2a                       No              128 GiB
no-disk-size  No           2         m5.xlarge                          us-west-2a                       No              default
```

In the above output:

* Default: represents the default mp and the cluster spec has the size
  set to 256
* mp-ocm-15: represents an mp with a size set to 128
* no-disk-size: represents an mp with no specified size

Signed-off-by: Sébastien Han <seb@redhat.com>