### PR TITLE
OCM-3609 | feat: Disable prompt & flag for HCP while using a govcloud account

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -188,6 +188,7 @@ func run(cmd *cobra.Command, argv []string) {
 	callerIdentityOutput, err := r.AWSClient.GetCallerIdentity()
 	if err != nil {
 		r.Reporter.Warnf("Unable to get AWS Caller Identity.")
+		os.Exit(1)
 	}
 
 	callerIsGovcloud := false

--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -204,6 +204,7 @@ func run(cmd *cobra.Command, argv []string) {
 
 	if cmd.Flags().Changed("hosted-cp") && callerIsGovcloud {
 		r.Reporter.Errorf("Setting `hosted-cp` is not supported for Govcloud AWS accounts")
+		os.Exit(1)
 	}
 
 	// Validate AWS credentials for current user

--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -183,18 +183,12 @@ func run(cmd *cobra.Command, argv []string) {
 			"any supported ROSA version can be installed with managed policies")
 	}
 
-	callerIsGovcloud := false
-
-	if r.Creator.IsGovcloud {
-		callerIsGovcloud = true
-	}
-
 	// Hosted cluster roles always use managed policies
 	if cmd.Flags().Changed("hosted-cp") && cmd.Flags().Changed("managed-policies") && !args.managed {
 		r.Reporter.Errorf("Setting `hosted-cp` as unmanaged policies is not supported")
 	}
 
-	if cmd.Flags().Changed("hosted-cp") && callerIsGovcloud {
+	if cmd.Flags().Changed("hosted-cp") && r.Creator.IsGovcloud {
 		r.Reporter.Errorf("Setting `hosted-cp` is not supported for Govcloud AWS accounts")
 		os.Exit(1)
 	}
@@ -366,7 +360,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	createHostedCP := args.hostedCP
-	if interactive.Enabled() && !cmd.Flags().Changed("hosted-cp") && !callerIsGovcloud {
+	if interactive.Enabled() && !cmd.Flags().Changed("hosted-cp") && !r.Creator.IsGovcloud {
 		createHostedCP, err = interactive.GetBool(interactive.Input{
 			Question: "Create Hosted CP account roles",
 			Help:     cmd.Flags().Lookup("hosted-cp").Usage,

--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -183,16 +183,9 @@ func run(cmd *cobra.Command, argv []string) {
 			"any supported ROSA version can be installed with managed policies")
 	}
 
-	// Check whether or not AWS account is govcloud
-	callerIdentityOutput, err := r.AWSClient.GetCallerIdentity()
-	if err != nil {
-		r.Reporter.Warnf("Unable to get AWS Caller Identity.")
-		os.Exit(1)
-	}
-
 	callerIsGovcloud := false
 
-	if r.AWSClient.StringValue(callerIdentityOutput.Arn)[:14] == "arn:aws-us-gov" {
+	if r.Creator.IsGovcloud {
 		callerIsGovcloud = true
 	}
 

--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -182,6 +182,8 @@ func run(cmd *cobra.Command, argv []string) {
 			"any supported ROSA version can be installed with managed policies")
 	}
 
+	r.WithAWS()
+
 	// Check whether or not AWS account is govcloud
 	callerIdentityOutput, err := r.AWSClient.GetCallerIdentity()
 	if err != nil {
@@ -203,7 +205,6 @@ func run(cmd *cobra.Command, argv []string) {
 		r.Reporter.Errorf("Setting `hosted-cp` is not supported for Govcloud AWS accounts")
 	}
 
-	r.WithAWS()
 	// Validate AWS credentials for current user
 	if r.Reporter.IsTerminal() {
 		r.Reporter.Infof("Validating AWS credentials...")

--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -140,6 +140,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) {
 	r := rosa.NewRuntime()
+	r.WithAWS()
 
 	mode, err := aws.GetMode()
 	if err != nil {
@@ -182,8 +183,6 @@ func run(cmd *cobra.Command, argv []string) {
 			"any supported ROSA version can be installed with managed policies")
 	}
 
-	r.WithAWS()
-
 	// Check whether or not AWS account is govcloud
 	callerIdentityOutput, err := r.AWSClient.GetCallerIdentity()
 	if err != nil {
@@ -193,7 +192,7 @@ func run(cmd *cobra.Command, argv []string) {
 
 	callerIsGovcloud := false
 
-	if (*callerIdentityOutput.Arn)[:14] == "arn:aws-us-gov" {
+	if r.AWSClient.StringValue(callerIdentityOutput.Arn)[:14] == "arn:aws-us-gov" {
 		callerIsGovcloud = true
 	}
 

--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -139,8 +139,7 @@ func init() {
 }
 
 func run(cmd *cobra.Command, argv []string) {
-	r := rosa.NewRuntime()
-	r.WithAWS()
+	r := rosa.NewRuntime().WithAWS()
 
 	mode, err := aws.GetMode()
 	if err != nil {

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -71,6 +71,8 @@ const (
 	DefaultRegion = "us-east-1"
 	Inline        = "inline"
 	Attached      = "attached"
+
+	govPartition = "aws-us-gov"
 )
 
 // addROSAVersionToUserAgent is a named handler that will add ROSA CLI
@@ -612,10 +614,7 @@ func (c *awsClient) GetCreator() (*Creator, error) {
 		creatorARN = *stsRole
 	}
 
-	isGovcloud := false
-	if creatorParsedARN.Partition == "aws-us-gov" {
-		isGovcloud = true
-	}
+	isGovcloud := creatorParsedARN.Partition == govPartition
 
 	return &Creator{
 		ARN:        creatorARN,

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -186,6 +186,7 @@ type Client interface {
 	ValidateAccountRoleVersionCompatibility(
 		roleName string, roleType string, minVersion string) (bool, error)
 	GetDefaultPolicyDocument(policyArn string) (string, error)
+	GetCallerIdentity() (*sts.GetCallerIdentityOutput, error)
 }
 
 // ClientBuilder contains the information and logic needed to build a new AWS client.
@@ -1132,6 +1133,10 @@ func (c *awsClient) DeleteSecretInSecretsManager(secretArn string) error {
 		return err
 	}
 	return nil
+}
+
+func (c *awsClient) GetCallerIdentity() (*sts.GetCallerIdentityOutput, error) {
+	return c.stsClient.GetCallerIdentity(&sts.GetCallerIdentityInput{})
 }
 
 // CustomRetryer wraps the aws SDK's built in DefaultRetryer allowing for

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -187,6 +187,7 @@ type Client interface {
 		roleName string, roleType string, minVersion string) (bool, error)
 	GetDefaultPolicyDocument(policyArn string) (string, error)
 	GetCallerIdentity() (*sts.GetCallerIdentityOutput, error)
+	StringValue(str *string) string
 }
 
 // ClientBuilder contains the information and logic needed to build a new AWS client.
@@ -1137,6 +1138,10 @@ func (c *awsClient) DeleteSecretInSecretsManager(secretArn string) error {
 
 func (c *awsClient) GetCallerIdentity() (*sts.GetCallerIdentityOutput, error) {
 	return c.stsClient.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+}
+
+func (c *awsClient) StringValue(str *string) string {
+	return aws.StringValue(str)
 }
 
 // CustomRetryer wraps the aws SDK's built in DefaultRetryer allowing for


### PR DESCRIPTION
This MR accomplishes 2 things with `create accountroles`:

1. Return an error when AWS caller is a govcloud account
2. Disable prompt for asking if user if they'd like to create HCP roles when AWS caller is a govcloud account