### PR TITLE
Revert "OCM-2653 | fix: Create operator-roles - hide hosted cp managed policies

### DIFF
--- a/cmd/create/operatorroles/by_prefix.go
+++ b/cmd/create/operatorroles/by_prefix.go
@@ -21,7 +21,7 @@ import (
 	"github.com/openshift/rosa/pkg/rosa"
 )
 
-func handleOperatorRolesPrefixOptions(r *rosa.Runtime, cmd *cobra.Command, env string) {
+func handleOperatorRolesPrefixOptions(r *rosa.Runtime, cmd *cobra.Command) {
 	operatorRolesPrefix := args.prefix
 	operatorRolesPrefix, err := interactive.GetString(interactive.Input{
 		Question: "Operator roles prefix",
@@ -44,14 +44,12 @@ func handleOperatorRolesPrefixOptions(r *rosa.Runtime, cmd *cobra.Command, env s
 	}
 
 	isHostedCP := args.hostedCp
-	if env != ocm.Production {
-		isHostedCP, err = interactive.GetBool(interactive.Input{
-			Question: "Create hosted control plane operator roles",
-			Help:     cmd.Flags().Lookup("hosted-cp").Usage,
-			Default:  isHostedCP,
-			Required: false,
-		})
-	}
+	isHostedCP, err = interactive.GetBool(interactive.Input{
+		Question: "Create hosted control plane operator roles",
+		Help:     cmd.Flags().Lookup("hosted-cp").Usage,
+		Default:  isHostedCP,
+		Required: false,
+	})
 	if err != nil {
 		r.Reporter.Errorf("Expected a valid --hosted-cp value: %s", err)
 		os.Exit(1)

--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -92,7 +92,6 @@ func init() {
 		false,
 		"Indicates whether to create the hosted control planes operator roles when using --prefix option.",
 	)
-	flags.MarkHidden(HostedCpFlag)
 
 	flags.StringVar(
 		&args.permissionsBoundary,
@@ -141,11 +140,6 @@ func run(cmd *cobra.Command, argv []string) error {
 	env, err := ocm.GetEnv()
 	if err != nil {
 		r.Reporter.Errorf("Failed to determine OCM environment: %v", err)
-		os.Exit(1)
-	}
-
-	if cmd.Flags().Changed(HostedCpFlag) && env == ocm.Production {
-		r.Reporter.Errorf("Hosted control plane managed policies are not supported in this environment")
 		os.Exit(1)
 	}
 
@@ -201,7 +195,7 @@ func run(cmd *cobra.Command, argv []string) error {
 	}
 
 	if cluster == nil && interactive.Enabled() && !isProgmaticallyCalled {
-		handleOperatorRolesPrefixOptions(r, cmd, env)
+		handleOperatorRolesPrefixOptions(r, cmd)
 	}
 
 	permissionsBoundary := args.permissionsBoundary


### PR DESCRIPTION
This reverts commit 5283ce9191fd7f275a40db9111bd5fcfbabcd353.