### PR TITLE
OCM-1233 | fix: The interactive mode should not exit after input invalid ingress label

### DIFF
--- a/cmd/edit/ingress/cmd.go
+++ b/cmd/edit/ingress/cmd.go
@@ -227,6 +227,12 @@ func run(cmd *cobra.Command, argv []string) {
 			Question: "Route Selector for ingress",
 			Help:     cmd.Flags().Lookup(routeSelectorFlag).Usage,
 			Default:  args.routeSelector,
+			Validators: []interactive.Validator{
+				func(routeSelector interface{}) error {
+					_, err := helper.GetRouteSelector(routeSelector.(string))
+					return err
+				},
+			},
 		})
 		if err != nil {
 			r.Reporter.Errorf("Expected a valid comma-separated list of attributes: %s", err)


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/OCM-1233