### PR TITLE
OCM-3535 | fix: set max-nodes-total default value to 180

### DIFF
--- a/pkg/clusterautoscaler/flags.go
+++ b/pkg/clusterautoscaler/flags.go
@@ -135,7 +135,7 @@ func AddClusterAutoscalerFlags(cmd *pflag.FlagSet, prefix string) *AutoscalerArg
 	cmd.IntVar(
 		&args.ResourceLimits.MaxNodesTotal,
 		fmt.Sprintf("%s%s", prefix, maxNodesTotalFlag),
-		1000,
+		180,
 		"Total amount of nodes that can exist in the cluster, including non-scaled nodes.",
 	)
 


### PR DESCRIPTION
1000 is way over the number of nodes we're currently supporting in OpenShift (it's rather 180 for most versions).

Changing the value to make it more sensible.