### PR TITLE
OCM-3439 | fix: add info message to create account roles

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -369,7 +369,7 @@ func run(cmd *cobra.Command, argv []string) {
 		isHostedCPValueSet = true
 	}
 
-	rolesCreator, createRoles := initCreator(managedPolicies, createClassic, createHostedCP,
+	rolesCreator, createRoles := initCreator(r, managedPolicies, createClassic, createHostedCP,
 		isClassicValueSet, isHostedCPValueSet)
 	if !createRoles {
 		os.Exit(1)

--- a/cmd/create/accountroles/creators.go
+++ b/cmd/create/accountroles/creators.go
@@ -16,7 +16,7 @@ type creator interface {
 	printCommands(*rosa.Runtime, *accountRolesCreationInput) error
 }
 
-func initCreator(managedPolicies bool, classic bool, hostedCP bool, isClassicValueSet bool,
+func initCreator(r *rosa.Runtime, managedPolicies bool, classic bool, hostedCP bool, isClassicValueSet bool,
 	isHostedCPValueSet bool) (creator, bool) {
 	// Classic ROSA managed policies
 	if managedPolicies && !hostedCP {
@@ -25,6 +25,9 @@ func initCreator(managedPolicies bool, classic bool, hostedCP bool, isClassicVal
 
 	// If the user didn't select topologies (default flow creates both), or selected both topologies
 	if !isClassicValueSet && !isHostedCPValueSet || hostedCP && classic {
+		r.Reporter.Infof("By default, the create account-roles command creates two sets of account roles, " +
+			"one for classic ROSA clusters, and one for Hosted Control Plane clusters." +
+			"\nIn order to create a single set, please set one of the following flags: --classic or --hosted-cp")
 		return &doubleRolesCreator{}, true
 	}
 


### PR DESCRIPTION
Provide more info to the user about the command default flow.

![image](https://github.com/openshift/rosa/assets/57869309/5fdd5d72-086b-48d9-8964-009f9c93426f)
