### PR TITLE
OCM-3737 | fix: align version computation create machinepool for HCP

### DIFF
--- a/cmd/create/machinepool/nodepool.go
+++ b/cmd/create/machinepool/nodepool.go
@@ -62,7 +62,9 @@ func addNodePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster, r
 		// NodePool will take channel group from the cluster
 		channelGroup := cluster.Version().ChannelGroup()
 		clusterVersion := cluster.Version().RawID()
-		versionList, err := versions.GetVersionList(r, channelGroup, true, true, false)
+		// This is called in HyperShift, but we don't want to exclude version which are HCP disabled for node pools
+		// so we pass the relative parameter as false
+		versionList, err := versions.GetVersionList(r, channelGroup, true, false, false)
 		if err != nil {
 			r.Reporter.Errorf("%s", err)
 			os.Exit(1)
@@ -98,7 +100,9 @@ func addNodePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster, r
 				os.Exit(1)
 			}
 		}
-		version, err = r.OCMClient.ValidateVersion(version, filteredVersionList, channelGroup, true, true)
+		// This is called in HyperShift, but we don't want to exclude version which are HCP disabled for node pools
+		// so we pass the relative parameter as false
+		version, err = r.OCMClient.ValidateVersion(version, filteredVersionList, channelGroup, true, false)
 		if err != nil {
 			r.Reporter.Errorf("Expected a valid OpenShift version: %s", err)
 			os.Exit(1)


### PR DESCRIPTION
HCP control plane version needs to be hcp enabled versions. For HCP node pools instead, node pool version can be any version which is rosa enabled. This is already checked at upgrade time, we now align also the behaviour at creation time.

Related: [OCM-3737](https://issues.redhat.com//browse/OCM-3737)