### PR TITLE
[OCM-2380] Rosa CLI "build command" should not show "--audit-log-arn" flag when value == ""

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2882,7 +2882,7 @@ func buildCommand(spec ocm.Spec, operatorRolesPrefix string,
 		command += fmt.Sprintf(" --etcd-encryption-kms-arn %s", spec.EtcdEncryptionKMSArn)
 	}
 
-	if spec.AuditLogRoleARN != nil {
+	if spec.AuditLogRoleARN != nil && *spec.AuditLogRoleARN != "" {
 		command += fmt.Sprintf(" --audit-log-arn %s", *spec.AuditLogRoleARN)
 	}
 


### PR DESCRIPTION
Bug Fix: 
Should not show --audit-log-arn flag in the buildCommand output if no audit log arn value is passed during cluster create command in ROSA CLI. (rosa create cluster --hosted-cp output)

CURRENT:
Previous output when value --audit-log-arn was not being passed
```
I: To create this cluster again in the future, you can run:
rosa create cluster --cluster-name test --sts --role-arn arn:aws:iam::############:role/############-ROSA-
Installer-Role --support-role-arn arn:aws:iam::############:role/############-ROSA-Support-Role --worker-iam-
role arn:aws:iam::############:role/############-ROSA-Worker-Role --operator-roles-prefix ############ --
oidc-config-id ############ --region ############ --version #### --replicas 2 --compute-machine-type m5.xlarge --
machine-cidr ############ --service-cidr ############ --pod-cidr ############ --host-prefix ## --subnet-ids 
subnet-############,subnet-############ --hosted-cp --audit-log-arn
```
  
EXPECTED RESULT:
```
I: To create this cluster again in the future, you can run:
rosa create cluster --cluster-name test --sts --role-arn arn:aws:iam::############:role/############-ROSA-
Installer-Role --support-role-arn arn:aws:iam::############:role/############-ROSA-Support-Role --worker-iam-
role arn:aws:iam::############:role/############-ROSA-Worker-Role --operator-roles-prefix ############ --
oidc-config-id ############ --region ############ --version #### --replicas 2 --compute-machine-type m5.xlarge --
machine-cidr ############ --service-cidr ############ --pod-cidr ############ --host-prefix ## --subnet-ids 
subnet-############,subnet-############ --hosted-cp
```
