### PR TITLE
OCM-2107 | fix: add name to subnet details when selecting interactively

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1791,16 +1791,13 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 
 		for i, subnet := range subnets {
-			subnetID := awssdk.StringValue(subnet.SubnetId)
-			availabilityZone := awssdk.StringValue(subnet.AvailabilityZone)
-
 			// Create the options to prompt the user.
-			options[i] = aws.SetSubnetOption(subnetID, availabilityZone)
-			if subnetsProvided {
-				for _, subnetArg := range subnetIDs {
-					defaultOptions = append(defaultOptions, aws.SetSubnetOption(subnetArg, availabilityZone))
-				}
+			options[i] = aws.SetSubnetOption(subnet)
+			subnetID := awssdk.StringValue(subnet.SubnetId)
+			if subnetsProvided && helper.Contains(subnetIDs, subnetID) {
+				defaultOptions = append(defaultOptions, aws.SetSubnetOption(subnet))
 			}
+			availabilityZone := awssdk.StringValue(subnet.AvailabilityZone)
 			mapSubnetToAZ[subnetID] = availabilityZone
 			mapAZCreated[availabilityZone] = false
 		}

--- a/cmd/create/machinepool/helper.go
+++ b/cmd/create/machinepool/helper.go
@@ -73,7 +73,7 @@ func getSubnetOptions(r *rosa.Runtime, cluster *cmv1.Cluster) ([]string, error) 
 	// Format subnet options
 	var subnetOptions []string
 	for _, subnet := range privateSubnets {
-		subnetOptions = append(subnetOptions, aws.SetSubnetOption(*subnet.SubnetId, *subnet.AvailabilityZone))
+		subnetOptions = append(subnetOptions, aws.SetSubnetOption(subnet))
 	}
 
 	return subnetOptions, nil


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/OCM-2107

```
 Subnet IDs:  [Use arrows to move, space to select, <right> to all, <left> to none, type to filter, ? for more help]
  [ ]  subnet-0d8b6a7d088842406 ('c12345678901234567890-9bzsf-public-us-east-1a',us-east-1a)
  [ ]  subnet-0d55f331fa1124d08 ('dle-classic2-8rc8w-public-us-east-1a',us-east-1a)
  [ ]  subnet-043cedb258fd4f28f ('rc-test-subnet-public1-us-east-1a',us-east-1a)
> [ ]  subnet-0caf94303dc775611 ('proxy-tests-public-do-not-delete',us-east-1b)
  [ ]  subnet-09ae7dd300d7f9e61 ('zg-2-public-us-east-1a',us-east-1a)
  [ ]  subnet-07cde4227fa425efb ('c12345678901234567890-9bzsf-private-us-east-1c',us-east-1c)
  [ ]  subnet-0f87f640e56934cbc ('',us-east-1a)
```