### PR TITLE
OCM-3366 | fix: force --enable-autoscaling flag when autoscaling flags are used

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -206,6 +206,7 @@ var args struct {
 }
 
 var autoscalerArgs *clusterautoscaler.AutoscalerArgs
+var userSpecifiedAutoscalerValues []*pflag.Flag
 
 var Cmd = &cobra.Command{
 	Use:   "cluster",
@@ -513,10 +514,10 @@ func init() {
 	)
 
 	autoscalerArgs = clusterautoscaler.AddClusterAutoscalerFlags(Cmd, clusterAutoscalerFlagsPrefix)
-
+	// iterates through all autoscaling flags and stores them in slice to track user input
 	flags.VisitAll(func(f *pflag.Flag) {
 		if strings.HasPrefix(f.Name, clusterAutoscalerFlagsPrefix) {
-			Cmd.MarkFlagsRequiredTogether("enable-autoscaling", f.Name)
+			userSpecifiedAutoscalerValues = append(userSpecifiedAutoscalerValues, f)
 		}
 	})
 
@@ -774,6 +775,14 @@ func run(cmd *cobra.Command, _ []string) {
 	if err != nil {
 		r.Reporter.Errorf("%s", err)
 		os.Exit(1)
+	}
+
+	for _, val := range userSpecifiedAutoscalerValues {
+		if val.Changed && !args.autoscalingEnabled {
+			r.Reporter.Errorf("Using autoscaling flag '%s', requires flag '--enable-autoscaling'. "+
+				"Please try again with flag", val.Name)
+			os.Exit(1)
+		}
 	}
 
 	// validate flags for cluster admin


### PR DESCRIPTION
Please see two separate calls
![image](https://github.com/openshift/rosa/assets/118839428/d28b8651-de52-4495-8603-4a3941aedece)

In Day 1 cluster create, it now properly forces the flag `--enable-autoscaling` if any of the autoscaling flags are used.