### PR TITLE
OCM-2864 | feat: Added default push request template

### DIFF
--- a/.github/merge_request_template/Default.md
+++ b/.github/merge_request_template/Default.md
@@ -1,0 +1,21 @@
+## Describe your changes
+
+### JIRA link
+<!--- Please include a link to the JIRA ticket if there is one associated with -->
+<!--- If you do not have a JIRA ticket associated with your changes please look at https://github.com/openshift/rosa/blob/master/CONTRIBUTING.md -->
+
+### What's new?
+<!--- Please describe the changes in this PR -->
+
+### How to test?
+<!--- Please describe how to test these changes -->
+
+## PR Author Check List
+
+* [ ]  All commit messages adhere to the project [standard](https://github.com/openshift/rosa/blob/master/CONTRIBUTING.md) 
+
+* [ ]  All commits are squashed into a single commit `git rebase -i HEAD~<number of commits>`
+
+* [ ]  All code changes have unit test coverage
+
+* [ ]  All changes have been tested locally and the steps documented in the `How to Test?` section


### PR DESCRIPTION
Added a new template for merge request's on the ROSA repo.

[OCM-2864](https://issues.redhat.com/browse/OCM-2864)

example of what it will look like :

## Describe your changes

### JIRA link
<!--- Please include a link to the JIRA ticket if there is one associated with -->
Please include a link to the JIRA

### Design document
<!--- Please include a link to the design document if there is one 
associated with these changes-->
Please include a link to the design document if there is one 
associated with these changes

### What's new?
<!--- Please describe the changes in this PR -->
Please describe the changes in this PR

### How to test?
<!--- Please describe how to test these changes -->
Please describe how to test these changes

## PR Author Check List

* [ ]  All commit messages adhere to the project [standard](https://github.com/openshift/rosa/blob/master/CONTRIBUTING.md) 

* [ ]  All commits are squashed into a single commit `git rebase -i HEAD~<number of commits>`

* [ ]  All code changes have unit test coverage

* [ ]  All changes have been tested locally and the steps documented in the `How to Test?` section

* [ ]  All required API changes are deployed to production