### PR TITLE
Revert "OCM-2653 | fix: remove/hide HCP managed policies before release"

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -124,7 +124,6 @@ func init() {
 		false,
 		"Technology Preview: Enable the use of Hosted Control Planes",
 	)
-	flags.MarkHidden("hosted-cp")
 
 	flags.BoolVar(
 		&args.classic,
@@ -132,7 +131,6 @@ func init() {
 		false,
 		"Create only classic Rosa account roles",
 	)
-	flags.MarkHidden("classic")
 
 	aws.AddModeFlag(Cmd)
 
@@ -173,11 +171,6 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 	managedPolicies := args.managed
-
-	if cmd.Flags().Changed("hosted-cp") && env == ocm.Production {
-		r.Reporter.Errorf("Hosted control plane managed policies are not supported in this environment")
-		os.Exit(1)
-	}
 
 	if args.forcePolicyCreation && managedPolicies {
 		r.Reporter.Warnf("Forcing creation of policies only works for unmanaged policies")
@@ -343,6 +336,9 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
+	isClassicValueSet := cmd.Flags().Changed("classic")
+	isHostedCPValueSet := cmd.Flags().Changed("hosted-cp")
+
 	createClassic := args.classic
 	if interactive.Enabled() && !cmd.Flags().Changed("classic") {
 		createClassic, err = interactive.GetBool(interactive.Input{
@@ -355,25 +351,30 @@ func run(cmd *cobra.Command, argv []string) {
 			r.Reporter.Errorf("Expected a valid value: %s", err)
 			os.Exit(1)
 		}
+		isClassicValueSet = true
 	}
 
 	createHostedCP := args.hostedCP
-	if env != ocm.Production {
-		if interactive.Enabled() && !cmd.Flags().Changed("hosted-cp") {
-			createHostedCP, err = interactive.GetBool(interactive.Input{
-				Question: "Create Hosted CP account roles",
-				Help:     cmd.Flags().Lookup("hosted-cp").Usage,
-				Default:  false,
-				Required: false,
-			})
-			if err != nil {
-				r.Reporter.Errorf("Expected a valid value: %s", err)
-				os.Exit(1)
-			}
+	if interactive.Enabled() && !cmd.Flags().Changed("hosted-cp") {
+		createHostedCP, err = interactive.GetBool(interactive.Input{
+			Question: "Create Hosted CP account roles",
+			Help:     cmd.Flags().Lookup("hosted-cp").Usage,
+			Default:  false,
+			Required: false,
+		})
+		if err != nil {
+			r.Reporter.Errorf("Expected a valid value: %s", err)
+			os.Exit(1)
 		}
+		isHostedCPValueSet = true
 	}
 
-	rolesCreator := initCreator(managedPolicies, createClassic, createHostedCP)
+	rolesCreator, createRoles := initCreator(managedPolicies, createClassic, createHostedCP,
+		isClassicValueSet, isHostedCPValueSet)
+	if !createRoles {
+		os.Exit(1)
+	}
+
 	input := buildRolesCreationInput(prefix, permissionsBoundary, r.Creator.AccountID, env, policies,
 		policyVersion, path)
 

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1070,6 +1070,9 @@ func run(cmd *cobra.Command, _ []string) {
 			roleARN = roleARNs[0]
 		} else {
 			createAccountRolesCommand := "rosa create account-roles"
+			if isHostedCP {
+				createAccountRolesCommand = createAccountRolesCommand + " --hosted-cp"
+			}
 			r.Reporter.Warnf(fmt.Sprintf("No account roles found. You will need to manually set them in the "+
 				"next steps or run '%s' to create them first.", createAccountRolesCommand))
 			interactive.Enable()
@@ -1124,6 +1127,9 @@ func run(cmd *cobra.Command, _ []string) {
 				}
 				if selectedARN == "" {
 					createAccountRolesCommand := "rosa create account-roles"
+					if isHostedCP {
+						createAccountRolesCommand = createAccountRolesCommand + " --hosted-cp"
+					}
 					r.Reporter.Warnf(fmt.Sprintf("No %s account roles found. You will need to manually set "+
 						"them in the next steps or run '%s' to create "+
 						"them first.", role.Name, createAccountRolesCommand))

--- a/cmd/dlt/accountroles/cmd.go
+++ b/cmd/dlt/accountroles/cmd.go
@@ -65,7 +65,6 @@ func init() {
 		false,
 		"Delete Hosted Control Planes roles",
 	)
-	flags.MarkHidden("hosted-cp")
 
 	flags.BoolVar(
 		&args.classic,
@@ -73,7 +72,6 @@ func init() {
 		false,
 		"Delete classic account roles",
 	)
-	flags.MarkHidden("classic")
 
 	aws.AddModeFlag(Cmd)
 	confirm.AddFlag(flags)

--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -90,7 +90,6 @@ func init() {
 		false,
 		"Technology Preview: Enable the use of Hosted Control Planes",
 	)
-	flags.MarkHidden("hosted-cp")
 
 	confirm.AddFlag(flags)
 	interactive.AddFlag(flags)
@@ -135,7 +134,13 @@ func run(cmd *cobra.Command, argv []string) error {
 
 	roleARN, err := awsClient.GetAccountRoleARN(prefix, role.Name)
 	if err != nil {
-		r.Reporter.Errorf("Failed to get account roles ARN: %v", err)
+		if args.hostedCP {
+			r.Reporter.Errorf("Failed to get hosted CP account roles ARN: %v. "+
+				"To upgrade classic account roles run the command without the '--hosted-cp' flag", err)
+		} else {
+			r.Reporter.Errorf("Failed to get classic account roles ARN: %v. "+
+				"To upgrade hosted CP account roles use the '--hosted-cp' flag", err)
+		}
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
This reverts commit 0cd43cabc5063077b528c04bb74828ca1c83242c.