### PR TITLE
OCM-2649 | fix: add 'rosa verify network' help message

### DIFF
--- a/cmd/verify/network/cmd.go
+++ b/cmd/verify/network/cmd.go
@@ -41,8 +41,9 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:  "network",
-	Long: "Verify that the VPC subnets are configured correctly.",
+	Use:   "network",
+	Short: "Verify VPC subnets are configured correctly",
+	Long:  "Verify that the VPC subnets are configured correctly.",
 	Example: `  # Verify two subnets
   rosa verify network --subnet-ids subnet-03046a9b92b5014fb,subnet-03046a9c92b5014fb`,
 	Run: run,


### PR DESCRIPTION
```
$ rosa verify -h
Verify resources are configured correctly for cluster install

Usage:
  rosa verify [command]

Available Commands:
  network          Verify VPC subnets are configured correctly
  openshift-client Verify OpenShift client tools
  permissions      Verify AWS permissions are ok for non-STS cluster install
  quota            Verify AWS quota is ok for cluster install
  rosa-client      Verify ROSA client tools

Flags:
  -h, --help   help for verify

Global Flags:
      --color string   Surround certain characters with escape sequences to display them in color on the terminal. Allowed options are [auto never always] (default "auto")
      --debug          Enable debug mode.

Use "rosa verify [command] --help" for more information about a command.
```