### PR TITLE
OCM-2892 | fix: Adding default value of http tokens metadata for describe command

### DIFF
--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -251,6 +251,9 @@ func run(cmd *cobra.Command, argv []string) {
 
 	if cluster.AWS().Ec2MetadataHttpTokens() != "" {
 		str = fmt.Sprintf("%s"+"Ec2 Metadata Http Tokens:   %s\n", str, cluster.AWS().Ec2MetadataHttpTokens())
+	} else {
+		// show default value for clusters that didn't set it.
+		str = fmt.Sprintf("%s"+"Ec2 Metadata Http Tokens:   %s\n", str, cmv1.Ec2MetadataHttpTokensOptional)
 	}
 
 	if cluster.AWS().STS().RoleARN() != "" {


### PR DESCRIPTION
We should always show value for http tokens and currently backend (cause of backward compatibility issues) will still return value as empty string