### PR TITLE
OCM-2942 | fix: adjust help usage for cluster routes attributes

### DIFF
--- a/cmd/edit/ingress/cmd.go
+++ b/cmd/edit/ingress/cmd.go
@@ -163,14 +163,14 @@ func init() {
 		&args.clusterRoutesHostname,
 		clusterRoutesHostnameFlag,
 		"",
-		"Cluster Routes Hostname.",
+		"Components route hostname for oauth, console, download.",
 	)
 
 	flags.StringVar(
 		&args.clusterRoutesTlsSecretRef,
 		clusterRoutesTlsSecretRefFlag,
 		"",
-		"Cluster Routes TLS Secret Reference.",
+		"Components route TLS secret reference for oauth, console, download.",
 	)
 
 	Cmd.RegisterFlagCompletionFunc(lbTypeFlag, lbTypeCompletion)


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/OCM-2942