### PR TITLE
OCM-3397 Support machine pools with zero replicas on day two

### DIFF
--- a/cmd/create/machinepool/nodepool.go
+++ b/cmd/create/machinepool/nodepool.go
@@ -155,7 +155,7 @@ func addNodePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster, r
 				Default:  minReplicas,
 				Required: true,
 				Validators: []interactive.Validator{
-					machinepools.MinNodePoolReplicaValidator(),
+					machinepools.MinNodePoolReplicaValidator(true),
 				},
 			})
 			if err != nil {
@@ -163,7 +163,7 @@ func addNodePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster, r
 				os.Exit(1)
 			}
 		}
-		err = machinepools.MinNodePoolReplicaValidator()(minReplicas)
+		err = machinepools.MinNodePoolReplicaValidator(true)(minReplicas)
 		if err != nil {
 			r.Reporter.Errorf("%s", err)
 			os.Exit(1)
@@ -202,7 +202,7 @@ func addNodePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster, r
 				Default:  replicas,
 				Required: true,
 				Validators: []interactive.Validator{
-					machinepools.MinNodePoolReplicaValidator(),
+					machinepools.MinNodePoolReplicaValidator(false),
 				},
 			})
 			if err != nil {
@@ -210,7 +210,7 @@ func addNodePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster, r
 				os.Exit(1)
 			}
 		}
-		err = machinepools.MinNodePoolReplicaValidator()(replicas)
+		err = machinepools.MinNodePoolReplicaValidator(false)(replicas)
 		if err != nil {
 			r.Reporter.Errorf("%s", err)
 			os.Exit(1)

--- a/cmd/edit/machinepool/nodepool.go
+++ b/cmd/edit/machinepool/nodepool.go
@@ -52,9 +52,13 @@ func editNodePool(cmd *cobra.Command, nodePoolID string, clusterKey string, clus
 	autoscaling, replicas, minReplicas, maxReplicas := getNodePoolReplicas(cmd, r.Reporter, nodePoolID,
 		nodePool.Replicas(), nodePool.Autoscaling(), isAnyAdditionalParameterSet)
 
-	if !autoscaling && replicas < 1 ||
-		(autoscaling && cmd.Flags().Changed("min-replicas") && minReplicas < 1) {
-		r.Reporter.Errorf("The number of machine pool replicas needs to be greater than zero")
+	if !autoscaling && replicas < 0 {
+		r.Reporter.Errorf("The number of machine pool replicas needs to be a non-negative integer")
+		os.Exit(1)
+	}
+
+	if autoscaling && cmd.Flags().Changed("min-replicas") && minReplicas < 1 {
+		r.Reporter.Errorf("The number of machine pool min-replicas needs to be greater than zero")
 		os.Exit(1)
 	}
 
@@ -234,7 +238,7 @@ func getNodePoolReplicas(cmd *cobra.Command,
 				Default:  existingAutoscaling.MinReplica(),
 				Required: replicasRequired,
 				Validators: []interactive.Validator{
-					machinepools.MinNodePoolReplicaValidator(),
+					machinepools.MinNodePoolReplicaValidator(true),
 				},
 			})
 			if err != nil {
@@ -273,7 +277,7 @@ func getNodePoolReplicas(cmd *cobra.Command,
 			Default:  replicas,
 			Required: true,
 			Validators: []interactive.Validator{
-				machinepools.MinNodePoolReplicaValidator(),
+				machinepools.MinNodePoolReplicaValidator(false),
 			},
 		})
 		if err != nil {

--- a/pkg/helper/machinepools/helpers.go
+++ b/pkg/helper/machinepools/helpers.go
@@ -14,14 +14,20 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 )
 
-func MinNodePoolReplicaValidator() interactive.Validator {
+func MinNodePoolReplicaValidator(autoscaling bool) interactive.Validator {
 	return func(val interface{}) error {
 		minReplicas, err := strconv.Atoi(fmt.Sprintf("%v", val))
 		if err != nil {
 			return err
 		}
-		if minReplicas < 1 {
-			return fmt.Errorf("min-replicas must be greater than zero")
+		if autoscaling {
+			if minReplicas < 1 {
+				return fmt.Errorf("min-replicas must be greater than zero")
+			}
+		} else {
+			if minReplicas < 0 {
+				return fmt.Errorf("replicas must be a non-negative integer")
+			}
 		}
 		return nil
 	}

--- a/pkg/helper/machinepools/helpers_test.go
+++ b/pkg/helper/machinepools/helpers_test.go
@@ -48,3 +48,36 @@ var _ = Describe("MachinePool", func() {
 			"Invalid label value 'node-role.kubernetes.io/infra': at key: 'key'", 0),
 	)
 })
+
+var _ = Describe("Machine pool for hosted clusters", func() {
+	DescribeTable("Machine pool replicas validation",
+		func(minReplicas int, autoscaling bool, hasError bool) {
+			err := MinNodePoolReplicaValidator(autoscaling)(minReplicas)
+			if hasError {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).ToNot(HaveOccurred())
+			}
+		},
+		Entry("Zero replicas - no autoscaling",
+			0,
+			false,
+			false,
+		),
+		Entry("Negative replicas - no autoscaling",
+			-1,
+			false,
+			true,
+		),
+		Entry("Zero replicas - autoscaling",
+			0,
+			true,
+			true,
+		),
+		Entry("One replicas - autoscaling",
+			1,
+			true,
+			false,
+		),
+	)
+})


### PR DESCRIPTION
As part of https://issues.redhat.com/browse/OCM-2522 backend work.

This PR updates the validation of machine pool replicas for hosted clusters on day 2.

Non autoscaling machine pools support zero replicas, meanwhile, machine pools with autoscaling must validate at least one replica.

Related to https://issues.redhat.com/browse/OCM-3397