### PR TITLE
Pass channel group for HCP version validation

### DIFF
--- a/pkg/ocm/versions.go
+++ b/pkg/ocm/versions.go
@@ -393,7 +393,7 @@ func (c *Client) ValidateVersion(version string, versionList []string, channelGr
 
 	if isHostedCP {
 		collection := c.ocm.ClustersMgmt().V1().Versions()
-		filter := fmt.Sprintf("raw_id='%s'", version)
+		filter := fmt.Sprintf("raw_id='%s' AND channel_group='%s'", version, channelGroup)
 		response, err := collection.List().
 			Search(filter).
 			Page(1).


### PR DESCRIPTION
So far we were not passing the channel group when checking if a version was HCP validated, so effectively always checking the stable channel. In some cases, versions are enabled only in some channels, so we should honor the channel group parameter.

Related: [OCM-2714](https://issues.redhat.com//browse/OCM-2714)

Issue is visible in production with 4.13.4.
```
% ocm get /api/clusters_mgmt/v1/versions/ -p search="raw_id='4.13.4'" | jq '.items[] | "\(.channel_group) \(.hosted_control_plane_enabled)"'
"stable false"
"candidate true"
"fast true"
```
Creation on candidate channel should not be rejected