### PR TITLE
OCM-2728 | fix: version validation to check against correct channel g…

### DIFF
--- a/pkg/ocm/versions.go
+++ b/pkg/ocm/versions.go
@@ -394,6 +394,9 @@ func (c *Client) ValidateVersion(version string, versionList []string, channelGr
 	if isHostedCP {
 		collection := c.ocm.ClustersMgmt().V1().Versions()
 		filter := fmt.Sprintf("raw_id='%s'", version)
+		if channelGroup != "" {
+			filter = fmt.Sprintf("%s AND channel_group = '%s'", filter, channelGroup)
+		}
 		response, err := collection.List().
 			Search(filter).
 			Page(1).


### PR DESCRIPTION
JIRA - https://issues.redhat.com/browse/OCM-2728

Issue was when validating a version we never took into account the channel group. This was picked up when checking a version from the candidate channel, that is enabled for hcp by disabled in the stable channel.

## Validation
```
rosa create cluster --channel-group candidate --mode auto -y --hosted-cp -i
I: Interactive mode enabled.
Any optional fields can be left empty and a default will be selected.
? Cluster name: croche
? Deploy cluster with Hosted Control Plane: Yes
I: NOTE: Hosted control planes are currently in Technology Preview (https://access.redhat.com/support/offerings/techpreview). Any Technology Preview clusters will need to be destroyed and recreated prior to general availability.
? OpenShift version: 4.12.19
W: More than one Installer role found
? Installer role ARN: arn:aws:iam::765374464689:role/ManagedOpenShift-Installer-Role
I: Using arn:aws:iam::765374464689:role/ManagedOpenShift-Worker-Role for the Worker role
I: Using arn:aws:iam::765374464689:role/ManagedOpenShift-Support-Role for the Support role
? External ID (optional): [? for help] 
E: Expected a valid External ID: interrupt
```