### PR TITLE
OCM-1150 | fix: Validation for 'value' in tags when creating a non-sts cluster

### DIFF
--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -258,6 +258,9 @@ func UserTagValidator(input interface{}) error {
 			if len(tag) != 2 {
 				return fmt.Errorf("invalid tag format. Expected tag format: 'key:value'")
 			}
+			if tag[1] == "" {
+				return fmt.Errorf("invalid tag format, Tags must have values. Expected tag format: 'key:value'")
+			}
 			if !UserTagKeyRE.MatchString(tag[0]) {
 				return fmt.Errorf("expected a valid user tag key '%s' matching %s", tag[0], UserTagKeyRE.String())
 			}


### PR DESCRIPTION
[OCM-1150](https://issues.redhat.com/browse/OCM-1150)
Tags previously had no validation for a value, leaving them susceptible to being empty upon cluster creation. This leads to an error when creating the cluster, and the whole interactive process must be redone to try again.

This validation checks if the substring after ":" is empty. If it is, throw an error and ask for tags again.

PS if someone could let me know if this is a proper way of handling, or if I should log an error then keep going/ignore the tags? I feel like it's best to re-try, but this might affect scripts to create clusters if they have invalid tags in them.