### PR TITLE
OCM-3574 | fix: cores range validation

### DIFF
--- a/pkg/clusterautoscaler/flags.go
+++ b/pkg/clusterautoscaler/flags.go
@@ -468,7 +468,7 @@ func GetAutoscalerOptions(
 			Default:  result.ResourceLimits.Cores.Max,
 			Validators: []interactive.Validator{
 				ocm.NonNegativeIntValidator,
-				getValidMaxRangeValidator(result.ResourceLimits.Cores.Max),
+				getValidMaxRangeValidator(result.ResourceLimits.Cores.Min),
 			},
 		})
 		if err != nil {


### PR DESCRIPTION
When creating autoscaler interactively, the cores range is being compared wrongly. For example, when given the value 99 it will try to compare it with the default value of 100:

```
$ rosa create cluster 
...
? Maximum number of cores to deploy in cluster: [? for help] (100)
<giving it 99>
X Sorry, your reply was invalid: max value must be greater or equal than
min value 100.
```

FYI @sunzhaohua2 
/cc @gdbranco @ciaranRoche 