### PR TITLE
OCM-853 | feat: day1/2 operations for managed ingress attributes

### DIFF
--- a/cmd/create/ingress/cmd.go
+++ b/cmd/create/ingress/cmd.go
@@ -24,6 +24,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
+	helper "github.com/openshift/rosa/pkg/ingress"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
@@ -113,7 +114,7 @@ func run(cmd *cobra.Command, _ []string) {
 			os.Exit(1)
 		}
 	}
-	routeSelectors, err := getRouteSelector(labelMatch)
+	routeSelectors, err := helper.GetRouteSelector(labelMatch)
 	if err != nil {
 		r.Reporter.Errorf("%s", err)
 		os.Exit(1)
@@ -211,26 +212,11 @@ func run(cmd *cobra.Command, _ []string) {
 
 func labelValidator(val interface{}) error {
 	if labelMatch, ok := val.(string); ok {
-		_, err := getRouteSelector(labelMatch)
+		_, err := helper.GetRouteSelector(labelMatch)
 		if err != nil {
 			return err
 		}
 		return nil
 	}
 	return fmt.Errorf("can only validate strings, got %v", val)
-}
-
-func getRouteSelector(labelMatch string) (map[string]string, error) {
-	routeSelectors := make(map[string]string)
-	if labelMatch == "" {
-		return routeSelectors, nil
-	}
-	for _, labelMatch := range strings.Split(labelMatch, ",") {
-		if !strings.Contains(labelMatch, "=") {
-			return nil, fmt.Errorf("Expected key=value format for label-match")
-		}
-		tokens := strings.Split(labelMatch, "=")
-		routeSelectors[strings.TrimSpace(tokens[0])] = strings.TrimSpace(tokens[1])
-	}
-	return routeSelectors, nil
 }

--- a/cmd/list/ingress/cmd.go
+++ b/cmd/list/ingress/cmd.go
@@ -25,6 +25,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/rosa/pkg/helper"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/rosa"
@@ -80,17 +81,23 @@ func run(_ *cobra.Command, _ []string) {
 	}
 
 	// Create the writer that will be used to print the tabulated results:
-	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	writer := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
 
-	fmt.Fprintf(writer, "ID\tAPPLICATION ROUTER\t\t\tPRIVATE\t\tDEFAULT\t\tROUTE SELECTORS\t\tLB-TYPE\n")
+	fmt.Fprintf(writer, "ID\tAPPLICATION ROUTER\tPRIVATE\tDEFAULT\tROUTE SELECTORS\tLB-TYPE"+
+		"\tEXCLUDED NAMESPACE\tWILDCARD POLICY\tNAMESPACE OWNERSHIP\tHOSTNAME\tTLS SECRET REF\n")
 	for _, ingress := range ingresses {
-		fmt.Fprintf(writer, "%s\thttps://%s\t\t\t%s\t\t%s\t\t%s\t\t%s\n",
+		fmt.Fprintf(writer, "%s\thttps://%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			ingress.ID(),
 			ingress.DNSName(),
 			isPrivate(ingress.Listening()),
 			isDefault(ingress),
 			printRouteSelectors(ingress),
 			ingress.LoadBalancerType(),
+			helper.SliceToSortedString(ingress.ExcludedNamespaces()),
+			ingress.RouteWildcardPolicy(),
+			ingress.RouteNamespaceOwnershipPolicy(),
+			ingress.ClusterRoutesHostname(),
+			ingress.ClusterRoutesTlsSecretRef(),
 		)
 	}
 	writer.Flush()

--- a/pkg/ingress/policies.go
+++ b/pkg/ingress/policies.go
@@ -1,0 +1,10 @@
+package ingress
+
+import (
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+)
+
+var ValidWildcardPolicies = []string{string(cmv1.WildcardPolicyWildcardsDisallowed),
+	string(cmv1.WildcardPolicyWildcardsAllowed)}
+var ValidNamespaceOwnershipPolicies = []string{string(cmv1.NamespaceOwnershipPolicyStrict),
+	string(cmv1.NamespaceOwnershipPolicyInterNamespaceAllowed)}

--- a/pkg/ingress/route_selector.go
+++ b/pkg/ingress/route_selector.go
@@ -1,0 +1,24 @@
+package ingress
+
+import (
+	"fmt"
+	"strings"
+)
+
+func GetRouteSelector(labelMatches string) (map[string]string, error) {
+	routeSelectors := make(map[string]string)
+
+	if labelMatches == "" {
+		return routeSelectors, nil
+	}
+
+	for _, labelMatch := range strings.Split(labelMatches, ",") {
+		if !strings.Contains(labelMatch, "=") {
+			return nil, fmt.Errorf("Expected key=value format for label-match")
+		}
+		tokens := strings.Split(labelMatch, "=")
+		routeSelectors[strings.TrimSpace(tokens[0])] = strings.TrimSpace(tokens[1])
+	}
+
+	return routeSelectors, nil
+}

--- a/pkg/interactive/interactive.go
+++ b/pkg/interactive/interactive.go
@@ -177,7 +177,9 @@ func GetOption(input Input) (a string, err error) {
 	}
 	question := input.Question
 	if !input.Required && dflt == "" {
-		question = fmt.Sprintf("%s (optional)", question)
+		question = fmt.Sprintf("%s (optional, choose 'none' to skip selection)", question)
+		input.Options = append([]string{"none"}, input.Options...)
+		dflt = "none"
 	}
 	// if default is empty or not in the options, default to the first available option
 	if (dflt == "" || !containsString(input.Options, dflt)) && len(input.Options) > 0 {
@@ -193,6 +195,9 @@ func GetOption(input Input) (a string, err error) {
 		input.Validators = append([]Validator{required}, input.Validators...)
 	}
 	err = survey.AskOne(prompt, &a, survey.WithValidator(compose(input.Validators)))
+	if a == "none" {
+		return "", nil
+	}
 	return
 }
 


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/OCM-853

Day 2
```
rosa edit ingress -c 24qu5qv2ips5j2bhsan1kv0osagkq6pb apps
? Label match for ingress (optional): foo=bar
? Excluded namespaces for ingress (optional): stage,dev,int
? Private ingress (optional): No
? Wildcard Policy (optional, choose 'none' to skip selection): WildcardsAllowed
? Namespace Ownership Policy (optional, choose 'none' to skip selection): InterNamespaceAllowed
? Cluster Routes Hostname (optional): 
? Cluster Routes TLS Secret Reference (optional): 
I: Updated ingress 'f8g2' on cluster '24qu5qv2ips5j2bhsan1kv0osagkq6pb'
```

Syncset
```
 kind: IngressController
      name: default
      namespace: openshift-ingress-operator
      patch: >-
        {"spec":{"defaultCertificate":{"name":"gdb-413-primary-cert-bundle-secret"},"domain":"apps.gdb-413.caas.i1.devshift.org","endpointPublishingStrategy":{"loadBalancer":{"providerParameters":{"aws":{"type":"NLB"},"type":"AWS"},"scope":"External"},"type":"LoadBalancerService"},"namespaceSelector":{"matchExpressions":[{"key":"kubernetes.io/metadata.name","operator":"NotIn","values":["stage","dev","int"]}]},"routeAdmission":{"namespaceOwnership":"InterNamespaceAllowed","wildcardPolicy":"WildcardsAllowed"},"routeSelector":{"matchExpressions":[{"key":"foo","operator":"NotIn","values":["bar"]}]}}}
```

Day 1
```
rosa create cluster --sts \
--cluster-name gdb-413 \
--role-arn arn:aws:iam::xxx:role/ManagedOpenShift-Installer-Role \
--controlplane-iam-role arn:aws:iam::xxx:role/ManagedOpenShift-ControlPlane-Role \
--support-role-arn arn:aws:iam::xxx:role/ManagedOpenShift-Support-Role \
--worker-iam-role arn:aws:iam::xxx:role/ManagedOpenShift-Worker-Role --mode auto -y --version 4.13.1 --fake-cluster --default-ingress-route-selector="foo=bar" --default-ingress-excluded-namespaces="stage,int,dev" --default-ingress-wildcard-policy="WildcardsAllowed"
```

Syncset
```
patch: >-
        {"spec":{"defaultCertificate":{"name":"gdb-413-primary-cert-bundle-secret"},"domain":"apps.gdb-413.9e04.i1.devshift.org","endpointPublishingStrategy":{"loadBalancer":{"providerParameters":{"aws":{"type":"NLB"},"type":"AWS"},"scope":"External"},"type":"LoadBalancerService"},"namespaceSelector":{"matchExpressions":[{"key":"kubernetes.io/metadata.name","operator":"NotIn","values":["stage","int","dev"]}]},"routeAdmission":{"namespaceOwnership":"Strict","wildcardPolicy":"WildcardsAllowed"},"routeSelector":{"matchExpressions":[{"key":"foo","operator":"NotIn","values":["bar"]}]}}}
```