### PR TITLE
OCM-2683 | feat: include policies,namespace,name,in-use when listing operator roles

### DIFF
--- a/cmd/dlt/accountroles/cmd.go
+++ b/cmd/dlt/accountroles/cmd.go
@@ -307,7 +307,7 @@ func buildCommand(roleNames []string, policyMap map[string][]aws.PolicyDetail, m
 	for _, roleName := range roleNames {
 		policyDetails := policyMap[roleName]
 		for _, policyDetail := range policyDetails {
-			if policyDetail.PolicType == aws.Attached && policyDetail.PolicyArn != "" {
+			if policyDetail.PolicyType == aws.Attached && policyDetail.PolicyArn != "" {
 				detachPolicy := awscb.NewIAMCommandBuilder().
 					SetCommand(awscb.DetachRolePolicy).
 					AddParam(awscb.RoleName, roleName).
@@ -323,7 +323,7 @@ func buildCommand(roleNames []string, policyMap map[string][]aws.PolicyDetail, m
 					commands = append(commands, deletePolicy)
 				}
 			}
-			if policyDetail.PolicType == aws.Inline && policyDetail.PolicyName != "" {
+			if policyDetail.PolicyType == aws.Inline && policyDetail.PolicyName != "" {
 				deletePolicy := awscb.NewIAMCommandBuilder().
 					SetCommand(awscb.DeleteRolePolicy).
 					AddParam(awscb.RoleName, roleName).

--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -369,7 +369,7 @@ func getAccountPolicyPath(awsClient aws.Client, prefix string) (string, error) {
 		for _, rolePolicy := range rolePolicies {
 			if rolePolicy.PolicyName == policyName {
 				policyARN = rolePolicy.PolicyArn
-				policyType = rolePolicy.PolicType
+				policyType = rolePolicy.PolicyType
 				break
 			}
 		}

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -121,7 +121,7 @@ type Client interface {
 	ListUserRoles() ([]Role, error)
 	ListOCMRoles() ([]Role, error)
 	ListAccountRoles(version string) ([]Role, error)
-	ListOperatorRoles(version string, clusterID string) (map[string][]Role, error)
+	ListOperatorRoles(version string, clusterID string) (map[string][]OperatorRoleDetail, error)
 	ListOidcProviders(targetClusterId string) ([]OidcProviderOutput, error)
 	GetRoleByARN(roleARN string) (*iam.Role, error)
 	HasCompatibleVersionTags(iamTags []*iam.Tag, version string) (bool, error)

--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -747,7 +747,7 @@ func BuildOperatorRolePolicies(prefix string, accountID string, awsClient Client
 func FindAllAttachedPolicyDetails(policiesDetails []PolicyDetail) []PolicyDetail {
 	attachedPolicies := make([]PolicyDetail, 0)
 	for _, policy := range policiesDetails {
-		if policy.PolicType == Attached {
+		if policy.PolicyType == Attached {
 			attachedPolicies = append(attachedPolicies, policy)
 		}
 	}
@@ -756,7 +756,7 @@ func FindAllAttachedPolicyDetails(policiesDetails []PolicyDetail) []PolicyDetail
 
 func FindFirstAttachedPolicy(policiesDetails []PolicyDetail) PolicyDetail {
 	for _, policy := range policiesDetails {
-		if policy.PolicType == Attached {
+		if policy.PolicyType == Attached {
 			return policy
 		}
 	}

--- a/pkg/aws/tags/tags.go
+++ b/pkg/aws/tags/tags.go
@@ -58,4 +58,6 @@ const OperatorNamespace = "operator_namespace"
 
 const OperatorName = "operator_name"
 
+const InUse = "in_use"
+
 const True = "true"

--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -866,7 +866,7 @@ func ValidateOperatorRolesMatchOidcProvider(reporter *reporter.Object, awsClient
 			return err
 		}
 		for _, policyDetails := range policiesDetails {
-			if policyDetails.PolicType == aws.Inline {
+			if policyDetails.PolicyType == aws.Inline {
 				continue
 			}
 			isCompatible, err := awsClient.IsPolicyCompatible(policyDetails.PolicyArn, clusterVersion)


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/OCM-2683

Adds following values to the output when listing operator roles
- Operator name
- Operator namespace
- In-use status
- Attached policies