### PR TITLE
OCM-2425 | fix: no need to choose installer arn when already specified in args

### DIFF
--- a/cmd/register/oidcconfig/cmd.go
+++ b/cmd/register/oidcconfig/cmd.go
@@ -120,7 +120,7 @@ func run(cmd *cobra.Command, argv []string) {
 
 	checkInteractiveModeNeeded(cmd)
 
-	if interactive.Enabled() || (confirm.Yes() && args.installerRoleArn == "") {
+	if args.installerRoleArn == "" && (interactive.Enabled() || confirm.Yes()) {
 		args.installerRoleArn = interactive.GetInstallerRoleArn(r, cmd, args.installerRoleArn, MinorVersionForGetSecret)
 	}
 	roleName, _ := aws.GetResourceIdFromARN(args.installerRoleArn)


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/OCM-2425