### PR TITLE
OCM-1081 | fix: checks hcp role tag in all flows

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1086,13 +1086,10 @@ func run(cmd *cobra.Command, _ []string) {
 
 		if roleARN != "" {
 			// check if role has hosted cp policy via AWS tag value
-			var hostedCPPolicies bool
-			if isHostedCP {
-				hostedCPPolicies, err = awsClient.HasHostedCPPolicies(roleARN)
-				if err != nil {
-					r.Reporter.Errorf("Failed to determine if cluster has hosted CP policies: %v", err)
-					os.Exit(1)
-				}
+			hostedCPPolicies, err := awsClient.HasHostedCPPolicies(roleARN)
+			if err != nil {
+				r.Reporter.Errorf("Failed to determine if cluster has hosted CP policies: %v", err)
+				os.Exit(1)
 			}
 			hasRoles = true
 			for roleType, role := range aws.AccountRoles {
@@ -1312,16 +1309,13 @@ func run(cmd *cobra.Command, _ []string) {
 		r.Reporter.Errorf("Failed to determine if cluster has managed policies: %v", err)
 		os.Exit(1)
 	}
-
 	// check if role has hosted cp policy via AWS tag value
-	var hostedCPPolicies bool
-	if isHostedCP {
-		hostedCPPolicies, err = awsClient.HasHostedCPPolicies(roleARN)
-		if err != nil {
-			r.Reporter.Errorf("Failed to determine if cluster has hosted CP policies: %v", err)
-			os.Exit(1)
-		}
+	hostedCPPolicies, err := awsClient.HasHostedCPPolicies(roleARN)
+	if err != nil {
+		r.Reporter.Errorf("Failed to determine if cluster has hosted CP policies: %v", err)
+		os.Exit(1)
 	}
+
 	if managedPolicies {
 		rolePrefix, err := getAccountRolePrefix(hostedCPPolicies, roleARN, aws.InstallerAccountRole)
 		if err != nil {


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/OCM-1081

After fix allows to go through but hits preflight from backend
```
E: Creating cluster 'gdb-test' should fail: Role 'arn:aws:iam::xxx:role/ManagedOpenShift-HCP-ROSA-Installer-Role' has hosted CP managed policies. Creating a Classic cluster with hosted CP managed policies isn't allowed. Please create a new set of account roles with Classic ROSA policies
```