### PR TITLE
OCM-3297 | feat: improve help message for the shared VPC flow

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -702,21 +702,24 @@ The password must
 		&args.privateHostedZoneID,
 		"private-hosted-zone-id",
 		"",
-		`ID of shared private hosted zone`,
+		"ID assigned by AWS to private Route 53 hosted zone associated with intended shared VPC, "+
+			"e.g., 'Z05646003S02O1ENCDCSN'.",
 	)
 
 	flags.StringVar(
 		&args.sharedVPCRoleARN,
 		"shared-vpc-role-arn",
 		"",
-		`Role ARN for permissions in the shared private hosted zone`,
+		"AWS IAM role ARN with a policy attached, granting permissions necessary to create and manage Route 53 DNS records "+
+			"in private Route 53 hosted zone associated with intended shared VPC.",
 	)
 
 	flags.StringVar(
 		&args.baseDomain,
 		"base-domain",
 		"",
-		`Base domain name for the shared private hosted zone`,
+		"Base DNS domain name previously reserved and matching the hosted zone name of the private Route 53 hosted zone "+
+			"associated with intended shared VPC, e.g., '1vo8.p1.openshiftapps.com'.",
 	)
 
 	aws.AddModeFlag(Cmd)

--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -112,7 +112,8 @@ func init() {
 		&args.sharedVpcRoleArn,
 		"shared-vpc-role-arn",
 		"",
-		"The ARN of the role in the shared VPC account, the role is used to modify the private hosted zone records",
+		"AWS IAM role ARN with a policy attached, granting permissions necessary to create and manage Route 53 DNS records "+
+			"in private Route 53 hosted zone associated with intended shared VPC.",
 	)
 
 	aws.AddModeFlag(Cmd)


### PR DESCRIPTION
Improve the new flags help messages to provide more info to the user.

```
oadler@fedora:rosa (OCM-3297)$ ./rosa create cluster --help | grep shared-vpc
      --shared-vpc-role-arn string                          AWS IAM role ARN with a policy attached, granting permissions necessary to create and manage Route 53 DNS records in private Route 53 hosted zone associated with intended shared VPC.
oadler@fedora:rosa (OCM-3297)$ ./rosa create operator-roles --help | grep shared-vpc
      --shared-vpc-role-arn string    AWS IAM role ARN with a policy attached, granting permissions necessary to create and manage Route 53 DNS records in private Route 53 hosted zone associated with intended shared VPC.
oadler@fedora:rosa (OCM-3297)$ ./rosa create cluster --help | grep hosted-zone-id
      --private-hosted-zone-id string                       ID assigned by AWS to private Route 53 hosted zone associated with intended shared VPC, e.g., 'Z05646003S02O1ENCDCSN'.
oadler@fedora:rosa (OCM-3297)$ ./rosa create cluster --help | grep base-domain
      --base-domain string                                  Base DNS domain name previously reserved and matching the hosted zone name of the private Route 53 hosted zone associated with intended shared VPC, e.g., '1vo8.p1.openshiftapps.com'.
```
