### PR TITLE
OCM-3336 | fix: Describe cluster compute node shows wrong value as we should not look on cluster.nodes.compute anymore

### DIFF
--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -498,14 +498,7 @@ func clusterInfraConfig(cluster *cmv1.Cluster, clusterKey string, r *rosa.Runtim
 				maxNodes += machinePool.Replicas()
 			}
 		}
-		// Add compute nodes as well
-		if cluster.Nodes().AutoscaleCompute() != nil {
-			minNodes += cluster.Nodes().AutoscaleCompute().MinReplicas()
-			maxNodes += cluster.Nodes().AutoscaleCompute().MaxReplicas()
-		} else {
-			minNodes += cluster.Nodes().Compute()
-			maxNodes += cluster.Nodes().Compute()
-		}
+
 		// Determine whether there is any auto-scaling in the cluster
 		if minNodes == maxNodes {
 			infraConfig = fmt.Sprintf(""+


### PR DESCRIPTION
[OCM-3336](https://issues.redhat.com//browse/OCM-3336): Describe cluster compute node shows wrong value as we should not look on cluster.nodes.compute anymore