### PR TITLE
OCM-2731 | fix: ensure policy versions use the cluster channel

### DIFF
--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -221,7 +221,7 @@ func run(cmd *cobra.Command, argv []string) error {
 		os.Exit(1)
 	}
 
-	latestPolicyVersion, err := r.OCMClient.GetLatestVersion()
+	latestPolicyVersion, err := r.OCMClient.GetLatestVersion(cluster.Version().ChannelGroup())
 	if err != nil {
 		r.Reporter.Errorf("Error getting latest version: %s", err)
 		os.Exit(1)

--- a/cmd/upgrade/operatorroles/cmd.go
+++ b/cmd/upgrade/operatorroles/cmd.go
@@ -75,14 +75,14 @@ func run(cmd *cobra.Command, argv []string) error {
 	}
 
 	clusterKey := r.GetClusterKey()
+	cluster := r.FetchCluster()
 
-	latestPolicyVersion, err := r.OCMClient.GetLatestVersion()
+	latestPolicyVersion, err := r.OCMClient.GetLatestVersion(cluster.Version().ChannelGroup())
 	if err != nil {
 		r.Reporter.Errorf("Error getting latest version: %s", err)
 		os.Exit(1)
 	}
 
-	cluster := r.FetchCluster()
 	/**
 	we dont want to give this option to the end-user. Adding this as a support for srep if needed.
 	*/

--- a/pkg/ocm/versions.go
+++ b/pkg/ocm/versions.go
@@ -243,16 +243,16 @@ func GetVersionMinorList(ocmClient *Client) (versionList []string, err error) {
 	return
 }
 
-func (c *Client) GetDefaultVersion() (version string, err error) {
-	return c.getFirstVersion(true)
+func (c *Client) GetDefaultVersion(channelGroup string) (version string, err error) {
+	return c.getFirstVersion(channelGroup, true)
 }
 
-func (c *Client) GetLatestVersion() (version string, err error) {
-	return c.getFirstVersion(false)
+func (c *Client) GetLatestVersion(channelGroup string) (version string, err error) {
+	return c.getFirstVersion(channelGroup, false)
 }
 
-func (c *Client) getFirstVersion(defaultFirst bool) (version string, err error) {
-	response, err := c.GetVersions("", true)
+func (c *Client) getFirstVersion(channelGroup string, defaultFirst bool) (version string, err error) {
+	response, err := c.GetVersions(channelGroup, defaultFirst)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
JIRA - https://issues.redhat.com/browse/OCM-2731

First issue was the function `getFirstVersion` was ignoring the `defaultFirst` param. 

Next issue is the upgrade operator roles ignores the channel of the cluster. This resulted in ending up with account roles and operator roles getting out of sync. This change uses the clusters version channel to determine the version needed to upgrade too. 
For pre-creating operator roles, this will default to the latest available on stable. 

### Verifications 
## Create 4.12 Cluster and Roles Stable Channel

### Create Account Roles 4.12

```
rosa create account-roles --version 4.12
I: Logged in as 'croche_openshift' on 'https://api.stage.openshift.com'
I: Validating AWS credentials...
I: AWS credentials are valid!
I: Validating AWS quota...
I: AWS quota ok. If cluster installation fails, validate actual AWS resource usage against https://docs.openshift.com/rosa/rosa_getting_started/rosa-required-aws-service-quotas.html
I: Verifying whether OpenShift command-line tool is available...
I: Current OpenShift Client Version: 4.12.15
I: Creating account roles
? Role prefix: crocher
? Permissions boundary ARN (optional): 
? Path (optional): 
? Role creation mode: auto
? Create Classic account roles: Yes
? Create Hosted CP account roles (optional): No
I: Creating classic account roles using 'arn:aws:iam::765374464689:user/croche'
I: Created role 'crocher-Installer-Role' with ARN 'arn:aws:iam::765374464689:role/crocher-Installer-Role'
I: Created role 'crocher-ControlPlane-Role' with ARN 'arn:aws:iam::765374464689:role/crocher-ControlPlane-Role'
I: Created role 'crocher-Worker-Role' with ARN 'arn:aws:iam::765374464689:role/crocher-Worker-Role'
I: Created role 'crocher-Support-Role' with ARN 'arn:aws:iam::765374464689:role/crocher-Support-Role'
I: To create an OIDC Config, run the following command:
	rosa create oidc-config
```

### Verify Acount roles

```
aws iam gerosa create cluster --channel-group candidate 
I: Enabling interactive mode
? Cluster name: crochecan
? Deploy cluster with Hosted Control Plane (optional): No
? Create cluster admin user: No
? Deploy cluster using AWS STS: Yes
W: In a future release STS will be the default mode.
W: --sts flag won't be necessary if you wish to use STS.
W: --non-sts/--mint-mode flag will be necessary if you do not wish to use STS.
? OpenShift version: 4.12.24
? Configure the use of IMDSv2 for ec2 instances optional/required (optional): 
W: More than one Installer role found
? Installer role ARN: arn:aws:iam::765374464689:role/crochecan-Installer-Role
I: Using arn:aws:iam::765374464689:role/crochecan-ControlPlane-Role for the ControlPlane role
I: Using arn:aws:iam::765374464689:role/crochecan-Worker-Role for the Worker role
I: Using arn:aws:iam::765374464689:role/crochecan-Support-Role for the Support role
? External ID (optional): 
? Operator roles prefix: crochecan-s0b6
? Deploy cluster using pre registered OIDC Configuration ID: No
W: No OIDC Configuration found; will continue with the classic flow.
? Tags (optional): 
? Multiple availability zones (optional): No
? AWS region: eu-west-1
? PrivateLink cluster (optional): No
? Machine CIDR: 10.0.0.0/16
? Service CIDR: 172.30.0.0/16
? Pod CIDR: 10.128.0.0/14
? Install into an existing VPC (optional): No
? Select availability zones (optional): No
? Enable Customer Managed key (optional): No
? Compute nodes instance type: m5.xlarge
? Enable autoscaling (optional): No
? Compute nodes: 2
? Default machine pool labels (optional): 
? Host prefix: 23
? Enable FIPS support (optional): No
? Encrypt etcd data (optional): No
? Disable Workload monitoring (optional): No
I: Creating cluster 'crochecan'
I: To create this cluster again in the future, you can run:
   rosa create cluster --cluster-name crochecan --sts --role-arn arn:aws:iam::765374464689:role/crochecan-Installer-Role --support-role-arn arn:aws:iam::765374464689:role/crochecan-Support-Role --controlplane-iam-role arn:aws:iam::765374464689:role/crochecan-ControlPlane-Role --worker-iam-role arn:aws:iam::765374464689:role/crochecan-Worker-Role --operator-roles-prefix crochecan-s0b6 --region eu-west-1 --channel-group candidate --version 4.12.24 --replicas 2 --compute-machine-type m5.xlarge --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23
I: To view a list of clusters and their status, run 'rosa list clusters'
I: Cluster 'crochecan' has been created.
I: Once the cluster is installed you will need to add an Identity Provider before you can login into the cluster. See 'rosa create idp --help' for more information.

Name:                       crochecan
ID:                         24vdtbtcagvf3umnc2icb7d13vhp05bk
External ID:                
Control Plane:              Customer Hosted
OpenShift Version:          
Channel Group:              candidate
DNS:                        Not ready
AWS Account:                765374464689
API URL:                    
Console URL:                
Region:                     eu-west-1
Multi-AZ:                   false
Nodes:
 - Control plane:           3
 - Infra:                   2
 - Compute:                 2
Network:
 - Type:                    OVNKubernetes
 - Service CIDR:            172.30.0.0/16
 - Machine CIDR:            10.0.0.0/16
 - Pod CIDR:                10.128.0.0/14
 - Host Prefix:             /23
STS Role ARN:               arn:aws:iam::765374464689:role/crochecan-Installer-Role
Support Role ARN:           arn:aws:iam::765374464689:role/crochecan-Support-Role
Instance IAM Roles:
 - Control plane:           arn:aws:iam::765374464689:role/crochecan-ControlPlane-Role
 - Worker:                  arn:aws:iam::765374464689:role/crochecan-Worker-Role
Operator IAM Roles:
 - arn:aws:iam::765374464689:role/crochecan-s0b6-openshift-cloud-network-config-controller-cloud-c
 - arn:aws:iam::765374464689:role/crochecan-s0b6-openshift-machine-api-aws-cloud-credentials
 - arn:aws:iam::765374464689:role/crochecan-s0b6-openshift-cloud-credential-operator-cloud-credent
 - arn:aws:iam::765374464689:role/crochecan-s0b6-openshift-image-registry-installer-cloud-credenti
 - arn:aws:iam::765374464689:role/crochecan-s0b6-openshift-ingress-operator-cloud-credentials
 - arn:aws:iam::765374464689:role/crochecan-s0b6-openshift-cluster-csi-drivers-ebs-cloud-credentia
Managed Policies:           No
State:                      waiting (Waiting for OIDC configuration)
Private:                    No
Created:                    Jul 14 2023 11:08:34 UTC
Details Page:               https://qaprodauth.console.redhat.com/openshift/details/s/2SYoXU2sajYR5gXPfqfjW9LxFYl
OIDC Endpoint URL:          https://d3gt1gce2zmg3d.cloudfront.net/24vdtbtcagvf3umnc2icb7d13vhp05bk (Classic)

I: 
Run the following commands to continue the cluster creation:

	rosa create operator-roles --cluster crochecan
	rosa create oidc-provider --cluster crochecan

I: To determine when your cluster is Ready, run 'rosa describe cluster -c crochecan'.
I: To watch your cluster installation logs, run 'rosa logs install -c crochecan --watch'.
t-role --role-name crocher-Worker-Role --profile default | jq                                                                            

{
  "Role": {
    "Path": "/",
    "RoleName": "crocher-Worker-Role",
    "RoleId": "AROA3EM67QKY3TI6OTCFW",
    "Arn": "arn:aws:iam::765374464689:role/crocher-Worker-Role",
    "CreateDate": "2023-07-14T10:09:14+00:00",
    "AssumeRolePolicyDocument": {
      "Version": "2012-10-17",
      "Statement": [
        {
          "Effect": "Allow",
          "Principal": {
            "Service": "ec2.amazonaws.com"
          },
          "Action": "sts:AssumeRole"
        }
      ]
    },
    "MaxSessionDuration": 3600,
    "Tags": [
      {
        "Key": "red-hat-managed",
        "Value": "true"
      },
      {
        "Key": "rosa_openshift_version",
        "Value": "4.12"
      },
      {
        "Key": "rosa_role_prefix",
        "Value": "crocher"
      },
      {
        "Key": "rosa_role_type",
        "Value": "instance_worker"
      }
    ],
    "RoleLastUsed": {}
  }
}
```

### Create the cluster 

```
rosa create cluster                           
I: Enabling interactive mode
? Cluster name: crochetest
? Deploy cluster with Hosted Control Plane (optional): No
? Create cluster admin user: No
? Deploy cluster using AWS STS: Yes
W: In a future release STS will be the default mode.
W: --sts flag won't be necessary if you wish to use STS.
W: --non-sts/--mint-mode flag will be necessary if you do not wish to use STS.
? OpenShift version: 4.12.23
? Configure the use of IMDSv2 for ec2 instances optional/required (optional): 
W: More than one Installer role found
? Installer role ARN: arn:aws:iam::765374464689:role/crocher-Installer-Role
I: Using arn:aws:iam::765374464689:role/crocher-ControlPlane-Role for the ControlPlane role
I: Using arn:aws:iam::765374464689:role/crocher-Worker-Role for the Worker role

I: Using arn:aws:iam::765374464689:role/crocher-Support-Role for the Support role
? External ID (optional): 
? Operator roles prefix: crochetest-d8a2
? Deploy cluster using pre registered OIDC Configuration ID: No
W: No OIDC Configuration found; will continue with the classic flow.
? Tags (optional): 
? Multiple availability zones (optional): No
? AWS region: eu-west-1
? PrivateLink cluster (optional): No
? Machine CIDR: 10.0.0.0/16
? Service CIDR: 172.30.0.0/16
? Pod CIDR: 10.128.0.0/14
? Install into an existing VPC (optional): No
? Select availability zones (optional): No
? Enable Customer Managed key (optional): No
? Compute nodes instance type: m5.xlarge
? Enable autoscaling (optional): No
? Compute nodes: 2
? Default machine pool labels (optional): 
? Host prefix: 23
? Enable FIPS support (optional): No
? Encrypt etcd data (optional): No
? Disable Workload monitoring (optional): No
I: Creating cluster 'crochetest'
I: To create this cluster again in the future, you can run:
   rosa create cluster --cluster-name crochetest --sts --role-arn arn:aws:iam::765374464689:role/crocher-Installer-Role --support-role-arn arn:aws:iam::765374464689:role/crocher-Support-Role --controlplane-iam-role arn:aws:iam::765374464689:role/crocher-ControlPlane-Role --worker-iam-role arn:aws:iam::765374464689:role/crocher-Worker-Role --operator-roles-prefix crochetest-d8a2 --region eu-west-1 --version 4.12.23 --replicas 2 --compute-machine-type m5.xlarge --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23
I: To view a list of clusters and their status, run 'rosa list clusters'
I: Cluster 'crochetest' has been created.
I: Once the cluster is installed you will need to add an Identity Provider before you can login into the cluster. See 'rosa create idp --help' for more information.

Name:                       crochetest
ID:                         24vd2hvjd5avnd8tp2sqa4iiko52mrck
External ID:                
Control Plane:              Customer Hosted
OpenShift Version:          
Channel Group:              stable
DNS:                        Not ready
AWS Account:                765374464689
API URL:                    
Console URL:                
Region:                     eu-west-1
Multi-AZ:                   false
Nodes:
 - Control plane:           3
 - Infra:                   2
 - Compute:                 2
Network:
 - Type:                    OVNKubernetes
 - Service CIDR:            172.30.0.0/16
 - Machine CIDR:            10.0.0.0/16
 - Pod CIDR:                10.128.0.0/14
 - Host Prefix:             /23
STS Role ARN:               arn:aws:iam::765374464689:role/crocher-Installer-Role
Support Role ARN:           arn:aws:iam::765374464689:role/crocher-Support-Role
Instance IAM Roles:
 - Control plane:           arn:aws:iam::765374464689:role/crocher-ControlPlane-Role
 - Worker:                  arn:aws:iam::765374464689:role/crocher-Worker-Role
Operator IAM Roles:
 - arn:aws:iam::765374464689:role/crochetest-d8a2-openshift-image-registry-installer-cloud-credent
 - arn:aws:iam::765374464689:role/crochetest-d8a2-openshift-ingress-operator-cloud-credentials
 - arn:aws:iam::765374464689:role/crochetest-d8a2-openshift-cluster-csi-drivers-ebs-cloud-credenti
 - arn:aws:iam::765374464689:role/crochetest-d8a2-openshift-cloud-network-config-controller-cloud-
 - arn:aws:iam::765374464689:role/crochetest-d8a2-openshift-machine-api-aws-cloud-credentials
 - arn:aws:iam::765374464689:role/crochetest-d8a2-openshift-cloud-credential-operator-cloud-creden
Managed Policies:           No
State:                      waiting (Waiting for OIDC configuration)
Private:                    No
Created:                    Jul 14 2023 10:11:21 UTC
Details Page:               https://qaprodauth.console.redhat.com/openshift/details/s/2SYha75HMlymipGK78Ms4T5ZojS
OIDC Endpoint URL:          https://d3gt1gce2zmg3d.cloudfront.net/24vd2hvjd5avnd8tp2sqa4iiko52mrck (Classic)

I: 
Run the following commands to continue the cluster creation:

	rosa create operator-roles --cluster crochetest
	rosa create oidc-provider --cluster crochetest

I: To determine when your cluster is Ready, run 'rosa describe cluster -c crochetest'.
I: To watch your cluster installation logs, run 'rosa logs install -c crochetest --watch'.
```
### Create the operator roles 
```
rosa create operator-roles --cluster crochetest
? Role creation mode: auto
? Permissions boundary ARN (optional): 
I: Creating roles using 'arn:aws:iam::765374464689:user/croche'
I: Created role 'crochetest-d8a2-openshift-cloud-credential-operator-cloud-creden' with ARN 'arn:aws:iam::765374464689:role/crochetest-d8a2-openshift-cloud-credential-operator-cloud-creden'
I: Created role 'crochetest-d8a2-openshift-image-registry-installer-cloud-credent' with ARN 'arn:aws:iam::765374464689:role/crochetest-d8a2-openshift-image-registry-installer-cloud-credent'
I: Created role 'crochetest-d8a2-openshift-ingress-operator-cloud-credentials' with ARN 'arn:aws:iam::765374464689:role/crochetest-d8a2-openshift-ingress-operator-cloud-credentials'
I: Created role 'crochetest-d8a2-openshift-cluster-csi-drivers-ebs-cloud-credenti' with ARN 'arn:aws:iam::765374464689:role/crochetest-d8a2-openshift-cluster-csi-drivers-ebs-cloud-credenti'
I: Created role 'crochetest-d8a2-openshift-cloud-network-config-controller-cloud-' with ARN 'arn:aws:iam::765374464689:role/crochetest-d8a2-openshift-cloud-network-config-controller-cloud-'
I: Created role 'crochetest-d8a2-openshift-machine-api-aws-cloud-credentials' with ARN 'arn:aws:iam::765374464689:role/crochetest-d8a2-openshift-machine-api-aws-cloud-credentials'

```

### Get the operator roles policies
```
aws iam list-attached-role-policies --role-name crochetest-d8a2-openshift-cloud-credential-operator-cloud-creden | jq .

{
  "AttachedPolicies": [
    {
      "PolicyName": "crocher-openshift-cloud-credential-operator-cloud-credential-ope",
      "PolicyArn": "arn:aws:iam::765374464689:policy/crocher-openshift-cloud-credential-operator-cloud-credential-ope"
    }
  ]
}

```

### Verify the policy version
Should match the version of the account roles and cluster
```
 aws iam list-policy-tags --policy-arn arn:aws:iam::765374464689:policy/crocher-openshift-cloud-credential-operator-cloud-credential-ope | jq .

{
  "Tags": [
    {
      "Key": "operator_name",
      "Value": "cloud-credential-operator-iam-ro-creds"
    },
    {
      "Key": "rosa_role_prefix",
      "Value": "crocher"
    },
    {
      "Key": "red-hat-managed",
      "Value": "true"
    },
    {
      "Key": "rosa_openshift_version",
      "Value": "4.12"
    },
    {
      "Key": "operator_namespace",
      "Value": "openshift-cloud-credential-operator"
    }
  ],
  "IsTruncated": false
}

```

### Attempt to upgrade the operator roles 
Expect to be informed account roles need to be upgraded first
```
rosa upgrade operator-roles -c crochetest
I: Account roles with prefix 'crocher' need to be upgraded before operator roles. Roles can be upgraded with the following command :

	rosa upgrade account-roles --prefix crocher

```

### Upgrade the account roles 
```
rosa upgrade account-roles --prefix crocher                                                                                                                                           1 ↵
I: Ensuring account role policies compatibility for upgrade
? Account role upgrade mode: auto
I: Starting to upgrade the policies
? Upgrade the 'crocher-Installer-Role' role policy latest version ? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/crocher-Installer-Role-Policy' to latest version
? Upgrade the 'crocher-ControlPlane-Role' role policy latest version ? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/crocher-ControlPlane-Role-Policy' to latest version
? Upgrade the 'crocher-Worker-Role' role policy latest version ? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/crocher-Worker-Role-Policy' to latest version
? Upgrade the 'crocher-Support-Role' role policy latest version ? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/crocher-Support-Role-Policy' to latest version
```

### Verify the account roles have been upgraded 

```
aws iam get-role --role-name crocher-Worker-Role --profile default | jq                                                                       

{
  "Role": {
    "Path": "/",
    "RoleName": "crocher-Worker-Role",
    "RoleId": "AROA3EM67QKY3TI6OTCFW",
    "Arn": "arn:aws:iam::765374464689:role/crocher-Worker-Role",
    "CreateDate": "2023-07-14T10:09:14+00:00",
    "AssumeRolePolicyDocument": {
      "Version": "2012-10-17",
      "Statement": [
        {
          "Effect": "Allow",
          "Principal": {
            "Service": "ec2.amazonaws.com"
          },
          "Action": "sts:AssumeRole"
        }
      ]
    },
    "MaxSessionDuration": 3600,
    "Tags": [
      {
        "Key": "rosa_openshift_version",
        "Value": "4.13"
      },
      {
        "Key": "red-hat-managed",
        "Value": "true"
      },
      {
        "Key": "rosa_role_prefix",
        "Value": "crocher"
      },
      {
        "Key": "rosa_role_type",
        "Value": "instance_worker"
      }
    ],
    "RoleLastUsed": {}
  }
}

```

### Upgrade the operator roles 
```
rosa upgrade operator-roles -c crochetest  
I: Starting to upgrade the operator IAM roles and policies
? Operator IAM role/policy upgrade mode: auto
? Upgrade the operator role policy to version 4.13? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/crocher-openshift-image-registry-installer-cloud-credentials' to version '4.13'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/crocher-openshift-ingress-operator-cloud-credentials' to version '4.13'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/crocher-openshift-cluster-csi-drivers-ebs-cloud-credentials' to version '4.13'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/crocher-openshift-cloud-network-config-controller-cloud-credenti' to version '4.13'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/crocher-openshift-machine-api-aws-cloud-credentials' to version '4.13'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/crocher-openshift-cloud-credential-operator-cloud-credential-ope' to version '4.13'
```

### Verify the operator roles
```
aws iam list-policy-tags --policy-arn arn:aws:iam::765374464689:policy/crocher-openshift-cloud-credential-operator-cloud-credential-ope | jq .

{
  "Tags": [
    {
      "Key": "operator_name",
      "Value": "cloud-credential-operator-iam-ro-creds"
    },
    {
      "Key": "rosa_role_prefix",
      "Value": "crocher"
    },
    {
      "Key": "red-hat-managed",
      "Value": "true"
    },
    {
      "Key": "rosa_openshift_version",
      "Value": "4.13"
    },
    {
      "Key": "operator_namespace",
      "Value": "openshift-cloud-credential-operator"
    }
  ],
  "IsTruncated": false
}

```

## Create OIDC provider
### Create account roles 
```
rosa create account-roles --version 4.12                                                                                                                                              1 ↵
I: Logged in as 'croche_openshift' on 'https://api.stage.openshift.com'
I: Validating AWS credentials...
I: AWS credentials are valid!
I: Validating AWS quota...
I: AWS quota ok. If cluster installation fails, validate actual AWS resource usage against https://docs.openshift.com/rosa/rosa_getting_started/rosa-required-aws-service-quotas.html
I: Verifying whether OpenShift command-line tool is available...
I: Current OpenShift Client Version: 4.12.15
I: Creating account roles
? Role prefix: croche12
? Permissions boundary ARN (optional): 
? Path (optional): 
? Role creation mode: auto
? Create Classic account roles: Yes
? Create Hosted CP account roles (optional): No
I: Creating classic account roles using 'arn:aws:iam::765374464689:user/croche'
I: Created role 'croche12-Installer-Role' with ARN 'arn:aws:iam::765374464689:role/croche12-Installer-Role'
I: Created role 'croche12-ControlPlane-Role' with ARN 'arn:aws:iam::765374464689:role/croche12-ControlPlane-Role'
I: Created role 'croche12-Worker-Role' with ARN 'arn:aws:iam::765374464689:role/croche12-Worker-Role'
I: Created role 'croche12-Support-Role' with ARN 'arn:aws:iam::765374464689:role/croche12-Support-Role'
I: To create an OIDC Config, run the following command:
	rosa create oidc-config
```
### Create OIDC provider
```
rosa create oidc-config                        
? Would you like to create a Managed (Red Hat hosted) OIDC Configuration Yes
W: For a managed OIDC Config only auto mode is supported. However, you may choose the provider creation mode
? OIDC Provider creation mode: auto
I: Setting up managed OIDC configuration
I: To create Operator Roles for this OIDC Configuration, run the following command and remember to replace <user-defined> with a prefix of your choice:
        rosa create operator-roles --prefix <user-defined> --oidc-config-id 24vdmgv7j21gsif10jn7jiivdi3se5js
If you are going to create a Hosted Control Plane cluster please include '--hosted-cp'
I: Creating OIDC provider using 'arn:aws:iam::765374464689:user/croche'
? Create the OIDC provider? Yes
I: Created OIDC provider with ARN 'arn:aws:iam::765374464689:oidc-provider/d3gt1gce2zmg3d.cloudfront.net/24vdmgv7j21gsif10jn7jiivdi3se5js'
```

### Create the operator roles 
```
rosa create operator-roles --prefix crochenoop --oidc-config-id 24vdmgv7j21gsif10jn7jiivdi3se5js                                                                                      1 ↵
? Role creation mode: auto
? Operator roles prefix: crochenoop
? Create hosted control plane operator roles (optional): No
W: More than one Installer role found
? Installer role ARN: arn:aws:iam::765374464689:role/croche12-Installer-Role
? Permissions boundary ARN (optional): 
I: Reusable OIDC Configuration detected. Validating trusted relationships to operator roles: 
I: Creating roles using 'arn:aws:iam::765374464689:user/croche'
I: Created role 'crochenoop-openshift-cloud-credential-operator-cloud-credential-' with ARN 'arn:aws:iam::765374464689:role/crochenoop-openshift-cloud-credential-operator-cloud-credential-'
I: Created role 'crochenoop-openshift-image-registry-installer-cloud-credentials' with ARN 'arn:aws:iam::765374464689:role/crochenoop-openshift-image-registry-installer-cloud-credentials'
I: Created role 'crochenoop-openshift-ingress-operator-cloud-credentials' with ARN 'arn:aws:iam::765374464689:role/crochenoop-openshift-ingress-operator-cloud-credentials'
I: Created role 'crochenoop-openshift-cluster-csi-drivers-ebs-cloud-credentials' with ARN 'arn:aws:iam::765374464689:role/crochenoop-openshift-cluster-csi-drivers-ebs-cloud-credentials'
I: Created role 'crochenoop-openshift-cloud-network-config-controller-cloud-crede' with ARN 'arn:aws:iam::765374464689:role/crochenoop-openshift-cloud-network-config-controller-cloud-crede'
I: Created role 'crochenoop-openshift-machine-api-aws-cloud-credentials' with ARN 'arn:aws:iam::765374464689:role/crochenoop-openshift-machine-api-aws-cloud-credentials'
I: To create a cluster with these roles, run the following command:
	rosa create cluster --sts --oidc-config-id 24vdmgv7j21gsif10jn7jiivdi3se5js --operator-roles-prefix crochenoop
```

### Verify the operator roles 
```
╭─croche@fedora ~ 
╰─$ aws iam list-attached-role-policies --role-name crochenoop-openshift-cloud-credential-operator-cloud-credential- | jq .                       

{
  "AttachedPolicies": [
    {
      "PolicyName": "croche12-openshift-cloud-credential-operator-cloud-credential-op",
      "PolicyArn": "arn:aws:iam::765374464689:policy/croche12-openshift-cloud-credential-operator-cloud-credential-op"
    }
  ]
}
╭─croche@fedora ~ 
╰─$ aws iam list-policy-tags --policy-arn arn:aws:iam::765374464689:policy/croche12-openshift-cloud-credential-operator-cloud-credential-op | jq .

{
  "Tags": [
    {
      "Key": "operator_name",
      "Value": "cloud-credential-operator-iam-ro-creds"
    },
    {
      "Key": "rosa_role_prefix",
      "Value": "croche12"
    },
    {
      "Key": "red-hat-managed",
      "Value": "true"
    },
    {
      "Key": "rosa_openshift_version",
      "Value": "4.14"
    },
    {
      "Key": "operator_namespace",
      "Value": "openshift-cloud-credential-operator"
    }
  ],
  "IsTruncated": false
}
```

## Create a cluster on candidate channel
### Create the cluster
```
rosa create cluster --channel-group candidate 
I: Enabling interactive mode
? Cluster name: crochecan
? Deploy cluster with Hosted Control Plane (optional): No
? Create cluster admin user: No
? Deploy cluster using AWS STS: Yes
W: In a future release STS will be the default mode.
W: --sts flag won't be necessary if you wish to use STS.
W: --non-sts/--mint-mode flag will be necessary if you do not wish to use STS.
? OpenShift version: 4.12.24
? Configure the use of IMDSv2 for ec2 instances optional/required (optional): 
W: More than one Installer role found
? Installer role ARN: arn:aws:iam::765374464689:role/crochecan-Installer-Role
I: Using arn:aws:iam::765374464689:role/crochecan-ControlPlane-Role for the ControlPlane role
I: Using arn:aws:iam::765374464689:role/crochecan-Worker-Role for the Worker role
I: Using arn:aws:iam::765374464689:role/crochecan-Support-Role for the Support role
? External ID (optional): 
? Operator roles prefix: crochecan-s0b6
? Deploy cluster using pre registered OIDC Configuration ID: No
W: No OIDC Configuration found; will continue with the classic flow.
? Tags (optional): 
? Multiple availability zones (optional): No
? AWS region: eu-west-1
? PrivateLink cluster (optional): No
? Machine CIDR: 10.0.0.0/16
? Service CIDR: 172.30.0.0/16
? Pod CIDR: 10.128.0.0/14
? Install into an existing VPC (optional): No
? Select availability zones (optional): No
? Enable Customer Managed key (optional): No
? Compute nodes instance type: m5.xlarge
? Enable autoscaling (optional): No
? Compute nodes: 2
? Default machine pool labels (optional): 
? Host prefix: 23
? Enable FIPS support (optional): No
? Encrypt etcd data (optional): No
? Disable Workload monitoring (optional): No
I: Creating cluster 'crochecan'
I: To create this cluster again in the future, you can run:
   rosa create cluster --cluster-name crochecan --sts --role-arn arn:aws:iam::765374464689:role/crochecan-Installer-Role --support-role-arn arn:aws:iam::765374464689:role/crochecan-Support-Role --controlplane-iam-role arn:aws:iam::765374464689:role/crochecan-ControlPlane-Role --worker-iam-role arn:aws:iam::765374464689:role/crochecan-Worker-Role --operator-roles-prefix crochecan-s0b6 --region eu-west-1 --channel-group candidate --version 4.12.24 --replicas 2 --compute-machine-type m5.xlarge --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23
I: To view a list of clusters and their status, run 'rosa list clusters'
I: Cluster 'crochecan' has been created.
I: Once the cluster is installed you will need to add an Identity Provider before you can login into the cluster. See 'rosa create idp --help' for more information.

Name:                       crochecan
ID:                         24vdtbtcagvf3umnc2icb7d13vhp05bk
External ID:                
Control Plane:              Customer Hosted
OpenShift Version:          
Channel Group:              candidate
DNS:                        Not ready
AWS Account:                765374464689
API URL:                    
Console URL:                
Region:                     eu-west-1
Multi-AZ:                   false
Nodes:
 - Control plane:           3
 - Infra:                   2
 - Compute:                 2
Network:
 - Type:                    OVNKubernetes
 - Service CIDR:            172.30.0.0/16
 - Machine CIDR:            10.0.0.0/16
 - Pod CIDR:                10.128.0.0/14
 - Host Prefix:             /23
STS Role ARN:               arn:aws:iam::765374464689:role/crochecan-Installer-Role
Support Role ARN:           arn:aws:iam::765374464689:role/crochecan-Support-Role
Instance IAM Roles:
 - Control plane:           arn:aws:iam::765374464689:role/crochecan-ControlPlane-Role
 - Worker:                  arn:aws:iam::765374464689:role/crochecan-Worker-Role
Operator IAM Roles:
 - arn:aws:iam::765374464689:role/crochecan-s0b6-openshift-cloud-network-config-controller-cloud-c
 - arn:aws:iam::765374464689:role/crochecan-s0b6-openshift-machine-api-aws-cloud-credentials
 - arn:aws:iam::765374464689:role/crochecan-s0b6-openshift-cloud-credential-operator-cloud-credent
 - arn:aws:iam::765374464689:role/crochecan-s0b6-openshift-image-registry-installer-cloud-credenti
 - arn:aws:iam::765374464689:role/crochecan-s0b6-openshift-ingress-operator-cloud-credentials
 - arn:aws:iam::765374464689:role/crochecan-s0b6-openshift-cluster-csi-drivers-ebs-cloud-credentia
Managed Policies:           No
State:                      waiting (Waiting for OIDC configuration)
Private:                    No
Created:                    Jul 14 2023 11:08:34 UTC
Details Page:               https://qaprodauth.console.redhat.com/openshift/details/s/2SYoXU2sajYR5gXPfqfjW9LxFYl
OIDC Endpoint URL:          https://d3gt1gce2zmg3d.cloudfront.net/24vdtbtcagvf3umnc2icb7d13vhp05bk (Classic)

I: 
Run the following commands to continue the cluster creation:

	rosa create operator-roles --cluster crochecan
	rosa create oidc-provider --cluster crochecan

I: To determine when your cluster is Ready, run 'rosa describe cluster -c crochecan'.
I: To watch your cluster installation logs, run 'rosa logs install -c crochecan --watch'.
```
### Create the operator roles 
```
rosa create operator-roles --cluster crochecan
? Role creation mode: auto
? Permissions boundary ARN (optional): 
I: Creating roles using 'arn:aws:iam::765374464689:user/croche'
I: Created role 'crochecan-s0b6-openshift-cluster-csi-drivers-ebs-cloud-credentia' with ARN 'arn:aws:iam::765374464689:role/crochecan-s0b6-openshift-cluster-csi-drivers-ebs-cloud-credentia'
I: Created role 'crochecan-s0b6-openshift-cloud-network-config-controller-cloud-c' with ARN 'arn:aws:iam::765374464689:role/crochecan-s0b6-openshift-cloud-network-config-controller-cloud-c'
I: Created role 'crochecan-s0b6-openshift-machine-api-aws-cloud-credentials' with ARN 'arn:aws:iam::765374464689:role/crochecan-s0b6-openshift-machine-api-aws-cloud-credentials'
I: Created role 'crochecan-s0b6-openshift-cloud-credential-operator-cloud-credent' with ARN 'arn:aws:iam::765374464689:role/crochecan-s0b6-openshift-cloud-credential-operator-cloud-credent'
I: Created role 'crochecan-s0b6-openshift-image-registry-installer-cloud-credenti' with ARN 'arn:aws:iam::765374464689:role/crochecan-s0b6-openshift-image-registry-installer-cloud-credenti'
I: Created role 'crochecan-s0b6-openshift-ingress-operator-cloud-credentials' with ARN 'arn:aws:iam::765374464689:role/crochecan-s0b6-openshift-ingress-operator-cloud-credentials'
```
### Verify operator roles
```
aws iam list-attached-role-policies --role-name crochecan-s0b6-openshift-cluster-csi-drivers-ebs-cloud-credentia | jq .                       

{
  "AttachedPolicies": [
    {
      "PolicyName": "crochecan-openshift-cluster-csi-drivers-ebs-cloud-credentials",
      "PolicyArn": "arn:aws:iam::765374464689:policy/crochecan-openshift-cluster-csi-drivers-ebs-cloud-credentials"
    }
  ]
}
╭─croche@fedora ~ 
╰─$ aws iam list-policy-tags --policy-arn arn:aws:iam::765374464689:policy/crochecan-openshift-cluster-csi-drivers-ebs-cloud-credentials | jq .   

{
  "Tags": [
    {
      "Key": "operator_name",
      "Value": "ebs-cloud-credentials"
    },
    {
      "Key": "rosa_role_prefix",
      "Value": "crochecan"
    },
    {
      "Key": "red-hat-managed",
      "Value": "true"
    },
    {
      "Key": "rosa_openshift_version",
      "Value": "4.12"
    },
    {
      "Key": "operator_namespace",
      "Value": "openshift-cluster-csi-drivers"
    }
  ],
  "IsTruncated": false
}
```
### Attempt to upgrade roles 
```
rosa upgrade operator-roles -c crochecan 
I: Account roles with prefix 'crochecan' need to be upgraded before operator roles. Roles can be upgraded with the following command :

	rosa upgrade account-roles --prefix crochecan
```

### Upgrade account roles to candidate channel
```
rosa upgrade account-roles --prefix crochecan --channel-group candidate   
I: Ensuring account role policies compatibility for upgrade
? Account role upgrade mode: auto
I: Starting to upgrade the policies
? Upgrade the 'crochecan-ControlPlane-Role' role policy latest version ? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/crochecan-ControlPlane-Role-Policy' to latest version
? Upgrade the 'crochecan-Worker-Role' role policy latest version ? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/crochecan-Worker-Role-Policy' to latest version
? Upgrade the 'crochecan-Support-Role' role policy latest version ? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/crochecan-Support-Role-Policy' to latest version
? Upgrade the 'crochecan-Installer-Role' role policy latest version ? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/crochecan-Installer-Role-Policy' to latest version
╭─croche@fedora ~ 
╰─$ aws iam get-role --role-name crochecan-Worker-Role --profile default | jq 

{
  "Role": {
    "Path": "/",
    "RoleName": "crochecan-Worker-Role",
    "RoleId": "AROA3EM67QKYRVCDV237G",
    "Arn": "arn:aws:iam::765374464689:role/crochecan-Worker-Role",
    "CreateDate": "2023-07-14T11:02:58+00:00",
    "AssumeRolePolicyDocument": {
      "Version": "2012-10-17",
      "Statement": [
        {
          "Effect": "Allow",
          "Principal": {
            "Service": "ec2.amazonaws.com"
          },
          "Action": "sts:AssumeRole"
        }
      ]
    },
    "MaxSessionDuration": 3600,
    "Tags": [
      {
        "Key": "rosa_openshift_version",
        "Value": "4.14"
      },
      {
        "Key": "rosa_role_prefix",
        "Value": "crochecan"
      },
      {
        "Key": "rosa_role_type",
        "Value": "instance_worker"
      },
      {
        "Key": "red-hat-managed",
        "Value": "true"
      }
    ],
    "RoleLastUsed": {}
  }
}
```
### Update operator roles 
```
rosa upgrade operator-roles -c crochecan                                  
I: Starting to upgrade the operator IAM roles and policies
? Operator IAM role/policy upgrade mode: auto
? Upgrade the operator role policy to version 4.14? Yes
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/crochecan-openshift-image-registry-installer-cloud-credentials' to version '4.14'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/crochecan-openshift-ingress-operator-cloud-credentials' to version '4.14'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/crochecan-openshift-cluster-csi-drivers-ebs-cloud-credentials' to version '4.14'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/crochecan-openshift-cloud-network-config-controller-cloud-creden' to version '4.14'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/crochecan-openshift-machine-api-aws-cloud-credentials' to version '4.14'
I: Upgraded policy with ARN 'arn:aws:iam::765374464689:policy/crochecan-openshift-cloud-credential-operator-cloud-credential-o' to version '4.14'
```

### Validate roles 
```
aws iam list-policy-tags --policy-arn arn:aws:iam::765374464689:policy/crochecan-openshift-cluster-csi-drivers-ebs-cloud-credentials | jq .

{
  "Tags": [
    {
      "Key": "operator_name",
      "Value": "ebs-cloud-credentials"
    },
    {
      "Key": "rosa_role_prefix",
      "Value": "crochecan"
    },
    {
      "Key": "red-hat-managed",
      "Value": "true"
    },
    {
      "Key": "rosa_openshift_version",
      "Value": "4.14"
    },
    {
      "Key": "operator_namespace",
      "Value": "openshift-cluster-csi-drivers"
    }
  ],
  "IsTruncated": false
}
```