### PR TITLE
OCM-3473 | fix: create operator-roles for shared VPC

### DIFF
--- a/cmd/create/operatorroles/common_utils.go
+++ b/cmd/create/operatorroles/common_utils.go
@@ -2,9 +2,14 @@ package operatorroles
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/rosa"
+	errors "github.com/zgalor/weberr"
 )
+
+const assumePolicyAction = "AssumeRole"
 
 func computePolicyARN(accountID string, prefix string, namespace string, name string, path string) string {
 	if prefix == "" {
@@ -18,4 +23,31 @@ func computePolicyARN(accountID string, prefix string, namespace string, name st
 		return fmt.Sprintf("arn:%s:iam::%s:policy%s%s", aws.GetPartition(), accountID, path, policy)
 	}
 	return fmt.Sprintf("arn:%s:iam::%s:policy/%s", aws.GetPartition(), accountID, policy)
+}
+
+func validateIngressOperatorPolicyOverride(r *rosa.Runtime, policyArn string, sharedVpcRoleArn string,
+	installerRolePrefix string) error {
+	_, err := r.AWSClient.IsPolicyExists(policyArn)
+	policyExists := err == nil
+	if !policyExists {
+		return nil
+	}
+
+	policyDocument, err := r.AWSClient.GetDefaultPolicyDocument(policyArn)
+	if err != nil {
+		return err
+	}
+
+	// The policy associated with the installer role. In the case it contains a different shared VPC role ARN,
+	// don't override it.
+	if strings.Contains(policyDocument, assumePolicyAction) && !strings.Contains(policyDocument, sharedVpcRoleArn) {
+		return errors.UserErrorf("Policy with ARN '%s' contains 'sts:AssumeRole' action with different shared VPC role ARN "+
+			"than '%s'."+
+			"\nThe policy is associated with the installer role with the prefix '%s'."+
+			"\nTo create operator roles with shared vpc role ARN '%s', "+
+			"please provide a different value for '--installer-role-arn'.",
+			policyArn, sharedVpcRoleArn, installerRolePrefix, sharedVpcRoleArn)
+	}
+
+	return nil
 }

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -185,6 +185,7 @@ type Client interface {
 	DeleteSecretInSecretsManager(secretArn string) error
 	ValidateAccountRoleVersionCompatibility(
 		roleName string, roleType string, minVersion string) (bool, error)
+	GetDefaultPolicyDocument(policyArn string) (string, error)
 }
 
 // ClientBuilder contains the information and logic needed to build a new AWS client.


### PR DESCRIPTION
Operator roles' policies are associated with the installer role prefix. In case the operator role policy already has `sts:AssumeRole` action with shared VPC role ARN, and the user provides a different shared VPC role ARN, error out, and guide the user to use a different account role ARN.

**Note:** Currently the command overrides the shared VPC role ARN value with the value provided by the user.

Examples:
1. User create operator roles outside of the shared VPC scope:
![image](https://github.com/openshift/rosa/assets/57869309/6c68583e-d244-42be-acca-84e2745a0609)
![image](https://github.com/openshift/rosa/assets/57869309/1f848954-cade-4f03-9ef5-e461facb4ea1)
2. User overrides the policy created in [1], while creating operator roles with shared VPC role ARN:
(A new policy version is created with a `sts:AssumeRole` permission)
![image](https://github.com/openshift/rosa/assets/57869309/d1a8f886-1751-465f-a20f-99af194c0785)
![image](https://github.com/openshift/rosa/assets/57869309/6c1e5864-26d5-46fc-82cc-6f938e06d856)
3. The user tries to create operator roles with the same installer role from [2] with a different **shared-vpc-role-arn** and is prompted to use a different installer role:
![image](https://github.com/openshift/rosa/assets/57869309/317a964c-ade4-432d-8baf-8237cc083cdb)
4. The user is using a different role ARN, and creates successfully the operator roles:
![image](https://github.com/openshift/rosa/assets/57869309/a1e7f119-7235-4cc4-b79c-79b8179ae758)
![image](https://github.com/openshift/rosa/assets/57869309/69947bfd-8d2c-467c-9a55-2c8d43165a04)
