### PR TITLE
OCM-3677 | fix: cluster-autoscaler enabled for HCP

### DIFF
--- a/cmd/create/autoscaler/cmd.go
+++ b/cmd/create/autoscaler/cmd.go
@@ -68,6 +68,12 @@ func run(cmd *cobra.Command, _ []string) {
 	clusterKey := r.GetClusterKey()
 
 	cluster := r.FetchCluster()
+
+	if cluster.Hypershift().Enabled() {
+		r.Reporter.Errorf("Hosted Control Plane clusters do not support cluster-autoscaler configuration")
+		os.Exit(1)
+	}
+
 	if cluster.State() != cmv1.ClusterStateReady {
 		r.Reporter.Errorf("Cluster '%s' is not yet ready. Current state is '%s'", clusterKey, cluster.State())
 		os.Exit(1)

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2143,11 +2143,18 @@ func run(cmd *cobra.Command, _ []string) {
 			os.Exit(1)
 		}
 
-		clusterAutoscaler, err = clusterautoscaler.GetAutoscalerOptions(
-			cmd.Flags(), clusterAutoscalerFlagsPrefix, true, autoscalerArgs)
-		if err != nil {
-			r.Reporter.Errorf("%s", err)
-			os.Exit(1)
+		if isHostedCP {
+			if clusterautoscaler.IsAutoscalerSetViaCLI(cmd.Flags(), clusterAutoscalerFlagsPrefix) {
+				r.Reporter.Errorf("Hosted Control Plane clusters do not support cluster-autoscaler configuration")
+				os.Exit(1)
+			}
+		} else {
+			clusterAutoscaler, err = clusterautoscaler.GetAutoscalerOptions(
+				cmd.Flags(), clusterAutoscalerFlagsPrefix, true, autoscalerArgs)
+			if err != nil {
+				r.Reporter.Errorf("%s", err)
+				os.Exit(1)
+			}
 		}
 	}
 

--- a/cmd/dlt/autoscaler/cmd.go
+++ b/cmd/dlt/autoscaler/cmd.go
@@ -46,6 +46,11 @@ func run(cmd *cobra.Command, _ []string) {
 	clusterKey := r.GetClusterKey()
 	cluster := r.FetchCluster()
 
+	if cluster.Hypershift().Enabled() {
+		r.Reporter.Errorf("Hosted Control Plane clusters do not support cluster-autoscaler configuration")
+		os.Exit(1)
+	}
+
 	r.Reporter.Debugf("Deleting autoscaler for cluster '%s''", clusterKey)
 
 	err := r.OCMClient.DeleteClusterAutoscaler(cluster.ID())

--- a/cmd/edit/autoscaler/cmd.go
+++ b/cmd/edit/autoscaler/cmd.go
@@ -69,6 +69,12 @@ func run(cmd *cobra.Command, _ []string) {
 	clusterKey := r.GetClusterKey()
 
 	cluster := r.FetchCluster()
+
+	if cluster.Hypershift().Enabled() {
+		r.Reporter.Errorf("Hosted Control Plane clusters do not support cluster-autoscaler configuration")
+		os.Exit(1)
+	}
+
 	if cluster.State() != cmv1.ClusterStateReady {
 		r.Reporter.Errorf("Cluster '%s' is not yet ready. Current state is '%s'", clusterKey, cluster.State())
 		os.Exit(1)


### PR DESCRIPTION
When creating a HCP cluster, or when handling it in day2 operations, `rosa`` CLI allows handling of cluster-autoscaler resource even though it's not yet supported.

This displays an error and exits the program for those cases.