### PR TITLE
OCM-3580 | fix: Validation issues of configuring autoscaler interactively

### DIFF
--- a/pkg/clusterautoscaler/flags.go
+++ b/pkg/clusterautoscaler/flags.go
@@ -340,7 +340,7 @@ func GetAutoscalerOptions(
 			Default:  result.LogVerbosity,
 			Required: false,
 			Validators: []interactive.Validator{
-				ocm.IntValidator,
+				ocm.NonNegativeIntValidator,
 			},
 		})
 		if err != nil {
@@ -406,6 +406,9 @@ func GetAutoscalerOptions(
 			Help:     cmd.Lookup(fmt.Sprintf("%s%s", prefix, maxPodGracePeriodFlag)).Usage,
 			Required: false,
 			Default:  result.MaxPodGracePeriod,
+			Validators: []interactive.Validator{
+				ocm.NonNegativeIntValidator,
+			},
 		})
 		if err != nil {
 			return nil, err
@@ -418,6 +421,9 @@ func GetAutoscalerOptions(
 			Help:     cmd.Lookup(fmt.Sprintf("%s%s", prefix, podPriorityThresholdFlag)).Usage,
 			Required: false,
 			Default:  result.PodPriorityThreshold,
+			Validators: []interactive.Validator{
+				ocm.IntValidator,
+			},
 		})
 		if err != nil {
 			return nil, err

--- a/pkg/ocm/validators.go
+++ b/pkg/ocm/validators.go
@@ -2,8 +2,8 @@ package ocm
 
 import (
 	"fmt"
-	"regexp"
 	"strconv"
+	"time"
 )
 
 func IntValidator(val interface{}) error {
@@ -40,14 +40,8 @@ func DurationStringValidator(val interface{}) error {
 		return fmt.Errorf("Can only validate strings, got %v", val)
 	}
 
-	re := regexp.MustCompile("^([0-9]+(.[0-9]+)?(ns|us|µs|ms|s|m|h))+$")
-	regexPass := re.MatchString(input)
-	if !regexPass {
-		return fmt.Errorf("Expecting an integer plus unit of time (without spaces). " +
-			"Options for time units include: ns, us, µs, ms, s, m, h. Examples: 2000000ns, 180s, 2m, etc.")
-	}
-	return nil
-
+	_, err := time.ParseDuration(input)
+	return err
 }
 
 func PercentageValidator(val interface{}) error {


### PR DESCRIPTION
* pod-priority-threshold was missing integer validation interactively.
* log verbosity wasn't validated to be a non-negative number interactively. same goes for maximum-pod-grace-period
* duration strings validation wasn't properly catching issues like in "1 00m". changed the code to just try doing the parsing using golang's stdlib