### PR TITLE
OCM-4123 | fix: Remove unnecessary warning messages about Red Hat owned subnets when user explicitly specifies subnets to use

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1815,7 +1815,7 @@ func run(cmd *cobra.Command, _ []string) {
 	var subnets []*ec2.Subnet
 	mapSubnetIDToSubnet := make(map[string]aws.Subnet)
 	if useExistingVPC || subnetsProvided {
-		initialSubnets, err := getInitialValidSubnets(awsClient, r.Reporter)
+		initialSubnets, err := getInitialValidSubnets(awsClient, args.subnetIDs, r.Reporter)
 		if err != nil {
 			r.Reporter.Errorf("Failed to get the list of subnets: %s", err)
 			os.Exit(1)
@@ -3444,14 +3444,16 @@ func getExpectedResourceIDForAccRole(hostedCPPolicies bool, roleARN string, role
 	return strings.ToLower(fmt.Sprintf("%s-%s-Role", rolePrefix, accountRoles[roleType].Name)), rolePrefix, nil
 }
 
-func getInitialValidSubnets(awsClient aws.Client, reporter *reporter.Object) ([]*ec2.Subnet, error) {
+func getInitialValidSubnets(aws aws.Client, ids []string, r *reporter.Object) ([]*ec2.Subnet, error) {
 	initialValidSubnets := []*ec2.Subnet{}
 	excludedSubnets := []string{}
-	allSubnets, err := awsClient.GetSubnetIDs()
+
+	validSubnets, err := aws.ListSubnets(ids...)
+
 	if err != nil {
 		return initialValidSubnets, err
 	}
-	for _, subnet := range allSubnets {
+	for _, subnet := range validSubnets {
 		hasRHManaged := tags.Ec2ResourceHasTag(subnet.Tags, tags.RedHatManaged, strconv.FormatBool(true))
 		if !hasRHManaged {
 			initialValidSubnets = append(initialValidSubnets, subnet)
@@ -3459,8 +3461,8 @@ func getInitialValidSubnets(awsClient aws.Client, reporter *reporter.Object) ([]
 			excludedSubnets = append(excludedSubnets, awssdk.StringValue(subnet.SubnetId))
 		}
 	}
-	if len(allSubnets) != len(initialValidSubnets) {
-		reporter.Warnf("The following subnets were excluded because they belong"+
+	if len(validSubnets) != len(initialValidSubnets) {
+		r.Warnf("The following subnets were excluded because they belong"+
 			" to a VPC that is managed by Red Hat: %s", helper.SliceToSortedString(excludedSubnets))
 	}
 	return initialValidSubnets, nil

--- a/cmd/create/service/cmd.go
+++ b/cmd/create/service/cmd.go
@@ -259,7 +259,7 @@ func run(cmd *cobra.Command, argv []string) {
 
 	var availabilityZones []string
 	if subnetsProvided {
-		subnets, err := r.AWSClient.GetSubnetIDs()
+		subnets, err := r.AWSClient.ListSubnets()
 		if err != nil {
 			r.Reporter.Errorf("Failed to get the list of subnets: %s", err)
 			os.Exit(1)


### PR DESCRIPTION
This PR updates the `getInitialValidSubnets` function in the `rosa create cluster` command to consider the list of subnets passed as a command line argument by the user via the `--subnet-ids` switch.

The `getInitialValidSubnets` function treats the subnets specified via `--subnet-ids` as the only ones it check, rather than pulling and checking all available subnets (which is the cause of the erroneous warning). The function still checks if any of the subnets specified by the user via `--subnet-ids` are Red Hat managed and will print the warning if they are.