### PR TITLE
adds new admin flag and SREP login/url aliases for FedRAMP

### DIFF
--- a/cmd/login/cmd.go
+++ b/cmd/login/cmd.go
@@ -157,7 +157,11 @@ func run(cmd *cobra.Command, argv []string) {
 		if env == sdk.DefaultURL {
 			env = "production"
 		}
-		uiTokenPage = fedramp.LoginURLs[env]
+		if fedramp.HasAdminFlag(cmd) {
+			uiTokenPage = fedramp.SREPLoginURLs[env]
+		} else {
+			uiTokenPage = fedramp.LoginURLs[env]
+		}
 	} else {
 		fedramp.Disable()
 	}
@@ -223,9 +227,16 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 	// Override configuration details for FedRAMP:
 	if fedramp.Enabled() {
-		gatewayURL, ok = fedramp.URLAliases[env]
-		if !ok {
-			gatewayURL = env
+		if fedramp.HasAdminFlag(cmd) {
+			gatewayURL, ok = fedramp.SREPURLAliases[env]
+			if !ok {
+				gatewayURL = env
+			}
+		} else {
+			gatewayURL, ok = fedramp.URLAliases[env]
+			if !ok {
+				gatewayURL = env
+			}
 		}
 		tokenURL, ok = fedramp.TokenURLs[env]
 		if !ok {

--- a/pkg/fedramp/config.go
+++ b/pkg/fedramp/config.go
@@ -46,11 +46,25 @@ var LoginURLs = map[string]string{
 	"integration": "https://api.int.openshiftusgov.com/auth",
 }
 
+// SREPLoginURLs allows the value of the `--env` option to map to the various SREP login URLs.
+var SREPLoginURLs = map[string]string{
+	"production":  "https://api-admin.openshiftusgov.com/auth",
+	"staging":     "https://api-admin.stage.openshiftusgov.com/auth",
+	"integration": "https://api-admin.int.openshiftusgov.com/auth",
+}
+
 // URLAliases allows the value of the `--env` option to map to the various API URLs.
 var URLAliases = map[string]string{
 	"production":  "https://api.openshiftusgov.com",
 	"staging":     "https://api.stage.openshiftusgov.com",
 	"integration": "https://api.int.openshiftusgov.com",
+}
+
+// SREPURLAliases allows the value of the `--env` option to map to the various SREP API URLs.
+var SREPURLAliases = map[string]string{
+	"production":  "https://api-admin.openshiftusgov.com",
+	"staging":     "https://api-admin.stage.openshiftusgov.com",
+	"integration": "https://api-admin.int.openshiftusgov.com",
 }
 
 const cognitoURL = "auth-fips.us-gov-west-1.amazoncognito.com/oauth2/token"

--- a/pkg/fedramp/flag.go
+++ b/pkg/fedramp/flag.go
@@ -33,10 +33,25 @@ func AddFlag(flags *pflag.FlagSet) {
 		false,
 		"Uses the FedRAMP High OpenShift Cluster Manager API for creating clusters in AWS GovCloud regions",
 	)
+
+	flags.BoolVar(
+		&enabled,
+		"admin",
+		false,
+		"Uses the FedRAMP High OpenShift Cluster Manager API Endpoint for SREP Access",
+	)
 }
 
 func HasFlag(cmd *cobra.Command) bool {
 	flag := cmd.Flags().Lookup("govcloud")
+	if flag == nil {
+		return false
+	}
+	return flag.Changed
+}
+
+func HasAdminFlag(cmd *cobra.Command) bool {
+	flag := cmd.Flags().Lookup("admin")
 	if flag == nil {
 		return false
 	}

--- a/pkg/fedramp/flag.go
+++ b/pkg/fedramp/flag.go
@@ -40,6 +40,7 @@ func AddFlag(flags *pflag.FlagSet) {
 		false,
 		"Uses the FedRAMP High OpenShift Cluster Manager API Endpoint for SREP Access",
 	)
+	flags.MarkHidden("admin")
 }
 
 func HasFlag(cmd *cobra.Command) bool {


### PR DESCRIPTION
For [OSD-16451](https://issues.redhat.com/browse/OSD-16451) and [OCM-2433](https://issues.redhat.com/browse/OCM-2433)
- adds new `--admin` flag that overrides aliases for FedRAMP for the SREP Cognito endpoints
- adds new login/url aliases for SREP endpoints for FedRAMP
- updates all related logic to check for this flag and set the correct aliases accordingly