### PR TITLE
OCM-3377 | fix: only show warning message about EOL if there is an EOL timestamp

### DIFF
--- a/pkg/ocm/versions.go
+++ b/pkg/ocm/versions.go
@@ -382,7 +382,9 @@ func (c *Client) IsVersionCloseToEol(daysAwayToCheck int, version string, channe
 	}
 	ocmVersion := response.Items().Get(0)
 	now := time.Now().UTC()
-	if ocmVersion.EndOfLifeTimestamp().Compare(now.Add(time.Duration(daysAwayToCheck)*OneDayHourDuration*time.Hour)) <= 0 {
+	if !ocmVersion.EndOfLifeTimestamp().IsZero() &&
+		ocmVersion.EndOfLifeTimestamp().Compare(
+			now.Add(time.Duration(daysAwayToCheck)*OneDayHourDuration*time.Hour)) <= 0 {
 		return fmt.Errorf(
 			"The version of Red Hat OpenShift Service on AWS that you are installing will no longer be supported after '%s'."+
 				" Red Hat recommends selecting a newer version. For more information,"+


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/OCM-3377