### PR TITLE
OCM-2157 | fix: ensure policy when calling delete policy versions was  not checking for errors

### DIFF
--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -1102,10 +1102,13 @@ func (c *awsClient) deletePolicyVersions(policyArn string) error {
 		if aws.BoolValue(version.IsDefaultVersion) {
 			continue
 		}
-		c.iamClient.DeletePolicyVersion(&iam.DeletePolicyVersionInput{
+		_, err := c.iamClient.DeletePolicyVersion(&iam.DeletePolicyVersionInput{
 			PolicyArn: aws.String(policyArn),
 			VersionId: version.VersionId,
 		})
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/OCM-2157
# What
When creating policies the error check for deleting older policy versions was missing