### PR TITLE
OCM-2257 | fix: Ensure only one of users or username flags is provided

### DIFF
--- a/cmd/create/idp/cmd.go
+++ b/cmd/create/idp/cmd.go
@@ -292,6 +292,10 @@ func init() {
 			"- Include uppercase letters, lowercase letters, and numbers or symbols (ASCII-standard characters only)",
 	)
 
+	//makring hidden as this is now only for backwards compatibility
+	flags.MarkHidden("username")
+	flags.MarkHidden("password")
+
 	// HTPasswd
 	flags.StringSliceVarP(
 		&args.htpasswdUsers,
@@ -299,7 +303,7 @@ func init() {
 		"u",
 		[]string{},
 		"HTPasswd: List of users to add to the IDP. \n"+
-			"It must be a comma separate list of  username:password, i.e user1:password,user2:password",
+			"It must be a comma separate list of  username:password, i.e user1:password,user2:password \n",
 	)
 
 	interactive.AddFlag(flags)

--- a/cmd/create/idp/htpasswd.go
+++ b/cmd/create/idp/htpasswd.go
@@ -114,6 +114,12 @@ func buildUserList(cmd *cobra.Command, r *rosa.Runtime) *cmv1.HTPasswdUserListBu
 	username := args.htpasswdUsername
 	password := args.htpasswdPassword
 
+	if username != "" && len(users) > 0 {
+		r.Reporter.Errorf("Only one of  'users' or 'username/password' may be specified. " +
+			"Choose the option 'users' to add one or more users to the IDP.")
+		os.Exit(1)
+	}
+
 	userList := make(map[string]string)
 
 	if len(users) != 0 {


### PR DESCRIPTION
REF: https://issues.redhat.com/browse/OCM-2257

Remove  flags  username/password from help/usage msg as they are only for backwards compatibility.
Validate users and username flags are mutually exclusive