### PR TITLE
OCM-2347: Accept path setting thru iam role check - regex

### DIFF
--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -31,7 +31,7 @@ import (
 var RoleNameRE = regexp.MustCompile(`^[\w+=,.@-]+$`)
 
 var AuditLogArnRE = regexp.MustCompile(
-	`^arn:aws:iam::\d{12}:role/[a-zA-Z0-9_-]+$`,
+	`^arn:aws:iam::\d{12}:role(?:\/[\w+=,.@-]+)*(?:\/[a-zA-Z0-9_-]+)$`,
 )
 
 // UserTagKeyRE , UserTagValueRE - https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html#tag-conventions


### PR DESCRIPTION
Description of problem:
The AuditLogArnRE (regex) should allow the iam role arn with path setting and pass the validation.

BEFORE FIX
Example that passes:
arn:aws:iam::000000000000:role/asdf-audit-r
Example that fails:
arn:aws:iam::000000000000:role/aa/asd/asdf-audit-r

AFTER FIX
Example that passes:
arn:aws:iam::000000000000:role/asdf-audit-r
arn:aws:iam::000000000000:role/aa/asd/asdf-audit-r
