### PR TITLE
OCM-3012 | fix: trim spaces in each excluded namespace

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2502,10 +2502,7 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 		excludedNamespaces = excludedNamespacesArg
 	}
-	sliceExcludedNamespaces := []string{}
-	if excludedNamespaces != "" {
-		sliceExcludedNamespaces = strings.Split(excludedNamespaces, ",")
-	}
+	sliceExcludedNamespaces := ingress.GetExcludedNamespaces(excludedNamespaces)
 
 	wildcardPolicy := ""
 	if cmd.Flags().Changed(defaultIngressWildcardPolicyFlag) {

--- a/cmd/edit/ingress/cmd.go
+++ b/cmd/edit/ingress/cmd.go
@@ -479,14 +479,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	if excludedNamespaces != nil {
-		_excludedNamespaces := []string{}
-		if *excludedNamespaces != "" {
-			_excludedNamespaces = strings.Split(*excludedNamespaces, ",")
-			if err != nil {
-				r.Reporter.Errorf("%s", err)
-				os.Exit(1)
-			}
-		}
+		_excludedNamespaces := helper.GetExcludedNamespaces(*excludedNamespaces)
 		if len(_excludedNamespaces) > 0 {
 			ingressBuilder = ingressBuilder.ExcludedNamespaces(_excludedNamespaces...)
 		}

--- a/pkg/ingress/excluded_namespaces.go
+++ b/pkg/ingress/excluded_namespaces.go
@@ -1,0 +1,16 @@
+package ingress
+
+import (
+	"strings"
+)
+
+func GetExcludedNamespaces(excludedNamespaces string) []string {
+	if excludedNamespaces == "" {
+		return []string{}
+	}
+	sliceExcludedNamespaces := strings.Split(excludedNamespaces, ",")
+	for i := range sliceExcludedNamespaces {
+		sliceExcludedNamespaces[i] = strings.TrimSpace(sliceExcludedNamespaces[i])
+	}
+	return sliceExcludedNamespaces
+}

--- a/pkg/ingress/excluded_namespaces_test.go
+++ b/pkg/ingress/excluded_namespaces_test.go
@@ -1,0 +1,27 @@
+package ingress
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("GetExcludedNamespaces", func() {
+	When("input is empty", func() {
+		It("should return empty slice", func() {
+			output := GetExcludedNamespaces("")
+			Expect(0).To(Equal(len(output)))
+		})
+	})
+	When("input doesn't contain spaces", func() {
+		It("should return correct array", func() {
+			output := GetExcludedNamespaces("stage,dev,int")
+			Expect([]string{"stage", "dev", "int"}).To(Equal(output))
+		})
+	})
+	When("input contain spaces", func() {
+		It("should return correct array", func() {
+			output := GetExcludedNamespaces("stage, dev, int")
+			Expect([]string{"stage", "dev", "int"}).To(Equal(output))
+		})
+	})
+})

--- a/pkg/ingress/ingress_suite_test.go
+++ b/pkg/ingress/ingress_suite_test.go
@@ -1,0 +1,13 @@
+package ingress_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestIngress(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Ingress Suite")
+}

--- a/pkg/ingress/route_selector_test.go
+++ b/pkg/ingress/route_selector_test.go
@@ -1,0 +1,39 @@
+package ingress
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("GetRouteSelector", func() {
+	When("input is empty", func() {
+		It("should return nil", func() {
+			output, err := GetRouteSelector("")
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(0).To(Equal(len(output)))
+		})
+	})
+	When("input doesn't contain spaces", func() {
+		It("should return correct map", func() {
+			output, err := GetRouteSelector("foo=bar,bar=foo")
+			Expect(err).To(Not(HaveOccurred()))
+			Expect("map[bar:foo foo:bar]").To(Equal(fmt.Sprintf("%v", output)))
+		})
+	})
+	When("input contain spaces", func() {
+		It("should return correct map", func() {
+			output, err := GetRouteSelector("foo=bar, bar=foo")
+			Expect(err).To(Not(HaveOccurred()))
+			Expect("map[bar:foo foo:bar]").To(Equal(fmt.Sprintf("%v", output)))
+		})
+	})
+	When("input has wrong delimiter", func() {
+		It("should return error", func() {
+			_, err := GetRouteSelector("foo:bar, bar:foo")
+			Expect(err).To(HaveOccurred())
+			Expect("Expected key=value format for label-match").To(Equal(err.Error()))
+		})
+	})
+})


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/OCM-3012