### PR TITLE
OCM-3318 | fix: use latest policies if user version is empty

### DIFF
--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -44,6 +44,7 @@ var args struct {
 	forcePolicyCreation bool
 	oidcConfigId        string
 	sharedVpcRoleArn    string
+	channelGroup        string
 }
 
 var Cmd = &cobra.Command{
@@ -114,6 +115,14 @@ func init() {
 		"",
 		"The ARN of the role in the shared VPC account, the role is used to modify the private hosted zone records",
 	)
+
+	flags.StringVar(
+		&args.channelGroup,
+		"channel-group",
+		ocm.DefaultChannelGroup,
+		"Channel group is the name of the channel where this image belongs, for example \"stable\" or \"fast\".",
+	)
+	flags.MarkHidden("channel-group")
 
 	aws.AddModeFlag(Cmd)
 	confirm.AddFlag(flags)
@@ -228,12 +237,6 @@ func run(cmd *cobra.Command, argv []string) error {
 		os.Exit(1)
 	}
 
-	latestPolicyVersion, err := r.OCMClient.GetLatestVersion(cluster.Version().ChannelGroup())
-	if err != nil {
-		r.Reporter.Errorf("Error getting latest version: %s", err)
-		os.Exit(1)
-	}
-
 	if args.prefix != "" {
 		if args.oidcConfigId == "" {
 			r.Reporter.Errorf("%s is mandatory for %s param flow.", OidcConfigIdFlag, PrefixFlag)
@@ -244,8 +247,19 @@ func run(cmd *cobra.Command, argv []string) error {
 			r.Reporter.Errorf("%s is mandatory for %s param flow.", InstallerRoleArnFlag, PrefixFlag)
 			os.Exit(1)
 		}
+		channelGroup := args.channelGroup
+		latestPolicyVersion, err := r.OCMClient.GetLatestVersion(channelGroup)
+		if err != nil {
+			r.Reporter.Errorf("Error getting latest version: %s", err)
+			os.Exit(1)
+		}
 		return handleOperatorRoleCreationByPrefix(r, env, permissionsBoundary,
 			mode, policies, latestPolicyVersion)
+	}
+	latestPolicyVersion, err := r.OCMClient.GetLatestVersion(cluster.Version().ChannelGroup())
+	if err != nil {
+		r.Reporter.Errorf("Error getting latest version: %s", err)
+		os.Exit(1)
 	}
 	return handleOperatorRoleCreationByClusterKey(r, env, permissionsBoundary,
 		mode, policies, latestPolicyVersion)

--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -739,14 +739,18 @@ func (c *Client) CheckUpgradeClusterVersion(
 }
 
 func (c *Client) GetPolicyVersion(userRequestedVersion string, channelGroup string) (string, error) {
+	if userRequestedVersion == "" {
+		version, err := c.GetLatestVersion(channelGroup)
+		if err != nil {
+			return userRequestedVersion, err
+		}
+		return version, nil
+	}
+
 	versionList, err := c.GetVersionsList(channelGroup, false)
 	if err != nil {
 		err := fmt.Errorf("%v", err)
 		return userRequestedVersion, err
-	}
-
-	if userRequestedVersion == "" {
-		return versionList[0], nil
 	}
 
 	hasVersion := false


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/OCM-3318