### PR TITLE
OCM-3152 | fix: show roles with missing policies and order by prefix

### DIFF
--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -867,7 +867,7 @@ func (c *awsClient) ListOperatorRoles(version string, targetClusterId string) (m
 			continue
 		}
 
-		if operatorRole.ManagedPolicy {
+		if operatorRole.ManagedPolicy || len(attachedPoliciesOutput.AttachedPolicies) == 0 {
 			operatorRole.RoleName = aws.StringValue(role.RoleName)
 			operatorRole.RoleARN = aws.StringValue(role.Arn)
 			operatorMap[foundPrefix] = append(operatorMap[foundPrefix], operatorRole)


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/OCM-3152