### PR TITLE
OCM-3873 | fix: change references to default machine pool to worker machine pool

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -529,7 +529,7 @@ func init() {
 		&args.defaultMachinePoolLabels,
 		"default-mp-labels",
 		"",
-		"Labels for the default machine pool. Format should be a comma-separated list of 'key=value'. "+
+		"Labels for the worker machine pool. Format should be a comma-separated list of 'key=value'. "+
 			"This list will overwrite any modifications made to Node labels on an ongoing basis.",
 	)
 
@@ -933,7 +933,7 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	if isHostedCP && cmd.Flags().Changed("default-mp-labels") {
-		r.Reporter.Errorf("Setting the default machine pool labels is not supported for hosted clusters")
+		r.Reporter.Errorf("Setting the worker machine pool labels is not supported for hosted clusters")
 		os.Exit(1)
 	}
 
@@ -2232,11 +2232,11 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 	}
 
-	// Default machine pool labels
+	// Worker machine pool labels
 	labels := args.defaultMachinePoolLabels
 	if interactive.Enabled() && !isHostedCP {
 		labels, err = interactive.GetString(interactive.Input{
-			Question: "Default machine pool labels",
+			Question: "Worker machine pool labels",
 			Help:     cmd.Flags().Lookup("default-mp-labels").Usage,
 			Default:  labels,
 			Validators: []interactive.Validator{


### PR DESCRIPTION
[OCM-3873](https://issues.redhat.com//browse/OCM-3873) | fix: change references to default machine pool to worker machine pool