### PR TITLE
OCM-2918 | fix: setting up the help in route-selector attribute

### DIFF
--- a/cmd/edit/ingress/cmd.go
+++ b/cmd/edit/ingress/cmd.go
@@ -124,7 +124,8 @@ func init() {
 		routeSelectorFlag,
 		"",
 		"Route Selector for ingress. Format should be a comma-separated list of 'key=value'. "+
-			"If no label is specified, all routes will be exposed on both routers.",
+			"If no label is specified, all routes will be exposed on both routers."+
+			" For legacy ingress support these are inclusion labels, otherwise they are treated as exclusion label.",
 	)
 
 	flags.StringVar(
@@ -139,8 +140,7 @@ func init() {
 		excludedNamespacesFlag,
 		"",
 		"Excluded namespaces for ingress. Format should be a comma-separated list 'value1, value2...'. "+
-			"If no values are specified, all namespaces will be exposed."+
-			" For legacy ingress support these are inclusion labels, otherwise they are treated as exclusion label.",
+			"If no values are specified, all namespaces will be exposed.",
 	)
 
 	flags.StringVar(


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/OCM-2918