### PR TITLE
OCM-210 | Delete cluster autoscaler functionality

### DIFF
--- a/cmd/dlt/autoscaler/cmd.go
+++ b/cmd/dlt/autoscaler/cmd.go
@@ -1,0 +1,58 @@
+/*
+Copyright (c) 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autoscaler
+
+import (
+	"os"
+
+	"github.com/openshift/rosa/pkg/interactive/confirm"
+	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/rosa"
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "autoscaler",
+	Short: "Delete autoscaler for cluster",
+	Long:  "Delete autoscaler configuration for a given cluster.",
+	Example: `  # Delete the autoscaler config for cluster named "mycluster"
+  rosa delete autoscaler --cluster=mycluster`,
+	Run: run,
+}
+
+func init() {
+	ocm.AddClusterFlag(Cmd)
+	confirm.AddFlag(Cmd.Flags())
+}
+
+func run(cmd *cobra.Command, _ []string) {
+	r := rosa.NewRuntime().WithAWS().WithOCM()
+	defer r.Cleanup()
+
+	clusterKey := r.GetClusterKey()
+	cluster := r.FetchCluster()
+
+	r.Reporter.Debugf("Deleting autoscaler for cluster '%s''", clusterKey)
+
+	err := r.OCMClient.DeleteClusterAutoscaler(cluster.ID())
+	if err != nil {
+		r.Reporter.Errorf("Failed to delete autoscaler configuration for cluster '%s': %s",
+			cluster.ID(), err)
+		os.Exit(1)
+	}
+	r.Reporter.Infof("Successfully deleted autoscaler configuration for cluster '%s'", cluster.ID())
+}

--- a/cmd/dlt/cmd.go
+++ b/cmd/dlt/cmd.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/openshift/rosa/cmd/dlt/accountroles"
 	"github.com/openshift/rosa/cmd/dlt/admin"
+	"github.com/openshift/rosa/cmd/dlt/autoscaler"
 	"github.com/openshift/rosa/cmd/dlt/cluster"
 	"github.com/openshift/rosa/cmd/dlt/dnsdomains"
 	"github.com/openshift/rosa/cmd/dlt/idp"
@@ -61,6 +62,7 @@ func init() {
 	Cmd.AddCommand(service.Cmd)
 	Cmd.AddCommand(tuningconfigs.Cmd)
 	Cmd.AddCommand(dnsdomains.Cmd)
+	Cmd.AddCommand(autoscaler.Cmd)
 
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)

--- a/pkg/ocm/clusterautoscaler.go
+++ b/pkg/ocm/clusterautoscaler.go
@@ -1,0 +1,29 @@
+/*
+Copyright (c) 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ocm
+
+func (c *Client) DeleteClusterAutoscaler(clusterID string) error {
+	response, err := c.ocm.ClustersMgmt().V1().
+		Clusters().Cluster(clusterID).
+		Autoscaler().
+		Delete().
+		Send()
+	if err != nil {
+		return handleErr(response.Error(), err)
+	}
+	return nil
+}


### PR DESCRIPTION
Adresses [OCM-210](https://issues.redhat.com/browse/OCM-210).

This PR should allow for the delete functionality of the cluster autoscaler configuration. This functionality was moved out of #1371 but is related.

/cc @osherdp 