### PR TITLE
OCM-1154 | feat: add warning message for public ingress when switching HCP cluster visibility

### DIFF
--- a/cmd/edit/cluster/cmd_test.go
+++ b/cmd/edit/cluster/cmd_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright (c) 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+	"github.com/openshift/rosa/pkg/test"
+)
+
+const (
+	clusterName                  = "fakeClusterName"
+	existingPrivateWarningString = "warning string "
+)
+
+var _ = Describe("Edit cluster", func() {
+	Context("warnUserForOAuthHCPVisibility", func() {
+		var testRuntime test.TestingRuntime
+		mockHypershiftClusterReady, err := test.MockOCMCluster(func(c *cmv1.ClusterBuilder) {
+			c.AWS(cmv1.NewAWS().SubnetIDs("subnet-0b761d44d3d9a4663", "subnet-0f87f640e56934cbc"))
+			c.Region(cmv1.NewCloudRegion().ID("us-east-1"))
+			c.State(cmv1.ClusterStateReady)
+			c.Hypershift(cmv1.NewHypershift().Enabled(true))
+		})
+		Expect(err).To(BeNil())
+
+		mockClassicCluster, err := test.MockOCMCluster(func(c *cmv1.ClusterBuilder) {
+			c.AWS(cmv1.NewAWS().SubnetIDs("subnet-0b761d44d3d9a4663", "subnet-0f87f640e56934cbc"))
+			c.Region(cmv1.NewCloudRegion().ID("us-east-1"))
+			c.State(cmv1.ClusterStateReady)
+			c.Hypershift(cmv1.NewHypershift().Enabled(false))
+		})
+		Expect(err).To(BeNil())
+
+		BeforeEach(func() {
+			testRuntime.InitRuntime()
+		})
+		It("Return input string for classic cluster", func() {
+			outputString, err := warnUserForOAuthHCPVisibility(testRuntime.RosaRuntime,
+				clusterName, mockClassicCluster, existingPrivateWarningString)
+			Expect(err).To(BeNil())
+			Expect(outputString).To(Equal(existingPrivateWarningString))
+		})
+		It("Return error if ingress call fails", func() {
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusInternalServerError, ""))
+			outputString, err := warnUserForOAuthHCPVisibility(testRuntime.RosaRuntime,
+				clusterName, mockHypershiftClusterReady, existingPrivateWarningString)
+			Expect(err).To(Not(BeNil()))
+			Expect(outputString).To(BeEmpty())
+			Expect(err.Error()).To(ContainSubstring(
+				fmt.Sprintf("failed to get ingresses for cluster '%s", clusterName)))
+		})
+		It("Return input string for HyperShift cluster with no ingress", func() {
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK,
+				test.FormatIngressList(buildTestIngresses(0, 0))))
+			outputString, err := warnUserForOAuthHCPVisibility(testRuntime.RosaRuntime,
+				clusterName, mockHypershiftClusterReady, existingPrivateWarningString)
+			Expect(err).To(BeNil())
+			Expect(outputString).To(Equal(existingPrivateWarningString))
+		})
+		It("Return input string for  HyperShift cluster with no public ingress", func() {
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK,
+				test.FormatIngressList(buildTestIngresses(3, 0))))
+			outputString, err := warnUserForOAuthHCPVisibility(testRuntime.RosaRuntime,
+				clusterName, mockHypershiftClusterReady, existingPrivateWarningString)
+			Expect(err).To(BeNil())
+			Expect(outputString).To(Equal(existingPrivateWarningString))
+		})
+		It("Append string for HyperShift cluster with some public ingress", func() {
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK,
+				test.FormatIngressList(buildTestIngresses(3, 2))))
+			outputString, err := warnUserForOAuthHCPVisibility(testRuntime.RosaRuntime,
+				clusterName, mockHypershiftClusterReady, existingPrivateWarningString)
+			Expect(err).To(BeNil())
+			Expect(outputString).To(
+				ContainSubstring("warning string OAuth visibility will be affected by cluster visibility change"))
+		})
+	})
+})
+
+func buildTestIngresses(total int, public int) []*cmv1.Ingress {
+	Expect(public).Should(BeNumerically("<=", total))
+	ingresses := make([]*cmv1.Ingress, 0)
+	currentPublic := 0
+	for i := 0; i < total; i++ {
+		ingressBuilder := cmv1.NewIngress().ID(fmt.Sprintf("ingress%d", i))
+		if public > currentPublic {
+			ingressBuilder.Listening(cmv1.ListeningMethodExternal)
+			currentPublic += 1
+		} else {
+			ingressBuilder.Listening(cmv1.ListeningMethodInternal)
+		}
+		ingress, err := ingressBuilder.Build()
+		Expect(err).To(BeNil())
+		ingresses = append(ingresses, ingress)
+	}
+	return ingresses
+}

--- a/cmd/edit/cluster/main_test.go
+++ b/cmd/edit/cluster/main_test.go
@@ -1,0 +1,13 @@
+package cluster
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestEditCluster(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Edit cluster suite")
+}

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -111,6 +111,21 @@ func FormatClusterList(clusters []*v1.Cluster) string {
 	}`, len(clusters), len(clusters), clusterJson.String())
 }
 
+func FormatIngressList(ingresses []*v1.Ingress) string {
+	var ingressJson bytes.Buffer
+
+	v1.MarshalIngressList(ingresses, &ingressJson)
+
+	return fmt.Sprintf(`
+	{
+		"kind": "IngressList",
+		"page": 1,
+		"size": %d,
+		"total": %d,
+		"items": %s
+	}`, len(ingresses), len(ingresses), ingressJson.String())
+}
+
 // TestingRuntime is a wrapper for the structure used for testing
 type TestingRuntime struct {
 	SsoServer   *ghttp.Server


### PR DESCRIPTION
When switching cluster visibility to private, also OAuth becomes private and this can impact applications behind the public ingress using OAuth (e.g. OpenShift console). So add a warning for this in case the cluster is HCP and the user has public ingress.

Related: [OCM-1154](https://issues.redhat.com//browse/OCM-1154)

Examples:
non HCP cluster (no change)
```
rosa edit cluster -c 25pc7psbfn5j9juleu6in6857jvs03p2 -i
I: Interactive mode enabled.
Any optional fields can be ignored and will not be updated.
? Restrict master API endpoint to direct, private connectivity. You will not be able to access your cluster until you edit network settings in your cloud provider. To also change the privacy setting of the application router endpoints, use the 'rosa edit ingress' command.
? Private cluster (optional): (y/N)
```

HCP cluster (both interactive and not interactive)
```
rosa edit cluster -c 25pptbr6ufn5aoj93vjqfj9f4jthqkmi -i
I: Interactive mode enabled.
Any optional fields can be ignored and will not be updated.
? Restrict master API endpoint to direct, private connectivity. You will not be able to access your cluster until you edit network settings in your cloud provider. To also change the privacy setting of the application router endpoints, use the 'rosa edit ingress' command. OAuth visibility will be affected by cluster visibility change. Any application using OAuth behind a public ingress like the OpenShift Console will not be accessible anymore unless the user already has access to the private network. List of affected public ingresses: t0y0
? Private cluster (optional): (y/N)
```
```
rosa edit cluster -c 25pptbr6ufn5aoj93vjqfj9f4jthqkmi --private
W: You are choosing to make your cluster API private. You will not be able to access your cluster until you edit network settings in your cloud provider. To also change the privacy setting of the application router endpoints, use the 'rosa edit ingress' command. OAuth visibility will be affected by cluster visibility change. Any application using OAuth behind a public ingress like the OpenShift Console will not be accessible anymore unless the user already has access to the private network. List of affected public ingresses: t0y0
? Are you sure you want to set cluster '25pptbr6ufn5aoj93vjqfj9f4jthqkmi' as private? (y/N)
```
