### PR TITLE
OCM-2256| Fix : Remove debug msg that prints the user/password list

### DIFF
--- a/cmd/create/idp/htpasswd.go
+++ b/cmd/create/idp/htpasswd.go
@@ -136,7 +136,6 @@ func buildUserList(cmd *cobra.Command, r *rosa.Runtime) *cmv1.HTPasswdUserListBu
 		username, password = getUserDetails(cmd, r)
 		userList[username] = password
 	}
-	r.Reporter.Infof("Adding users %v", userList)
 
 	htpasswdUsers := []*cmv1.HTPasswdUserBuilder{}
 	for username, password := range userList {


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/OCM-2256