### PR TITLE
OCM-3361 | fix: in interactive mode, version is required for node pools

### DIFF
--- a/cmd/create/machinepool/nodepool.go
+++ b/cmd/create/machinepool/nodepool.go
@@ -91,6 +91,7 @@ func addNodePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster, r
 				Help:     cmd.Flags().Lookup("version").Usage,
 				Options:  filteredVersionList,
 				Default:  version,
+				Required: true,
 			})
 			if err != nil {
 				r.Reporter.Errorf("Expected a valid OpenShift version: %s", err)

--- a/cmd/edit/machinepool/nodepool.go
+++ b/cmd/edit/machinepool/nodepool.go
@@ -115,6 +115,7 @@ func editNodePool(cmd *cobra.Command, nodePoolID string, clusterKey string, clus
 				Help:     cmd.Flags().Lookup("version").Usage,
 				Options:  filteredVersionList,
 				Default:  version,
+				Required: true,
 			})
 			if err != nil {
 				r.Reporter.Errorf("Expected a valid OpenShift version: %s", err)


### PR DESCRIPTION
In interactive mode when creating/editing node pools, the version is required. 
By default the user will be presented with the cluster version if he didn't specify an existing version, but he can't skip the choice anymore.

Related: [OCM-3361](https://issues.redhat.com//browse/OCM-3361)