### PR TITLE
OCM-2440 | fix: reuse operator roles - validate compatible policies

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1316,7 +1316,7 @@ func run(cmd *cobra.Command, _ []string) {
 				os.Exit(1)
 			} else {
 				err = ocm.ValidateOperatorRolesMatchOidcProvider(r.Reporter, awsClient, computedOperatorIamRoleList,
-					oidcConfig.IssuerUrl(), ocm.GetVersionMinor(version), expectedOperatorRolePath)
+					oidcConfig.IssuerUrl(), ocm.GetVersionMinor(version), expectedOperatorRolePath, managedPolicies)
 				if err != nil {
 					r.Reporter.Errorf("%v", err)
 					os.Exit(1)

--- a/cmd/create/operatorroles/by_clusterkey.go
+++ b/cmd/create/operatorroles/by_clusterkey.go
@@ -387,5 +387,5 @@ func validateOperatorRolesMatchOidcProvider(r *rosa.Runtime, cluster *cmv1.Clust
 	}
 	return ocm.ValidateOperatorRolesMatchOidcProvider(r.Reporter, r.AWSClient,
 		operatorRolesList, cluster.AWS().STS().OidcConfig().IssuerUrl(),
-		ocm.GetVersionMinor(cluster.Version().RawID()), expectedPath)
+		ocm.GetVersionMinor(cluster.Version().RawID()), expectedPath, cluster.AWS().STS().ManagedPolicies())
 }

--- a/cmd/create/operatorroles/by_prefix.go
+++ b/cmd/create/operatorroles/by_prefix.go
@@ -135,7 +135,7 @@ func handleOperatorRoleCreationByPrefix(r *rosa.Runtime, env string,
 		os.Exit(1)
 	}
 	err = ocm.ValidateOperatorRolesMatchOidcProvider(r.Reporter, r.AWSClient,
-		operatorRolesList, oidcConfig.IssuerUrl(), "4.0", path)
+		operatorRolesList, oidcConfig.IssuerUrl(), "4.0", path, managedPolicies)
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
 			switch aerr.Code() {

--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -817,7 +817,7 @@ func (c *Client) GetVersionsList(channelGroup string) ([]string, error) {
 
 func ValidateOperatorRolesMatchOidcProvider(reporter *reporter.Object, awsClient aws.Client,
 	operatorIAMRoleList []OperatorIAMRole, oidcEndpointUrl string,
-	clusterVersion string, expectedOperatorRolePath string) error {
+	clusterVersion string, expectedOperatorRolePath string, accountRolesHasManagedPolicies bool) error {
 	operatorIAMRoles := operatorIAMRoleList
 	parsedUrl, err := url.Parse(oidcEndpointUrl)
 	if err != nil {
@@ -852,6 +852,10 @@ func ValidateOperatorRolesMatchOidcProvider(reporter *reporter.Object, awsClient
 		hasManagedPolicies, err := awsClient.HasManagedPolicies(roleARN)
 		if err != nil {
 			return err
+		}
+		if accountRolesHasManagedPolicies && !hasManagedPolicies {
+			return errors.Errorf("Operator role '%s' has unmanaged policies and is not compatible with the account "+
+				"role's managed policies.", roleARN)
 		}
 		if hasManagedPolicies {
 			// Managed policies should be compatible with all versions


### PR DESCRIPTION
In the case of creating a cluster with managed policies and reusing existing operator roles, validate the operator roles have managed policies.

Related: [OCM-2440](https://issues.redhat.com/browse/OCM-2440)

![image](https://github.com/openshift/rosa/assets/57869309/123bf2f0-5b4b-4af1-8622-ab4f9ee5547a)
