### PR TITLE
OCM-954 | Feat: Hypershift node pool upgrades

### DIFF
--- a/cmd/create/machinepool/nodepool.go
+++ b/cmd/create/machinepool/nodepool.go
@@ -76,7 +76,7 @@ func addNodePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster, r
 		}
 
 		// Filter the available list of versions for a hosted machine pool
-		filteredVersionList := versions.GetFilteredVersionList(versionList, minVersion, clusterVersion)
+		filteredVersionList := versions.GetFilteredVersionListForCreation(versionList, minVersion, clusterVersion)
 		if err != nil {
 			r.Reporter.Errorf("%s", err)
 			os.Exit(1)

--- a/cmd/describe/upgrade/cmd.go
+++ b/cmd/describe/upgrade/cmd.go
@@ -19,16 +19,18 @@ package upgrade
 import (
 	"fmt"
 	"os"
+	"strings"
 
-	"github.com/spf13/cobra"
-
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
+	"github.com/spf13/cobra"
 )
 
 var Cmd = &cobra.Command{
 	Use:     "upgrade",
-	Aliases: []string{"appliance", "upgrade"},
+	Aliases: []string{"appliance", "upgrades"},
 	Short:   "Show details of an upgrade",
 	Long:    "Show details of an upgrade",
 	Example: `  # Describe an upgrade-policy"
@@ -37,74 +39,128 @@ var Cmd = &cobra.Command{
 	Hidden: false,
 }
 
-func init() {
-	ocm.AddClusterFlag(Cmd)
+var args struct {
+	nodePool string
 }
 
-func run(cmd *cobra.Command, argv []string) {
+func init() {
+	flags := Cmd.Flags()
+	flags.SortFlags = false
+
+	ocm.AddClusterFlag(Cmd)
+
+	flags.StringVar(
+		&args.nodePool,
+		"machinepool",
+		"",
+		"Machine pool of the cluster to target",
+	)
+
+	confirm.AddFlag(flags)
+}
+
+func run(_ *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithOCM()
 	defer r.Cleanup()
-	cluster := r.FetchCluster()
-
-	// Try to find the cluster:
-	r.Reporter.Debugf("Loading upgrade with id '%s'", cluster.ID())
-	if ocm.IsHyperShiftCluster(cluster) {
-		returnHypershiftUpgrades(r, cluster.ID())
-	} else {
-		returnClassicUpgrades(r, cluster.ID())
+	err := runWithRuntime(r)
+	if err != nil {
+		r.Reporter.Errorf(err.Error())
+		os.Exit(1)
 	}
 }
 
-func returnHypershiftUpgrades(r *rosa.Runtime, clusterID string) {
-	upgrades, err := r.OCMClient.GetControlPlaneUpgradePolicies(clusterID)
-	if err != nil {
-		r.Reporter.Errorf("Failed to get upgrade with cluster id '%s': %v", clusterID, err)
-		os.Exit(1)
-	}
-	if len(upgrades) < 1 {
-		r.Reporter.Warnf("No scheduled upgrades for cluster id '%s'", clusterID)
-		os.Exit(1)
+func runWithRuntime(r *rosa.Runtime) error {
+	clusterKey := r.GetClusterKey()
+	cluster := r.FetchCluster()
+
+	if cluster.State() != cmv1.ClusterStateReady {
+		return fmt.Errorf("Cluster '%s' is not yet ready", clusterKey)
 	}
 
-	for _, upgrade := range upgrades {
-		fmt.Printf(`%19s%68s
+	if args.nodePool != "" && !ocm.IsHyperShiftCluster(cluster) {
+		return fmt.Errorf("The '--machinepool' option is only supported for Hosted Control Planes")
+	}
+
+	r.Reporter.Debugf("Loading upgrades for cluster id '%s'", cluster.ID())
+	if ocm.IsHyperShiftCluster(cluster) {
+		return describeHypershiftUpgrades(r, cluster.ID(), args.nodePool)
+	} else {
+		return describeClassicUpgrades(r, cluster.ID())
+	}
+}
+
+func describeHypershiftUpgrades(r *rosa.Runtime, clusterID string, nodePoolID string) error {
+	clusterKey := r.GetClusterKey()
+	if args.nodePool == "" {
+		upgrades, err := r.OCMClient.GetControlPlaneUpgradePolicies(clusterID)
+		if err != nil {
+			return fmt.Errorf("Failed to get upgrades for cluster '%s': %v", clusterKey, err)
+		}
+		if len(upgrades) < 1 {
+			r.Reporter.Infof("No scheduled upgrades for cluster '%s'", clusterKey)
+			return nil
+		}
+
+		for _, upgrade := range upgrades {
+			fmt.Print(formatHypershiftUpgrade(upgrade))
+		}
+	} else {
+		_, upgrades, err := r.OCMClient.GetHypershiftNodePoolUpgrades(clusterID, clusterKey, nodePoolID)
+		if err != nil {
+			return fmt.Errorf("Failed to get upgrades for machine pool '%s' in cluster '%s': %v", nodePoolID,
+				clusterKey, err)
+		}
+		if upgrades == nil || len(upgrades) < 1 {
+			r.Reporter.Infof("No scheduled upgrades for machine pool '%s' in cluster '%s'", nodePoolID, clusterKey)
+			return nil
+		}
+
+		for _, upgrade := range upgrades {
+			fmt.Print(formatHypershiftUpgrade(upgrade))
+		}
+	}
+	return nil
+}
+
+// formatHypershiftUpgrade is a generic printer for Hypershift Upgrades types
+func formatHypershiftUpgrade(upgrade ocm.HypershiftUpgrader) string {
+	builder := make([]string, 0)
+	builder = append(builder, fmt.Sprintf(`%19s%68s
 		%-35s%s
 		%-35s%s
 		%-35s%s
 		%-35s%s
 `,
-			"ID:", upgrade.ID(),
-			"Cluster ID:", upgrade.ClusterID(),
-			"Schedule Type:", upgrade.ScheduleType(),
-			"Next Run:", upgrade.NextRun(),
-			"Upgrade State:", upgrade.State().Value())
-		if upgrade.Schedule() != "" {
-			fmt.Printf(`                %-35s%s
-`, "Schedule At:", upgrade.Schedule())
-			fmt.Printf(`                %-35s%t
-`, "Enable minor version upgrades:", upgrade.EnableMinorVersionUpgrades())
-		}
-		if upgrade.Version() != "" {
-			fmt.Printf(`                %-35s%s
-`, "Version:", upgrade.Version())
-		}
+		"ID:", upgrade.ID(),
+		"Cluster ID:", upgrade.ClusterID(),
+		"Schedule Type:", upgrade.ScheduleType(),
+		"Next Run:", upgrade.NextRun().Format("2006-01-02 15:04 MST"),
+		"Upgrade State:", upgrade.State().Value()))
+	if upgrade.Schedule() != "" {
+		builder = append(builder, fmt.Sprintf(`                %-35s%s
+`, "Schedule At:", upgrade.Schedule()))
+		builder = append(builder, fmt.Sprintf(`                %-35s%t
+`, "Enable minor version upgrades:", upgrade.EnableMinorVersionUpgrades()))
 	}
+	if upgrade.Version() != "" {
+		builder = append(builder, fmt.Sprintf(`                %-35s%s
+`, "Version:", upgrade.Version()))
+	}
+	return strings.Join(builder, "\n")
 }
 
-func returnClassicUpgrades(r *rosa.Runtime, clusterID string) {
+func describeClassicUpgrades(r *rosa.Runtime, clusterID string) error {
 	upgrades, err := r.OCMClient.GetUpgradePolicies(clusterID)
 	if err != nil {
-		r.Reporter.Errorf("Failed to get upgrade with cluster id '%s': %v", clusterID, err)
-		os.Exit(1)
+		return fmt.Errorf("Failed to get upgrade with cluster id '%s': %v", clusterID, err)
 	}
 	_, upgradeState, err := r.OCMClient.GetScheduledUpgrade(clusterID)
 	if err != nil {
-		r.Reporter.Errorf("Failed to get scheduled upgrades for cluster '%s': %v", clusterID, err)
-		os.Exit(1)
+		return fmt.Errorf("Failed to get scheduled upgrades for cluster '%s': %v", clusterID, err)
 	}
 	if len(upgrades) < 1 {
-		r.Reporter.Warnf("No scheduled upgrades for cluster id '%s'", clusterID)
-		os.Exit(1)
+		r.Reporter.Infof("No scheduled upgrades for cluster id '%s'", clusterID)
+		return nil
 	}
 
 	for _, upgrade := range upgrades {
@@ -115,7 +171,7 @@ func returnClassicUpgrades(r *rosa.Runtime, clusterID string) {
 `,
 			"ID:", upgrade.ID(),
 			"Cluster ID:", upgrade.ClusterID(),
-			"Next Run:", upgrade.NextRun(),
+			"Next Run:", upgrade.NextRun().Format("2006-01-02 15:04 MST"),
 			"Upgrade State:", upgradeState.Value())
 		if upgrade.Schedule() != "" {
 			fmt.Printf(`                %-28s%s
@@ -126,4 +182,5 @@ func returnClassicUpgrades(r *rosa.Runtime, clusterID string) {
 `, "Version:", upgrade.Version())
 		}
 	}
+	return nil
 }

--- a/cmd/describe/upgrade/cmd_test.go
+++ b/cmd/describe/upgrade/cmd_test.go
@@ -1,0 +1,145 @@
+package upgrade
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+	"github.com/openshift/rosa/pkg/test"
+)
+
+var _ = Describe("Describe upgrade", func() {
+	Context("Format Hypershift upgrade", func() {
+		It("Node pool upgrade is scheduled", func() {
+			nowUTC := time.Now().UTC()
+			upgradeState := cmv1.NewUpgradePolicyState().Value("scheduled")
+			npUpgradePolicy, err := cmv1.NewNodePoolUpgradePolicy().ID("id1").Version("4.12.19").
+				State(upgradeState).NextRun(nowUTC).Build()
+			Expect(err).To(BeNil())
+			result := formatHypershiftUpgrade(npUpgradePolicy)
+			Expect(result).To(Equal(
+				fmt.Sprintf(
+					`                ID:                                                                 id1
+		Cluster ID:                        
+		Schedule Type:                     
+		Next Run:                          %s
+		Upgrade State:                     scheduled
+
+                Version:                           4.12.19
+`, nowUTC.Format("2006-01-02 15:04 MST"))))
+		})
+		It("Node pool upgrade is scheduled with a date", func() {
+			format.TruncatedDiff = false
+			nowUTC := time.Now().UTC()
+			upgradeState := cmv1.NewUpgradePolicyState().Value("scheduled")
+			npUpgradePolicy, err := cmv1.NewNodePoolUpgradePolicy().ID("id1").Version("4.12.19").
+				State(upgradeState).NextRun(nowUTC).Schedule(nowUTC.Format("2006-01-02 15:04 MST")).
+				EnableMinorVersionUpgrades(true).Build()
+			Expect(err).To(BeNil())
+			result := formatHypershiftUpgrade(npUpgradePolicy)
+			Expect(result).To(Equal(
+				fmt.Sprintf(
+					`                ID:                                                                 id1
+		Cluster ID:                        
+		Schedule Type:                     
+		Next Run:                          %s
+		Upgrade State:                     scheduled
+
+                Schedule At:                       %s
+
+                Enable minor version upgrades:     true
+
+                Version:                           4.12.19
+`, nowUTC.Format("2006-01-02 15:04 MST"), nowUTC.Format("2006-01-02 15:04 MST"))))
+		})
+	})
+	Context("Describe Hypershift upgrade", func() {
+		var testRuntime test.TestingRuntime
+		var clusterID = "cluster1"
+		var nodePoolID = "nodepool85"
+
+		const nodePoolResponse = `{
+						  "kind": "NodePool",
+						  "href": "/api/clusters_mgmt/v1/clusters/243nmgjr5v2q9rn5sf3456euj2lcq5tn/node_pools/workers",
+						  "id": "workers",
+						  "replicas": 2,
+						  "auto_repair": true,
+						  "aws_node_pool": {
+							"instance_type": "m5.xlarge",
+							"instance_profile": "rosa-service-managed-integration-243nmgjr5v2q9rn5sf3456euj2lcq5tn-ad-int1-worker",
+							"tags": {
+							  "api.openshift.com/environment": "integration",
+							  "api.openshift.com/id": "243nmgjr5v2q9rn5sf3456euj2lcq5tn",
+							  "api.openshift.com/legal-entity-id": "1jIHnIbrnLH9kQD57W0BuPm78f1",
+							  "api.openshift.com/name": "ad-int1",
+							  "api.openshift.com/nodepool-hypershift": "ad-int1-workers",
+							  "api.openshift.com/nodepool-ocm": "workers",
+							  "red-hat-clustertype": "rosa",
+							  "red-hat-managed": "true"
+							}
+						  },
+						  "availability_zone": "us-west-2a",
+						  "subnet": "subnet-0e3a4046c1c2f1078",
+						  "status": {
+							"current_replicas": 0,
+							"message": "WaitingForAvailableMachines: NodeProvisioning"
+						  },
+						  "version": {
+							"kind": "VersionLink",
+							"id": "openshift-v4.12.%s",
+							"href": "/api/clusters_mgmt/v1/versions/openshift-v4.12.%s"
+						  },
+						  "tuning_configs": []
+						}`
+
+		// nolint:lll
+		const nodePoolUpgradePolicy = `{
+  "kind": "NodePoolUpgradePolicyList",
+  "page": 1,
+  "size": 1,
+  "total": 1,
+  "items": [
+    {
+      "kind": "NodePoolUpgradePolicy",
+      "id": "e2800d05-3534-11ee-b9bc-0a580a811709",
+      "href": "/api/clusters_mgmt/v1/clusters/25f96obptkqc5mh9vdc779jiqb3sihnn/node_pools/workers/upgrade_policies/e2800d05-3534-11ee-b9bc-0a580a811709",
+      "schedule_type": "manual",
+      "upgrade_type": "NodePool",
+      "version": "4.12.25",
+      "next_run": "2023-08-07T15:22:00Z",
+      "cluster_id": "25f96obptkqc5mh9vdc779jiqb3sihnn",
+      "node_pool_id": "workers",
+      "enable_minor_version_upgrades": true,
+      "creation_timestamp": "2023-08-07T15:12:54.967835Z",
+      "last_update_timestamp": "2023-08-07T15:12:54.967835Z",
+      "state": {
+        "value": "scheduled",
+        "description": "Upgrade scheduled."
+      }
+    }
+  ]
+}`
+
+		BeforeEach(func() {
+			testRuntime.InitRuntime()
+		})
+		It("Upgrade policy found, no error", func() {
+			args.nodePool = nodePoolID
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, nodePoolResponse))
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, nodePoolUpgradePolicy))
+			err := describeHypershiftUpgrades(testRuntime.RosaRuntime, clusterID, nodePoolID)
+			Expect(err).To(BeNil())
+		})
+		It("Error on the node pool response", func() {
+			args.nodePool = nodePoolID
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusNotFound, ""))
+			err := describeHypershiftUpgrades(testRuntime.RosaRuntime, clusterID, nodePoolID)
+			Expect(err).ToNot(BeNil())
+		})
+	})
+})

--- a/cmd/describe/upgrade/main_test.go
+++ b/cmd/describe/upgrade/main_test.go
@@ -1,0 +1,13 @@
+package upgrade
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDescribeUpgrade(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Describe upgrades suite")
+}

--- a/cmd/dlt/upgrade/cmd_test.go
+++ b/cmd/dlt/upgrade/cmd_test.go
@@ -1,0 +1,52 @@
+package upgrade
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+	"github.com/openshift/rosa/pkg/test"
+)
+
+var _ = Describe("Delete upgrade", func() {
+	var testRuntime test.TestingRuntime
+
+	mockClusterError, err := test.MockOCMCluster(func(c *cmv1.ClusterBuilder) {
+		c.AWS(cmv1.NewAWS().SubnetIDs("subnet-0b761d44d3d9a4663", "subnet-0f87f640e56934cbc"))
+		c.Region(cmv1.NewCloudRegion().ID("us-east-1"))
+		c.State(cmv1.ClusterStateError)
+		c.Hypershift(cmv1.NewHypershift().Enabled(true))
+	})
+	Expect(err).To(BeNil())
+	var hypershiftClusterNotReady = test.FormatClusterList([]*cmv1.Cluster{mockClusterError})
+
+	mockClassicCluster, err := test.MockOCMCluster(func(c *cmv1.ClusterBuilder) {
+		c.AWS(cmv1.NewAWS().SubnetIDs("subnet-0b761d44d3d9a4663", "subnet-0f87f640e56934cbc"))
+		c.Region(cmv1.NewCloudRegion().ID("us-east-1"))
+		c.State(cmv1.ClusterStateReady)
+		c.Hypershift(cmv1.NewHypershift().Enabled(false))
+	})
+	Expect(err).To(BeNil())
+	var classicCluster = test.FormatClusterList([]*cmv1.Cluster{mockClassicCluster})
+
+	BeforeEach(func() {
+		testRuntime.InitRuntime()
+	})
+	It("Fails if cluster is not ready", func() {
+		testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterNotReady))
+		err := runWithRuntime(testRuntime.RosaRuntime)
+		Expect(err).ToNot(BeNil())
+		Expect(err.Error()).To(
+			ContainSubstring("Cluster 'cluster1' is not yet ready"))
+	})
+	It("Fails if cluster is not hypershift and we are using hypershift specific flags", func() {
+		args.nodePool = "nodepool1"
+		testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, classicCluster))
+		err := runWithRuntime(testRuntime.RosaRuntime)
+		Expect(err).ToNot(BeNil())
+		Expect(err.Error()).To(
+			ContainSubstring("The '--machinepool' option is only supported for Hosted Control Planes"))
+	})
+})

--- a/cmd/dlt/upgrade/main_test.go
+++ b/cmd/dlt/upgrade/main_test.go
@@ -1,0 +1,13 @@
+package upgrade
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDeleteUpgrade(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Delete upgrade suite")
+}

--- a/cmd/edit/machinepool/cmd.go
+++ b/cmd/edit/machinepool/cmd.go
@@ -129,6 +129,8 @@ func init() {
 			"Tuning config must already exist. "+
 			"This list will overwrite any modifications made to node tuning configs on an ongoing basis.",
 	)
+
+	flags.MarkDeprecated("version", "for upgrades, please use 'rosa upgrade machinepool' instead")
 }
 
 func run(cmd *cobra.Command, argv []string) {

--- a/cmd/edit/machinepool/nodepool.go
+++ b/cmd/edit/machinepool/nodepool.go
@@ -5,11 +5,10 @@ import (
 	"strings"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/rosa/cmd/upgrade/machinepool"
 	"github.com/openshift/rosa/pkg/helper/machinepools"
 	mpHelpers "github.com/openshift/rosa/pkg/helper/machinepools"
-	"github.com/openshift/rosa/pkg/helper/versions"
 	"github.com/openshift/rosa/pkg/interactive"
-	"github.com/openshift/rosa/pkg/ocm"
 	rprtr "github.com/openshift/rosa/pkg/reporter"
 	"github.com/openshift/rosa/pkg/rosa"
 	"github.com/spf13/cobra"
@@ -92,39 +91,16 @@ func editNodePool(cmd *cobra.Command, nodePoolID string, clusterKey string, clus
 	}
 
 	if isVersionSet || interactive.Enabled() {
-		version := args.version
-		channelGroup := cluster.Version().ChannelGroup()
-		clusterVersion := cluster.Version().RawID()
-		nodePoolVersion := ocm.GetRawVersionId(nodePool.Version().ID())
-		versionList, err := versions.GetVersionList(r, channelGroup, true, true, false)
+		// TODO flag marked as deprecated. To be removed
+		version, err := machinepool.ComputeNodePoolVersion(r, cmd, cluster, nodePool, args.version)
 		if err != nil {
 			r.Reporter.Errorf("%s", err)
 			os.Exit(1)
 		}
-
-		// Filter the available list of versions for a hosted machine pool
-		filteredVersionList := versions.GetFilteredVersionList(versionList, nodePoolVersion, clusterVersion)
-		if err != nil {
-			r.Reporter.Errorf("%s", err)
-			os.Exit(1)
-		}
-
-		if interactive.Enabled() {
-			version, err = interactive.GetOption(interactive.Input{
-				Question: "OpenShift version",
-				Help:     cmd.Flags().Lookup("version").Usage,
-				Options:  filteredVersionList,
-				Default:  version,
-			})
-			if err != nil {
-				r.Reporter.Errorf("Expected a valid OpenShift version: %s", err)
-				os.Exit(1)
-			}
-		}
-		version, err = r.OCMClient.ValidateVersion(version, filteredVersionList, channelGroup, true, true)
-		if err != nil {
-			r.Reporter.Errorf("Expected a valid OpenShift version: %s", err)
-			os.Exit(1)
+		if version == "" {
+			r.Reporter.Infof("No upgrade available for the machine pool '%s' on cluster '%s'", nodePoolID,
+				clusterKey)
+			os.Exit(0)
 		}
 		npBuilder.Version(cmv1.NewVersion().ID(version))
 	}

--- a/cmd/list/upgrade/cmd.go
+++ b/cmd/list/upgrade/cmd.go
@@ -24,11 +24,17 @@ import (
 	"text/tabwriter"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/rosa/cmd/upgrade/machinepool"
+	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
 )
+
+var args struct {
+	nodePool string
+}
 
 var Cmd = &cobra.Command{
 	Use:     "upgrades",
@@ -39,37 +45,78 @@ var Cmd = &cobra.Command{
 }
 
 func init() {
+	flags := Cmd.Flags()
+	flags.SortFlags = false
+
 	ocm.AddClusterFlag(Cmd)
+
+	flags.StringVar(
+		&args.nodePool,
+		"machinepool",
+		"",
+		"Machine pool of the cluster to target",
+	)
+
+	confirm.AddFlag(flags)
 }
 
-func run(_ *cobra.Command, _ []string) {
+func run(cmd *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
+	err := runWithRuntime(r, cmd)
+	if err != nil {
+		r.Reporter.Errorf(err.Error())
+		os.Exit(1)
+	}
+}
 
+func runWithRuntime(r *rosa.Runtime, _ *cobra.Command) error {
 	clusterKey := r.GetClusterKey()
 	cluster := r.FetchCluster()
-	if cluster.State() != cmv1.ClusterStateReady {
-		r.Reporter.Errorf("Cluster '%s' is not yet ready", clusterKey)
-		os.Exit(1)
-	}
-
+	isNodePool := args.nodePool != ""
 	isHypershift := ocm.IsHyperShiftCluster(cluster)
 
-	var scheduledUpgrade *cmv1.UpgradePolicy
-	var upgradeState *cmv1.UpgradePolicyState
-	var controlPlaneScheduledUpgrade *cmv1.ControlPlaneUpgradePolicy
-
-	// Load available upgrades for this cluster
-	r.Reporter.Debugf("Loading available upgrades for cluster '%s'", clusterKey)
-	availableUpgrades, err := r.OCMClient.GetAvailableUpgrades(ocm.GetVersionID(cluster))
-	if err != nil {
-		r.Reporter.Errorf("Failed to get available upgrades for cluster '%s': %v", clusterKey, err)
-		os.Exit(1)
+	if cluster.State() != cmv1.ClusterStateReady {
+		return fmt.Errorf("Cluster '%s' is not yet ready", clusterKey)
 	}
 
-	if len(availableUpgrades) == 0 {
-		r.Reporter.Infof("There are no available upgrades for cluster '%s'", clusterKey)
-		os.Exit(0)
+	if isNodePool && !ocm.IsHyperShiftCluster(cluster) {
+		return fmt.Errorf("The '--machinepool' option is only supported for Hosted Control Planes")
+	}
+
+	var scheduledUpgrade *cmv1.UpgradePolicy
+	var nodePoolScheduledUpgrade *cmv1.NodePoolUpgradePolicy
+	var nodePool *cmv1.NodePool
+	var upgradeState *cmv1.UpgradePolicyState
+	var controlPlaneScheduledUpgrade *cmv1.ControlPlaneUpgradePolicy
+	var availableUpgrades []string
+	var err error
+
+	if isNodePool {
+		r.Reporter.Debugf("Loading available upgrades for node pool '%s' cluster '%s'", args.nodePool, clusterKey)
+		nodePool, nodePoolScheduledUpgrade, err = r.OCMClient.GetHypershiftNodePoolUpgrade(cluster.ID(), clusterKey,
+			args.nodePool)
+		if err != nil {
+			return err
+		}
+
+		// Get available node pool upgrades
+		availableUpgrades, err = machinepool.GetAvailableVersion(r, cluster, nodePool)
+		if err != nil {
+			return err
+		}
+	} else {
+		// Control plane or cluster updates
+		r.Reporter.Debugf("Loading available upgrades for cluster '%s'", clusterKey)
+		availableUpgrades, err = r.OCMClient.GetAvailableUpgrades(ocm.GetVersionID(cluster))
+		if err != nil {
+			return fmt.Errorf("Failed to get available upgrades for cluster '%s': %v", clusterKey, err)
+		}
+
+		if len(availableUpgrades) == 0 {
+			r.Reporter.Infof("There are no available upgrades for cluster '%s'", clusterKey)
+			return nil
+		}
 	}
 
 	latestRev := latestInCurrentMinor(ocm.GetVersionID(cluster), availableUpgrades)
@@ -78,14 +125,14 @@ func run(_ *cobra.Command, _ []string) {
 	if !isHypershift {
 		scheduledUpgrade, upgradeState, err = r.OCMClient.GetScheduledUpgrade(cluster.ID())
 		if err != nil {
-			r.Reporter.Errorf("Failed to get scheduled upgrades for cluster '%s': %v", clusterKey, err)
-			os.Exit(1)
+			return fmt.Errorf("Failed to get scheduled upgrades for cluster '%s': %v", clusterKey, err)
 		}
 	} else {
-		controlPlaneScheduledUpgrade, err = r.OCMClient.GetControlPlaneScheduledUpgrade(cluster.ID())
-		if err != nil {
-			r.Reporter.Errorf("Failed to get scheduled control plane upgrades for cluster '%s': %v", clusterKey, err)
-			os.Exit(1)
+		if !isNodePool {
+			controlPlaneScheduledUpgrade, err = r.OCMClient.GetControlPlaneScheduledUpgrade(cluster.ID())
+			if err != nil {
+				return fmt.Errorf("Failed to get scheduled control plane upgrades for cluster '%s': %v", clusterKey, err)
+			}
 		}
 	}
 
@@ -93,36 +140,41 @@ func run(_ *cobra.Command, _ []string) {
 	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	fmt.Fprintf(writer, "VERSION\tNOTES\n")
 	for i, availableUpgrade := range availableUpgrades {
-		notes := ""
-		if notes == "" && (i == 0 || availableUpgrade == latestRev) {
-			notes = "recommended"
+		notes := make([]string, 0)
+		if i == 0 || availableUpgrade == latestRev {
+			notes = append(notes, "recommended")
 		}
 		if !isHypershift {
-			notes = formatScheduledUpgrade(availableUpgrade, scheduledUpgrade, notes, upgradeState)
+			upgradeNotes := formatScheduledUpgrade(availableUpgrade, scheduledUpgrade, upgradeState)
+			if len(upgradeNotes) != 0 {
+				notes = append(notes, upgradeNotes)
+			}
 		} else {
-			notes = formatScheduledUpgradeHypershift(availableUpgrade, controlPlaneScheduledUpgrade, notes)
+			if isNodePool {
+				upgradeNotes := formatScheduledUpgradeHypershift(availableUpgrade, nodePoolScheduledUpgrade)
+				if len(upgradeNotes) != 0 {
+					notes = append(notes, upgradeNotes)
+				}
+			} else {
+				upgradeNotes := formatScheduledUpgradeHypershift(availableUpgrade, controlPlaneScheduledUpgrade)
+				if len(upgradeNotes) != 0 {
+					notes = append(notes, upgradeNotes)
+				}
+			}
 		}
-		fmt.Fprintf(writer, "%s\t%s\n", availableUpgrade, notes)
+		fmt.Fprintf(writer, "%s\t%s\n", availableUpgrade, strings.Join(notes, " - "))
 	}
 	writer.Flush()
+	return nil
 }
 
 func formatScheduledUpgrade(availableUpgrade string,
-	scheduledUpgrade *cmv1.UpgradePolicy, notes string, upgradeState *cmv1.UpgradePolicyState) string {
+	scheduledUpgrade *cmv1.UpgradePolicy, upgradeState *cmv1.UpgradePolicyState) (notes string) {
 	if availableUpgrade == scheduledUpgrade.Version() {
 		notes = fmt.Sprintf("%s for %s", upgradeState.Value(),
 			scheduledUpgrade.NextRun().Format("2006-01-02 15:04 MST"))
 	}
-	return notes
-}
-
-func formatScheduledUpgradeHypershift(availableUpgrade string,
-	scheduledUpgrade *cmv1.ControlPlaneUpgradePolicy, notes string) string {
-	if availableUpgrade == scheduledUpgrade.Version() {
-		notes = fmt.Sprintf("%s for %s", scheduledUpgrade.State().Value(),
-			scheduledUpgrade.NextRun().Format("2006-01-02 15:04 MST"))
-	}
-	return notes
+	return
 }
 
 func latestInCurrentMinor(current string, versions []string) string {
@@ -145,4 +197,13 @@ func latestInCurrentMinor(current string, versions []string) string {
 		}
 	}
 	return latestVersion
+}
+
+func formatScheduledUpgradeHypershift(availableUpgrade string,
+	scheduledUpgrade ocm.HypershiftUpgrader) (notes string) {
+	if availableUpgrade == scheduledUpgrade.Version() {
+		notes = fmt.Sprintf("%s for %s", scheduledUpgrade.State().Value(),
+			scheduledUpgrade.NextRun().Format("2006-01-02 15:04 MST"))
+	}
+	return
 }

--- a/cmd/list/upgrade/cmd_test.go
+++ b/cmd/list/upgrade/cmd_test.go
@@ -1,0 +1,386 @@
+package upgrade
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+	"github.com/openshift/rosa/pkg/test"
+)
+
+const noUpgradeOutput = `VERSION  NOTES
+`
+const ongoingUpgradeOutput = `VERSION  NOTES
+4.12.26  recommended
+4.12.25  pending for 2023-06-02 12:30 UTC
+`
+const upgradeAvailableOutput = `VERSION  NOTES
+4.12.26  recommended
+4.12.25  
+`
+
+var _ = Describe("List upgrade", func() {
+	Context("Format scheduled upgrade", func() {
+		It("Node pool upgrade is scheduled", func() {
+			availableUpgrade := "4.12.19"
+			nowUTC := time.Now().UTC()
+			upgradeState := cmv1.NewUpgradePolicyState().Value("scheduled")
+			npUpgradePolicy, err := cmv1.NewNodePoolUpgradePolicy().ID("id1").Version("4.12.19").
+				State(upgradeState).NextRun(nowUTC).Build()
+			Expect(err).To(BeNil())
+			notes := formatScheduledUpgradeHypershift(availableUpgrade, npUpgradePolicy)
+			Expect(notes).To(Equal(fmt.Sprintf("scheduled for %s", nowUTC.Format("2006-01-02 15:04 MST"))))
+		})
+		It("Nothing scheduled for this node pool", func() {
+			availableUpgrade := "4.12.18"
+			npUpgradePolicy, err := cmv1.NewNodePoolUpgradePolicy().ID("id1").Version("4.12.19").Build()
+			Expect(err).To(BeNil())
+			notes := formatScheduledUpgradeHypershift(availableUpgrade, npUpgradePolicy)
+			Expect(notes).To(Equal(""))
+		})
+	})
+	Context("Latest rev in minor", func() {
+		It("Find latest minor", func() {
+			currentVersion := "4.12.16"
+			availableUpgrades := []string{"4.12.17", "4.12.18", "4.13.0"}
+			latestRev := latestInCurrentMinor(currentVersion, availableUpgrades)
+			Expect(latestRev).To(Equal("4.12.18"))
+		})
+		It("Only upgrades to a major available", func() {
+			currentVersion := "4.12.16"
+			availableUpgrades := []string{"4.13.0"}
+			latestRev := latestInCurrentMinor(currentVersion, availableUpgrades)
+			Expect(latestRev).To(Equal("4.12.16"))
+		})
+	})
+	Context("List upgrades command", func() {
+		var testRuntime test.TestingRuntime
+		var nodePoolName = "nodepool85"
+
+		mockClusterError, err := test.MockOCMCluster(func(c *cmv1.ClusterBuilder) {
+			c.AWS(cmv1.NewAWS().SubnetIDs("subnet-0b761d44d3d9a4663", "subnet-0f87f640e56934cbc"))
+			c.Region(cmv1.NewCloudRegion().ID("us-east-1"))
+			c.State(cmv1.ClusterStateError)
+			c.Hypershift(cmv1.NewHypershift().Enabled(true))
+		})
+		Expect(err).To(BeNil())
+		var hypershiftClusterNotReady = test.FormatClusterList([]*cmv1.Cluster{mockClusterError})
+
+		mockClusterReady, err := test.MockOCMCluster(func(c *cmv1.ClusterBuilder) {
+			c.AWS(cmv1.NewAWS().SubnetIDs("subnet-0b761d44d3d9a4663", "subnet-0f87f640e56934cbc"))
+			c.Region(cmv1.NewCloudRegion().ID("us-east-1"))
+			c.State(cmv1.ClusterStateReady)
+			c.Hypershift(cmv1.NewHypershift().Enabled(true))
+			c.Version(cmv1.NewVersion().RawID("4.12.26").ChannelGroup("stable").
+				ID("4.12.26").Enabled(true).AvailableUpgrades("4.12.27"))
+		})
+		Expect(err).To(BeNil())
+		var hypershiftClusterReady = test.FormatClusterList([]*cmv1.Cluster{mockClusterReady})
+
+		mockClassicCluster, err := test.MockOCMCluster(func(c *cmv1.ClusterBuilder) {
+			c.AWS(cmv1.NewAWS().SubnetIDs("subnet-0b761d44d3d9a4663", "subnet-0f87f640e56934cbc"))
+			c.Region(cmv1.NewCloudRegion().ID("us-east-1"))
+			c.State(cmv1.ClusterStateReady)
+			c.Hypershift(cmv1.NewHypershift().Enabled(false))
+		})
+		Expect(err).To(BeNil())
+		var classicCluster = test.FormatClusterList([]*cmv1.Cluster{mockClassicCluster})
+
+		// nolint:lll
+		const versionListResponse = `{
+					  "kind": "VersionList",
+					  "page": 1,
+					  "size": 3,
+					  "total": 3,
+					  "items": [
+						{
+						  "kind": "Version",
+						  "id": "openshift-v4.12.26",
+						  "href": "/api/clusters_mgmt/v1/versions/openshift-v4.12.26",
+						  "raw_id": "4.12.26",
+						  "enabled": true,
+						  "default": true,
+						  "channel_group": "stable",
+						  "rosa_enabled": true,
+						  "hosted_control_plane_enabled": true,
+						  "end_of_life_timestamp": "2024-05-17T00:00:00Z",
+						  "ami_overrides": [
+							{
+							  "product": {
+								"kind": "ProductLink",
+								"id": "rosa",
+								"href": "/api/clusters_mgmt/v1/products/rosa"
+							  },
+							  "region": {
+								"kind": "CloudRegionLink",
+								"id": "us-east-2",
+								"href": "/api/clusters_mgmt/v1/cloud_providers/aws/regions/us-east-2"
+							  },
+							  "ami": "ami-0e677f92eb4180cc0"
+							},
+							{
+							  "product": {
+								"kind": "ProductLink",
+								"id": "rosa",
+								"href": "/api/clusters_mgmt/v1/products/rosa"
+							  },
+							  "region": {
+								"kind": "CloudRegionLink",
+								"id": "us-east-1",
+								"href": "/api/clusters_mgmt/v1/cloud_providers/aws/regions/us-east-1"
+							  },
+							  "ami": "ami-00354720d36d019f9"
+							}
+						  ],
+						  "release_image": "quay.io/openshift-release-dev/ocp-release@sha256:8d72f29227418d2ae12ee52e25cce9edef7cd645bdaea02410a89fe8a0ec6a47"
+						},
+						{
+						  "kind": "Version",
+						  "id": "openshift-v4.12.25",
+						  "href": "/api/clusters_mgmt/v1/versions/openshift-v4.12.25",
+						  "raw_id": "4.12.25",
+						  "enabled": true,
+						  "default": false,
+						  "channel_group": "stable",
+						  "available_upgrades": [
+							"4.12.26"
+						  ],
+						  "rosa_enabled": true,
+						  "hosted_control_plane_enabled": true,
+						  "end_of_life_timestamp": "2024-05-17T00:00:00Z",
+						  "ami_overrides": [
+							{
+							  "product": {
+								"kind": "ProductLink",
+								"id": "rosa",
+								"href": "/api/clusters_mgmt/v1/products/rosa"
+							  },
+							  "region": {
+								"kind": "CloudRegionLink",
+								"id": "us-east-1",
+								"href": "/api/clusters_mgmt/v1/cloud_providers/aws/regions/us-east-1"
+							  },
+							  "ami": "ami-00354720d36d019f9"
+							},
+							{
+							  "product": {
+								"kind": "ProductLink",
+								"id": "rosa",
+								"href": "/api/clusters_mgmt/v1/products/rosa"
+							  },
+							  "region": {
+								"kind": "CloudRegionLink",
+								"id": "us-east-2",
+								"href": "/api/clusters_mgmt/v1/cloud_providers/aws/regions/us-east-2"
+							  },
+							  "ami": "ami-0e677f92eb4180cc0"
+							}
+						  ],
+						  "release_image": "quay.io/openshift-release-dev/ocp-release@sha256:5a4fb052cda1d14d1e306ce87e6b0ded84edddaa76f1cf401bcded99cef2ad84"
+						},
+						{
+						  "kind": "Version",
+						  "id": "openshift-v4.12.24",
+						  "href": "/api/clusters_mgmt/v1/versions/openshift-v4.12.24",
+						  "raw_id": "4.12.24",
+						  "enabled": true,
+						  "default": false,
+						  "channel_group": "stable",
+						  "available_upgrades": [
+							"4.12.25",
+							"4.12.26"
+						  ],
+						  "rosa_enabled": true,
+						  "hosted_control_plane_enabled": true,
+						  "end_of_life_timestamp": "2024-05-17T00:00:00Z",
+						  "ami_overrides": [
+							{
+							  "product": {
+								"kind": "ProductLink",
+								"id": "rosa",
+								"href": "/api/clusters_mgmt/v1/products/rosa"
+							  },
+							  "region": {
+								"kind": "CloudRegionLink",
+								"id": "us-east-2",
+								"href": "/api/clusters_mgmt/v1/cloud_providers/aws/regions/us-east-2"
+							  },
+							  "ami": "ami-0e677f92eb4180cc0"
+							},
+							{
+							  "product": {
+								"kind": "ProductLink",
+								"id": "rosa",
+								"href": "/api/clusters_mgmt/v1/products/rosa"
+							  },
+							  "region": {
+								"kind": "CloudRegionLink",
+								"id": "us-east-1",
+								"href": "/api/clusters_mgmt/v1/cloud_providers/aws/regions/us-east-1"
+							  },
+							  "ami": "ami-00354720d36d019f9"
+							}
+						  ],
+						  "release_image": "quay.io/openshift-release-dev/ocp-release@sha256:b0b11eedf91175459b5d7aefcf3936d0cabf00f01ced756677483f5f26227328"
+						}
+					  ]
+					}`
+
+		// nolint:lll
+		const nodePoolResponse = `{
+						  "kind": "NodePool",
+						  "href": "/api/clusters_mgmt/v1/clusters/243nmgjr5v2q9rn5sf3456euj2lcq5tn/node_pools/workers",
+						  "id": "workers",
+						  "replicas": 2,
+						  "auto_repair": true,
+						  "aws_node_pool": {
+							"instance_type": "m5.xlarge",
+							"instance_profile": "rosa-service-managed-integration-243nmgjr5v2q9rn5sf3456euj2lcq5tn-ad-int1-worker",
+							"tags": {
+							  "api.openshift.com/environment": "integration",
+							  "api.openshift.com/id": "243nmgjr5v2q9rn5sf3456euj2lcq5tn",
+							  "api.openshift.com/legal-entity-id": "1jIHnIbrnLH9kQD57W0BuPm78f1",
+							  "api.openshift.com/name": "ad-int1",
+							  "api.openshift.com/nodepool-hypershift": "ad-int1-workers",
+							  "api.openshift.com/nodepool-ocm": "workers",
+							  "red-hat-clustertype": "rosa",
+							  "red-hat-managed": "true"
+							}
+						  },
+						  "availability_zone": "us-west-2a",
+						  "subnet": "subnet-0e3a4046c1c2f1078",
+						  "status": {
+							"current_replicas": 0,
+							"message": "WaitingForAvailableMachines: NodeProvisioning"
+						  },
+						  "version": {
+							"kind": "VersionLink",
+							"id": "openshift-v4.12.%s",
+							"href": "/api/clusters_mgmt/v1/versions/openshift-v4.12.%s"
+						  },
+						  "tuning_configs": []
+						}`
+		BeforeEach(func() {
+			testRuntime.InitRuntime()
+		})
+		It("Fails if cluster is not hypershift and we are using hypershift specific flags", func() {
+			args.nodePool = nodePoolName
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, classicCluster))
+			err := runWithRuntime(testRuntime.RosaRuntime, Cmd)
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(
+				ContainSubstring("The '--machinepool' option is only supported for Hosted Control Planes"))
+		})
+		It("Fails if cluster is not ready", func() {
+			args.nodePool = nodePoolName
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterNotReady))
+			err := runWithRuntime(testRuntime.RosaRuntime, Cmd)
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring("Cluster 'cluster1' is not yet ready"))
+		})
+
+		It("Cluster is ready and node pool no upgrade available", func() {
+			args.nodePool = nodePoolName
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
+			// A node pool
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK,
+				fmt.Sprintf(nodePoolResponse, "26", "26")))
+			// No existing policy upgrade
+			testRuntime.ApiServer.AppendHandlers(
+				RespondWithJSON(
+					http.StatusOK,
+					`{
+						"kind": "NodePoolUpgradePolicyList",
+						"page": 1,
+						"size": 0,
+						"total": 0,
+						"items": []
+				}`,
+				),
+			)
+			// available versions
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, versionListResponse))
+			stdout, _, err := test.RunWithOutputCapture(runWithRuntime, testRuntime.RosaRuntime, Cmd)
+			Expect(stdout).To(Equal(noUpgradeOutput))
+			Expect(err).To(BeNil())
+		})
+
+		It("Cluster is ready and node pool can be upgraded with 2 upgrades available", func() {
+			format.TruncatedDiff = true
+			args.nodePool = nodePoolName
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
+			// A node pool
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK,
+				fmt.Sprintf(nodePoolResponse, "24", "24")))
+			// No existing policy upgrade
+			testRuntime.ApiServer.AppendHandlers(
+				RespondWithJSON(
+					http.StatusOK,
+					`{
+						"kind": "NodePoolUpgradePolicyList",
+						"page": 1,
+						"size": 0,
+						"total": 0,
+						"items": []
+				}`,
+				),
+			)
+			// available versions
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, versionListResponse))
+			stdout, _, err := test.RunWithOutputCapture(runWithRuntime, testRuntime.RosaRuntime, Cmd)
+			Expect(stdout).To(Equal(upgradeAvailableOutput))
+			Expect(err).To(BeNil())
+		})
+
+		It("Cluster is ready and node pool can be upgraded with 2 upgrades available, 1 is scheduled", func() {
+			format.TruncatedDiff = false
+			args.nodePool = nodePoolName
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
+			// A node pool
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK,
+				fmt.Sprintf(nodePoolResponse, "24", "24")))
+			// An existing policy upgrade
+			// nolint:lll
+			testRuntime.ApiServer.AppendHandlers(
+				RespondWithJSON(
+					http.StatusOK,
+					`{
+						"kind": "NodePoolUpgradePolicyList",
+						"page": 1,
+						"size": 1,
+						"total": 1,
+						"items": [
+							{
+							"kind": "NodePoolUpgradePolicy",
+							"id": "a33c8cae-013f-11ee-a3b2-acde48001122",
+							"href": "/api/clusters_mgmt/v1/clusters/243nmgjr5v2q9rn5sf3456euj2lcq5tn/node_pools/upgrade_policies/a33c8cae-013f-11ee-a3b2-acde48001122",
+							"schedule_type": "manual",
+							"upgrade_type": "NodePool",
+							"version": "4.12.25",
+							"next_run": "2023-06-02T12:30:00Z",
+							"cluster_id": "243nmgjr5v2q9rn5sf3456euj2lcq5tn",
+							"enable_minor_version_upgrades": false,
+							"creation_timestamp": "2023-06-02T14:18:52.828589+02:00",
+							"last_update_timestamp": "2023-06-02T14:18:52.828589+02:00",
+							"state": {
+							"value": "pending",
+							"description": "Upgrade policy defined, pending scheduling."
+							}
+						}
+					]
+				}`,
+				),
+			)
+			// available versions
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, versionListResponse))
+			stdout, _, err := test.RunWithOutputCapture(runWithRuntime, testRuntime.RosaRuntime, Cmd)
+			Expect(stdout).To(Equal(ongoingUpgradeOutput))
+			Expect(err).To(BeNil())
+		})
+	})
+})

--- a/cmd/list/upgrade/main_test.go
+++ b/cmd/list/upgrade/main_test.go
@@ -1,0 +1,13 @@
+package upgrade
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestListUpgrades(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "List upgrades suite")
+}

--- a/cmd/upgrade/cmd.go
+++ b/cmd/upgrade/cmd.go
@@ -17,14 +17,14 @@ limitations under the License.
 package upgrade
 
 import (
-	"github.com/spf13/cobra"
-
 	"github.com/openshift/rosa/cmd/upgrade/accountroles"
 	"github.com/openshift/rosa/cmd/upgrade/cluster"
+	"github.com/openshift/rosa/cmd/upgrade/machinepool"
 	"github.com/openshift/rosa/cmd/upgrade/operatorroles"
 	"github.com/openshift/rosa/cmd/upgrade/roles"
 	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/spf13/cobra"
 )
 
 var Cmd = &cobra.Command{
@@ -35,6 +35,7 @@ var Cmd = &cobra.Command{
 
 func init() {
 	Cmd.AddCommand(cluster.Cmd)
+	Cmd.AddCommand(machinepool.Cmd)
 	Cmd.AddCommand(accountroles.Cmd)
 	Cmd.AddCommand(operatorroles.Cmd)
 	Cmd.AddCommand(roles.Cmd)

--- a/cmd/upgrade/machinepool/cmd.go
+++ b/cmd/upgrade/machinepool/cmd.go
@@ -1,0 +1,248 @@
+/*
+Copyright (c) 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machinepool
+
+import (
+	"fmt"
+	"os"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/rosa/pkg/helper/versions"
+	"github.com/openshift/rosa/pkg/input"
+	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/interactive/confirm"
+	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/rosa"
+	"github.com/spf13/cobra"
+)
+
+var args struct {
+	version      string
+	scheduleDate string
+	scheduleTime string
+}
+
+var Cmd = &cobra.Command{
+	Use:     "machinepool",
+	Aliases: []string{"machinepools", "machine-pool", "machine-pools"},
+	Short:   "Upgrade machinepool",
+	Long:    "Upgrade machinepool to a new available version. This is supported only for Hosted Control Planes.",
+	Example: `  # Interactively schedule an upgrade on the cluster named "mycluster"" for a machinepool named "np1"
+  rosa upgrade machinepool np1 --cluster=mycluster --interactive
+
+  # Schedule a machinepool upgrade within the hour
+  rosa upgrade machinepool np1 -c mycluster --version 4.12.20`,
+	Run: run,
+	Args: func(_ *cobra.Command, argv []string) error {
+		if len(argv) != 1 {
+			return fmt.Errorf(
+				"expected exactly one command line parameter containing the id of the machine pool",
+			)
+		}
+		return nil
+	},
+}
+
+func init() {
+	flags := Cmd.Flags()
+	flags.SortFlags = false
+
+	ocm.AddClusterFlag(Cmd)
+
+	flags.StringVar(
+		&args.version,
+		"version",
+		"",
+		"Version of OpenShift that the cluster will be upgraded to",
+	)
+
+	flags.StringVar(
+		&args.scheduleDate,
+		"schedule-date",
+		"",
+		"Next date the upgrade should run at the specified UTC time. Format should be 'yyyy-mm-dd'",
+	)
+
+	flags.StringVar(
+		&args.scheduleTime,
+		"schedule-time",
+		"",
+		"Next UTC time that the upgrade should run on the specified date. Format should be 'HH:mm'",
+	)
+
+	confirm.AddFlag(flags)
+	interactive.AddFlag(flags)
+}
+
+func run(cmd *cobra.Command, argv []string) {
+	r := rosa.NewRuntime().WithAWS().WithOCM()
+	defer r.Cleanup()
+	err := runWithRuntime(r, cmd, argv)
+	if err != nil {
+		r.Reporter.Errorf(err.Error())
+		os.Exit(1)
+	}
+}
+
+func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command, argv []string) error {
+	clusterKey := r.GetClusterKey()
+	cluster := r.FetchCluster()
+	machinePoolID := argv[0]
+	scheduleDate := args.scheduleDate
+	scheduleTime := args.scheduleTime
+	isVersionSet := cmd.Flags().Changed("version")
+
+	// Validate cluster state
+	input.CheckIfHypershiftClusterOrExit(r, cluster)
+	if cluster.State() != cmv1.ClusterStateReady {
+		return fmt.Errorf("Cluster '%s' is not yet ready", clusterKey)
+	}
+	if scheduleDate == "" || scheduleTime == "" {
+		interactive.Enable()
+	}
+
+	// check existing upgrades
+	r.Reporter.Debugf("Checking existing upgrades for hosted cluster '%s'", clusterKey)
+	nodePool, exists, err := checkNodePoolExistingScheduledUpgrade(r, cluster, clusterKey, machinePoolID)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+
+	// check version
+	version := args.version
+	if isVersionSet || interactive.Enabled() {
+		version, err = ComputeNodePoolVersion(r, cmd, cluster, nodePool, version)
+		if err != nil {
+			return err
+		}
+		if version == "" {
+			r.Reporter.Infof("No upgrade available for the machine pool '%s' on cluster '%s'", machinePoolID,
+				clusterKey)
+			return nil
+		}
+	}
+	version = ocm.GetRawVersionId(version)
+
+	// build the upgrade policy
+	r.Reporter.Debugf("Building and scheduling the upgrade policy")
+	var upgradePolicy *cmv1.NodePoolUpgradePolicy
+	upgradePolicy, err = buildPolicy(r, cmd, version, machinePoolID, scheduleDate, scheduleTime)
+	if err != nil {
+		return fmt.Errorf("Failed to build schedule upgrade for machine pool %s in cluster '%s': %v",
+			machinePoolID, clusterKey, err)
+	}
+
+	// Ask for confirmation
+	if r.Reporter.IsTerminal() && !confirm.Confirm("upgrade machine pool '%s' to version '%s'", machinePoolID,
+		version) {
+		return nil
+	}
+
+	// schedule the upgrade policy
+	err = r.OCMClient.ScheduleNodePoolUpgrade(cluster.ID(), machinePoolID, upgradePolicy)
+	if err != nil {
+		return fmt.Errorf("Failed to schedule upgrade for machine pool %s in cluster '%s': %v",
+			machinePoolID, clusterKey, err)
+	}
+
+	r.Reporter.Infof("Upgrade successfully scheduled for the machine pool '%s' on cluster '%s'", machinePoolID,
+		clusterKey)
+	return nil
+}
+
+func checkNodePoolExistingScheduledUpgrade(r *rosa.Runtime, cluster *cmv1.Cluster, clusterKey string,
+	nodePoolId string) (*cmv1.NodePool, bool, error) {
+	nodePool, scheduledUpgrade, err := r.OCMClient.GetHypershiftNodePoolUpgrade(cluster.ID(), clusterKey, nodePoolId)
+	if err != nil {
+		return nil, false, err
+	}
+	if scheduledUpgrade != nil {
+		r.Reporter.Warnf("There is already a %s upgrade to version %s on %s",
+			scheduledUpgrade.State().Value(),
+			scheduledUpgrade.Version(),
+			scheduledUpgrade.NextRun().Format("2006-01-02 15:04 MST"),
+		)
+		return nil, true, nil
+	}
+	return nodePool, false, nil
+}
+
+func ComputeNodePoolVersion(r *rosa.Runtime, cmd *cobra.Command, cluster *cmv1.Cluster,
+	nodePool *cmv1.NodePool, version string) (string, error) {
+	channelGroup := cluster.Version().ChannelGroup()
+	filteredVersionList, err := GetAvailableVersion(r, cluster, nodePool)
+	if err != nil {
+		return "", err
+	}
+	// No updates available
+	if len(filteredVersionList) == 0 {
+		return "", nil
+	}
+	if version == "" {
+		// Use as default latest version if we don't specify anything
+		version = filteredVersionList[0]
+	}
+
+	if interactive.Enabled() {
+		version, err = interactive.GetOption(interactive.Input{
+			Question: "Machine pool version",
+			Help:     cmd.Flags().Lookup("version").Usage,
+			Options:  filteredVersionList,
+			Default:  version,
+		})
+		if err != nil {
+			return "", fmt.Errorf("Expected a valid machine pool version from interactive prompt: %s", err)
+		}
+	}
+	// This is called in HyperShift, but we don't want to exclude version which are HCP disabled for node pools
+	// so we pass the relative parameter as false
+	version, err = r.OCMClient.ValidateVersion(version, filteredVersionList, channelGroup, true, false)
+	if err != nil {
+		return "", fmt.Errorf("Expected a valid machine pool version: %s", err)
+	}
+	return version, nil
+}
+
+func GetAvailableVersion(r *rosa.Runtime, cluster *cmv1.Cluster, nodePool *cmv1.NodePool) ([]string, error) {
+	clusterVersion := cluster.Version().RawID()
+	nodePoolVersion := ocm.GetRawVersionId(nodePool.Version().ID())
+	// This is called in HyperShift, but we don't want to exclude version which are HCP disabled for node pools
+	// so we pass the relative parameter as false
+	versionList, err := versions.GetVersionList(r, cluster.Version().ChannelGroup(), true, false, false)
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter the available list of versions for a hosted machine pool
+	filteredVersionList := versions.GetFilteredVersionListForUpdate(versionList, nodePoolVersion, clusterVersion)
+	if err != nil {
+		return nil, err
+	}
+	return filteredVersionList, nil
+}
+
+func buildPolicy(r *rosa.Runtime, cmd *cobra.Command,
+	version string, machinePoolID string, scheduleDate string, scheduleTime string) (*cmv1.NodePoolUpgradePolicy, error) {
+	nextRun, err := interactive.BuildManualUpgradeSchedule(cmd, scheduleDate, scheduleTime)
+	if err != nil {
+		return nil, err
+	}
+	return r.OCMClient.BuildNodeUpgradePolicy(version, machinePoolID, nextRun)
+}

--- a/cmd/upgrade/machinepool/cmd_test.go
+++ b/cmd/upgrade/machinepool/cmd_test.go
@@ -1,0 +1,361 @@
+package machinepool
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+	"github.com/openshift/rosa/pkg/test"
+)
+
+const (
+	scheduleTime        = "10:00"
+	invalidScheduleDate = "25h December"
+	validScheduleDate   = "2023-12-25"
+	invalidVersionError = `Expected a valid machine pool version: A valid version number must be specified
+Valid versions: 4.12.26 4.12.25 4.12.24`
+)
+
+var _ = Describe("Upgrade machine pool", func() {
+	Context("Upgrade machine pool command", func() {
+		var testRuntime test.TestingRuntime
+		var nodePoolName = "nodepool85"
+		mockClusterError, err := test.MockOCMCluster(func(c *cmv1.ClusterBuilder) {
+			c.AWS(cmv1.NewAWS().SubnetIDs("subnet-0b761d44d3d9a4663", "subnet-0f87f640e56934cbc"))
+			c.Region(cmv1.NewCloudRegion().ID("us-east-1"))
+			c.State(cmv1.ClusterStateError)
+			c.Hypershift(cmv1.NewHypershift().Enabled(true))
+		})
+		Expect(err).To(BeNil())
+		hypershiftClusterNotReady := test.FormatClusterList([]*cmv1.Cluster{mockClusterError})
+
+		mockClusterReady, err := test.MockOCMCluster(func(c *cmv1.ClusterBuilder) {
+			c.AWS(cmv1.NewAWS().SubnetIDs("subnet-0b761d44d3d9a4663", "subnet-0f87f640e56934cbc"))
+			c.Region(cmv1.NewCloudRegion().ID("us-east-1"))
+			c.State(cmv1.ClusterStateReady)
+			c.Hypershift(cmv1.NewHypershift().Enabled(true))
+		})
+		Expect(err).To(BeNil())
+		hypershiftClusterReady := test.FormatClusterList([]*cmv1.Cluster{mockClusterReady})
+
+		// nolint:lll
+		const versionListResponse = `{
+					  "kind": "VersionList",
+					  "page": 1,
+					  "size": 3,
+					  "total": 3,
+					  "items": [
+						{
+						  "kind": "Version",
+						  "id": "openshift-v4.12.26",
+						  "href": "/api/clusters_mgmt/v1/versions/openshift-v4.12.26",
+						  "raw_id": "4.12.26",
+						  "enabled": true,
+						  "default": true,
+						  "channel_group": "stable",
+						  "rosa_enabled": true,
+						  "hosted_control_plane_enabled": true,
+						  "end_of_life_timestamp": "2024-05-17T00:00:00Z",
+						  "ami_overrides": [
+							{
+							  "product": {
+								"kind": "ProductLink",
+								"id": "rosa",
+								"href": "/api/clusters_mgmt/v1/products/rosa"
+							  },
+							  "region": {
+								"kind": "CloudRegionLink",
+								"id": "us-east-2",
+								"href": "/api/clusters_mgmt/v1/cloud_providers/aws/regions/us-east-2"
+							  },
+							  "ami": "ami-0e677f92eb4180cc0"
+							},
+							{
+							  "product": {
+								"kind": "ProductLink",
+								"id": "rosa",
+								"href": "/api/clusters_mgmt/v1/products/rosa"
+							  },
+							  "region": {
+								"kind": "CloudRegionLink",
+								"id": "us-east-1",
+								"href": "/api/clusters_mgmt/v1/cloud_providers/aws/regions/us-east-1"
+							  },
+							  "ami": "ami-00354720d36d019f9"
+							}
+						  ],
+						  "release_image": "quay.io/openshift-release-dev/ocp-release@sha256:8d72f29227418d2ae12ee52e25cce9edef7cd645bdaea02410a89fe8a0ec6a47"
+						},
+						{
+						  "kind": "Version",
+						  "id": "openshift-v4.12.25",
+						  "href": "/api/clusters_mgmt/v1/versions/openshift-v4.12.25",
+						  "raw_id": "4.12.25",
+						  "enabled": true,
+						  "default": false,
+						  "channel_group": "stable",
+						  "available_upgrades": [
+							"4.12.26"
+						  ],
+						  "rosa_enabled": true,
+						  "hosted_control_plane_enabled": true,
+						  "end_of_life_timestamp": "2024-05-17T00:00:00Z",
+						  "ami_overrides": [
+							{
+							  "product": {
+								"kind": "ProductLink",
+								"id": "rosa",
+								"href": "/api/clusters_mgmt/v1/products/rosa"
+							  },
+							  "region": {
+								"kind": "CloudRegionLink",
+								"id": "us-east-1",
+								"href": "/api/clusters_mgmt/v1/cloud_providers/aws/regions/us-east-1"
+							  },
+							  "ami": "ami-00354720d36d019f9"
+							},
+							{
+							  "product": {
+								"kind": "ProductLink",
+								"id": "rosa",
+								"href": "/api/clusters_mgmt/v1/products/rosa"
+							  },
+							  "region": {
+								"kind": "CloudRegionLink",
+								"id": "us-east-2",
+								"href": "/api/clusters_mgmt/v1/cloud_providers/aws/regions/us-east-2"
+							  },
+							  "ami": "ami-0e677f92eb4180cc0"
+							}
+						  ],
+						  "release_image": "quay.io/openshift-release-dev/ocp-release@sha256:5a4fb052cda1d14d1e306ce87e6b0ded84edddaa76f1cf401bcded99cef2ad84"
+						},
+						{
+						  "kind": "Version",
+						  "id": "openshift-v4.12.24",
+						  "href": "/api/clusters_mgmt/v1/versions/openshift-v4.12.24",
+						  "raw_id": "4.12.24",
+						  "enabled": true,
+						  "default": false,
+						  "channel_group": "stable",
+						  "available_upgrades": [
+							"4.12.25",
+							"4.12.26"
+						  ],
+						  "rosa_enabled": true,
+						  "hosted_control_plane_enabled": true,
+						  "end_of_life_timestamp": "2024-05-17T00:00:00Z",
+						  "ami_overrides": [
+							{
+							  "product": {
+								"kind": "ProductLink",
+								"id": "rosa",
+								"href": "/api/clusters_mgmt/v1/products/rosa"
+							  },
+							  "region": {
+								"kind": "CloudRegionLink",
+								"id": "us-east-2",
+								"href": "/api/clusters_mgmt/v1/cloud_providers/aws/regions/us-east-2"
+							  },
+							  "ami": "ami-0e677f92eb4180cc0"
+							},
+							{
+							  "product": {
+								"kind": "ProductLink",
+								"id": "rosa",
+								"href": "/api/clusters_mgmt/v1/products/rosa"
+							  },
+							  "region": {
+								"kind": "CloudRegionLink",
+								"id": "us-east-1",
+								"href": "/api/clusters_mgmt/v1/cloud_providers/aws/regions/us-east-1"
+							  },
+							  "ami": "ami-00354720d36d019f9"
+							}
+						  ],
+						  "release_image": "quay.io/openshift-release-dev/ocp-release@sha256:b0b11eedf91175459b5d7aefcf3936d0cabf00f01ced756677483f5f26227328"
+						}
+					  ]
+					}`
+
+		// nolint:lll
+		const nodePoolResponse = `{
+						  "kind": "NodePool",
+						  "href": "/api/clusters_mgmt/v1/clusters/243nmgjr5v2q9rn5sf3456euj2lcq5tn/node_pools/workers",
+						  "id": "workers",
+						  "replicas": 2,
+						  "auto_repair": true,
+						  "aws_node_pool": {
+							"instance_type": "m5.xlarge",
+							"instance_profile": "rosa-service-managed-integration-243nmgjr5v2q9rn5sf3456euj2lcq5tn-ad-int1-worker",
+							"tags": {
+							  "api.openshift.com/environment": "integration",
+							  "api.openshift.com/id": "243nmgjr5v2q9rn5sf3456euj2lcq5tn",
+							  "api.openshift.com/legal-entity-id": "1jIHnIbrnLH9kQD57W0BuPm78f1",
+							  "api.openshift.com/name": "ad-int1",
+							  "api.openshift.com/nodepool-hypershift": "ad-int1-workers",
+							  "api.openshift.com/nodepool-ocm": "workers",
+							  "red-hat-clustertype": "rosa",
+							  "red-hat-managed": "true"
+							}
+						  },
+						  "availability_zone": "us-west-2a",
+						  "subnet": "subnet-0e3a4046c1c2f1078",
+						  "status": {
+							"current_replicas": 0,
+							"message": "WaitingForAvailableMachines: NodeProvisioning"
+						  },
+						  "version": {
+							"kind": "VersionLink",
+							"id": "openshift-v4.12.%s",
+							"href": "/api/clusters_mgmt/v1/versions/openshift-v4.12.%s"
+						  },
+						  "tuning_configs": []
+						}`
+
+		// nolint:lll
+		const nodePoolUpgradePolicy = `{
+  "kind": "NodePoolUpgradePolicyList",
+  "page": 1,
+  "size": 1,
+  "total": 1,
+  "items": [
+    {
+      "kind": "NodePoolUpgradePolicy",
+      "id": "e2800d05-3534-11ee-b9bc-0a580a811709",
+      "href": "/api/clusters_mgmt/v1/clusters/25f96obptkqc5mh9vdc779jiqb3sihnn/node_pools/workers/upgrade_policies/e2800d05-3534-11ee-b9bc-0a580a811709",
+      "schedule_type": "manual",
+      "upgrade_type": "NodePool",
+      "version": "4.12.25",
+      "next_run": "2023-08-07T15:22:00Z",
+      "cluster_id": "25f96obptkqc5mh9vdc779jiqb3sihnn",
+      "node_pool_id": "workers",
+      "enable_minor_version_upgrades": true,
+      "creation_timestamp": "2023-08-07T15:12:54.967835Z",
+      "last_update_timestamp": "2023-08-07T15:12:54.967835Z",
+      "state": {
+        "value": "scheduled",
+        "description": "Upgrade scheduled."
+      }
+    }
+  ]
+}`
+
+		const noNodePoolUpgradePolicy = `{
+  "kind": "NodePoolUpgradePolicyList",
+  "page": 1,
+  "size": 0,
+  "total": 0,
+  "items": []
+}`
+
+		BeforeEach(func() {
+			testRuntime.InitRuntime()
+		})
+		It("Fails if cluster is not ready", func() {
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterNotReady))
+			err := runWithRuntime(testRuntime.RosaRuntime, Cmd, []string{nodePoolName})
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring("Cluster 'cluster1' is not yet ready"))
+		})
+		It("Cluster is ready but node pool not found", func() {
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusNotFound, ""))
+			err := runWithRuntime(testRuntime.RosaRuntime, Cmd, []string{nodePoolName})
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring(
+				"Failed to get scheduled upgrades for machine pool 'nodepool85': " +
+					"Machine pool 'nodepool85' does not exist for hosted cluster 'cluster1'"))
+		})
+		It("Cluster is ready and there is a scheduled upgraded", func() {
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, nodePoolResponse))
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, nodePoolUpgradePolicy))
+			_, stderr, err := test.RunWithOutputCaptureAndArgv(runWithRuntime, testRuntime.RosaRuntime,
+				Cmd, &[]string{nodePoolName})
+			Expect(err).To(BeNil())
+			Expect(stderr).To(ContainSubstring(
+				"WARN: There is already a scheduled upgrade to version 4.12.25 on 2023-08-07 15:22 UTC"))
+		})
+		It("Cluster is ready and there is a scheduled upgraded", func() {
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, nodePoolResponse))
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, nodePoolUpgradePolicy))
+			_, stderr, err := test.RunWithOutputCaptureAndArgv(runWithRuntime, testRuntime.RosaRuntime,
+				Cmd, &[]string{nodePoolName})
+			Expect(err).To(BeNil())
+			Expect(stderr).To(ContainSubstring(
+				"WARN: There is already a scheduled upgrade to version 4.12.25 on 2023-08-07 15:22 UTC"))
+		})
+		It("Cluster is ready and there is no scheduled upgraded but schedule date is invalid -> fail", func() {
+			args.scheduleTime = scheduleTime
+			args.scheduleDate = invalidScheduleDate
+			Cmd.Flags().Set("interactive", "false")
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, nodePoolResponse))
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, noNodePoolUpgradePolicy))
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, versionListResponse))
+			stdout, stderr, err := test.RunWithOutputCaptureAndArgv(runWithRuntime, testRuntime.RosaRuntime,
+				Cmd, &[]string{nodePoolName})
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring(
+				"Failed to build schedule upgrade for machine pool nodepool85 in cluster 'cluster1': " +
+					"schedule date should use the format 'yyyy-mm-dd'"))
+			Expect(stdout).To(BeEmpty())
+			Expect(stderr).To(BeEmpty())
+		})
+		It("Cluster is ready and there is no scheduled upgraded and an invalid version is specified -> fail",
+			func() {
+				args.scheduleTime = scheduleTime
+				args.scheduleDate = validScheduleDate
+				Cmd.Flags().Set("version", "4.13.26")
+				Cmd.Flags().Set("interactive", "false")
+				testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
+				testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, nodePoolResponse))
+				testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, noNodePoolUpgradePolicy))
+				testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, versionListResponse))
+				testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, ""))
+				stdout, stderr, err := test.RunWithOutputCaptureAndArgv(runWithRuntime, testRuntime.RosaRuntime,
+					Cmd, &[]string{nodePoolName})
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(Equal(invalidVersionError))
+				Expect(stderr).To(BeEmpty())
+				Expect(stdout).To(BeEmpty())
+			})
+		It("Cluster is ready and there is no scheduled upgraded and a version is specified -> success", func() {
+			args.scheduleTime = scheduleTime
+			args.scheduleDate = validScheduleDate
+			Cmd.Flags().Set("version", "4.12.26")
+			Cmd.Flags().Set("interactive", "false")
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, nodePoolResponse))
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, noNodePoolUpgradePolicy))
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, versionListResponse))
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, ""))
+			stdout, stderr, err := test.RunWithOutputCaptureAndArgv(runWithRuntime, testRuntime.RosaRuntime,
+				Cmd, &[]string{nodePoolName})
+			Expect(err).To(BeNil())
+			Expect(stderr).To(BeEmpty())
+			Expect(stdout).To(ContainSubstring(
+				"Upgrade successfully scheduled for the machine pool 'nodepool85' on cluster 'cluster1"))
+		})
+		It("Cluster is ready and there is no scheduled upgraded -> success", func() {
+			args.scheduleTime = scheduleTime
+			args.scheduleDate = validScheduleDate
+			Cmd.Flags().Set("interactive", "false")
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, nodePoolResponse))
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, noNodePoolUpgradePolicy))
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, versionListResponse))
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, ""))
+			stdout, stderr, err := test.RunWithOutputCaptureAndArgv(runWithRuntime, testRuntime.RosaRuntime,
+				Cmd, &[]string{nodePoolName})
+			Expect(err).To(BeNil())
+			Expect(stderr).To(BeEmpty())
+			Expect(stdout).To(ContainSubstring(
+				"Upgrade successfully scheduled for the machine pool 'nodepool85' on cluster 'cluster1"))
+		})
+	})
+})

--- a/cmd/upgrade/machinepool/main_test.go
+++ b/cmd/upgrade/machinepool/main_test.go
@@ -1,0 +1,13 @@
+package machinepool
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestUpgradeMachinePool(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Upgrade machine pool suite")
+}

--- a/pkg/helper/versions/helpers.go
+++ b/pkg/helper/versions/helpers.go
@@ -44,7 +44,15 @@ func GetVersionList(r *rosa.Runtime, channelGroup string, isSTS bool, isHostedCP
 	return
 }
 
-func GetFilteredVersionList(versionList []string, minVersion string, maxVersion string) []string {
+func GetFilteredVersionListForCreation(versionList []string, minVersion string, maxVersion string) []string {
+	return getFilteredVersionList(versionList, minVersion, maxVersion, false)
+}
+
+func GetFilteredVersionListForUpdate(versionList []string, minVersion string, maxVersion string) []string {
+	return getFilteredVersionList(versionList, minVersion, maxVersion, true)
+}
+
+func getFilteredVersionList(versionList []string, minVersion string, maxVersion string, excludeCurrent bool) []string {
 	var filteredVersionList []string
 
 	// Parse the versions for comparison
@@ -61,6 +69,10 @@ func GetFilteredVersionList(versionList []string, minVersion string, maxVersion 
 			continue
 		}
 		if ver.GreaterThanOrEqual(min) && ver.LessThanOrEqual(max) {
+			// For upgrades, we don't want to show the current version. For creation, it should be shown
+			if excludeCurrent && ver.Equal(min) {
+				continue
+			}
 			filteredVersionList = append(filteredVersionList, version)
 		}
 	}

--- a/pkg/helper/versions/helpers_test.go
+++ b/pkg/helper/versions/helpers_test.go
@@ -11,9 +11,9 @@ var _ = Describe("Version Helpers", Ordered, func() {
 
 	Context("when creating a hosted machine pool ", func() {
 		DescribeTable("Filtered versions",
-			func(versionList []string, minVersion string, maxVersion string, expetedVersionList []string) {
-				filteredVersionList := GetFilteredVersionList(versionList, minVersion, maxVersion)
-				Expect(filteredVersionList).To(BeEquivalentTo(expetedVersionList))
+			func(versionList []string, minVersion string, maxVersion string, expectedVersionList []string) {
+				filteredVersionList := getFilteredVersionList(versionList, minVersion, maxVersion, false)
+				Expect(filteredVersionList).To(BeEquivalentTo(expectedVersionList))
 			},
 			Entry("machinepool create",
 				[]string{
@@ -73,6 +73,32 @@ var _ = Describe("Version Helpers", Ordered, func() {
 			),
 		)
 
+	})
+	Context("when updating a hosted machine pool ", func() {
+		DescribeTable("Filtered versions",
+			func(versionList []string, minVersion string, maxVersion string, expectedVersionList []string) {
+				filteredVersionList := getFilteredVersionList(versionList, minVersion, maxVersion, true)
+				Expect(filteredVersionList).To(BeEquivalentTo(expectedVersionList))
+			},
+			Entry("machinepool update",
+				[]string{
+					"4.12.22",
+					"4.12.23",
+					"4.12.24",
+					"4.12.25",
+					"4.12.26",
+					"4.13.0-0.nightly-2023-02-22-192922",
+				},
+				"4.12.22",
+				"4.12.26",
+				[]string{
+					"4.12.23",
+					"4.12.24",
+					"4.12.25",
+					"4.12.26",
+				},
+			),
+		)
 	})
 
 })

--- a/pkg/ocm/hypershift_upgrades.go
+++ b/pkg/ocm/hypershift_upgrades.go
@@ -1,0 +1,29 @@
+package ocm
+
+import (
+	"time"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+)
+
+// HypershiftUpgrader represents a Hypershift Control Plane or Node Pool Update
+type HypershiftUpgrader interface {
+	ID() string
+	ClusterID() string
+	Version() string
+	State() *cmv1.UpgradePolicyState
+	NextRun() time.Time
+	CreationTimestamp() time.Time
+	EnableMinorVersionUpgrades() bool
+	Schedule() string
+	ScheduleType() cmv1.ScheduleType
+}
+
+type UpgradeScheduling struct {
+	ScheduleDate             string
+	ScheduleTime             string
+	Schedule                 string
+	AllowMinorVersionUpdates bool
+	AutomaticUpgrades        bool
+	NextRun                  time.Time
+}

--- a/pkg/ocm/nodepools_upgrades.go
+++ b/pkg/ocm/nodepools_upgrades.go
@@ -1,0 +1,112 @@
+/*
+Copyright (c) 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ocm
+
+import (
+	"fmt"
+	"time"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+)
+
+func (c *Client) ScheduleNodePoolUpgrade(clusterID string, nodePoolId string,
+	upgradePolicy *cmv1.NodePoolUpgradePolicy) error {
+	response, err := c.ocm.ClustersMgmt().V1().
+		Clusters().Cluster(clusterID).NodePools().NodePool(nodePoolId).
+		UpgradePolicies().
+		Add().Body(upgradePolicy).
+		Send()
+	if err != nil {
+		return handleErr(response.Error(), err)
+	}
+	return nil
+}
+
+func (c *Client) BuildNodeUpgradePolicy(version string, machinePoolID string,
+	nextRun time.Time) (*cmv1.NodePoolUpgradePolicy, error) {
+	upgradePolicyBuilder := cmv1.NewNodePoolUpgradePolicy().ScheduleType(cmv1.ScheduleTypeManual).
+		UpgradeType(cmv1.UpgradeTypeNodePool).Version(version).NodePoolID(machinePoolID).NextRun(nextRun)
+	return upgradePolicyBuilder.Build()
+}
+
+func (c *Client) CancelNodePoolUpgrade(clusterID, nodePoolID string, upgradeID string) (bool, error) {
+	response, err := c.ocm.ClustersMgmt().V1().
+		Clusters().Cluster(clusterID).NodePools().NodePool(nodePoolID).UpgradePolicies().
+		NodePoolUpgradePolicy(upgradeID).Delete().Send()
+	if err != nil {
+		return false, handleErr(response.Error(), err)
+	}
+	return true, nil
+}
+
+func (c *Client) getNodePoolUpgradePolicies(clusterID string, nodePoolID string) (
+	nodePoolUpgradePolicies []*cmv1.NodePoolUpgradePolicy,
+	err error) {
+	collection := c.ocm.ClustersMgmt().V1().
+		Clusters().
+		Cluster(clusterID).NodePools().NodePool(nodePoolID).UpgradePolicies()
+	page := 1
+	size := 100
+	for {
+		response, err := collection.List().
+			Page(page).
+			Size(size).
+			Send()
+		if err != nil {
+			return nil, handleErr(response.Error(), err)
+		}
+		nodePoolUpgradePolicies = append(nodePoolUpgradePolicies, response.Items().Slice()...)
+		if response.Size() < size {
+			break
+		}
+		page++
+	}
+	return
+}
+
+func (c *Client) GetHypershiftNodePoolUpgrades(clusterID, clusterKey,
+	nodePoolID string) (*cmv1.NodePool, []*cmv1.NodePoolUpgradePolicy, error) {
+	nodePool, exists, err := c.GetNodePool(clusterID, nodePoolID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed to get machine pools for hosted cluster '%s': %v", clusterKey, err)
+	}
+	if !exists {
+		return nil, nil, fmt.Errorf("Machine pool '%s' does not exist for hosted cluster '%s'", nodePoolID, clusterKey)
+	}
+
+	scheduledUpgrades, err := c.getNodePoolUpgradePolicies(clusterID, nodePoolID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed to get scheduled upgrades for machine pool '%s': %v", nodePoolID, err)
+	}
+
+	return nodePool, scheduledUpgrades, nil
+}
+
+func (c *Client) GetHypershiftNodePoolUpgrade(clusterID, clusterKey,
+	nodePoolID string) (*cmv1.NodePool, *cmv1.NodePoolUpgradePolicy, error) {
+	nodePool, upgradePolicies, err := c.GetHypershiftNodePoolUpgrades(clusterID, clusterKey, nodePoolID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed to get scheduled upgrades for machine pool '%s': %v", nodePoolID, err)
+	}
+	for _, upgradePolicy := range upgradePolicies {
+		if upgradePolicy.UpgradeType() == cmv1.UpgradeTypeNodePool {
+			return nodePool, upgradePolicy, nil
+		}
+	}
+
+	return nodePool, nil, nil
+}

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -4,9 +4,19 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
+	"time"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
 	"github.com/spf13/cobra"
 )
@@ -30,6 +40,34 @@ func RunWithOutputCapture(runWithRuntime func(*rosa.Runtime, *cobra.Command) err
 
 	go func() {
 		err = runWithRuntime(runtime, cmd)
+		wout.Close()
+		werr.Close()
+	}()
+	stdout, _ = io.ReadAll(rout)
+	stderr, _ = io.ReadAll(rerr)
+
+	return string(stdout), string(stderr), err
+}
+
+func RunWithOutputCaptureAndArgv(runWithRuntime func(*rosa.Runtime, *cobra.Command, []string) error,
+	runtime *rosa.Runtime, cmd *cobra.Command, argv *[]string) (string, string, error) {
+	var err error
+	var stdout []byte
+	var stderr []byte
+
+	rout, wout, _ := os.Pipe()
+	tmpout := os.Stdout
+	rerr, werr, _ := os.Pipe()
+	tmperr := os.Stderr
+	defer func() {
+		os.Stdout = tmpout
+		os.Stderr = tmperr
+	}()
+	os.Stdout = wout
+	os.Stderr = werr
+
+	go func() {
+		err = runWithRuntime(runtime, cmd, *argv)
 		wout.Close()
 		werr.Close()
 	}()
@@ -71,4 +109,52 @@ func FormatClusterList(clusters []*v1.Cluster) string {
 		"total": %d,
 		"items": %s
 	}`, len(clusters), len(clusters), clusterJson.String())
+}
+
+// TestingRuntime is a wrapper for the structure used for testing
+type TestingRuntime struct {
+	SsoServer   *ghttp.Server
+	ApiServer   *ghttp.Server
+	RosaRuntime *rosa.Runtime
+}
+
+func (t *TestingRuntime) InitRuntime() {
+	// Create the servers:
+	t.SsoServer = MakeTCPServer()
+	t.ApiServer = MakeTCPServer()
+	t.ApiServer.SetAllowUnhandledRequests(true)
+	t.ApiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+
+	// Create the token:
+	accessToken := MakeTokenString("Bearer", 15*time.Minute)
+
+	// Prepare the server:
+	t.SsoServer.AppendHandlers(
+		RespondWithAccessToken(accessToken),
+	)
+	// Prepare the logger:
+	logger, err := logging.NewGoLoggerBuilder().
+		Debug(true).
+		Build()
+	Expect(err).To(BeNil())
+	// Set up the connection with the fake config
+	connection, err := sdk.NewConnectionBuilder().
+		Logger(logger).
+		Tokens(accessToken).
+		URL(t.ApiServer.URL()).
+		Build()
+	// Initialize client object
+	Expect(err).To(BeNil())
+	ocmClient := ocm.NewClientWithConnection(connection)
+	ocm.SetClusterKey("cluster1")
+	t.RosaRuntime = rosa.NewRuntime()
+	t.RosaRuntime.OCMClient = ocmClient
+	t.RosaRuntime.Creator = &aws.Creator{
+		ARN:       "fake",
+		AccountID: "123",
+		IsSTS:     false,
+	}
+	DeferCleanup(t.RosaRuntime.Cleanup)
+	DeferCleanup(t.SsoServer.Close)
+	DeferCleanup(t.ApiServer.Close)
 }


### PR DESCRIPTION
Adds support for HyperShift node pool upgrades:
- upgrade machinepool
- delete upgrade
- describe upgrade
- list upgrade 

Marking also as deprecated the version change in editing machinepools.
Related: [OCM-954](https://issues.redhat.com//browse/OCM-954)

Upgrade UX design document: https://docs.google.com/document/d/15S3TXJXu6_iUJFDFT-mpcUp2uC4cWVKwZbt_bwgwqZ4/edit#