### PR TITLE
OCM-2919 | fix: mention default values for args

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -670,15 +670,16 @@ The password must
 		&args.defaultIngressWildcardPolicy,
 		defaultIngressWildcardPolicyFlag,
 		"",
-		fmt.Sprintf("Wildcard Policy for ingress. Options are %s", strings.Join(ingress.ValidWildcardPolicies, ",")),
+		fmt.Sprintf("Wildcard Policy for ingress. Options are %s. Default is '%s'.",
+			strings.Join(ingress.ValidWildcardPolicies, ","), ingress.DefaultWildcardPolicy),
 	)
 
 	flags.StringVar(
 		&args.defaultIngressNamespaceOwnershipPolicy,
 		defaultIngressNamespaceOwnershipPolicyFlag,
 		"",
-		fmt.Sprintf("Namespace Ownership Policy for ingress. Options are %s",
-			strings.Join(ingress.ValidNamespaceOwnershipPolicies, ",")),
+		fmt.Sprintf("Namespace Ownership Policy for ingress. Options are %s. Default is '%s'.",
+			strings.Join(ingress.ValidNamespaceOwnershipPolicies, ","), ingress.DefaultNamespaceOwnershipPolicy),
 	)
 
 	aws.AddModeFlag(Cmd)

--- a/cmd/edit/ingress/cmd.go
+++ b/cmd/edit/ingress/cmd.go
@@ -146,15 +146,16 @@ func init() {
 		&args.wildcardPolicy,
 		wildcardPolicyFlag,
 		"",
-		fmt.Sprintf("Wildcard Policy for ingress. Options are %s", strings.Join(helper.ValidWildcardPolicies, ",")),
+		fmt.Sprintf("Wildcard Policy for ingress. Options are %s. Default is '%s'.",
+			strings.Join(helper.ValidWildcardPolicies, ","), helper.DefaultWildcardPolicy),
 	)
 
 	flags.StringVar(
 		&args.namespaceOwnershipPolicy,
 		namespaceOwnershipPolicyFlag,
 		"",
-		fmt.Sprintf("Namespace Ownership Policy for ingress. Options are %s",
-			strings.Join(helper.ValidNamespaceOwnershipPolicies, ",")),
+		fmt.Sprintf("Namespace Ownership Policy for ingress. Options are %s. Default is '%s'.",
+			strings.Join(helper.ValidNamespaceOwnershipPolicies, ","), helper.DefaultNamespaceOwnershipPolicy),
 	)
 
 	flags.StringVar(

--- a/pkg/ingress/policies.go
+++ b/pkg/ingress/policies.go
@@ -6,5 +6,7 @@ import (
 
 var ValidWildcardPolicies = []string{string(cmv1.WildcardPolicyWildcardsDisallowed),
 	string(cmv1.WildcardPolicyWildcardsAllowed)}
+var DefaultWildcardPolicy = cmv1.WildcardPolicyWildcardsDisallowed
 var ValidNamespaceOwnershipPolicies = []string{string(cmv1.NamespaceOwnershipPolicyStrict),
 	string(cmv1.NamespaceOwnershipPolicyInterNamespaceAllowed)}
+var DefaultNamespaceOwnershipPolicy = cmv1.NamespaceOwnershipPolicyStrict


### PR DESCRIPTION
```
 --namespace-ownership-policy string      Namespace Ownership Policy for ingress. Options are Strict,InterNamespaceAllowed. Default is 'Strict'.
 --wildcard-policy string                 Wildcard Policy for ingress. Options are WildcardsDisallowed,WildcardsAllowed. Default is 'WildcardsDisallowed'.
```

```
 --default-ingress-wildcard-policy string              Wildcard Policy for ingress. Options are WildcardsDisallowed,WildcardsAllowed. Default is 'WildcardsDisallowed'.
--default-ingress-namespace-ownership-policy string   Namespace Ownership Policy for ingress. Options are Strict,InterNamespaceAllowed. Default is 'Strict'.
```