### PR TITLE
OCM-3203 | fix: Update help message on rosa upgrade role command to be consistent

### DIFF
--- a/cmd/upgrade/roles/cmd.go
+++ b/cmd/upgrade/roles/cmd.go
@@ -52,9 +52,9 @@ var args struct {
 var Cmd = &cobra.Command{
 	Use:     "roles",
 	Aliases: []string{},
-	Short:   "Upgrade account-wide IAM roles to the latest version.",
-	Long:    "Upgrade account-wide IAM roles to the latest version before upgrading your cluster.",
-	Example: `  # Upgrade account/operator roles for ROSA STS clusters 
+	Short:   "Upgrade cluster-specific IAM roles to the latest version.",
+	Long:    "Upgrade cluster-specific IAM roles to the latest version before upgrading your cluster.",
+	Example: `  # Upgrade cluster roles for ROSA STS clusters 
 		rosa upgrade roles -c <cluster_key>`,
 	RunE: run,
 }


### PR DESCRIPTION
This PR updates the help message on the `rosa upgrade role` command to be consistent and not talk about account-wide IAM roles.