### PR TITLE
OCM-3404 | fix: handle output for listing operator roles

### DIFF
--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -127,7 +127,8 @@ func Print(resource interface{}) error {
 				}
 			}
 		}
-	case "object.Object", "map[string]interface {}", "[]map[string]interface {}":
+	// default to catch non concrete types
+	default:
 		{
 			reqBodyBytes := new(bytes.Buffer)
 			json.NewEncoder(reqBodyBytes).Encode(resource)


### PR DESCRIPTION
### What 

This change sets a default to the output print function, to catch any non concrete types passed to output. 

### JIRA 
https://issues.redhat.com/browse/OCM-3404 

### Validation
Original issue, of not being able to handle listing operator roles 
```
$ rosa list operator-roles --prefix cse2etests -o json
I: Fetching operator roles
[
  {
    "Name": "cloud-credential-operator-iam-ro-creds",
    "Namespace": "openshift-cloud-credential-operator",
    "Version": "4.14",
    "RoleName": "cse2etests-openshift-cloud-credential-operator-cloud-credential-",
    "RoleARN": "arn:aws:iam::501358428071:role/cse2etests-openshift-cloud-credential-operator-cloud-credential-",
    "Policy": [
      "oadler-openshift-cloud-credential-operator-cloud-credential-oper"
    ]
  },
  {
    "Name": "cloud-credentials",
    "Namespace": "openshift-cloud-network-config-controller",
    "Version": "4.14",
    "RoleName": "cse2etests-openshift-cloud-network-config-controller-cloud-crede",
    "RoleARN": "arn:aws:iam::501358428071:role/cse2etests-openshift-cloud-network-config-controller-cloud-crede",
    "Policy": [
      "oadler-openshift-cloud-network-config-controller-cloud-credentia"
    ]
  },
  {
    "Name": "ebs-cloud-credentials",
    "Namespace": "openshift-cluster-csi-drivers",
    "Version": "4.14",
    "RoleName": "cse2etests-openshift-cluster-csi-drivers-ebs-cloud-credentials",
    "RoleARN": "arn:aws:iam::501358428071:role/cse2etests-openshift-cluster-csi-drivers-ebs-cloud-credentials",
    "Policy": [
      "oadler-openshift-cluster-csi-drivers-ebs-cloud-credentials"
    ]
  },
  {
    "Name": "installer-cloud-credentials",
    "Namespace": "openshift-image-registry",
    "Version": "4.14",
    "RoleName": "cse2etests-openshift-image-registry-installer-cloud-credentials",
    "RoleARN": "arn:aws:iam::501358428071:role/cse2etests-openshift-image-registry-installer-cloud-credentials",
    "Policy": [
      "oadler-openshift-image-registry-installer-cloud-credentials"
    ]
  },
  {
    "Name": "cloud-credentials",
    "Namespace": "openshift-ingress-operator",
    "Version": "4.13",
    "RoleName": "cse2etests-openshift-ingress-operator-cloud-credentials",
    "RoleARN": "arn:aws:iam::501358428071:role/cse2etests-openshift-ingress-operator-cloud-credentials",
    "Policy": [
      "oadler-openshift-ingress-operator-cloud-credentials"
    ]
  },
  {
    "Name": "aws-cloud-credentials",
    "Namespace": "openshift-machine-api",
    "Version": "4.14",
    "RoleName": "cse2etests-openshift-machine-api-aws-cloud-credentials",
    "RoleARN": "arn:aws:iam::501358428071:role/cse2etests-openshift-machine-api-aws-cloud-credentials",
    "Policy": [
      "oadler-openshift-machine-api-aws-cloud-credentials"
    ]
  }
]
```

Some other non concrete type structs
```
 rosa whoami -o json             
{
  "AWS ARN": "arn:aws:iam::501358428071:user/croche",
  "AWS Account ID": "501358428071",
  "AWS Default Region": "eu-west-1",
  "OCM API": "https://api.integration.openshift.com",
  "OCM Account Email": "croche@redhat.com",
  "OCM Account ID": "1mhXw4gsKOC4yZ9FLrSWPVswtSl",
  "OCM Account Name": "Ciaran Roche",
  "OCM Account Username": "croche_openshift",
  "OCM Organization External ID": "12541229",
  "OCM Organization ID": "1jIHnIbrnLH9kQD57W0BuPm78f1",
  "OCM Organization Name": "Red Hat : Service Delivery : SDA/B"
}
```
```
$ rosa list oidc-providers -o yaml
I: Fetching OIDC providers
- arn: arn:aws:iam::501358428071:oidc-provider/cse2etests-oidc-x7o6.s3.us-east-1.amazonaws.com
  cluster_id: ""
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/d3gt1gce2zmg3d.cloudfront.net/256jstqocu045ae6h4n4s8ks1bguvejt
  cluster_id: ""
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/d3gt1gce2zmg3d.cloudfront.net/25fq9bb0gslcla7ug4t4u7pd15q9oh5s
  cluster_id: ""
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/d3gt1gce2zmg3d.cloudfront.net/25fur0n25j7717ddirj05n3vh2frerdq
  cluster_id: ""
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/d3gt1gce2zmg3d.cloudfront.net/25g02n62rp9aq6vrp2g1oqqhjaiaqgle
  cluster_id: ""
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/d3gt1gce2zmg3d.cloudfront.net/25g5cnet7utdkpcjvhpravculsbq1o3g
  cluster_id: 25g5cnet7utdkpcjvhpravculsbq1o3g
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/d3gt1gce2zmg3d.cloudfront.net/25gfrh3u1vtpvthkrmie9g7ugtbnp0qf
  cluster_id: ""
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/d3gt1gce2zmg3d.cloudfront.net/25h9clhvpjiggealsm3fi7s9fjhp88dl
  cluster_id: ""
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/d3gt1gce2zmg3d.cloudfront.net/25jpakt77c491fdop13he8rftdt41mkd
  cluster_id: ""
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/d3gt1gce2zmg3d.cloudfront.net/25ltsih2bp89sidmilejfkmbjoub58hj
  cluster_id: ""
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/d3gt1gce2zmg3d.cloudfront.net/25ogk5paq1dfnr5carltnmknfnbtb7kf
  cluster_id: ""
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/d3gt1gce2zmg3d.cloudfront.net/25oh7aj7e4qfk9nvdog2q7ib882cd9is
  cluster_id: ""
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/d3gt1gce2zmg3d.cloudfront.net/25ojamqosamg05m1f2r87ld0bncb2bjh
  cluster_id: ""
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/dvbwgdztaeq9o.cloudfront.net/24s6v2kv3sgbr4kci0i61472j7np1h53
  cluster_id: ""
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/oidc-v8x7.s3.us-east-1.amazonaws.com
  cluster_id: ""
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/rh-oidc-dev.s3.us-east-1.amazonaws.com/24k93vsiujlfqorh3l425mq39mgumct1
  cluster_id: 24k93vsiujlfqorh3l425mq39mgumct1
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/rh-oidc-dev.s3.us-east-1.amazonaws.com/24kr1nt0uqfharosibnjdbp9b13go3j5
  cluster_id: 24kr1nt0uqfharosibnjdbp9b13go3j5
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/rh-oidc-dev.s3.us-east-1.amazonaws.com/24lkefie3htt591rlmi67phmubqcbj0d
  cluster_id: 24lkefie3htt591rlmi67phmubqcbj0d
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/rh-oidc-dev.s3.us-east-1.amazonaws.com/24njmjcmp1qlcpl4u6r841r6fjf7d0uh
  cluster_id: 24njmjcmp1qlcpl4u6r841r6fjf7d0uh
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/rh-oidc-dev.s3.us-east-1.amazonaws.com/24o70vfn7srl04e92ficbf6ptmaeaosn
  cluster_id: 24o70vfn7srl04e92ficbf6ptmaeaosn
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/rh-oidc-dev.s3.us-east-1.amazonaws.com/24o8l8ip7n9rfm0gpe930p1cgpo6hrpd
  cluster_id: 24o8l8ip7n9rfm0gpe930p1cgpo6hrpd
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/rh-oidc-dev.s3.us-east-1.amazonaws.com/24oosdbvfkhv6k23c2crgsd5vpedcosa
  cluster_id: 24oosdbvfkhv6k23c2crgsd5vpedcosa
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/rh-oidc-dev.s3.us-east-1.amazonaws.com/24oppmmkdv4t564ukv0amhn5qcromer2
  cluster_id: 24oppmmkdv4t564ukv0amhn5qcromer2
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/rh-oidc-dev.s3.us-east-1.amazonaws.com/24q20nlp6j7vpe3tc5glfl0dacs06093
  cluster_id: ""
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/rh-oidc-dev.s3.us-east-1.amazonaws.com/24q2s0kecea5jtt9ectv297nverj03p2
  cluster_id: 24q2s0kecea5jtt9ectv297nverj03p2
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/rh-oidc-dev.s3.us-east-1.amazonaws.com/24tgcu29bk1uocaeq804j5e0ovalin2f
  cluster_id: ""
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/rh-oidc-dev.s3.us-east-1.amazonaws.com/257tlhikfcs6on3idk4c7mhih77e8884
  cluster_id: ""
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/rh-oidc-dev.s3.us-east-1.amazonaws.com/25cis3050ss5t94s6u5oltdvcmaku7ic
  cluster_id: ""
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/rh-oidc-dev.s3.us-east-1.amazonaws.com/25ctop8l6rleu7cpl688q436t1ipomhi
  cluster_id: ""
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/rh-oidc-dev.s3.us-east-1.amazonaws.com/25hbnbr3doqd768uo8mcdmnpul60rod3
  cluster_id: ""
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/rh-oidc-dev.s3.us-east-1.amazonaws.com/25kihl311v1mmtbai11l59j2u7iuakg7
  cluster_id: ""
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/rh-oidc-dev.s3.us-east-1.amazonaws.com/25oegk0e8ep11vbfb68tm47u0odqo6le
  cluster_id: ""
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/rh-oidc-dev.s3.us-east-1.amazonaws.com/25of98ren2f6nr74vhpm8delbho06bs4
  cluster_id: ""
  in_use: false
- arn: arn:aws:iam::501358428071:oidc-provider/rh-oidc-dev.s3.us-east-1.amazonaws.com/25pnhcvuh7n7hfdci52898bptnr84qi2
  cluster_id: ""
  in_use: false
```