### PR TITLE
OCM-3650 | fix: negative durations are allowed

### DIFF
--- a/pkg/clusterautoscaler/flags.go
+++ b/pkg/clusterautoscaler/flags.go
@@ -400,14 +400,14 @@ func GetAutoscalerOptions(
 			Required: false,
 			Default:  result.MaxNodeProvisionTime,
 			Validators: []interactive.Validator{
-				ocm.DurationStringValidator,
+				ocm.PositiveDurationStringValidator,
 			},
 		})
 		if err != nil {
 			return nil, err
 		}
 	}
-	if err := ocm.DurationStringValidator(result.MaxNodeProvisionTime); err != nil {
+	if err := ocm.PositiveDurationStringValidator(result.MaxNodeProvisionTime); err != nil {
 		return nil, err
 	}
 
@@ -619,14 +619,14 @@ func GetAutoscalerOptions(
 			Default:  result.ScaleDown.UnneededTime,
 			Required: false,
 			Validators: []interactive.Validator{
-				ocm.DurationStringValidator,
+				ocm.PositiveDurationStringValidator,
 			},
 		})
 		if err != nil {
 			return nil, err
 		}
 
-		if err := ocm.DurationStringValidator(result.ScaleDown.UnneededTime); err != nil {
+		if err := ocm.PositiveDurationStringValidator(result.ScaleDown.UnneededTime); err != nil {
 			return nil, err
 		}
 	}
@@ -653,7 +653,7 @@ func GetAutoscalerOptions(
 			Default:  result.ScaleDown.DelayAfterAdd,
 			Required: false,
 			Validators: []interactive.Validator{
-				ocm.DurationStringValidator,
+				ocm.PositiveDurationStringValidator,
 			},
 		})
 		if err != nil {
@@ -661,7 +661,7 @@ func GetAutoscalerOptions(
 		}
 	}
 
-	if err := ocm.DurationStringValidator(result.ScaleDown.DelayAfterAdd); err != nil {
+	if err := ocm.PositiveDurationStringValidator(result.ScaleDown.DelayAfterAdd); err != nil {
 		return nil, err
 	}
 
@@ -672,14 +672,14 @@ func GetAutoscalerOptions(
 			Default:  result.ScaleDown.DelayAfterDelete,
 			Required: false,
 			Validators: []interactive.Validator{
-				ocm.DurationStringValidator,
+				ocm.PositiveDurationStringValidator,
 			},
 		})
 		if err != nil {
 			return nil, err
 		}
 
-		if err := ocm.DurationStringValidator(result.ScaleDown.DelayAfterDelete); err != nil {
+		if err := ocm.PositiveDurationStringValidator(result.ScaleDown.DelayAfterDelete); err != nil {
 			return nil, err
 		}
 	}
@@ -691,14 +691,14 @@ func GetAutoscalerOptions(
 			Default:  result.ScaleDown.DelayAfterFailure,
 			Required: false,
 			Validators: []interactive.Validator{
-				ocm.DurationStringValidator,
+				ocm.PositiveDurationStringValidator,
 			},
 		})
 		if err != nil {
 			return nil, err
 		}
 
-		if err := ocm.DurationStringValidator(result.ScaleDown.DelayAfterFailure); err != nil {
+		if err := ocm.PositiveDurationStringValidator(result.ScaleDown.DelayAfterFailure); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/ocm/validators.go
+++ b/pkg/ocm/validators.go
@@ -30,7 +30,7 @@ func NonNegativeIntValidator(val interface{}) error {
 	return nil
 }
 
-func DurationStringValidator(val interface{}) error {
+func PositiveDurationStringValidator(val interface{}) error {
 	if val == "" {
 		return nil
 	}
@@ -40,8 +40,17 @@ func DurationStringValidator(val interface{}) error {
 		return fmt.Errorf("Can only validate strings, got %v", val)
 	}
 
-	_, err := time.ParseDuration(input)
-	return err
+	duration, err := time.ParseDuration(input)
+
+	if err != nil {
+		return err
+	}
+
+	if duration < 0 {
+		return fmt.Errorf("Only positive durations are allowed, got '%v'", val)
+	}
+
+	return nil
 }
 
 func PercentageValidator(val interface{}) error {

--- a/pkg/ocm/validators_test.go
+++ b/pkg/ocm/validators_test.go
@@ -48,15 +48,19 @@ var _ = Describe("Input Validators", Ordered, func() {
 
 	Context("duration string validator", func() {
 		It("succeeds if got an empty string", func() {
-			Expect(DurationStringValidator("")).To(BeNil())
+			Expect(PositiveDurationStringValidator("")).To(BeNil())
 		})
 
 		It("raises an error if the format is wrong", func() {
-			Expect(DurationStringValidator("something")).ToNot(BeNil())
+			Expect(PositiveDurationStringValidator("something")).ToNot(BeNil())
+		})
+
+		It("raises an error if got a negative duration", func() {
+			Expect(PositiveDurationStringValidator("-1h")).ToNot(BeNil())
 		})
 
 		It("successfully parses a valid duration string", func() {
-			Expect(DurationStringValidator("200h")).To(BeNil())
+			Expect(PositiveDurationStringValidator("200h")).To(BeNil())
 		})
 	})
 


### PR DESCRIPTION
Make it impossible to use negative duration strings, as they are not allowed in our fields.