### PR TITLE
OCM-2385 | fix: Allow users to reset machinepool labels in interactive mode

### DIFF
--- a/pkg/helper/machinepools/helpers.go
+++ b/pkg/helper/machinepools/helpers.go
@@ -14,6 +14,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 )
 
+// To clear existing labels in interactive mode, the user enters "" as an empty list value
+const interactiveModeEmptyLabels = `""`
+
 func MinNodePoolReplicaValidator(autoscaling bool) interactive.Validator {
 	return func(val interface{}) error {
 		minReplicas, err := strconv.Atoi(fmt.Sprintf("%v", val))
@@ -48,9 +51,10 @@ func MaxNodePoolReplicaValidator(minReplicas int) interactive.Validator {
 
 func ParseLabels(labels string) (map[string]string, error) {
 	labelMap := make(map[string]string)
-	if labels == "" {
+	if labels == "" || labels == interactiveModeEmptyLabels {
 		return labelMap, nil
 	}
+
 	for _, label := range strings.Split(labels, ",") {
 		if !strings.Contains(label, "=") {
 			return nil, fmt.Errorf("Expected key=value format for labels")

--- a/pkg/helper/machinepools/helpers_test.go
+++ b/pkg/helper/machinepools/helpers_test.go
@@ -47,6 +47,40 @@ var _ = Describe("MachinePool", func() {
 			"key=node-role.kubernetes.io/infra:NoEffect",
 			"Invalid label value 'node-role.kubernetes.io/infra': at key: 'key'", 0),
 	)
+
+	DescribeTable("Parse Labels", func(userLabels, expectedError string, numberOfLabels int) {
+		labels, err := ParseLabels(userLabels)
+		if expectedError == "" {
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(labels)).To(Equal(numberOfLabels))
+		} else {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(expectedError))
+		}
+	},
+		Entry("Empty Labels are parsed correctly",
+			"", "", 0,
+		),
+		Entry("Resetting labels in interactive mode is parsed correctly",
+			`""`, "", 0,
+		),
+		Entry("Single label is parsed correctly",
+			"com.example.foo=bar", "", 1,
+		),
+		Entry("Multiple labels are parsed correctly",
+			"com.example.foo=bar,com.example.baz=bob", "", 2,
+		),
+		Entry("Labels with no value are parsed correctly",
+			"com.example.foo=,com.example.baz=bob", "", 2,
+		),
+		Entry("Duplicate labels are not supported",
+			"com.example.foo=bar,com.example.foo=bob", "Duplicated label key 'com.example.foo' used", 0,
+		),
+		Entry("Malformed labels are not supported",
+			"com.example.foo,com.example.bar=bob", "Expected key=value format for labels", 0,
+		),
+	)
+
 })
 
 var _ = Describe("Machine pool for hosted clusters", func() {


### PR DESCRIPTION
This PR allows users to remove all existing labels on a MachinePool when using interactive mode on the CLI. It aligns functionality with normal mode where the user passes an empty string  `""` to remove all existing labels e.g `rosa update machinepool -c rblake-test --labels="" mp-1`

Existing labels on a MachinePool can now be removed by the user by entering the `""` string in interactive mode when prompted for the new labels.