### PR TITLE
OCM-3640 | fix: autoscaler created when not enabled

### DIFF
--- a/cmd/create/autoscaler/cmd.go
+++ b/cmd/create/autoscaler/cmd.go
@@ -28,6 +28,8 @@ import (
 	"github.com/openshift/rosa/pkg/rosa"
 )
 
+const argsPrefix string = ""
+
 var Cmd = &cobra.Command{
 	Use:     "autoscaler",
 	Aliases: []string{"cluster-autoscaler"},
@@ -56,7 +58,7 @@ func init() {
 
 	ocm.AddClusterFlag(Cmd)
 	interactive.AddFlag(flags)
-	autoscalerArgs = clusterautoscaler.AddClusterAutoscalerFlags(flags, "")
+	autoscalerArgs = clusterautoscaler.AddClusterAutoscalerFlags(flags, argsPrefix)
 }
 
 func run(cmd *cobra.Command, _ []string) {
@@ -84,7 +86,7 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
-	if !clusterautoscaler.IsAutoscalerSetViaCLI(cmd.Flags()) && !interactive.Enabled() {
+	if !clusterautoscaler.IsAutoscalerSetViaCLI(cmd.Flags(), argsPrefix) && !interactive.Enabled() {
 		interactive.Enable()
 		r.Reporter.Infof("Enabling interactive mode")
 	}

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2092,7 +2092,10 @@ func run(cmd *cobra.Command, _ []string) {
 		isHostedCP,
 		multiAZ)
 
-	if autoscaling {
+	var clusterAutoscaler *clusterautoscaler.AutoscalerArgs
+	if !autoscaling {
+		clusterAutoscaler = nil
+	} else {
 		// if the user set compute-nodes and enabled autoscaling
 		if isReplicasSet {
 			r.Reporter.Errorf("Compute-nodes can't be set when autoscaling is enabled")
@@ -2140,7 +2143,7 @@ func run(cmd *cobra.Command, _ []string) {
 			os.Exit(1)
 		}
 
-		autoscalerArgs, err = clusterautoscaler.GetAutoscalerOptions(
+		clusterAutoscaler, err = clusterautoscaler.GetAutoscalerOptions(
 			cmd.Flags(), clusterAutoscalerFlagsPrefix, true, autoscalerArgs)
 		if err != nil {
 			r.Reporter.Errorf("%s", err)
@@ -2749,8 +2752,8 @@ func run(cmd *cobra.Command, _ []string) {
 		clusterConfig.SharedVPCRoleArn = sharedVPCRoleARN
 		clusterConfig.BaseDomain = baseDomain
 	}
-	if autoscalerArgs != nil {
-		autoscalerConfig, err := clusterautoscaler.CreateAutoscalerConfig(autoscalerArgs)
+	if clusterAutoscaler != nil {
+		autoscalerConfig, err := clusterautoscaler.CreateAutoscalerConfig(clusterAutoscaler)
 		if err != nil {
 			r.Reporter.Errorf("Failed creating autoscaler configuration: %s", err)
 			os.Exit(1)

--- a/cmd/edit/autoscaler/cmd.go
+++ b/cmd/edit/autoscaler/cmd.go
@@ -29,6 +29,8 @@ import (
 	"github.com/openshift/rosa/pkg/rosa"
 )
 
+const argsPrefix string = ""
+
 var Cmd = &cobra.Command{
 	Use:     "autoscaler",
 	Aliases: []string{"cluster-autoscaler"},
@@ -57,7 +59,7 @@ func init() {
 
 	ocm.AddClusterFlag(Cmd)
 	interactive.AddFlag(flags)
-	autoscalerArgs = clusterautoscaler.AddClusterAutoscalerFlags(flags, "")
+	autoscalerArgs = clusterautoscaler.AddClusterAutoscalerFlags(flags, argsPrefix)
 }
 
 func run(cmd *cobra.Command, _ []string) {
@@ -85,7 +87,7 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
-	if !clusterautoscaler.IsAutoscalerSetViaCLI(cmd.Flags()) && !interactive.Enabled() {
+	if !clusterautoscaler.IsAutoscalerSetViaCLI(cmd.Flags(), argsPrefix) && !interactive.Enabled() {
 		interactive.Enable()
 		r.Reporter.Infof("Enabling interactive mode")
 	}


### PR DESCRIPTION
When not enabling autoscaling feature, the cluster-autoscaler is still being created due to us not unsetting the autoscaler configuration for that case.

Also, we were missing including the prefix for the arguments, which made us miss detecting that autoscaler options were used. This should also be fixed now.