### PR TITLE
OCM-2653 | fix: remove/hide HCP managed policies before release

### DIFF
--- a/cmd/create/accountroles/creators.go
+++ b/cmd/create/accountroles/creators.go
@@ -16,28 +16,22 @@ type creator interface {
 	printCommands(*rosa.Runtime, *accountRolesCreationInput) error
 }
 
-func initCreator(managedPolicies bool, classic bool, hostedCP bool, isClassicValueSet bool,
-	isHostedCPValueSet bool) (creator, bool) {
+func initCreator(managedPolicies bool, classic bool, hostedCP bool) creator {
 	// Classic ROSA managed policies
 	if managedPolicies && !hostedCP {
-		return &managedPoliciesCreator{}, true
+		return &managedPoliciesCreator{}
 	}
 
-	// If the user didn't select topologies (default flow creates both), or selected both topologies
-	if !isClassicValueSet && !isHostedCPValueSet || hostedCP && classic {
-		return &doubleRolesCreator{}, true
+	if hostedCP && classic {
+		return &doubleRolesCreator{}
 	}
 
 	if hostedCP {
-		return &hcpManagedPoliciesCreator{}, true
+		return &hcpManagedPoliciesCreator{}
 	}
 
-	// Classic ROSA unmanaged policies
-	if classic {
-		return &unmanagedPoliciesCreator{}, true
-	}
-
-	return nil, false
+	// Default flow creates a set of roles with unmanaged policies
+	return &unmanagedPoliciesCreator{}
 }
 
 type accountRolesCreationInput struct {

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1005,9 +1005,6 @@ func run(cmd *cobra.Command, _ []string) {
 			roleARN = roleARNs[0]
 		} else {
 			createAccountRolesCommand := "rosa create account-roles"
-			if isHostedCP {
-				createAccountRolesCommand = createAccountRolesCommand + " --hosted-cp"
-			}
 			r.Reporter.Warnf(fmt.Sprintf("No account roles found. You will need to manually set them in the "+
 				"next steps or run '%s' to create them first.", createAccountRolesCommand))
 			interactive.Enable()
@@ -1062,9 +1059,6 @@ func run(cmd *cobra.Command, _ []string) {
 				}
 				if selectedARN == "" {
 					createAccountRolesCommand := "rosa create account-roles"
-					if isHostedCP {
-						createAccountRolesCommand = createAccountRolesCommand + " --hosted-cp"
-					}
 					r.Reporter.Warnf(fmt.Sprintf("No %s account roles found. You will need to manually set "+
 						"them in the next steps or run '%s' to create "+
 						"them first.", role.Name, createAccountRolesCommand))

--- a/cmd/dlt/accountroles/cmd.go
+++ b/cmd/dlt/accountroles/cmd.go
@@ -65,6 +65,7 @@ func init() {
 		false,
 		"Delete Hosted Control Planes roles",
 	)
+	flags.MarkHidden("hosted-cp")
 
 	flags.BoolVar(
 		&args.classic,
@@ -72,6 +73,7 @@ func init() {
 		false,
 		"Delete classic account roles",
 	)
+	flags.MarkHidden("classic")
 
 	aws.AddModeFlag(Cmd)
 	confirm.AddFlag(flags)

--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -90,6 +90,7 @@ func init() {
 		false,
 		"Technology Preview: Enable the use of Hosted Control Planes",
 	)
+	flags.MarkHidden("hosted-cp")
 
 	confirm.AddFlag(flags)
 	interactive.AddFlag(flags)
@@ -134,13 +135,7 @@ func run(cmd *cobra.Command, argv []string) error {
 
 	roleARN, err := awsClient.GetAccountRoleARN(prefix, role.Name)
 	if err != nil {
-		if args.hostedCP {
-			r.Reporter.Errorf("Failed to get hosted CP account roles ARN: %v. "+
-				"To upgrade classic account roles run the command without the '--hosted-cp' flag", err)
-		} else {
-			r.Reporter.Errorf("Failed to get classic account roles ARN: %v. "+
-				"To upgrade hosted CP account roles use the '--hosted-cp' flag", err)
-		}
+		r.Reporter.Errorf("Failed to get account roles ARN: %v", err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
As there are still some blockers for HCP-managed policies, we need to:
1. Hide the "hosted-cp" flags for the roles commands.
2. Block the creation of HCP account roles in production.
3. Revert the default flow of creating account roles (not creating two sets).
4. Adjust error messages for creating/upgrade clusters.

Related: [OCM-2653](https://issues.redhat.com/browse/OCM-2653)