### PR TITLE
OCM-3428 | fix: inform user about visibility change impact in interactive mode

### DIFF
--- a/cmd/edit/cluster/cmd.go
+++ b/cmd/edit/cluster/cmd.go
@@ -239,7 +239,7 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 	if interactive.Enabled() {
 		privateValue, err = interactive.GetBool(interactive.Input{
-			Question: "Private cluster",
+			Question: "Private cluster, check this command's help for possible impacts",
 			Help:     fmt.Sprintf("%s %s", cmd.Flags().Lookup("private").Usage, privateWarning),
 			Default:  privateValue,
 		})


### PR DESCRIPTION
The warning is always displayed in non interactive mode, so this help user discover the possible impacts of this change.

Current form
```
Private cluster (optional): [? for help] (y/N)
```

After this change
```
Private cluster, check this command's help for possible impacts (optional): [? for help] (y/N)
```

Related: [OCM-3428](https://issues.redhat.com//browse/OCM-3428)