### PR TITLE
OCM-3831 | fix: 'rosa describe admin' cannot find 'cluster-admin' htpasswd idp and user (updated)

### DIFF
--- a/cmd/create/admin/cmd.go
+++ b/cmd/create/admin/cmd.go
@@ -32,6 +32,8 @@ import (
 
 const ClusterAdminUsername = "cluster-admin"
 const ClusterAdminIDPname = "cluster-admin"
+const GeneratingRandomPasswordString = "Generating random password"
+const MaxPasswordLength = 23
 
 var Cmd = &cobra.Command{
 	Use:   "admin",
@@ -83,8 +85,8 @@ func run(cmd *cobra.Command, _ []string) {
 	var err error
 	passwordArg := args.passwordArg
 	if len(passwordArg) == 0 {
-		r.Reporter.Debugf("Generating random password")
-		password, err = generateRandomPassword(23)
+		r.Reporter.Debugf(GeneratingRandomPasswordString)
+		password, err = GenerateRandomPassword()
 		if err != nil {
 			r.Reporter.Errorf("Failed to generate a random password")
 			os.Exit(1)
@@ -171,7 +173,7 @@ func run(cmd *cobra.Command, _ []string) {
 	r.Reporter.Infof("It may take several minutes for this access to become active.")
 }
 
-func generateRandomPassword(length int) (string, error) {
+func GenerateRandomPassword() (string, error) {
 	const (
 		lowerLetters = "abcdefghijkmnopqrstuvwxyz"
 		upperLetters = "ABCDEFGHIJKLMNPQRSTUVWXYZ"
@@ -179,7 +181,7 @@ func generateRandomPassword(length int) (string, error) {
 		all          = lowerLetters + upperLetters + digits
 	)
 	var password string
-	for i := 0; i < length; i++ {
+	for i := 0; i < MaxPasswordLength; i++ {
 		n, err := rand.Int(rand.Reader, big.NewInt(int64(len(all))))
 		if err != nil {
 			return "", err
@@ -188,7 +190,7 @@ func generateRandomPassword(length int) (string, error) {
 		if password == "" {
 			password = newchar
 		}
-		if i < length-1 {
+		if i < MaxPasswordLength-1 {
 			n, err = rand.Int(rand.Reader, big.NewInt(int64(len(password)+1)))
 			if err != nil {
 				return "", err

--- a/cmd/create/idp/htpasswd.go
+++ b/cmd/create/idp/htpasswd.go
@@ -180,6 +180,12 @@ func getUserList(cmd *cobra.Command, r *rosa.Runtime) (userList map[string]strin
 
 func GetUserDetails(cmd *cobra.Command, r *rosa.Runtime,
 	usernameKey, passwordKey, defaultUsername, defaultPassword string) (string, string) {
+	return GetIdpUserNameFromPrompt(cmd, r, usernameKey, defaultUsername),
+		GetIdpPasswordFromPrompt(cmd, r, passwordKey, defaultPassword)
+}
+
+func GetIdpUserNameFromPrompt(cmd *cobra.Command, r *rosa.Runtime,
+	usernameKey, defaultUsername string) string {
 	username, err := interactive.GetString(interactive.Input{
 		Question: "Username",
 		Help:     cmd.Flags().Lookup(usernameKey).Usage,
@@ -192,6 +198,11 @@ func GetUserDetails(cmd *cobra.Command, r *rosa.Runtime,
 	if err != nil {
 		exitHTPasswdCreate("Expected a valid username: %s", r.ClusterKey, err, r)
 	}
+	return username
+}
+
+func GetIdpPasswordFromPrompt(cmd *cobra.Command, r *rosa.Runtime,
+	passwordKey, defaultPassword string) string {
 	password, err := interactive.GetPassword(interactive.Input{
 		Question: "Password",
 		Help:     cmd.Flags().Lookup(passwordKey).Usage,
@@ -204,7 +215,7 @@ func GetUserDetails(cmd *cobra.Command, r *rosa.Runtime,
 	if err != nil {
 		exitHTPasswdCreate("Expected a valid password: %s", r.ClusterKey, err, r)
 	}
-	return username, password
+	return password
 }
 
 func shouldAddAnotherUser(r *rosa.Runtime) bool {


### PR DESCRIPTION
Covers fixes for both cards:
[OCM-3831](https://issues.redhat.com//browse/OCM-3831), [OCM-3293](https://issues.redhat.com//browse/OCM-3293)

**Initial Issue:**
The `rosa describe admin -c <cluster_id>` command is unable to find the idp that has the admin user, even though the admin user was created previously.

Returned response:
"There is no admin on cluster '%s'. To create it run the following command:\n"+
" rosa create admin -c %s"
 
Expected response:
"There is an admin on cluster '%s'. To login, run the following command:\n"+
" oc login %s --username %s"

**Reason**
For commands:
`rosa create admin` - always created admin username "cluster-admin" under the htpasswd IDP named "Cluster-Admin"
`rosa create cluster `--cluster-admin-user` - required users to generate admin username not equal to "cluster-admin" under the htpasswd IDP named "Cluster-Admin"

To cover both issues [OCM-3831](https://issues.redhat.com//browse/OCM-3831), [OCM-3293](https://issues.redhat.com//browse/OCM-3293); 
It was decided that the cluster admin user created via ROSA will always have the username "cluster-admin" under the htpasswd IDP named "Cluster-Admin".
Users will no longer be able to generate a customer username for the admin user created via ROSA.

A1. Indicate `--cluster-admin-user` flag is deprecated.
![image](https://github.com/openshift/rosa/assets/118839428/75eb5253-2926-4a9f-a762-60af056eef09)

A2. Indicate `--create-admin-user` and `--cluster-admin-password` flags can only be used with classic ROSA.
![image](https://github.com/openshift/rosa/assets/118839428/e5bca48d-6cff-462d-bbcc-4fe468c1aba0)

A3. Using `--create-admin-user` and `--cluster-admin-password` flags and electing `hosted cp` via interactive prompt will return an error.
![image](https://github.com/openshift/rosa/assets/118839428/6563dbb8-0751-4be9-9605-785294a71a81)

B. Users using flag `--create-admin-user` without `--cluster-admin-password` flag will auto generate the password
[Please note, --create-admin-user does not take in an input as it is now a boolean flag]
![image](https://github.com/openshift/rosa/assets/118839428/3437a9cc-4617-4011-816d-62602e179b5e)

C. Users using flag `--create-admin-user` AND `--create-admin-password` flag will allow user specified password
![image](https://github.com/openshift/rosa/assets/118839428/3037fe44-7fe4-4ff1-b6ef-da8045156c18)

D. Users can use `--cluster-admin-password` flag without `--create-admin-user` flag
[Using only `--cluster-admin-password` flag lets ROSA know that the user wants to create a cluster admin user]
![image](https://github.com/openshift/rosa/assets/118839428/be9c6d9c-b563-4f17-9fe8-48c80b233e3e)

E. Users can auto generate password via interactive prompts by answering `no` to  `Create custom password for cluster admin` question
![image](https://github.com/openshift/rosa/assets/118839428/1a04b60e-193f-4a29-be75-f266662b12b4)

F. Users can input custom password via interactive prompts by answering `yes` to  `Create custom password for cluster admin` question
![image](https://github.com/openshift/rosa/assets/118839428/efca54bc-64d5-4941-916d-37773e739a1a)

G. Build command output generated at the end of create cluster prompts correctly includes new admin flags:
![image](https://github.com/openshift/rosa/assets/118839428/92d4fab2-7602-4a58-909a-8d4bed97f897)

With the fixes, 
`rosa delete admin` and `rosa describe admin` will always work now if the cluster admin user was created via ROSA; since both commands search for the username, 'cluster-admin' within the htpasswd idp to confirm whether a cluster admin user exists.

**EDIT**
Kept --cluster-admin-password instead of --create-admin-password, following request.