### PR TITLE
OCM-3375 | feat: Add 'Workload Monitoring' to describe/cluster

### DIFF
--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -179,13 +179,13 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
-	workloadMonitoring, ok := cluster.GetDisableUserWorkloadMonitoring()
-	isWorkloadMonitoringEnabled := "Disabled"
+	workloadMonitoringDisabled, ok := cluster.GetDisableUserWorkloadMonitoring()
+	isWorkloadMonitoringEnabled := "Enabled"
 	if !ok {
 		isWorkloadMonitoringEnabled = "Unknown"
 	}
-	if workloadMonitoring {
-		isWorkloadMonitoringEnabled = "Enabled"
+	if workloadMonitoringDisabled {
+		isWorkloadMonitoringEnabled = "Disabled"
 	}
 
 	// Print short cluster description:

--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -179,6 +179,15 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
+	workloadMonitoring, ok := cluster.GetDisableUserWorkloadMonitoring()
+	isWorkloadMonitoringEnabled := "Disabled"
+	if !ok {
+		isWorkloadMonitoringEnabled = "Unknown"
+	}
+	if workloadMonitoring {
+		isWorkloadMonitoringEnabled = "Enabled"
+	}
+
 	// Print short cluster description:
 	str = fmt.Sprintf("\n"+
 		"Name:                       %s\n"+
@@ -200,7 +209,8 @@ func run(cmd *cobra.Command, argv []string) {
 		" - Service CIDR:            %s\n"+
 		" - Machine CIDR:            %s\n"+
 		" - Pod CIDR:                %s\n"+
-		" - Host Prefix:             /%d\n",
+		" - Host Prefix:             /%d\n"+
+		"Workload Monitoring:        %s\n",
 		clusterName,
 		cluster.ID(),
 		cluster.ExternalID(),
@@ -220,6 +230,7 @@ func run(cmd *cobra.Command, argv []string) {
 		cluster.Network().MachineCIDR(),
 		cluster.Network().PodCIDR(),
 		cluster.Network().HostPrefix(),
+		isWorkloadMonitoringEnabled,
 	)
 
 	if cluster.InfraID() != "" {

--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -180,13 +180,12 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	workloadMonitoringDisabled, ok := cluster.GetDisableUserWorkloadMonitoring()
-	workloadMonitoringStr := ""
 	if ok {
 		isWorkloadMonitoringEnabled := "Enabled"
 		if workloadMonitoringDisabled {
 			isWorkloadMonitoringEnabled = "Disabled"
 		}
-		workloadMonitoringStr = fmt.Sprintf("Workload Monitoring:        %s\n", isWorkloadMonitoringEnabled)
+		str = fmt.Sprintf("Workload Monitoring:        %s\n", isWorkloadMonitoringEnabled)
 	}
 
 	// Print short cluster description:
@@ -231,7 +230,7 @@ func run(cmd *cobra.Command, argv []string) {
 		cluster.Network().MachineCIDR(),
 		cluster.Network().PodCIDR(),
 		cluster.Network().HostPrefix(),
-		workloadMonitoringStr,
+		str,
 	)
 
 	if cluster.InfraID() != "" {

--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -180,12 +180,13 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	workloadMonitoringDisabled, ok := cluster.GetDisableUserWorkloadMonitoring()
-	isWorkloadMonitoringEnabled := "Enabled"
-	if !ok {
-		isWorkloadMonitoringEnabled = "Unknown"
-	}
-	if workloadMonitoringDisabled {
-		isWorkloadMonitoringEnabled = "Disabled"
+	workloadMonitoringStr := ""
+	if ok {
+		isWorkloadMonitoringEnabled := "Enabled"
+		if workloadMonitoringDisabled {
+			isWorkloadMonitoringEnabled = "Disabled"
+		}
+		workloadMonitoringStr = fmt.Sprintf("Workload Monitoring:        %s\n", isWorkloadMonitoringEnabled)
 	}
 
 	// Print short cluster description:
@@ -210,7 +211,7 @@ func run(cmd *cobra.Command, argv []string) {
 		" - Machine CIDR:            %s\n"+
 		" - Pod CIDR:                %s\n"+
 		" - Host Prefix:             /%d\n"+
-		"Workload Monitoring:        %s\n",
+		"%s",
 		clusterName,
 		cluster.ID(),
 		cluster.ExternalID(),
@@ -230,7 +231,7 @@ func run(cmd *cobra.Command, argv []string) {
 		cluster.Network().MachineCIDR(),
 		cluster.Network().PodCIDR(),
 		cluster.Network().HostPrefix(),
-		isWorkloadMonitoringEnabled,
+		workloadMonitoringStr,
 	)
 
 	if cluster.InfraID() != "" {


### PR DESCRIPTION


Workload monitoring will either say `Enabled` if it is enabled, `Disabled` if it is disabled, or `Unknown` if the check fails for whatever reason