### PR TITLE
OCM-2181 | Fix: error message was misleading

### DIFF
--- a/cmd/upgrade/cluster/cmd.go
+++ b/cmd/upgrade/cluster/cmd.go
@@ -671,8 +671,7 @@ func checkAndAckMissingAgreementsHypershift(r *rosa.Runtime, cluster *cmv1.Clust
 	// check if the cluster upgrade requires gate agreements
 	gates, err := r.OCMClient.GetMissingGateAgreementsHypershift(cluster.ID(), upgradePolicy)
 	if err != nil {
-		return fmt.Errorf("failed to check for missing gate agreements upgrade for "+
-			"cluster '%s': %v", clusterKey, err)
+		return err
 	}
 	return checkGates(r, cluster, gates, clusterKey)
 }


### PR DESCRIPTION
Backend is already returning enough context for the user, the additional message may be misleading

Related: [OCM-2181](https://issues.redhat.com//browse/OCM-2181)