### PR TITLE
OCM-3478 | fix: automatic control plane upgrade when no update is available

### DIFF
--- a/cmd/upgrade/cluster/cmd.go
+++ b/cmd/upgrade/cluster/cmd.go
@@ -291,11 +291,11 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	if len(availableUpgrades) == 0 {
-		r.Reporter.Warnf("There are no available upgrades")
-		return nil
-	}
 	if !currentUpgradeScheduling.AutomaticUpgrades {
+		if len(availableUpgrades) == 0 {
+			r.Reporter.Warnf("There are no available upgrades")
+			return nil
+		}
 		err = r.OCMClient.CheckUpgradeClusterVersion(availableUpgrades, version, cluster)
 		if err != nil {
 			return fmt.Errorf("%v", err)


### PR DESCRIPTION
we should be able to schedule an automatic control plane upgrade even if no upgrade is currently available.
Improve testing to cover this scenario and remove hardcoded JSON for easier mantainance.

Related: [OCM-3478](https://issues.redhat.com//browse/OCM-3478)