### PR TITLE
OCM-3267 | feat: Add interactive mode for shared VPC

### DIFF
--- a/cmd/create/cluster/shared_vpc.go
+++ b/cmd/create/cluster/shared_vpc.go
@@ -1,0 +1,96 @@
+package cluster
+
+import (
+	"fmt"
+
+	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/rosa"
+	"github.com/spf13/cobra"
+	errors "github.com/zgalor/weberr"
+)
+
+func isSubnetBelongToSharedVpc(r *rosa.Runtime, accountID string, subnetIDs []string,
+	mapSubnetIDToSubnet map[string]aws.Subnet) bool {
+	for _, subnetID := range subnetIDs {
+		ownerID := mapSubnetIDToSubnet[subnetID].OwnerID
+		if ownerID != "" && ownerID != accountID {
+			r.Reporter.Infof(fmt.Sprintf("Subnet with ID '%s' is shared by AWS account '%s', "+
+				"Defaulting to installing a cluster into a shared VPC.", subnetID, ownerID))
+			return true
+		}
+	}
+
+	return false
+}
+
+func getPrivateHostedZoneID(cmd *cobra.Command, privateHostedZoneID string) (string, error) {
+	res, err := interactive.GetString(interactive.Input{
+		Question: "Private hosted zone ID",
+		Help:     cmd.Flags().Lookup("private-hosted-zone-id").Usage,
+		Default:  privateHostedZoneID,
+		Required: true,
+	})
+	if err != nil {
+		return "", errors.Errorf("Expected a valid value for 'private-hosted-zone-id': %s", err)
+	}
+
+	return res, nil
+}
+
+func getSharedVpcRoleArn(cmd *cobra.Command, sharedVpcRoleArn string) (string, error) {
+	res, err := interactive.GetString(interactive.Input{
+		Question: "Shared VPC role ARN",
+		Help:     cmd.Flags().Lookup("shared-vpc-role-arn").Usage,
+		Default:  sharedVpcRoleArn,
+		Required: true,
+		Validators: []interactive.Validator{
+			aws.ARNValidator,
+		},
+	})
+	if err != nil {
+		return "", errors.Errorf("Expected a valid value for 'shared-vpc-role-arn': %s", err)
+	}
+
+	return res, nil
+}
+
+func getBaseDomain(r *rosa.Runtime, cmd *cobra.Command, baseDomain string) (string, error) {
+	dnsDomains, err := getAvailableBaseDomains(r)
+	if err != nil {
+		return "", err
+	}
+
+	res, err := interactive.GetOption(interactive.Input{
+		Question: "Base Domain",
+		Help:     cmd.Flags().Lookup("base-domain").Usage,
+		Default:  baseDomain,
+		Required: true,
+		Options:  dnsDomains,
+	})
+	if err != nil {
+		return "", errors.Errorf("Expected a valid value for 'base-domain': %s", err)
+	}
+
+	return res, nil
+}
+
+func getAvailableBaseDomains(r *rosa.Runtime) ([]string, error) {
+	organizationID, _, err := r.OCMClient.GetCurrentOrganization()
+	if err != nil {
+		return nil, errors.Errorf("Failed to get current OCM organization ID: %s", err)
+	}
+
+	dnsDomains, err := r.OCMClient.ListDNSDomains(
+		fmt.Sprintf("user_defined='true' and cluster.id='' and organization.id='%s'", organizationID))
+	if err != nil {
+		return nil, errors.Errorf("Failed to list DNS domains: %s", err)
+	}
+
+	var dnsDomainsIDs []string
+	for _, dnsDomain := range dnsDomains {
+		dnsDomainsIDs = append(dnsDomainsIDs, dnsDomain.ID())
+	}
+
+	return dnsDomainsIDs, nil
+}

--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -815,7 +815,12 @@ func UpgradeOperatorRolePolicies(
 	return nil
 }
 
-const subnetTemplate = "%s ('%s','%s','%s')"
+const subnetTemplate = "%s ('%s','%s','%s', Owner ID: '%s')"
+
+type Subnet struct {
+	AvailabilityZone string
+	OwnerID          string
+}
 
 // SetSubnetOption Creates a subnet options using a predefined template.
 func SetSubnetOption(subnet *ec2.Subnet) string {
@@ -830,7 +835,8 @@ func SetSubnetOption(subnet *ec2.Subnet) string {
 		}
 	}
 	return fmt.Sprintf(subnetTemplate, aws.StringValue(subnet.SubnetId),
-		subnetName, aws.StringValue(subnet.VpcId), aws.StringValue(subnet.AvailabilityZone))
+		subnetName, aws.StringValue(subnet.VpcId), aws.StringValue(subnet.AvailabilityZone),
+		aws.StringValue(subnet.OwnerId))
 }
 
 // ParseSubnet Parses the subnet from the option chosen by the user.


### PR DESCRIPTION
1. If the user didn't provide all the flags for the shared VPC flow, default to interactive mode.
2. Display AWS owner ID alongside the subnet selection.

Subnet selection:
```
? Install into an existing VPC (optional): Yes
W: Some subnets have been excluded because they do not fit into chosen CIDR ranges
? Subnet IDs (optional):  [Use arrows to move, space to select, <right> to all, <left> to none, type to filter, ? for more help]
> [ ]  subnet-0457887d7b27a56d3 ('disktest-bthz8-public-us-east-1a','vpc-04df95f8a614f7851','us-east-1a', Owner ID: '501358428071')
  [ ]  subnet-04a42219d1aa4297b ('disktest-bthz8-private-us-east-1a','vpc-04df95f8a614f7851','us-east-1a', Owner ID: '501358428071')
  [ ]  subnet-0be38de5605f1c4ad ('','vpc-05c422525aadd0731','us-east-1a', Owner ID: '962993289388')
  [ ]  subnet-0ed8ae29f147bf7ae ('','vpc-05c422525aadd0731','us-east-1d', Owner ID: '962993289388')
  [ ]  subnet-0ed6f282dc9e22e9a ('','vpc-05c422525aadd0731','us-east-1a', Owner ID: '962993289388')
  [ ]  subnet-0676575e02b630a9c ('','vpc-05c422525aadd0731','us-east-1c', Owner ID: '962993289388')
  [ ]  subnet-00c6d8c20e8ffb2c1 ('','vpc-05c422525aadd0731','us-east-1c', Owner ID: '962993289388')
```

Informing the user about shared VPC:
`I: Subnet with ID 'subnet-0be38de5605f1c4ad' is shared by AWS account '962993289388', Defaulting to installing a cluster into a shared VPC.`

Shared VPC input fields:
```
? Private hosted zone ID: Z02058382IP472TYY7PGG
? Shared VPC role ARN: arn:aws:iam::962993289388:role/oadler-shared-vpc
? Base Domain:  [Use arrows to move, type to filter, ? for more help]
> 31v6.s1.devshift.org
  34nb.s1.devshift.org
  sg9f.s1.devshift.org
  u2gj.s1.devshift.org
  xio1.s1.devshift.org
  xj4p.s1.devshift.org
  zi0e.s1.devshift.org
```