### PR TITLE
OCM-1625 | feat: Add the ability to list clusters using an Account Role

### DIFF
--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -188,6 +188,8 @@ type Client interface {
 	ValidateAccountRoleVersionCompatibility(
 		roleName string, roleType string, minVersion string) (bool, error)
 	GetDefaultPolicyDocument(policyArn string) (string, error)
+
+	GetAccountRoleByArn(roleArn string) (*Role, error)
 }
 
 // ClientBuilder contains the information and logic needed to build a new AWS client.


### PR DESCRIPTION
This PR adds the flag `--account-role-arn` to the `rosa list cluster` command to supporting listing clusters that are using the specified role.

When a user specifies the role of an ARN via the flag, we:

1. Lookup the Role to see if it exists
2. If the Role exists, check the `type` of the role
3. Perform a query to the `/api/clusters_mgmt/v1/clusters` endpoint, setting the query string to look for the role based upon the role type

