### PR TITLE
OCM-954 | Feat: small refactor to prepare for nodepool upgrades

### DIFF
--- a/cmd/dlt/machinepool/nodepool.go
+++ b/cmd/dlt/machinepool/nodepool.go
@@ -11,9 +11,13 @@ import (
 func deleteNodePool(r *rosa.Runtime, nodePoolID string, clusterKey string, cluster *cmv1.Cluster) {
 	// Try to find the machine pool:
 	r.Reporter.Debugf("Loading machine pools for hosted cluster '%s'", clusterKey)
-	nodePool, err := r.OCMClient.GetNodePool(cluster.ID(), nodePoolID)
+	nodePool, exists, err := r.OCMClient.GetNodePool(cluster.ID(), nodePoolID)
 	if err != nil {
 		r.Reporter.Errorf("Failed to get machine pools for hosted cluster '%s': %v", clusterKey, err)
+		os.Exit(1)
+	}
+	if !exists {
+		r.Reporter.Errorf("Machine pool '%s' does not exist for hosted cluster '%s'", nodePoolID, clusterKey)
 		os.Exit(1)
 	}
 

--- a/cmd/edit/machinepool/nodepool.go
+++ b/cmd/edit/machinepool/nodepool.go
@@ -40,9 +40,13 @@ func editNodePool(cmd *cobra.Command, nodePoolID string, clusterKey string, clus
 
 	// Try to find the node pool
 	r.Reporter.Debugf("Loading machine pool for hosted cluster '%s'", clusterKey)
-	nodePool, err := r.OCMClient.GetNodePool(cluster.ID(), nodePoolID)
+	nodePool, exists, err := r.OCMClient.GetNodePool(cluster.ID(), nodePoolID)
 	if err != nil {
 		r.Reporter.Errorf("Failed to get machine pools for hosted cluster '%s': %v", clusterKey, err)
+		os.Exit(1)
+	}
+	if !exists {
+		r.Reporter.Errorf("Machine pool '%s' does not exist for hosted cluster '%s'", nodePoolID, clusterKey)
 		os.Exit(1)
 	}
 

--- a/cmd/upgrade/cluster/cmd_test.go
+++ b/cmd/upgrade/cluster/cmd_test.go
@@ -156,7 +156,18 @@ var _ = Describe("Upgrade", Ordered, func() {
       "delete_protection": {
         "href": "/api/clusters_mgmt/v1/clusters/241p9e7ve372j8li66cdegd7t90ro5e4/delete_protection",
         "enabled": false
-      }
+      },
+	  "version": {
+		"kind": "Version",
+		"id": "openshift-v4.12.18",
+		"href": "/api/clusters_mgmt/v1/versions/openshift-v4.12.18",
+		"raw_id": "4.12.18",
+		"channel_group": "stable",
+		"available_upgrades": [
+		   "4.12.19"
+		],
+		"end_of_life_timestamp": "2024-03-17T00:00:00Z"
+	  }
     }
   ]
 }`
@@ -377,7 +388,7 @@ var _ = Describe("Upgrade", Ordered, func() {
 			),
 		)
 		// An existing policy upgrade
-		// nolint
+		// nolint:lll
 		apiServer.AppendHandlers(
 			RespondWithJSON(
 				http.StatusOK,
@@ -473,7 +484,7 @@ var _ = Describe("Upgrade", Ordered, func() {
 		Expect(err).ToNot(BeNil())
 		// Missing the upgrade type
 		Expect(err.Error()).To(ContainSubstring(
-			"Schedule date should use the format 'yyyy-mm-dd'\n   Schedule time should use the format 'HH:mm'"))
+			"schedule date should use the format 'yyyy-mm-dd'\n   Schedule time should use the format 'HH:mm'"))
 	})
 	It("Cluster is ready and with manual scheduling but no upgrades available", func() {
 		args.controlPlane = true

--- a/pkg/interactive/upgrades.go
+++ b/pkg/interactive/upgrades.go
@@ -1,0 +1,99 @@
+package interactive
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/robfig/cron/v3"
+	"github.com/spf13/cobra"
+)
+
+func BuildManualUpgradeSchedule(cmd *cobra.Command, scheduleDate string, scheduleTime string) (time.Time, error) {
+	// Set the default next run within the next 10 minutes
+	now := time.Now().UTC().Add(time.Minute * 10)
+	if scheduleDate == "" {
+		scheduleDate = now.Format("2006-01-02")
+	}
+	if scheduleTime == "" {
+		scheduleTime = now.Format("15:04")
+	}
+
+	if Enabled() {
+		// If datetimes are set, use them in the interactive form, otherwise fallback to 'now'
+		scheduleParsed, err := time.Parse("2006-01-02 15:04", fmt.Sprintf("%s %s", scheduleDate, scheduleTime))
+		if err != nil {
+			return now, fmt.Errorf("schedule date should use the format 'yyyy-mm-dd'\n" +
+				"   Schedule time should use the format 'HH:mm'")
+		}
+		if scheduleParsed.IsZero() {
+			scheduleParsed = now
+		}
+		scheduleDate = scheduleParsed.Format("2006-01-02")
+		scheduleTime = scheduleParsed.Format("15:04")
+
+		scheduleDate, err = GetString(Input{
+			Question: "Please input desired date in format yyyy-mm-dd",
+			Help:     cmd.Flags().Lookup("schedule-date").Usage,
+			Default:  scheduleDate,
+			Required: true,
+		})
+		if err != nil {
+			return now, fmt.Errorf("expected a valid date: %s", err)
+		}
+		_, err = time.Parse("2006-01-02", scheduleDate)
+		if err != nil {
+			return now, fmt.Errorf("date format '%s' invalid", scheduleDate)
+		}
+
+		scheduleTime, err = GetString(Input{
+			Question: "Please input desired UTC time in format HH:mm",
+			Help:     cmd.Flags().Lookup("schedule-time").Usage,
+			Default:  scheduleTime,
+			Required: true,
+		})
+		if err != nil {
+			return now, fmt.Errorf("expected a valid time: %s", err)
+		}
+		_, err = time.Parse("15:04", scheduleTime)
+		if err != nil {
+			return now, fmt.Errorf("time format '%s' invalid", scheduleTime)
+		}
+	}
+
+	// Parse next run to time.Time
+	nextRun, err := time.Parse("2006-01-02 15:04", fmt.Sprintf("%s %s", scheduleDate, scheduleTime))
+	if err != nil {
+		return now, fmt.Errorf("schedule date should use the format 'yyyy-mm-dd'\n" +
+			"   Schedule time should use the format 'HH:mm'")
+	}
+	return nextRun, nil
+}
+
+func BuildAutomaticUpgradeSchedule(cmd *cobra.Command, schedule string) (string, error) {
+	// Check automatic upgrade scheduling
+	cronParser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+	var err error
+	if schedule != "" {
+		_, err = cronParser.Parse(fmt.Sprintf("CRON_TZ=UTC %s", schedule))
+		if err != nil {
+			return schedule, fmt.Errorf("Schedule '%s' is not a valid cron expression", schedule)
+		}
+	}
+	if Enabled() {
+		schedule, err = GetString(Input{
+			Question: "Please input desired automatic schedule with a cron expression",
+			Help:     cmd.Flags().Lookup("schedule").Usage,
+			Default:  schedule,
+			Required: true,
+		})
+		if err != nil {
+			return schedule, fmt.Errorf("Expected a valid automatic schedule: %s", err)
+		}
+		_, err = cronParser.Parse(fmt.Sprintf("CRON_TZ=UTC %s", schedule))
+		if err != nil {
+			return schedule, fmt.Errorf("Schedule '%s' is not a valid cron expression", schedule)
+		}
+	}
+
+	return schedule, nil
+}

--- a/pkg/ocm/controlplane_upgrades.go
+++ b/pkg/ocm/controlplane_upgrades.go
@@ -1,0 +1,85 @@
+/*
+Copyright (c) 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ocm
+
+import cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
+const controlPlaneUpgradeType = "ControlPlane"
+
+func (c *Client) CancelControlPlaneUpgrade(clusterID, upgradeID string) (bool, error) {
+	response, err := c.ocm.ClustersMgmt().V1().
+		Clusters().Cluster(clusterID).ControlPlane().UpgradePolicies().
+		ControlPlaneUpgradePolicy(upgradeID).Delete().Send()
+	if err != nil {
+		return false, handleErr(response.Error(), err)
+	}
+	return true, nil
+}
+
+func (c *Client) GetControlPlaneScheduledUpgrade(clusterID string) (*cmv1.ControlPlaneUpgradePolicy, error) {
+	upgradePolicies, err := c.GetControlPlaneUpgradePolicies(clusterID)
+	if err != nil {
+		return nil, err
+	}
+	for _, upgradePolicy := range upgradePolicies {
+		if upgradePolicy.UpgradeType() == controlPlaneUpgradeType {
+			return upgradePolicy, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (c *Client) GetControlPlaneUpgradePolicies(clusterID string) (
+	controlPlaneUpgradePolicies []*cmv1.ControlPlaneUpgradePolicy,
+	err error) {
+	collection := c.ocm.ClustersMgmt().V1().
+		Clusters().
+		Cluster(clusterID).
+		ControlPlane().
+		UpgradePolicies()
+	page := 1
+	size := 100
+	for {
+		response, err := collection.List().
+			Page(page).
+			Size(size).
+			Send()
+		if err != nil {
+			return nil, handleErr(response.Error(), err)
+		}
+		controlPlaneUpgradePolicies = append(controlPlaneUpgradePolicies, response.Items().Slice()...)
+		if response.Size() < size {
+			break
+		}
+		page++
+	}
+	return
+}
+
+func (c *Client) ScheduleHypershiftControlPlaneUpgrade(clusterID string,
+	upgradePolicy *cmv1.ControlPlaneUpgradePolicy) error {
+	response, err := c.ocm.ClustersMgmt().V1().
+		Clusters().Cluster(clusterID).ControlPlane().
+		UpgradePolicies().
+		Add().Body(upgradePolicy).
+		Send()
+	if err != nil {
+		return handleErr(response.Error(), err)
+	}
+	return nil
+}

--- a/pkg/ocm/nodepools.go
+++ b/pkg/ocm/nodepools.go
@@ -26,17 +26,20 @@ func (c *Client) GetNodePools(clusterID string) ([]*cmv1.NodePool, error) {
 	return response.Items().Slice(), nil
 }
 
-func (c *Client) GetNodePool(clusterID string, nodePoolID string) (*cmv1.NodePool, error) {
+func (c *Client) GetNodePool(clusterID string, nodePoolID string) (*cmv1.NodePool, bool, error) {
 	response, err := c.ocm.ClustersMgmt().V1().
 		Clusters().Cluster(clusterID).
 		NodePools().
 		NodePool(nodePoolID).
 		Get().
 		Send()
-	if err != nil {
-		return nil, handleErr(response.Error(), err)
+	if response.Status() == 404 {
+		return nil, false, nil
 	}
-	return response.Body(), nil
+	if err != nil {
+		return nil, false, handleErr(response.Error(), err)
+	}
+	return response.Body(), true, nil
 }
 
 func (c *Client) UpdateNodePool(clusterID string, nodePool *cmv1.NodePool) (*cmv1.NodePool, error) {


### PR DESCRIPTION
No functional change. Changing the message when a node pool is not found from
```
Failed to get machine pools for hosted cluster 'ad-loc1': Node pool with id 'workers4' not found.
```
to
```
Machine pool 'workers4' does not exist for hosted cluster 'ad-loc1'
```
To be consistent with the wording.