### PR TITLE
OCM-3047 | fix: allow supplying empty values to reset component routes

### DIFF
--- a/cmd/edit/ingress/cmd.go
+++ b/cmd/edit/ingress/cmd.go
@@ -496,11 +496,11 @@ func run(cmd *cobra.Command, argv []string) {
 			cmv1.NamespaceOwnershipPolicy(*namespaceOwnershipPolicy))
 	}
 
-	if clusterRoutesHostname != nil && *clusterRoutesHostname != "" {
+	if clusterRoutesHostname != nil {
 		ingressBuilder = ingressBuilder.ClusterRoutesHostname(*clusterRoutesHostname)
 	}
 
-	if clusterRoutesTlsSecretRef != nil && *clusterRoutesTlsSecretRef != "" {
+	if clusterRoutesTlsSecretRef != nil {
 		ingressBuilder = ingressBuilder.ClusterRoutesTlsSecretRef(*clusterRoutesTlsSecretRef)
 	}
 


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/OCM-3047