### PR TITLE
OCM-2274 | Fix: skip version check for automated upgrade

### DIFF
--- a/cmd/describe/upgrade/cmd.go
+++ b/cmd/describe/upgrade/cmd.go
@@ -67,21 +67,25 @@ func returnHypershiftUpgrades(r *rosa.Runtime, clusterID string) {
 	}
 
 	for _, upgrade := range upgrades {
-		fmt.Printf(`%19s%61s
-		%-28s%s
-		%-28s%s
-		%-28s%s
+		fmt.Printf(`%19s%68s
+		%-35s%s
+		%-35s%s
+		%-35s%s
+		%-35s%s
 `,
 			"ID:", upgrade.ID(),
 			"Cluster ID:", upgrade.ClusterID(),
+			"Schedule Type:", upgrade.ScheduleType(),
 			"Next Run:", upgrade.NextRun(),
 			"Upgrade State:", upgrade.State().Value())
 		if upgrade.Schedule() != "" {
-			fmt.Printf(`                %-28s%s
+			fmt.Printf(`                %-35s%s
 `, "Schedule At:", upgrade.Schedule())
+			fmt.Printf(`                %-35s%t
+`, "Enable minor version upgrades:", upgrade.EnableMinorVersionUpgrades())
 		}
 		if upgrade.Version() != "" {
-			fmt.Printf(`                %-28s%s
+			fmt.Printf(`                %-35s%s
 `, "Version:", upgrade.Version())
 		}
 	}

--- a/cmd/upgrade/cluster/cmd.go
+++ b/cmd/upgrade/cluster/cmd.go
@@ -314,7 +314,8 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 	}
 
 	// if cluster is sts validate roles are compatible with upgrade version
-	if isSTS {
+	// for automatic upgrades, version is not available
+	if isSTS && !currentUpgradeScheduling.automaticUpgrades {
 		checkSTSRolesCompatibility(r, cluster, mode, version, clusterKey)
 	}
 


### PR DESCRIPTION
This is not available at this step. Version is computed by the backend. Improve also output of describe upgrade command

Related: [OCM-2274](https://issues.redhat.com//browse/OCM-2274) [OCM-2278](https://issues.redhat.com//browse/OCM-2278)

Output example
```
rosa describe upgrade -c ad-stg1
                ID:                                21ac7f1a-06da-11ee-b176-0a580a830047
		Cluster ID:                        248f2o9pi208rpjfe2mjdnqa1j11c1sg
		Schedule Type:                     automatic
		Next Run:                          2023-06-09 20:20:00 +0000 UTC
		Upgrade State:                     scheduled
                Schedule At:                       20 20 * * *
                Enable minor version upgrades:     true
                Version:                           4.12.19
```