### PR TITLE
OCM-2241| fix: Ensure all input users are added to the user list

### DIFF
--- a/cmd/create/idp/htpasswd.go
+++ b/cmd/create/idp/htpasswd.go
@@ -138,10 +138,12 @@ func buildUserList(cmd *cobra.Command, r *rosa.Runtime) *cmv1.HTPasswdUserListBu
 	}
 	r.Reporter.Infof("Adding users %v", userList)
 
-	htpassUserList := cmv1.NewHTPasswdUserList()
+	htpasswdUsers := []*cmv1.HTPasswdUserBuilder{}
 	for username, password := range userList {
-		htpassUserList = htpassUserList.Items(cmv1.NewHTPasswdUser().Username(username).Password(password))
+		htpasswdUsers = append(htpasswdUsers, cmv1.NewHTPasswdUser().Username(username).Password(password))
 	}
+
+	htpassUserList := cmv1.NewHTPasswdUserList().Items(htpasswdUsers...)
 	return htpassUserList
 }
 


### PR DESCRIPTION
Only the last user in the list was being set on the userlistBuilder, 
Adding each individual userBuilder to an array before setting the items on the userListBuilder

Ref: https://issues.redhat.com/browse/OCM-2241