### PR TITLE
OCM-3833 | fix: only go interactive on non hcp

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2277,7 +2277,7 @@ func run(cmd *cobra.Command, _ []string) {
 				additionalComputeSecurityGroupIdsFlag, ocm.MinVersionForAdditionalComputeSecurityGroupIdsDay1)
 			os.Exit(1)
 		}
-	} else if interactive.Enabled() && isVersionCompatibleComputeSgIds && useExistingVPC {
+	} else if interactive.Enabled() && isVersionCompatibleComputeSgIds && useExistingVPC && !isHostedCP {
 		vpcId := ""
 		for _, subnet := range subnets {
 			if awssdk.StringValue(subnet.SubnetId) == subnetIDs[0] {


### PR DESCRIPTION
Related issue: [OCM-3833](https://issues.redhat.com//browse/OCM-3833)