### PR TITLE
OCM-3643 | fix: check if autoscaler already exists before creation

### DIFF
--- a/cmd/create/autoscaler/cmd.go
+++ b/cmd/create/autoscaler/cmd.go
@@ -71,6 +71,19 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
+	autoscaler, err := r.OCMClient.GetClusterAutoscaler(cluster.ID())
+	if err != nil {
+		r.Reporter.Errorf("Failed getting autoscaler configuration for cluster '%s': %s",
+			cluster.ID(), err)
+		os.Exit(1)
+	}
+
+	if autoscaler != nil {
+		r.Reporter.Errorf("Autoscaler for cluster '%s' already exists. "+
+			"You should edit it via 'rosa edit autoscaler'", clusterKey)
+		os.Exit(1)
+	}
+
 	if !clusterautoscaler.IsAutoscalerSetViaCLI(cmd.Flags()) && !interactive.Enabled() {
 		interactive.Enable()
 		r.Reporter.Infof("Enabling interactive mode")


### PR DESCRIPTION
Instead of getting the error from the server, we can check for autoscaler existance right at the start.