### PR TITLE
OCM-2259 | feat: Expose `--hosted-cp` flag

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -125,7 +125,6 @@ func init() {
 		false,
 		"Technology Preview: Enable the use of Hosted Control Planes",
 	)
-	flags.MarkHidden("hosted-cp")
 
 	aws.AddModeFlag(Cmd)
 

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -584,7 +584,7 @@ func init() {
 			"roles in STS clusters.",
 	)
 
-	// Options releated to HyperShift:
+	// Options related to HyperShift:
 	flags.BoolVar(
 		&args.hostedClusterEnabled,
 		"hosted-cp",

--- a/cmd/dlt/accountroles/cmd.go
+++ b/cmd/dlt/accountroles/cmd.go
@@ -65,7 +65,6 @@ func init() {
 		false,
 		"Delete Hosted Control Planes roles",
 	)
-	flags.MarkHidden("hosted-cp")
 
 	flags.BoolVar(
 		&args.classic,
@@ -73,7 +72,6 @@ func init() {
 		false,
 		"Delete classic account roles",
 	)
-	flags.MarkHidden("classic")
 
 	aws.AddModeFlag(Cmd)
 	confirm.AddFlag(flags)

--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -90,7 +90,6 @@ func init() {
 		false,
 		"Technology Preview: Enable the use of Hosted Control Planes",
 	)
-	flags.MarkHidden("hosted-cp")
 
 	confirm.AddFlag(flags)
 	interactive.AddFlag(flags)


### PR DESCRIPTION
AWS published all the managed policies, therefore, exposing the flag.

Related: [OCM-2259](https://issues.redhat.com/browse/OCM-2259)