### PR TITLE
OCM-2422 | fix: Edited error message to no longer include 'please try again'

### DIFF
--- a/cmd/register/oidcconfig/cmd.go
+++ b/cmd/register/oidcconfig/cmd.go
@@ -218,10 +218,7 @@ func run(cmd *cobra.Command, argv []string) {
 		if spin != nil {
 			spin.Stop()
 		}
-		r.Reporter.Errorf("There was a problem building your unmanaged OIDC Configuration: %v. "+
-			"Please try again:\n"+
-			"\trosa register oidc-config --issuer-url %s --secret-arn %s --installer-role-arn %s",
-			err, args.issuerUrl, args.secretArn, installerRoleArn)
+		r.Reporter.Errorf("There was a problem building your unmanaged OIDC Configuration: %v", err)
 		os.Exit(1)
 	}
 	if output.HasFlag() {


### PR DESCRIPTION
[OCM-2422](https://issues.redhat.com/browse/OCM-2422) Is about an error message that has 'please try again' + a command to try again with the same information, which will cause the same error message to occur.

So, I have removed this command + 'please try again' from the error message.