### PR TITLE
OCM-2742 | fix: handle nil pointer in user tag validations

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1402,18 +1402,12 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 	}
 	if len(tags) > 0 {
-		delim := aws.GetTagsDelimiter(tags)
-		duplicate, found := aws.HasDuplicateTagKey(tags)
-		if found {
-			r.Reporter.Errorf("Invalid tags, user tag keys must be unique, duplicate key '%s' found", duplicate)
+		if err := aws.UserTagValidator(tags); err != nil {
+			r.Reporter.Errorf("%s", err)
 			os.Exit(1)
 		}
+		delim := aws.GetTagsDelimiter(tags)
 		for _, tag := range tags {
-			err := aws.UserTagValidator(tag)
-			if err != nil {
-				r.Reporter.Errorf("%s", err)
-				os.Exit(1)
-			}
 			t := strings.Split(tag, delim)
 			tagsList[t[0]] = strings.TrimSpace(t[1])
 		}


### PR DESCRIPTION
JIRA - https://issues.redhat.com/browse/OCM-1755

## Verification 

```
╭─croche@fedora ~/Work/ocm/rosa ‹OCM-2742› 
╰─$ rosa create cluster --cluster-name croche5 --sts --role-arn arn:aws:iam::765374464689:role/ManagedOpenShift-Installer-Role --support-role-arn arn:aws:iam::765374464689:role/ManagedOpenShift-Support-Role --controlplane-iam-role arn:aws:iam::765374464689:role/ManagedOpenShift-ControlPlane-Role --worker-iam-role arn:aws:iam::765374464689:role/ManagedOpenShift-Worker-Role --operator-roles-prefix croche4-u5n7 --tags "v l,asd kl:sad,h:p asd,a:sd" --region eu-west-1 --version 4.12.22 --replicas 2 --compute-machine-type m5.xlarge --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23

W: In a future release STS will be the default mode.
W: --sts flag won't be necessary if you wish to use STS.
W: --non-sts/--mint-mode flag will be necessary if you do not wish to use STS.
W: No OIDC Configuration found; will continue with the classic flow.
E: invalid tag format. Expected tag format: 'key value'
╭─croche@fedora ~/Work/ocm/rosa ‹OCM-2742› 
╰─$ rosa create cluster --tags "v l,asd kl:sad,h asd,a:sd"                                                                                                                                                                      1 ↵
I: Enabling interactive mode
? Cluster name: croche
? Deploy cluster with Hosted Control Plane (optional): No
? Create cluster admin user: No
? Deploy cluster using AWS STS: Yes
W: In a future release STS will be the default mode.
W: --sts flag won't be necessary if you wish to use STS.
W: --non-sts/--mint-mode flag will be necessary if you do not wish to use STS.
? OpenShift version: 4.12.22
? Configure the use of IMDSv2 for ec2 instances optional/required (optional): 
W: More than one Installer role found
? Installer role ARN: arn:aws:iam::765374464689:role/ManagedOpenShift-Installer-Role
I: Using arn:aws:iam::765374464689:role/ManagedOpenShift-ControlPlane-Role for the ControlPlane role
I: Using arn:aws:iam::765374464689:role/ManagedOpenShift-Worker-Role for the Worker role
I: Using arn:aws:iam::765374464689:role/ManagedOpenShift-Support-Role for the Support role
? External ID (optional): 
? Operator roles prefix: croche-w0o1
? Deploy cluster using pre registered OIDC Configuration ID: No
W: No OIDC Configuration found; will continue with the classic flow.
X Sorry, your reply was invalid: invalid tag format. Expected tag format: 'key value'
? Tags: validKey validValue, foo bar
? Multiple availability zones (optional): [? for help] (y/N) 
E: Expected a valid multi-AZ value: interrupt
```