### PR TITLE
OCM-3178 | fix: accept int64 max value for disk size

### DIFF
--- a/pkg/ocm/helpers_test.go
+++ b/pkg/ocm/helpers_test.go
@@ -229,4 +229,12 @@ var _ = Describe("ParseDiskSizeToGigibyte", func() {
 		Expect(got).To(Equal(0))
 	})
 
+	It("returns the correct value for valid unit: 200000000000000 Ti", func() {
+		// Hitting the max int64 value
+		size := "200000000000000 Ti"
+		got, err := ParseDiskSizeToGigibyte(size)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got).To(Equal(8589934591))
+	})
+
 })


### PR DESCRIPTION
When the disk size is parsed with a very large value input by the user it will return 9223372036854775807 which is the largest size of a 64bit integer. This is still valid and should not return an error.

Signed-off-by: Sébastien Han <seb@redhat.com>