### PR TITLE
OCM-4336 | feat: disable edit machinepool --version command

### DIFF
--- a/cmd/edit/machinepool/cmd.go
+++ b/cmd/edit/machinepool/cmd.go
@@ -130,7 +130,7 @@ func init() {
 			"This list will overwrite any modifications made to node tuning configs on an ongoing basis.",
 	)
 
-	flags.MarkDeprecated("version", "for upgrades, please use 'rosa upgrade machinepool' instead")
+	flags.MarkHidden("version")
 }
 
 func run(cmd *cobra.Command, argv []string) {


### PR DESCRIPTION
Disallow changing the version directly from the edit command as we have now the new flow with rosa upgrade machinepool available for everybody.
The command was already deprecated and it was meant to be a temporary solution.

Related: [OCM-4336](https://issues.redhat.com//browse/OCM-4336)