### PR TITLE
[OCM-2907] Add support for json/yaml output format on all "rosa list" commands

### DIFF
--- a/cmd/list/accountroles/cmd.go
+++ b/cmd/list/accountroles/cmd.go
@@ -93,16 +93,17 @@ func run(_ *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
-	if len(accountRoles) == 0 {
-		r.Reporter.Infof("No account roles available")
-		os.Exit(0)
-	}
 	if output.HasFlag() {
 		err = output.Print(accountRoles)
 		if err != nil {
 			r.Reporter.Errorf("%s", err)
 			os.Exit(1)
 		}
+		os.Exit(0)
+	}
+
+	if len(accountRoles) == 0 {
+		r.Reporter.Infof("No account roles available")
 		os.Exit(0)
 	}
 

--- a/cmd/list/instancetypes/cmd.go
+++ b/cmd/list/instancetypes/cmd.go
@@ -54,11 +54,6 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
-	if len(machineTypes.Items) == 0 {
-		r.Reporter.Warnf("There are no machine types supported for your account. Contact Red Hat support.")
-		os.Exit(1)
-	}
-
 	if output.HasFlag() {
 		var instanceTypes []*cmv1.MachineType
 		for _, machine := range machineTypes.Items {
@@ -70,6 +65,11 @@ func run(cmd *cobra.Command, _ []string) {
 			os.Exit(1)
 		}
 		os.Exit(0)
+	}
+
+	if len(machineTypes.Items) == 0 {
+		r.Reporter.Warnf("There are no machine types supported for your account. Contact Red Hat support.")
+		os.Exit(1)
 	}
 
 	// Create the writer that will be used to print the tabulated results:

--- a/cmd/list/machinepool/nodepool.go
+++ b/cmd/list/machinepool/nodepool.go
@@ -8,6 +8,7 @@ import (
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/rosa"
 )
 
@@ -18,6 +19,15 @@ func listNodePools(r *rosa.Runtime, clusterKey string, cluster *cmv1.Cluster) {
 	if err != nil {
 		r.Reporter.Errorf("Failed to get machine pools for cluster '%s': %v", clusterKey, err)
 		os.Exit(1)
+	}
+
+	if output.HasFlag() {
+		err = output.Print(nodePools)
+		if err != nil {
+			r.Reporter.Errorf("%s", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
 	}
 
 	// Create the writer that will be used to print the tabulated results:

--- a/cmd/list/ocmroles/cmd.go
+++ b/cmd/list/ocmroles/cmd.go
@@ -69,16 +69,17 @@ func run(_ *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
-	if len(ocmRoles) == 0 {
-		r.Reporter.Infof("No ocm roles available")
-		os.Exit(0)
-	}
 	if output.HasFlag() {
 		err = output.Print(ocmRoles)
 		if err != nil {
 			r.Reporter.Errorf("%s", err)
 			os.Exit(1)
 		}
+		os.Exit(0)
+	}
+
+	if len(ocmRoles) == 0 {
+		r.Reporter.Infof("No ocm roles available")
 		os.Exit(0)
 	}
 
@@ -100,8 +101,14 @@ func run(_ *cobra.Command, _ []string) {
 
 func listOCMRoles(r *rosa.Runtime) ([]aws.Role, error) {
 	ocmRoles, err := r.AWSClient.ListOCMRoles()
+
 	if err != nil {
 		return nil, err
+	}
+
+	// If there are no roles, return an empty slice to the caller and avoid additional work
+	if len(ocmRoles) == 0 {
+		return []aws.Role{}, nil
 	}
 
 	// Check if roles are linked to organization

--- a/cmd/list/oidcprovider/cmd.go
+++ b/cmd/list/oidcprovider/cmd.go
@@ -68,6 +68,7 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	providers, err := r.AWSClient.ListOidcProviders(clusterId)
+
 	if spin != nil {
 		spin.Stop()
 	}
@@ -76,10 +77,6 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
-	if len(providers) == 0 {
-		r.Reporter.Infof("No OIDC providers available")
-		os.Exit(0)
-	}
 	providersInUse := map[string]bool{}
 	for _, provider := range providers {
 		resourceName, err := aws.GetResourceIdFromOidcProviderARN(provider.Arn)
@@ -96,6 +93,7 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 		providersInUse[provider.Arn] = has
 	}
+
 	if output.HasFlag() {
 		outList := []map[string]interface{}{}
 		for _, provider := range providers {
@@ -107,6 +105,11 @@ func run(cmd *cobra.Command, _ []string) {
 			r.Reporter.Errorf("%s", err)
 			os.Exit(1)
 		}
+		os.Exit(0)
+	}
+
+	if len(providers) == 0 {
+		r.Reporter.Infof("No OIDC providers available")
 		os.Exit(0)
 	}
 

--- a/cmd/list/region/cmd.go
+++ b/cmd/list/region/cmd.go
@@ -105,11 +105,6 @@ func run(cmd *cobra.Command, _ []string) {
 		availableRegions = append(availableRegions, region)
 	}
 
-	if len(availableRegions) == 0 {
-		r.Reporter.Warnf("There are no regions available for this AWS account")
-		os.Exit(1)
-	}
-
 	if output.HasFlag() {
 		err = output.Print(availableRegions)
 		if err != nil {
@@ -117,6 +112,11 @@ func run(cmd *cobra.Command, _ []string) {
 			os.Exit(1)
 		}
 		os.Exit(0)
+	}
+
+	if len(availableRegions) == 0 {
+		r.Reporter.Warnf("There are no regions available for this AWS account")
+		os.Exit(1)
 	}
 
 	// Create the writer that will be used to print the tabulated results:

--- a/cmd/list/upgrade/cmd.go
+++ b/cmd/list/upgrade/cmd.go
@@ -29,6 +29,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/rosa"
 )
 
@@ -58,6 +59,7 @@ func init() {
 	)
 
 	confirm.AddFlag(flags)
+	output.AddFlag(Cmd)
 }
 
 func run(cmd *cobra.Command, _ []string) {
@@ -117,6 +119,16 @@ func runWithRuntime(r *rosa.Runtime, _ *cobra.Command) error {
 			r.Reporter.Infof("There are no available upgrades for cluster '%s'", clusterKey)
 			return nil
 		}
+	}
+
+	if output.HasFlag() {
+		err := output.Print(availableUpgrades)
+		if err != nil {
+			r.Reporter.Errorf("%s", err)
+			os.Exit(1)
+		}
+
+		os.Exit(0)
 	}
 
 	latestRev := latestInCurrentMinor(ocm.GetVersionID(cluster), availableUpgrades)

--- a/cmd/list/userroles/cmd.go
+++ b/cmd/list/userroles/cmd.go
@@ -66,16 +66,17 @@ func run(_ *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
-	if len(userRoles) == 0 {
-		r.Reporter.Infof("No user roles available")
-		os.Exit(0)
-	}
 	if output.HasFlag() {
 		err = output.Print(userRoles)
 		if err != nil {
 			r.Reporter.Errorf("%s", err)
 			os.Exit(1)
 		}
+		os.Exit(0)
+	}
+
+	if len(userRoles) == 0 {
+		r.Reporter.Infof("No user roles available")
 		os.Exit(0)
 	}
 
@@ -92,6 +93,11 @@ func listUserRoles(r *rosa.Runtime) ([]aws.Role, error) {
 	userRoles, err := r.AWSClient.ListUserRoles()
 	if err != nil {
 		return nil, err
+	}
+
+	// If no roles available, return empty slice to avoid further work
+	if len(userRoles) == 0 {
+		return []aws.Role{}, nil
 	}
 
 	// Check if roles are linked to account

--- a/cmd/list/version/cmd.go
+++ b/cmd/list/version/cmd.go
@@ -85,11 +85,6 @@ func run(cmd *cobra.Command, _ []string) {
 		availableVersions = append(availableVersions, version)
 	}
 
-	if len(availableVersions) == 0 {
-		r.Reporter.Warnf("There are no OpenShift versions available")
-		os.Exit(1)
-	}
-
 	if output.HasFlag() {
 		err = output.Print(availableVersions)
 		if err != nil {
@@ -97,6 +92,11 @@ func run(cmd *cobra.Command, _ []string) {
 			os.Exit(1)
 		}
 		os.Exit(0)
+	}
+
+	if len(availableVersions) == 0 {
+		r.Reporter.Warnf("There are no OpenShift versions available")
+		os.Exit(1)
 	}
 
 	// Create the writer that will be used to print the tabulated results:

--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -1,8 +1,6 @@
 package aws
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -413,20 +411,6 @@ func GetTagValues(tagsValue []*iam.Tag) (roleType string, version string) {
 		}
 	}
 	return
-}
-
-func MarshalRoles(role []Role, b *bytes.Buffer) error {
-	reqBodyBytes := new(bytes.Buffer)
-	json.NewEncoder(reqBodyBytes).Encode(role)
-	return prettyPrint(reqBodyBytes, b)
-}
-
-func prettyPrint(reqBodyBytes *bytes.Buffer, b *bytes.Buffer) error {
-	err := json.Indent(b, reqBodyBytes.Bytes(), "", "  ")
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 func GetRoleName(prefix string, role string) string {


### PR DESCRIPTION
This PR adds support for the `-o` output flag on all `rosa list` commands. The following approach has been taken when working through this:

- When the user specifies the `-o` flag, we prefer to print the raw API response and do not include any interpretation of the data provided by the tabulated output if the user does not use the `-o` flag
- If there are no results returned by the list command, we ensure an empty JSON array or YAML list is returned and not a log message saying "there are no results"