### PR TITLE
OCM-4257 | fix: doesn't check /labels for HCP

### DIFF
--- a/cmd/edit/ingress/cmd.go
+++ b/cmd/edit/ingress/cmd.go
@@ -207,10 +207,14 @@ func run(cmd *cobra.Command, argv []string) {
 		interactive.Enable()
 	}
 
-	hasLegacyIngressSupport, err := r.OCMClient.HasLegacyIngressSupport(cluster)
-	if err != nil {
-		r.Reporter.Errorf("There was a problem checking version compatibility: %v", err)
-		os.Exit(1)
+	hasLegacyIngressSupport := true
+	if !ocm.IsHyperShiftCluster(cluster) {
+		var err error
+		hasLegacyIngressSupport, err = r.OCMClient.HasLegacyIngressSupport(cluster)
+		if err != nil {
+			r.Reporter.Errorf("There was a problem checking version compatibility: %v", err)
+			os.Exit(1)
+		}
 	}
 
 	if hasLegacyIngressSupport && IsIngressV2SetViaCLI(cmd.Flags()) {


### PR DESCRIPTION
Related issue: [OCM-4257](https://issues.redhat.com//browse/OCM-4257)

A validation to /labels for HCP clusters was recently added and call needs to be refactored to skip HCP clusters