### PR TITLE
OCM-2424 | fix: Made info message only print when on auto mode

### DIFF
--- a/cmd/create/oidcconfig/cmd.go
+++ b/cmd/create/oidcconfig/cmd.go
@@ -230,7 +230,7 @@ func run(cmd *cobra.Command, argv []string) {
 			}
 			roleName, _ := aws.GetResourceIdFromARN(args.installerRoleArn)
 			if roleName != "" {
-				if !output.HasFlag() && r.Reporter.IsTerminal() {
+				if !output.HasFlag() && r.Reporter.IsTerminal() && mode == aws.ModeAuto {
 					r.Reporter.Infof("Using %s for the installer role", args.installerRoleArn)
 				}
 				err := aws.ARNValidator(args.installerRoleArn)


### PR DESCRIPTION
[OCM-2424](https://issues.redhat.com/browse/OCM-2424) Is about an info message that wasn't supposed to pop up when using the create oidc-config command in Manual mode, but it did. Now the info message should only pop up when the mode is Auto