### PR TITLE
OCM-2433 | feat: adds admin flag for fedramp

### DIFF
--- a/cmd/login/cmd.go
+++ b/cmd/login/cmd.go
@@ -157,7 +157,11 @@ func run(cmd *cobra.Command, argv []string) {
 		if env == sdk.DefaultURL {
 			env = "production"
 		}
-		uiTokenPage = fedramp.LoginURLs[env]
+		if fedramp.HasAdminFlag(cmd) {
+			uiTokenPage = fedramp.AdminLoginURLs[env]
+		} else {
+			uiTokenPage = fedramp.LoginURLs[env]
+		}
 	} else {
 		fedramp.Disable()
 	}
@@ -223,17 +227,32 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 	// Override configuration details for FedRAMP:
 	if fedramp.Enabled() {
-		gatewayURL, ok = fedramp.URLAliases[env]
-		if !ok {
-			gatewayURL = env
-		}
-		tokenURL, ok = fedramp.TokenURLs[env]
-		if !ok {
-			tokenURL = args.tokenURL
-		}
-		clientID, ok = fedramp.ClientIDs[env]
-		if !ok {
-			clientID = args.clientID
+		if fedramp.HasAdminFlag(cmd) {
+			gatewayURL, ok = fedramp.AdminURLAliases[env]
+			if !ok {
+				gatewayURL = env
+			}
+			tokenURL, ok = fedramp.AdminTokenURLs[env]
+			if !ok {
+				tokenURL = args.tokenURL
+			}
+			clientID, ok = fedramp.AdminClientIDs[env]
+			if !ok {
+				clientID = args.clientID
+			}
+		} else {
+			gatewayURL, ok = fedramp.URLAliases[env]
+			if !ok {
+				gatewayURL = env
+			}
+			tokenURL, ok = fedramp.TokenURLs[env]
+			if !ok {
+				tokenURL = args.tokenURL
+			}
+			clientID, ok = fedramp.ClientIDs[env]
+			if !ok {
+				clientID = args.clientID
+			}
 		}
 	}
 

--- a/pkg/fedramp/config.go
+++ b/pkg/fedramp/config.go
@@ -46,11 +46,25 @@ var LoginURLs = map[string]string{
 	"integration": "https://api.int.openshiftusgov.com/auth",
 }
 
+// AdminLoginURLs allows the value of the `--env` option to map to the various Admin login URLs.
+var AdminLoginURLs = map[string]string{
+	"production":  "https://api-admin.openshiftusgov.com/auth",
+	"staging":     "https://api-admin.stage.openshiftusgov.com/auth",
+	"integration": "https://api-admin.int.openshiftusgov.com/auth",
+}
+
 // URLAliases allows the value of the `--env` option to map to the various API URLs.
 var URLAliases = map[string]string{
 	"production":  "https://api.openshiftusgov.com",
 	"staging":     "https://api.stage.openshiftusgov.com",
 	"integration": "https://api.int.openshiftusgov.com",
+}
+
+// AdminURLAliases allows the value of the `--env` option to map to the various Admin API URLs.
+var AdminURLAliases = map[string]string{
+	"production":  "https://api-admin.openshiftusgov.com",
+	"staging":     "https://api-admin.stage.openshiftusgov.com",
+	"integration": "https://api-admin.int.openshiftusgov.com",
 }
 
 const cognitoURL = "auth-fips.us-gov-west-1.amazoncognito.com/oauth2/token"
@@ -62,8 +76,22 @@ var TokenURLs = map[string]string{
 	"integration": fmt.Sprintf("https://rh-ocm-appsre-integration.%s", cognitoURL),
 }
 
+// AdminTokenURLs allows the value of the `--env` option to map to the various Admin AWS Cognito token URLs.
+var AdminTokenURLs = map[string]string{
+	"production":  fmt.Sprintf("https://ocm-ra-production-domain.%s", cognitoURL),
+	"staging":     fmt.Sprintf("https://ocm-ra-stage-domain.%s", cognitoURL),
+	"integration": fmt.Sprintf("https://rh-ocm-appsre-integration.%s", cognitoURL),
+}
+
 // ClientIDs allows the value of the `--env` option to map to the various AWS Cognito user pool clients.
 var ClientIDs = map[string]string{
+	"production":  "72ekjh5laouap6qcfis521jlgi",
+	"staging":     "1lb687dlpsmsfuj53r3je06vpp",
+	"integration": "20fbrpgl28f8oehp6709mk3nnr",
+}
+
+// AdminClientIDs allows the value of the `--env` option to map to the various Admin AWS Cognito user pool clients.
+var AdminClientIDs = map[string]string{
 	"production":  "72ekjh5laouap6qcfis521jlgi",
 	"staging":     "1lb687dlpsmsfuj53r3je06vpp",
 	"integration": "20fbrpgl28f8oehp6709mk3nnr",

--- a/pkg/fedramp/flag.go
+++ b/pkg/fedramp/flag.go
@@ -33,10 +33,26 @@ func AddFlag(flags *pflag.FlagSet) {
 		false,
 		"Uses the FedRAMP High OpenShift Cluster Manager API for creating clusters in AWS GovCloud regions",
 	)
+
+	flags.BoolVar(
+		&enabled,
+		"admin",
+		false,
+		"Uses the FedRAMP High OpenShift Cluster Manager API Endpoint for Administrator Access",
+	)
+	flags.MarkHidden("admin")
 }
 
 func HasFlag(cmd *cobra.Command) bool {
 	flag := cmd.Flags().Lookup("govcloud")
+	if flag == nil {
+		return false
+	}
+	return flag.Changed
+}
+
+func HasAdminFlag(cmd *cobra.Command) bool {
+	flag := cmd.Flags().Lookup("admin")
 	if flag == nil {
 		return false
 	}

--- a/pkg/ocm/config.go
+++ b/pkg/ocm/config.go
@@ -56,5 +56,12 @@ func GetEnv() (string, error) {
 		}
 	}
 
+	// Special use case for Admin users in the GovCloud environment
+	for env, api := range fedramp.AdminURLAliases {
+		if api == strings.TrimSuffix(cfg.URL, "/") {
+			return env, nil
+		}
+	}
+
 	return "", fmt.Errorf("Invalid OCM API")
 }


### PR DESCRIPTION
REF: [OCM-2433](https://issues.redhat.com/browse/OCM-2433) and [OSD-16451](https://issues.redhat.com/browse/OSD-16451)

* adds new --admin flag that overrides aliases for FedRAMP for the SREP Cognito endpoints (hidden flag)
* adds new login/url aliases for SREP endpoints for FedRAMP
* updates all related logic to check for this flag and set the correct aliases accordingly