### PR TITLE
OCM-3322 | fix: add empty default ingress attribute in config for rosa init

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -3175,7 +3175,7 @@ func buildCommand(spec ocm.Spec, operatorRolesPrefix string,
 		}
 	}
 
-	if !reflect.DeepEqual(spec.DefaultIngress, ocm.DefaultIngressSpec{}) {
+	if !reflect.DeepEqual(spec.DefaultIngress, ocm.NewDefaultIngressSpec()) {
 		if len(spec.DefaultIngress.RouteSelectors) != 0 {
 			selectors := []string{}
 			for k, v := range spec.DefaultIngress.RouteSelectors {

--- a/cmd/initialize/cmd.go
+++ b/cmd/initialize/cmd.go
@@ -283,9 +283,10 @@ func simulateCluster(ocmClient *ocm.Client, region string) error {
 		region = aws.DefaultRegion
 	}
 	spec := ocm.Spec{
-		Name:   "rosa-init",
-		Region: region,
-		DryRun: &dryRun,
+		Name:           "rosa-init",
+		Region:         region,
+		DryRun:         &dryRun,
+		DefaultIngress: ocm.NewDefaultIngressSpec(),
 	}
 
 	_, err := ocmClient.CreateCluster(spec)


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/OCM-3322