### PR TITLE
OCM-3143 | Create operator-roles - ensure shared VPC policy

### DIFF
--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -932,7 +932,7 @@ func GetOperatorPolicyKey(roleType string, hostedCP bool, sharedVpc bool) string
 		return fmt.Sprintf("openshift_hcp_%s_policy", roleType)
 	}
 
-	if sharedVpc && roleType == "ingress_operator_cloud_credentials" {
+	if sharedVpc && roleType == IngressOperatorCloudCredentialsRoleType {
 		return fmt.Sprintf("shared_vpc_openshift_%s_policy", roleType)
 	}
 

--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -97,6 +97,8 @@ const (
 
 	// AWS preferred suffix for ROSA related account roles - HCP only
 	HCPSuffixPattern = "HCP-ROSA"
+
+	IngressOperatorCloudCredentialsRoleType = "ingress_operator_cloud_credentials"
 )
 
 const (


### PR DESCRIPTION
Multiple operator roles point to the same policy.
When creating a new set of operator roles with the `--shared-vpc-role-arn` flag provided, 
we need to ensure the ingress operator role is updated with the new policy.