### PR TITLE
OCM-2898 | fix: more accuracy to --worker-disk-size

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -829,7 +829,8 @@ func init() {
 	flags.StringVar(&args.machinePoolRootDiskSize,
 		"worker-disk-size",
 		"",
-		"Machine pool root disk size with a **unit suffix** like GiB or TiB, e.g. 200GiB.")
+		"Default worker machine pool root disk size with a **unit suffix** like GiB or TiB, "+
+			"e.g. 200GiB.")
 
 	flags.StringVar(
 		&args.billingAccount,


### PR DESCRIPTION
We clarify the "usage" description of the flag '--worker-disk-size' to highligh that this is affecting the default worker machine pool.

Signed-off-by: Sébastien Han <seb@redhat.com>