### PR TITLE
[OCM-2347] fix: accept limited symbols in role name section of arn

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2263,7 +2263,7 @@ func run(cmd *cobra.Command, _ []string) {
 				Default:  auditLogRoleARN,
 				Required: true,
 				Validators: []interactive.Validator{
-					interactive.RegExp(aws.AuditLogArnRE.String()),
+					interactive.RegExp(aws.RoleArnRE.String()),
 				},
 			})
 			if err != nil {
@@ -2275,8 +2275,8 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 	}
 
-	if auditLogRoleARN != "" && !aws.AuditLogArnRE.MatchString(auditLogRoleARN) {
-		r.Reporter.Errorf("Expected a valid value for audit log arn matching %s", aws.AuditLogArnRE)
+	if auditLogRoleARN != "" && !aws.RoleArnRE.MatchString(auditLogRoleARN) {
+		r.Reporter.Errorf("Expected a valid value for audit log arn matching %s", aws.RoleArnRE)
 		os.Exit(1)
 	}
 

--- a/cmd/edit/cluster/cmd.go
+++ b/cmd/edit/cluster/cmd.go
@@ -600,8 +600,8 @@ func setAuditLogForwarding(r *rosa.Runtime, cmd *cobra.Command, cluster *cmv1.Cl
 			return nil, fmt.Errorf("Audit log forwarding to AWS CloudWatch is only supported for Hosted Control Plane clusters")
 
 		}
-		if auditLogArn != "" && !aws.AuditLogArnRE.MatchString(auditLogArn) {
-			return nil, fmt.Errorf("Expected a valid value for audit-log-arn matching %s", aws.AuditLogArnRE.String())
+		if auditLogArn != "" && !aws.RoleArnRE.MatchString(auditLogArn) {
+			return nil, fmt.Errorf("Expected a valid value for audit-log-arn matching %s", aws.RoleArnRE.String())
 		}
 		argValuePtr := new(string)
 		*argValuePtr = auditLogArn
@@ -651,7 +651,7 @@ func auditLogInteractivePrompt(r *rosa.Runtime, cmd *cobra.Command, cluster *cmv
 			Default:  "",
 			Required: true,
 			Validators: []interactive.Validator{
-				interactive.RegExp(aws.AuditLogArnRE.String()),
+				interactive.RegExp(aws.RoleArnRE.String()),
 			},
 		})
 		if err != nil {

--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -28,10 +28,12 @@ import (
 	rprtr "github.com/openshift/rosa/pkg/reporter"
 )
 
+// AWS accepted role name: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html
 var RoleNameRE = regexp.MustCompile(`^[\w+=,.@-]+$`)
 
-var AuditLogArnRE = regexp.MustCompile(
-	`^arn:aws:iam::\d{12}:role(?:\/[\w+=,.@-]+)*(?:\/[a-zA-Z0-9_-]+)$`,
+// AWS accepted arn format: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html
+var RoleArnRE = regexp.MustCompile(
+	`^arn:aws[\w-]*:iam::\d{12}:role(?:\/+[\w+=,.@-]+)+$`,
 )
 
 // UserTagKeyRE , UserTagValueRE - https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html#tag-conventions


### PR DESCRIPTION
Per AWS documentation,
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html
Role name can compose of some characters outside of "alphanumeric" characters:
![image](https://github.com/openshift/rosa/assets/118839428/360bfc4b-204a-4bfa-85a7-bd6dcd745527)

I previously made an incorrect assumption; thus making the correct adjustment.
Regex (`^arn:aws[\w-]*:iam::\d{12}:role(?:\/+[\w+=,.@-]+)+$`) is also the same format being used in CS for generic IAM Roles
