### PR TITLE
OCM-1210 | fix: enables interactive if role arn is not supplied

### DIFF
--- a/cmd/dlt/ocmrole/cmd.go
+++ b/cmd/dlt/ocmrole/cmd.go
@@ -141,7 +141,7 @@ func run(cmd *cobra.Command, argv []string) error {
 	}
 	isLinked := helper.Contains(linkedRoles, roleARN)
 
-	if interactive.Enabled() {
+	if interactive.Enabled() && !cmd.Flags().Changed("mode") {
 		mode, err = interactive.GetOption(interactive.Input{
 			Question: "OCM role deletion mode",
 			Help:     cmd.Flags().Lookup("mode").Usage,

--- a/cmd/dlt/userrole/cmd.go
+++ b/cmd/dlt/userrole/cmd.go
@@ -84,6 +84,11 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	roleARN := args.roleARN
+
+	if !interactive.Enabled() && roleARN == "" {
+		interactive.Enable()
+	}
+
 	if interactive.Enabled() {
 		roleARN, err = interactive.GetString(interactive.Input{
 			Question: "User Role ARN",
@@ -129,7 +134,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 	isLinked := helper.Contains(linkedRoles, roleARN)
 
-	if interactive.Enabled() {
+	if interactive.Enabled() && !cmd.Flags().Changed("mode") {
 		mode, err = interactive.GetOption(interactive.Input{
 			Question: "User role deletion mode",
 			Help:     cmd.Flags().Lookup("mode").Usage,


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/OCM-1210