### PR TITLE
OCM-1478 | fix: Moved getMode to top of cluster creation so it checks mode firstly

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -935,6 +935,13 @@ func run(cmd *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
 
+	// Validate mode
+	mode, err := aws.GetMode()
+	if err != nil {
+		r.Reporter.Errorf("%s", err)
+		os.Exit(1)
+	}
+
 	// validate flags for cluster admin
 	isHostedCP := args.hostedClusterEnabled
 	clusterAdminUser := strings.Trim(args.clusterAdminUser, " \t")
@@ -1245,12 +1252,6 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 	if err := ocm.ValidateHttpTokensVersion(ocm.GetVersionMinor(version), httpTokens); err != nil {
 		r.Reporter.Errorf(err.Error())
-		os.Exit(1)
-	}
-
-	mode, err := aws.GetMode()
-	if err != nil {
-		r.Reporter.Errorf("%s", err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
In case of invalid mode, the command will not be run

```
./rosa create cluster --sts --mode atuo
E: Invalid mode. Allowed values are [auto manual]
```