### PR TITLE
OCM-1755 | fix: Removed unneeded log about creating cluster after creating accout-roles

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -17,7 +17,6 @@ limitations under the License.
 package accountroles
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -397,17 +396,9 @@ func run(cmd *cobra.Command, argv []string) {
 			})
 			os.Exit(1)
 		}
-		var createClusterFlag string
-		if args.hostedCP {
-			createClusterFlag = "--hosted-cp"
-		} else {
-			createClusterFlag = "--sts"
-		}
 		if r.Reporter.IsTerminal() {
 			r.Reporter.Infof("To create an OIDC Config, run the following command:\n" +
 				"\trosa create oidc-config")
-			r.Reporter.Infof(fmt.Sprintf("To create a cluster with these roles, run the following command:\n"+
-				"\trosa create cluster %s", createClusterFlag))
 		}
 		r.OCMClient.LogEvent("ROSACreateAccountRolesModeAuto", map[string]string{
 			ocm.Response: ocm.Success,


### PR DESCRIPTION
[OCM-1755](https://issues.redhat.com/browse/OCM-1755) is about removing an unneeded log message that pops up after creating account roles. This affects the ROSA UI.