### PR TITLE
OCM-3313 | feat: add 'rosa edit autoscaler' command

### DIFF
--- a/cmd/edit/autoscaler/cmd.go
+++ b/cmd/edit/autoscaler/cmd.go
@@ -1,0 +1,152 @@
+/*
+Copyright (c) 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autoscaler
+
+import (
+	"os"
+	"strconv"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/clusterautoscaler"
+	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+var Cmd = &cobra.Command{
+	Use:     "autoscaler",
+	Aliases: []string{"cluster-autoscaler"},
+	Short:   "Edit the autoscaler of a cluster",
+	Long: "Configuring cluster-wide autoscaling behavior. At least one machine-pool should " +
+		"have autoscaling enabled for the configuration to be active",
+	Example: `  # Interactively edit an autoscaler to a cluster named "mycluster"
+  rosa edit autoscaler --cluster=mycluster --interactive
+
+  # Create a cluster-autoscaler where it should skip nodes with local storage
+  rosa create autoscaler --cluster=mycluster --skip-nodes-with-local-storage
+
+  # Create a cluster-autoscaler with log verbosity of '3'
+  rosa create autoscaler --cluster=mycluster --log-verbosity 3
+
+  # Create a cluster-autoscaler with total CPU constraints
+  rosa create autoscaler --cluster=mycluster --min-cores 10 --max-cores 100`,
+	Run: run, // TODO: fix the examples
+}
+
+var autoscalerArgs *clusterautoscaler.AutoscalerArgs
+
+func init() {
+	flags := Cmd.Flags()
+	flags.SortFlags = false
+
+	ocm.AddClusterFlag(Cmd)
+	interactive.AddFlag(flags)
+	autoscalerArgs = clusterautoscaler.AddClusterAutoscalerFlags(flags, "")
+}
+
+func run(cmd *cobra.Command, _ []string) {
+	r := rosa.NewRuntime().WithOCM()
+	defer r.Cleanup()
+
+	clusterKey := r.GetClusterKey()
+
+	cluster := r.FetchCluster()
+	if cluster.State() != cmv1.ClusterStateReady {
+		r.Reporter.Errorf("Cluster '%s' is not yet ready. Current state is '%s'", clusterKey, cluster.State())
+		os.Exit(1)
+	}
+
+	autoscaler, err := r.OCMClient.GetClusterAutoscaler(cluster.ID())
+	if err != nil {
+		r.Reporter.Errorf("Failed updating autoscaler configuration for cluster '%s': %s",
+			cluster.ID(), err)
+		os.Exit(1)
+	}
+
+	if autoscaler == nil {
+		r.Reporter.Errorf("No autoscaler for cluster '%s' has been found. "+
+			"You should first create it via 'rosa create autoscaler'", clusterKey)
+		os.Exit(1)
+	}
+
+	if !clusterautoscaler.IsAutoscalerSetViaCLI(cmd.Flags()) && !interactive.Enabled() {
+		interactive.Enable()
+		r.Reporter.Infof("Enabling interactive mode")
+	}
+
+	r.Reporter.Debugf("Updating autoscaler for cluster '%s'", clusterKey)
+
+	if interactive.Enabled() {
+		// pre-filling the parameters from the existing resource if running in interactive mode
+
+		autoscalerArgs.BalanceSimilarNodeGroups = autoscaler.BalanceSimilarNodeGroups()
+		autoscalerArgs.SkipNodesWithLocalStorage = autoscaler.SkipNodesWithLocalStorage()
+		autoscalerArgs.LogVerbosity = autoscaler.LogVerbosity()
+		autoscalerArgs.MaxPodGracePeriod = autoscaler.MaxPodGracePeriod()
+		autoscalerArgs.PodPriorityThreshold = autoscaler.PodPriorityThreshold()
+		autoscalerArgs.IgnoreDaemonsetsUtilization = autoscaler.IgnoreDaemonsetsUtilization()
+		autoscalerArgs.MaxNodeProvisionTime = autoscaler.MaxNodeProvisionTime()
+		autoscalerArgs.BalancingIgnoredLabels = autoscaler.BalancingIgnoredLabels()
+		autoscalerArgs.ResourceLimits.MaxNodesTotal = autoscaler.ResourceLimits().MaxNodesTotal()
+		autoscalerArgs.ResourceLimits.Cores.Min = autoscaler.ResourceLimits().Cores().Min()
+		autoscalerArgs.ResourceLimits.Cores.Max = autoscaler.ResourceLimits().Cores().Max()
+		autoscalerArgs.ResourceLimits.Memory.Min = autoscaler.ResourceLimits().Memory().Min()
+		autoscalerArgs.ResourceLimits.Memory.Max = autoscaler.ResourceLimits().Memory().Max()
+
+		// be aware we cannot easily pre-load GPU limits from existing configuration, so we'll have to
+		// request it from scratch when interactive mode is on
+
+		autoscalerArgs.ScaleDown.Enabled = autoscaler.ScaleDown().Enabled()
+		autoscalerArgs.ScaleDown.UnneededTime = autoscaler.ScaleDown().UnneededTime()
+		autoscalerArgs.ScaleDown.DelayAfterAdd = autoscaler.ScaleDown().DelayAfterAdd()
+		autoscalerArgs.ScaleDown.DelayAfterDelete = autoscaler.ScaleDown().DelayAfterDelete()
+		autoscalerArgs.ScaleDown.DelayAfterFailure = autoscaler.ScaleDown().DelayAfterFailure()
+
+		utilizationThreshold, err := strconv.ParseFloat(autoscaler.ScaleDown().UtilizationThreshold(), 64)
+		if err != nil {
+			r.Reporter.Errorf("Failed updating autoscaler configuration for cluster '%s': %s",
+				cluster.ID(), err)
+			os.Exit(1)
+		}
+		autoscalerArgs.ScaleDown.UtilizationThreshold = utilizationThreshold
+	}
+
+	autoscalerArgs, err := clusterautoscaler.GetAutoscalerOptions(cmd.Flags(), "", false, autoscalerArgs)
+	if err != nil {
+		r.Reporter.Errorf("Failed updating autoscaler configuration for cluster '%s': %s",
+			cluster.ID(), err)
+		os.Exit(1)
+	}
+
+	autoscalerConfig, err := clusterautoscaler.CreateAutoscalerConfig(autoscalerArgs)
+	if err != nil {
+		r.Reporter.Errorf("Failed updating autoscaler configuration for cluster '%s': %s",
+			cluster.ID(), err)
+		os.Exit(1)
+	}
+
+	_, err = r.OCMClient.UpdateClusterAutoscaler(cluster.ID(), autoscalerConfig)
+	if err != nil {
+		r.Reporter.Errorf("Failed updating autoscaler configuration for cluster '%s': %s",
+			cluster.ID(), err)
+		os.Exit(1)
+	}
+
+	r.Reporter.Infof("Successfully updated autoscaler configuration for cluster '%s'", cluster.ID())
+}

--- a/cmd/edit/cmd.go
+++ b/cmd/edit/cmd.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/cmd/edit/addon"
+	"github.com/openshift/rosa/cmd/edit/autoscaler"
 	"github.com/openshift/rosa/cmd/edit/cluster"
 	"github.com/openshift/rosa/cmd/edit/ingress"
 	"github.com/openshift/rosa/cmd/edit/machinepool"
@@ -43,6 +44,7 @@ func init() {
 	Cmd.AddCommand(machinepool.Cmd)
 	Cmd.AddCommand(service.Cmd)
 	Cmd.AddCommand(tuningconfigs.Cmd)
+	Cmd.AddCommand(autoscaler.Cmd)
 
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)

--- a/pkg/clusterautoscaler/flags.go
+++ b/pkg/clusterautoscaler/flags.go
@@ -366,7 +366,7 @@ func GetAutoscalerOptions(
 		balancingIgnoredLabels, err := interactive.GetString(interactive.Input{
 			Question: "Labels that cluster autoscaler should ignore when considering node group similarity",
 			Help:     cmd.Lookup(fmt.Sprintf("%s%s", prefix, balancingIgnoredLabelsFlag)).Usage,
-			Default:  result.BalancingIgnoredLabels,
+			Default:  strings.Join(result.BalancingIgnoredLabels, ","),
 			Required: false,
 			Validators: []interactive.Validator{
 				ocm.ValidateBalancingIgnoredLabels,
@@ -381,7 +381,7 @@ func GetAutoscalerOptions(
 		}
 	}
 
-	if interactive.Enabled() && !isAutoscalerIgnoreDaemonsetsUtilizationSet && !result.IgnoreDaemonsetsUtilization {
+	if interactive.Enabled() && !isAutoscalerIgnoreDaemonsetsUtilizationSet {
 		result.IgnoreDaemonsetsUtilization, err = interactive.GetBool(interactive.Input{
 			Question: "Ignore daemonsets utilization",
 			Help:     cmd.Lookup(fmt.Sprintf("%s%s", prefix, ignoreDaemonsetsUtilizationFlag)).Usage,
@@ -411,7 +411,7 @@ func GetAutoscalerOptions(
 		return nil, err
 	}
 
-	if interactive.Enabled() && result.MaxPodGracePeriod == 0 && !isAutoscalerMaxPodGracePeriodSet {
+	if interactive.Enabled() && !isAutoscalerMaxPodGracePeriodSet {
 		result.MaxPodGracePeriod, err = interactive.GetInt(interactive.Input{
 			Question: "Maximum pod grace period",
 			Help:     cmd.Lookup(fmt.Sprintf("%s%s", prefix, maxPodGracePeriodFlag)).Usage,
@@ -426,7 +426,7 @@ func GetAutoscalerOptions(
 		}
 	}
 
-	if interactive.Enabled() && result.PodPriorityThreshold == 0 && !isAutoscalerPodPriorityThresholdSet {
+	if interactive.Enabled() && !isAutoscalerPodPriorityThresholdSet {
 		result.PodPriorityThreshold, err = interactive.GetInt(interactive.Input{
 			Question: "Pod priority threshold",
 			Help:     cmd.Lookup(fmt.Sprintf("%s%s", prefix, podPriorityThresholdFlag)).Usage,
@@ -600,7 +600,7 @@ func GetAutoscalerOptions(
 
 	// scale-down configs
 
-	if interactive.Enabled() && !result.ScaleDown.Enabled && !isScaleDownEnabledSet {
+	if interactive.Enabled() && !isScaleDownEnabledSet {
 		result.ScaleDown.Enabled, err = interactive.GetBool(interactive.Input{
 			Question: "Should scale-down be enabled",
 			Help:     cmd.Lookup(fmt.Sprintf("%s%s", prefix, scaleDownEnabledFlag)).Usage,
@@ -612,7 +612,7 @@ func GetAutoscalerOptions(
 		}
 	}
 
-	if interactive.Enabled() && !isScaleDownUnneededTimeSet && result.ScaleDown.UnneededTime == "" {
+	if interactive.Enabled() && !isScaleDownUnneededTimeSet {
 		result.ScaleDown.UnneededTime, err = interactive.GetString(interactive.Input{
 			Question: "How long a node should be unneeded before it is eligible for scale down",
 			Help:     cmd.Lookup(fmt.Sprintf("%s%s", prefix, scaleDownUnneededTimeFlag)).Usage,

--- a/pkg/interactive/interactive.go
+++ b/pkg/interactive/interactive.go
@@ -73,7 +73,7 @@ func GetInt(input Input) (a int, err error) {
 		dflt = 0
 	}
 	dfltStr := fmt.Sprintf("%d", dflt)
-	if dfltStr == "0" {
+	if dfltStr == "0" && input.Required {
 		dfltStr = ""
 	}
 	question := input.Question


### PR DESCRIPTION
Adding the option to edit an autoscaler for a cluster as a day2 operation, in two ways:

* Via CLI options, e.g.:
```
rosa edit autoscaler --cluster=mycluster
    --balance-similar-node-groups
    --log-verbosity 3
...
```
* Interactively. If user used `-i` or `--interactive` or provided no argument of autoscaler configuration, then the different options will be requested one-by-one. For example:
```
$ rosa edit autoscaler --cluster=mycluster
I: Enabling interactive mode
? Balance similar node groups (optional): Yes
? Skip nodes with local storage (optional): [? for help] (y/N)
...
```