### PR TITLE
OCM-3381 | fix: adjust so that it doesn't show new ingress attributes when not supported

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2548,101 +2548,111 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
-	routeSelector := ""
-	if cmd.Flags().Changed(defaultIngressRouteSelectorFlag) {
-		if isHostedCP {
-			r.Reporter.Errorf("Updating route selectors is not supported for Hosted Control Plane clusters")
-			os.Exit(1)
-		}
-		routeSelector = args.defaultIngressRouteSelectors
-	} else if interactive.Enabled() && !isHostedCP {
-		routeSelectorArg, err := interactive.GetString(interactive.Input{
-			Question: "Route Selector for ingress",
-			Help:     cmd.Flags().Lookup(defaultIngressRouteSelectorFlag).Usage,
-			Default:  args.defaultIngressRouteSelectors,
-			Validators: []interactive.Validator{
-				func(routeSelector interface{}) error {
-					_, err := ingress.GetRouteSelector(routeSelector.(string))
-					return err
-				},
-			},
-		})
-		if err != nil {
-			r.Reporter.Errorf("Expected a valid comma-separated list of attributes: %s", err)
-			os.Exit(1)
-		}
-		routeSelector = routeSelectorArg
-	}
-	routeSelectors, err := ingress.GetRouteSelector(routeSelector)
+	isVersionCompatibleManagedIngressV2, err := versions.IsGreaterThanOrEqual(
+		version, ocm.MinVersionForManagedIngressV2)
 	if err != nil {
-		r.Reporter.Errorf("%s", err)
+		r.Reporter.Errorf("There was a problem checking version compatibility: %v", err)
 		os.Exit(1)
 	}
-
+	routeSelector := ""
+	routeSelectors := map[string]string{}
 	excludedNamespaces := ""
-	if cmd.Flags().Changed(defaultIngressExcludedNamespacesFlag) {
-		if isHostedCP {
-			r.Reporter.Errorf("Updating excluded namespace is not supported for Hosted Control Plane clusters")
-			os.Exit(1)
-		}
-		excludedNamespaces = args.defaultIngressExcludedNamespaces
-	} else if interactive.Enabled() && !isHostedCP {
-		excludedNamespacesArg, err := interactive.GetString(interactive.Input{
-			Question: "Excluded namespaces for ingress",
-			Help:     cmd.Flags().Lookup(defaultIngressExcludedNamespacesFlag).Usage,
-			Default:  args.defaultIngressExcludedNamespaces,
-		})
-		if err != nil {
-			r.Reporter.Errorf("Expected a valid comma-separated list of attributes: %s", err)
-			os.Exit(1)
-		}
-		excludedNamespaces = excludedNamespacesArg
-	}
-	sliceExcludedNamespaces := ingress.GetExcludedNamespaces(excludedNamespaces)
-
+	sliceExcludedNamespaces := []string{}
 	wildcardPolicy := ""
-	if cmd.Flags().Changed(defaultIngressWildcardPolicyFlag) {
-		if isHostedCP {
-			r.Reporter.Errorf("Updating Wildcard Policy is not supported for Hosted Control Plane clusters")
-			os.Exit(1)
-		}
-		wildcardPolicy = args.defaultIngressWildcardPolicy
-	} else {
-		if interactive.Enabled() && !isHostedCP {
-			wildcardPolicyArg, err := interactive.GetOption(interactive.Input{
-				Question: "Wildcard Policy",
-				Options:  ingress.ValidWildcardPolicies,
-				Help:     cmd.Flags().Lookup(defaultIngressWildcardPolicyFlag).Usage,
-				Default:  args.defaultIngressWildcardPolicy,
-			})
-			if err != nil {
-				r.Reporter.Errorf("Expected a valid Wildcard Policy: %s", err)
-				os.Exit(1)
-			}
-			wildcardPolicy = wildcardPolicyArg
-		}
-	}
-
 	namespaceOwnershipPolicy := ""
-	if cmd.Flags().Changed(defaultIngressNamespaceOwnershipPolicyFlag) {
-		if isHostedCP {
-			r.Reporter.Errorf("Updating Namespace Ownership Policy is not supported for Hosted Control Plane clusters")
-			os.Exit(1)
-		}
-		namespaceOwnershipPolicy = args.defaultIngressNamespaceOwnershipPolicy
-	} else {
-		if interactive.Enabled() && !isHostedCP {
-			namespaceOwnershipPolicyArg, err := interactive.GetOption(interactive.Input{
-				Question: "Namespace Ownership Policy",
-				Options:  ingress.ValidNamespaceOwnershipPolicies,
-				Help:     cmd.Flags().Lookup(defaultIngressNamespaceOwnershipPolicyFlag).Usage,
-				Default:  args.defaultIngressNamespaceOwnershipPolicy,
-			})
-			if err != nil {
-				r.Reporter.Errorf("Expected a valid Namespace Ownership Policy: %s", err)
+	if isVersionCompatibleManagedIngressV2 {
+		if cmd.Flags().Changed(defaultIngressRouteSelectorFlag) {
+			if isHostedCP {
+				r.Reporter.Errorf("Updating route selectors is not supported for Hosted Control Plane clusters")
 				os.Exit(1)
 			}
-			namespaceOwnershipPolicy = namespaceOwnershipPolicyArg
+			routeSelector = args.defaultIngressRouteSelectors
+		} else if interactive.Enabled() && !isHostedCP {
+			routeSelectorArg, err := interactive.GetString(interactive.Input{
+				Question: "Route Selector for ingress",
+				Help:     cmd.Flags().Lookup(defaultIngressRouteSelectorFlag).Usage,
+				Default:  args.defaultIngressRouteSelectors,
+				Validators: []interactive.Validator{
+					func(routeSelector interface{}) error {
+						_, err := ingress.GetRouteSelector(routeSelector.(string))
+						return err
+					},
+				},
+			})
+			if err != nil {
+				r.Reporter.Errorf("Expected a valid comma-separated list of attributes: %s", err)
+				os.Exit(1)
+			}
+			routeSelector = routeSelectorArg
+		}
+		routeSelectors, err = ingress.GetRouteSelector(routeSelector)
+		if err != nil {
+			r.Reporter.Errorf("%s", err)
+			os.Exit(1)
+		}
+
+		if cmd.Flags().Changed(defaultIngressExcludedNamespacesFlag) {
+			if isHostedCP {
+				r.Reporter.Errorf("Updating excluded namespace is not supported for Hosted Control Plane clusters")
+				os.Exit(1)
+			}
+			excludedNamespaces = args.defaultIngressExcludedNamespaces
+		} else if interactive.Enabled() && !isHostedCP {
+			excludedNamespacesArg, err := interactive.GetString(interactive.Input{
+				Question: "Excluded namespaces for ingress",
+				Help:     cmd.Flags().Lookup(defaultIngressExcludedNamespacesFlag).Usage,
+				Default:  args.defaultIngressExcludedNamespaces,
+			})
+			if err != nil {
+				r.Reporter.Errorf("Expected a valid comma-separated list of attributes: %s", err)
+				os.Exit(1)
+			}
+			excludedNamespaces = excludedNamespacesArg
+		}
+		sliceExcludedNamespaces = ingress.GetExcludedNamespaces(excludedNamespaces)
+
+		if cmd.Flags().Changed(defaultIngressWildcardPolicyFlag) {
+			if isHostedCP {
+				r.Reporter.Errorf("Updating Wildcard Policy is not supported for Hosted Control Plane clusters")
+				os.Exit(1)
+			}
+			wildcardPolicy = args.defaultIngressWildcardPolicy
+		} else {
+			if interactive.Enabled() && !isHostedCP {
+				wildcardPolicyArg, err := interactive.GetOption(interactive.Input{
+					Question: "Wildcard Policy",
+					Options:  ingress.ValidWildcardPolicies,
+					Help:     cmd.Flags().Lookup(defaultIngressWildcardPolicyFlag).Usage,
+					Default:  args.defaultIngressWildcardPolicy,
+				})
+				if err != nil {
+					r.Reporter.Errorf("Expected a valid Wildcard Policy: %s", err)
+					os.Exit(1)
+				}
+				wildcardPolicy = wildcardPolicyArg
+			}
+		}
+
+		if cmd.Flags().Changed(defaultIngressNamespaceOwnershipPolicyFlag) {
+			if isHostedCP {
+				r.Reporter.Errorf("Updating Namespace Ownership Policy is not supported for Hosted Control Plane clusters")
+				os.Exit(1)
+			}
+			namespaceOwnershipPolicy = args.defaultIngressNamespaceOwnershipPolicy
+		} else {
+			if interactive.Enabled() && !isHostedCP {
+				namespaceOwnershipPolicyArg, err := interactive.GetOption(interactive.Input{
+					Question: "Namespace Ownership Policy",
+					Options:  ingress.ValidNamespaceOwnershipPolicies,
+					Help:     cmd.Flags().Lookup(defaultIngressNamespaceOwnershipPolicyFlag).Usage,
+					Default:  args.defaultIngressNamespaceOwnershipPolicy,
+				})
+				if err != nil {
+					r.Reporter.Errorf("Expected a valid Namespace Ownership Policy: %s", err)
+					os.Exit(1)
+				}
+				namespaceOwnershipPolicy = namespaceOwnershipPolicyArg
+			}
 		}
 	}
 

--- a/pkg/helper/versions/helpers.go
+++ b/pkg/helper/versions/helpers.go
@@ -2,7 +2,9 @@ package versions
 
 import (
 	"fmt"
+	"strings"
 
+	"github.com/hashicorp/go-version"
 	ver "github.com/hashicorp/go-version"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
@@ -104,4 +106,16 @@ func GetMinimalHostedMachinePoolVersion(controlPlaneVersion string) (string, err
 	}
 
 	return version, nil
+}
+
+func IsGreaterThanOrEqual(version1, version2 string) (bool, error) {
+	v1, err := version.NewVersion(strings.TrimPrefix(version1, ocm.VersionPrefix))
+	if err != nil {
+		return false, err
+	}
+	v2, err := version.NewVersion(strings.TrimPrefix(version2, ocm.VersionPrefix))
+	if err != nil {
+		return false, err
+	}
+	return v1.GreaterThanOrEqual(v2), nil
 }

--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -492,7 +492,7 @@ func (c *Client) CheckRoleExists(orgID string, roleName string, awsAccountID str
 }
 
 func GetVersionMinor(ver string) string {
-	rawID := strings.Replace(ver, "openshift-v", "", 1)
+	rawID := strings.Replace(ver, VersionPrefix, "", 1)
 	version, err := semver.NewVersion(rawID)
 	if err != nil {
 		segments := strings.Split(rawID, ".")

--- a/pkg/ocm/versions.go
+++ b/pkg/ocm/versions.go
@@ -36,6 +36,8 @@ const (
 	LowestHttpTokensRequiredSupport = "4.11.0"
 	LowestSTSMinor                  = "4.7"
 	LowestHostedCPSupport           = "4.12.0-0.a" //TODO: Remove the 0.a once stable 4.12 builds are available
+	MinVersionForManagedIngressV2   = "4.14-0"
+	VersionPrefix                   = "openshift-v"
 )
 
 func (c *Client) ManagedServiceVersionInquiry(serviceType string) (string, error) {
@@ -207,7 +209,7 @@ func CreateVersionID(version string, channelGroup string) string {
 }
 
 func GetRawVersionId(versionId string) string {
-	trimmedPrefix := strings.TrimPrefix(versionId, "openshift-v")
+	trimmedPrefix := strings.TrimPrefix(versionId, VersionPrefix)
 	channelSeparator := strings.LastIndex(trimmedPrefix, "-")
 	if channelSeparator > 0 {
 		return trimmedPrefix[:channelSeparator]


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/OCM-3381