### PR TITLE
OCM-1138 | fix: shouldnt ask for mode if supplied in args

### DIFF
--- a/cmd/dlt/ocmrole/cmd.go
+++ b/cmd/dlt/ocmrole/cmd.go
@@ -141,7 +141,7 @@ func run(cmd *cobra.Command, argv []string) error {
 	}
 	isLinked := helper.Contains(linkedRoles, roleARN)
 
-	if interactive.Enabled() {
+	if interactive.Enabled() && !cmd.Flags().Changed("mode") {
 		mode, err = interactive.GetOption(interactive.Input{
 			Question: "OCM role deletion mode",
 			Help:     cmd.Flags().Lookup("mode").Usage,


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/OCM-1138
