### PR TITLE
OCM-4512 | fix: align list upgrade output when no avl upgrades

### DIFF
--- a/cmd/list/upgrade/cmd.go
+++ b/cmd/list/upgrade/cmd.go
@@ -104,6 +104,10 @@ func runWithRuntime(r *rosa.Runtime, _ *cobra.Command) error {
 
 		// Get available node pool upgrades
 		availableUpgrades = ocm.GetNodePoolAvailableUpgrades(nodePool)
+		if len(availableUpgrades) == 0 {
+			r.Reporter.Infof("There are no available upgrades for machine pool '%s'", args.nodePool)
+			return nil
+		}
 	} else {
 		// Control plane or cluster updates
 		r.Reporter.Debugf("Loading available upgrades for cluster '%s'", clusterKey)

--- a/cmd/list/upgrade/cmd_test.go
+++ b/cmd/list/upgrade/cmd_test.go
@@ -13,8 +13,7 @@ import (
 	"github.com/openshift/rosa/pkg/test"
 )
 
-const noUpgradeOutput = `VERSION  NOTES
-`
+const noUpgradeOutput = "There are no available upgrades for machine pool 'nodepool85'"
 const ongoingUpgradeOutput = `VERSION  NOTES
 4.12.26  recommended
 4.12.25  pending for 2023-06-02 12:30 UTC
@@ -135,7 +134,7 @@ var _ = Describe("List upgrade", func() {
 			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK,
 				test.FormatNodePoolUpgradePolicyList(emptyUpgradePolicies)))
 			stdout, _, err := test.RunWithOutputCapture(runWithRuntime, testRuntime.RosaRuntime, Cmd)
-			Expect(stdout).To(Equal(noUpgradeOutput))
+			Expect(stdout).To(ContainSubstring(noUpgradeOutput))
 			Expect(err).To(BeNil())
 		})
 


### PR DESCRIPTION
Output an informative message when there is no available upgrades for node pools to align with control plane.

Before:
```
rosa list upgrades -c ad-int4 --machinepool workers
VERSION  NOTES
```

After:
```
rosa list upgrades -c ad-int4 --machinepool workers
I: There are no available upgrades for machine pool 'workers'
```

Related: OCM-4512