### PR TITLE
OCM-2421 | fix: Made prompt for OIDC COnfig ID not happen when flag given

### DIFF
--- a/cmd/dlt/oidcconfig/cmd.go
+++ b/cmd/dlt/oidcconfig/cmd.go
@@ -110,7 +110,7 @@ func run(cmd *cobra.Command, argv []string) {
 		}
 	}
 
-	if args.oidcConfigId == "" || interactive.Enabled() {
+	if (args.oidcConfigId == "" || interactive.Enabled()) && !cmd.Flags().Changed(OidcConfigIdFlag) {
 		args.oidcConfigId = interactive.GetOidcConfigID(r, cmd)
 	}
 


### PR DESCRIPTION
[OCM-2421](https://issues.redhat.com/browse/OCM-2421) is about a prompt that came up when deleting an oidc config and passing in the `--oidc-config-id` flag that should not have came up. It asked for the OIDC config ID when it was already given in the flag. The prompt no longer comes up if the flag is Changed.