### PR TITLE
OCM-4128 | fix: validate sgs flag out of byo vpc

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2267,6 +2267,11 @@ func run(cmd *cobra.Command, _ []string) {
 	additionalComputeSecurityGroupIds := args.additionalComputeSecurityGroupIds
 	hasChangedComputeSGIdsFlag := cmd.Flags().Changed(additionalComputeSecurityGroupIdsFlag)
 	if hasChangedComputeSGIdsFlag {
+		if !useExistingVPC {
+			r.Reporter.Errorf("Setting the `%s` flag is only allowed for BYO VPC clusters",
+				additionalComputeSecurityGroupIdsFlag)
+			os.Exit(1)
+		}
 		// HCP is still unsupported
 		if isHostedCP {
 			r.Reporter.Errorf("Parameter '%s' is not supported for Hosted Control Plane clusters",

--- a/cmd/create/machinepool/machinepool.go
+++ b/cmd/create/machinepool/machinepool.go
@@ -46,7 +46,7 @@ func addMachinePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster
 	isSubnetSet := cmd.Flags().Changed("subnet")
 	isByoVpc := isBYOVPC(cluster)
 	if !isByoVpc && isSubnetSet {
-		r.Reporter.Errorf("Setting the `subnet` flag is only allowed for BYOVPC clusters")
+		r.Reporter.Errorf("Setting the `subnet` flag is only allowed for BYO VPC clusters")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Related issue: [OCM-4128](https://issues.redhat.com//browse/OCM-4128)