### PR TITLE
OCM-2083 | fix: prompts with default value are not 'optional'

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2560,7 +2560,7 @@ func run(cmd *cobra.Command, _ []string) {
 
 	if interactive.Enabled() && isHostedCP {
 		requestAuditLogForwarding, err := interactive.GetBool(interactive.Input{
-			Question: "Enable audit log forwarding to AWS CloudWatch (optional)",
+			Question: "Enable audit log forwarding to AWS CloudWatch",
 			Default:  false,
 			Required: true,
 		})

--- a/pkg/interactive/interactive.go
+++ b/pkg/interactive/interactive.go
@@ -220,12 +220,8 @@ func GetBool(input Input) (a bool, err error) {
 	if !ok {
 		dflt = false
 	}
-	question := input.Question
-	if !input.Required && !dflt {
-		question = fmt.Sprintf("%s (optional)", question)
-	}
 	prompt := &survey.Confirm{
-		Message: fmt.Sprintf("%s:", question),
+		Message: fmt.Sprintf("%s:", input.Question),
 		Help:    input.Help,
 		Default: dflt,
 	}


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-2083

Prompts during interactive mode with a default value should not be called "optional". The only prompt type that was violating this is the "boolean" type (y/n).