### PR TITLE
OCM-2506 | feat : Allow creation of multiple htpasswd idps

### DIFF
--- a/cmd/create/idp/cmd.go
+++ b/cmd/create/idp/cmd.go
@@ -391,7 +391,7 @@ func run(cmd *cobra.Command, _ []string) {
 			os.Exit(1)
 		}
 	}
-	if interactive.Enabled() && idpType != "htpasswd" {
+	if interactive.Enabled() {
 		idpName = getIDPName(cmd, idpName, r)
 	}
 	idpName = strings.Trim(idpName, " \t")
@@ -498,10 +498,7 @@ func GenerateIdpName(idpType string, idps []IdentityProvider) string {
 		}
 	}
 
-	if idpType != HTPasswdIDPName {
-		return fmt.Sprintf("%s-%d", idpType, nextSuffix+1)
-	}
-	return idpType
+	return fmt.Sprintf("%s-%d", idpType, nextSuffix+1)
 }
 
 func getMappingMethod(cmd *cobra.Command, mappingMethod string) (string, error) {

--- a/cmd/describe/admin/cmd.go
+++ b/cmd/describe/admin/cmd.go
@@ -22,7 +22,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
-	"github.com/openshift/rosa/cmd/create/idp"
+	cadmin "github.com/openshift/rosa/cmd/create/admin"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
 )
@@ -54,11 +54,11 @@ func run(cmd *cobra.Command, _ []string) {
 
 	// Try to find an existing htpasswd identity provider and
 	// check if cluster-admin user already exists
-	_, existingUserList := idp.FindExistingHTPasswdIDP(cluster, r)
+	existingClusterAdminIdp, _ := cadmin.FindExistingClusterAdminIDP(cluster, r)
 
-	if idp.HasClusterAdmin(existingUserList) {
+	if existingClusterAdminIdp != nil {
 		r.Reporter.Infof("There is an admin on cluster '%s'. To login, run the following command:\n"+
-			"   oc login %s --username %s", clusterKey, cluster.API().URL(), idp.ClusterAdminUsername)
+			"   oc login %s --username %s", clusterKey, cluster.API().URL(), cadmin.ClusterAdminUsername)
 	} else {
 		r.Reporter.Warnf("There is no admin on cluster '%s'. To create it run the following command:\n"+
 			"   rosa create admin -c %s", clusterKey, clusterKey)

--- a/cmd/dlt/idp/cmd.go
+++ b/cmd/dlt/idp/cmd.go
@@ -23,7 +23,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
-	idpPack "github.com/openshift/rosa/cmd/create/idp"
+	cadmin "github.com/openshift/rosa/cmd/create/admin"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
@@ -72,6 +72,7 @@ func run(_ *cobra.Command, argv []string) {
 	for _, item := range idps {
 		if item.Name() == idpName {
 			idp = item
+			break
 		}
 	}
 	if idp == nil {
@@ -79,8 +80,8 @@ func run(_ *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 	if ocm.IdentityProviderType(idp) == ocm.HTPasswdIDPType {
-		_, existingUserList := idpPack.FindExistingHTPasswdIDP(cluster, r)
-		if idpPack.HasClusterAdmin(existingUserList) {
+		clusterAdminIDP, _ := cadmin.FindExistingClusterAdminIDP(cluster, r)
+		if clusterAdminIDP != nil && clusterAdminIDP.Name() == idp.Name() {
 			r.Reporter.Warnf("The cluster-admin user is contained in the HTPasswd IDP. Deleting the IDP will " +
 				"also delete the admin user.")
 		}


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/OCM-2506


As part of this work,

Any number of htpasswd IDPs can now be created just as any other IDP type like LDAP, OPENID etc.
admin user is created in a separate htpasswd IDP instance  named "cluster-admin".

Changes have been  made to the following flows to implement this design change.
admin - create, describe, delete flow to allow for this.
htpasswd idp - create, delete.