### PR TITLE
OCM-2246 | fix: check oidc provider from clusters within current aws account

### DIFF
--- a/cmd/dlt/oidcprovider/cmd.go
+++ b/cmd/dlt/oidcprovider/cmd.go
@@ -187,7 +187,9 @@ func run(cmd *cobra.Command, argv []string) {
 			r.Reporter.Infof("Provider '%s' not found.", oidcEndpointUrl)
 			return
 		}
-		hasClusterUsingOidcProvider, err := r.OCMClient.HasAClusterUsingOidcEndpointUrl(oidcEndpointUrl)
+		hasClusterUsingOidcProvider, err := r.OCMClient.
+			HasAClusterUsingOidcProvider(
+				oidcEndpointUrl, r.Creator.AccountID)
 		if err != nil {
 			r.Reporter.Errorf("There was a problem checking if any clusters are using OIDC provider '%s' : %v",
 				oidcEndpointUrl, err)

--- a/cmd/list/oidcprovider/cmd.go
+++ b/cmd/list/oidcprovider/cmd.go
@@ -87,7 +87,9 @@ func run(cmd *cobra.Command, _ []string) {
 			r.Reporter.Errorf("%v", err)
 			os.Exit(1)
 		}
-		has, err := r.OCMClient.HasAClusterUsingOidcEndpointUrl("https://" + resourceName)
+		has, err := r.OCMClient.
+			HasAClusterUsingOidcProvider(
+				fmt.Sprintf("https://%s", resourceName), r.Creator.AccountID)
 		if err != nil {
 			r.Reporter.Errorf("%v", err)
 			os.Exit(1)

--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -414,6 +414,24 @@ func (c *Client) HasAClusterUsingOperatorRolesPrefix(prefix string) (bool, error
 	return false, nil
 }
 
+func (c *Client) HasAClusterUsingOidcProvider(
+	issuerUrl string, curAccountId string) (bool, error) {
+	query := fmt.Sprintf(
+		"aws.sts.oidc_endpoint_url = '%s' AND aws.sts.role_arn like '%%%s%%'",
+		issuerUrl, curAccountId,
+	)
+	request := c.ocm.ClustersMgmt().V1().Clusters().List().Search(query)
+	page := 1
+	response, err := request.Page(page).Send()
+	if err != nil {
+		return false, err
+	}
+	if response.Total() > 0 {
+		return true, nil
+	}
+	return false, nil
+}
+
 func (c *Client) HasAClusterUsingOidcEndpointUrl(issuerUrl string) (bool, error) {
 	query := fmt.Sprintf(
 		"aws.sts.oidc_endpoint_url = '%s'", issuerUrl,


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/OCM-2246
# What
There are clusters which are created via managed oidc config, those are shared between org and stored within RH AWS account. By this it means there might be providers that refers to the same managed config, but live in different aws accounts.