### PR TITLE
OCM-3616 | fix: resource limits range defaults

### DIFF
--- a/pkg/clusterautoscaler/flags.go
+++ b/pkg/clusterautoscaler/flags.go
@@ -172,7 +172,7 @@ func AddClusterAutoscalerFlags(cmd *pflag.FlagSet, prefix string) *AutoscalerArg
 	cmd.IntVar(
 		&args.ResourceLimits.Cores.Max,
 		fmt.Sprintf("%s%s", prefix, maxCoresFlag),
-		100,
+		180*64,
 		"Maximum limit for the amount of cores to deploy in the cluster.",
 	)
 
@@ -186,7 +186,7 @@ func AddClusterAutoscalerFlags(cmd *pflag.FlagSet, prefix string) *AutoscalerArg
 	cmd.IntVar(
 		&args.ResourceLimits.Memory.Max,
 		fmt.Sprintf("%s%s", prefix, maxMemoryFlag),
-		4096,
+		180*64*20,
 		"Maximum limit for the amount of memory, in GiB, in the cluster.",
 	)
 


### PR DESCRIPTION
Trying to be more similar to the kubernetes default values, but instead we allow 180 nodes in OCM clusters rather than 5000 in kubernetes.

See: https://github.com/kubernetes/autoscaler/blob/632512c9dfdf18caebd55a9652d455c6c68ad496/cluster-autoscaler/config/const.go#L20-L23