### PR TITLE
OCM-4140 | fix: use output print slice instead of helper

### DIFF
--- a/cmd/describe/machinepool/machinepool.go
+++ b/cmd/describe/machinepool/machinepool.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	"github.com/openshift/rosa/pkg/helper"
 	ocmOutput "github.com/openshift/rosa/pkg/ocm/output"
 	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/rosa"
@@ -49,7 +48,7 @@ func describeMachinePool(r *rosa.Runtime, cluster *cmv1.Cluster, clusterKey stri
 		ocmOutput.PrintStringSlice(machinePool.Subnets()),
 		ocmOutput.PrintMachinePoolSpot(machinePool),
 		ocmOutput.PrintMachinePoolDiskSize(machinePool),
-		helper.SliceToSortedString(machinePool.AWS().AdditionalSecurityGroupIds()),
+		ocmOutput.PrintStringSlice(machinePool.AWS().AdditionalSecurityGroupIds()),
 	)
 	fmt.Print(machinePoolOutput)
 

--- a/cmd/list/machinepool/machinepool.go
+++ b/cmd/list/machinepool/machinepool.go
@@ -6,7 +6,6 @@ import (
 	"text/tabwriter"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	"github.com/openshift/rosa/pkg/helper"
 	ocmOutput "github.com/openshift/rosa/pkg/ocm/output"
 	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/rosa"
@@ -48,7 +47,7 @@ func listMachinePools(r *rosa.Runtime, clusterKey string, cluster *cmv1.Cluster)
 			ocmOutput.PrintStringSlice(machinePool.Subnets()),
 			ocmOutput.PrintMachinePoolSpot(machinePool),
 			ocmOutput.PrintMachinePoolDiskSize(machinePool),
-			helper.SliceToSortedString(machinePool.AWS().AdditionalSecurityGroupIds()),
+			ocmOutput.PrintStringSlice(machinePool.AWS().AdditionalSecurityGroupIds()),
 		)
 	}
 	writer.Flush()


### PR DESCRIPTION
Related issue: [OCM-4140](https://issues.redhat.com//browse/OCM-4140)