### PR TITLE
OCM-3049 | feat: upgrade operator roles for the shared VPC flow

### DIFF
--- a/cmd/upgrade/operatorroles/cmd.go
+++ b/cmd/upgrade/operatorroles/cmd.go
@@ -248,7 +248,7 @@ func upgradeOperatorPolicies(mode string, r *rosa.Runtime,
 			return nil
 		}
 		err := aws.UpgradeOperatorRolePolicies(r.Reporter, r.AWSClient, r.Creator.AccountID, prefix, policies,
-			defaultPolicyVersion, credRequests, policyPath)
+			defaultPolicyVersion, credRequests, policyPath, cluster)
 		if err != nil {
 			if strings.Contains(err.Error(), "Throttling") {
 				r.OCMClient.LogEvent("ROSAUpgradeOperatorRolesModeAuto", map[string]string{
@@ -262,7 +262,7 @@ func upgradeOperatorPolicies(mode string, r *rosa.Runtime,
 		return nil
 	case aws.ModeManual:
 		err := aws.GeneratePolicyFiles(r.Reporter, env, false,
-			true, policies, credRequests, false, "") //TODO: handle shared vpc
+			true, policies, credRequests, false, cluster.AWS().PrivateHostedZoneRoleARN())
 		if err != nil {
 			r.Reporter.Errorf("There was an error generating the policy files: %s", err)
 			os.Exit(1)
@@ -277,7 +277,7 @@ func upgradeOperatorPolicies(mode string, r *rosa.Runtime,
 			}
 		}
 		commands := aws.BuildOperatorRoleCommands(prefix, r.Creator.AccountID, r.AWSClient,
-			defaultPolicyVersion, credRequests, policyPath)
+			defaultPolicyVersion, credRequests, policyPath, cluster)
 		fmt.Println(awscb.JoinCommands(commands))
 	default:
 		return r.Reporter.Errorf("Invalid mode. Allowed values are %s", aws.Modes)

--- a/pkg/aws/commandbuilder/helper/roles/roles.go
+++ b/pkg/aws/commandbuilder/helper/roles/roles.go
@@ -59,6 +59,7 @@ type ManualCommandsForUpgradeOperatorRolePolicyInput struct {
 	PolicyName                               string
 	HasDetachPolicyCommandsForExpectedPolicy bool
 	OperatorRoleName                         string
+	FileName                                 string
 }
 
 func ManualCommandsForUpgradeOperatorRolePolicy(input ManualCommandsForUpgradeOperatorRolePolicyInput) []string {
@@ -74,7 +75,7 @@ func ManualCommandsForUpgradeOperatorRolePolicy(input ManualCommandsForUpgradeOp
 		createPolicy := awscb.NewIAMCommandBuilder().
 			SetCommand(awscb.CreatePolicy).
 			AddParam(awscb.PolicyName, input.PolicyName).
-			AddParam(awscb.PolicyDocument, fmt.Sprintf("file://openshift_%s_policy.json", input.CredRequest)).
+			AddParam(awscb.PolicyDocument, fmt.Sprintf("file://%s", input.FileName)).
 			AddTags(iamTags).
 			AddParam(awscb.Path, input.OperatorPolicyPath).
 			Build()
@@ -95,7 +96,7 @@ func ManualCommandsForUpgradeOperatorRolePolicy(input ManualCommandsForUpgradeOp
 		createPolicyVersion := awscb.NewIAMCommandBuilder().
 			SetCommand(awscb.CreatePolicyVersion).
 			AddParam(awscb.PolicyArn, input.PolicyARN).
-			AddParam(awscb.PolicyDocument, fmt.Sprintf("file://openshift_%s_policy.json", input.CredRequest)).
+			AddParam(awscb.PolicyDocument, fmt.Sprintf("file://%s", input.FileName)).
 			AddParamNoValue(awscb.SetAsDefault).
 			Build()
 


### PR DESCRIPTION
Update the adequate policy for the shared VPC flow.