### PR TITLE
OCM-3044 | fix: allow specifying empty values to remove route-selectors/excluded-namespaces

### DIFF
--- a/cmd/edit/ingress/cmd.go
+++ b/cmd/edit/ingress/cmd.go
@@ -469,9 +469,7 @@ func run(cmd *cobra.Command, argv []string) {
 				os.Exit(1)
 			}
 		}
-		if len(routeSelectors) > 0 {
-			ingressBuilder = ingressBuilder.RouteSelectors(routeSelectors)
-		}
+		ingressBuilder = ingressBuilder.RouteSelectors(routeSelectors)
 	}
 
 	if lbType != nil {
@@ -480,9 +478,7 @@ func run(cmd *cobra.Command, argv []string) {
 
 	if excludedNamespaces != nil {
 		_excludedNamespaces := helper.GetExcludedNamespaces(*excludedNamespaces)
-		if len(_excludedNamespaces) > 0 {
-			ingressBuilder = ingressBuilder.ExcludedNamespaces(_excludedNamespaces...)
-		}
+		ingressBuilder = ingressBuilder.ExcludedNamespaces(_excludedNamespaces...)
 	}
 
 	if wildcardPolicy != nil &&

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -100,6 +100,9 @@ func SliceToMap(s []string) map[string]bool {
 }
 
 func SliceToSortedString(s []string) string {
+	if len(s) == 0 {
+		return ""
+	}
 	SortStringRespectLength(s)
 	return "[" + strings.Join(s, ", ") + "]"
 }

--- a/pkg/ingress/route_selector.go
+++ b/pkg/ingress/route_selector.go
@@ -6,12 +6,10 @@ import (
 )
 
 func GetRouteSelector(labelMatches string) (map[string]string, error) {
-	routeSelectors := make(map[string]string)
-
 	if labelMatches == "" {
-		return routeSelectors, nil
+		return map[string]string{}, nil
 	}
-
+	routeSelectors := map[string]string{}
 	for _, labelMatch := range strings.Split(labelMatches, ",") {
 		if !strings.Contains(labelMatch, "=") {
 			return nil, fmt.Errorf("Expected key=value format for label-match")


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/OCM-3044