### PR TITLE
OCM-1448 | fix: improve subnet not found error message

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1869,7 +1869,8 @@ func run(cmd *cobra.Command, _ []string) {
 					}
 				}
 				if !verifiedSubnet {
-					r.Reporter.Errorf("Could not find the following subnet provided: %s", subnetArg)
+					r.Reporter.Errorf("Could not find the following subnet provided in region '%s': %s",
+						r.AWSClient.GetRegion(), subnetArg)
 					os.Exit(1)
 				}
 			}


### PR DESCRIPTION
Include the AWS client in the error message.

e.g
`E: Could not find the following subnet provided in region 'us-east-1': subnet-0bf9e87908dcc6155`
