### PR TITLE
OCM-4571 | fix: Validate upgrade versions from prerelease scenarios

### DIFF
--- a/pkg/ocm/versions.go
+++ b/pkg/ocm/versions.go
@@ -313,12 +313,21 @@ func IsValidVersion(userRequestedVersion string, supportedVersion string, cluste
 		return false, err
 	}
 
+	c, err := ver.NewVersion(clusterVersion)
+	if err != nil {
+		return false, err
+	}
+
 	isPreRelease := a.Prerelease() != "" && b.Prerelease() != ""
 
+	// User wants to upgrade from a prerelease version
+	// i.e. from 4.14.0-rc.4 to 4.10.0
+	fromPreRelease := c.Prerelease() != ""
+
 	versionSplit := a.Segments64()
-	// If user has specified patch or not specified patch but is a preRelease
+	// If user has specified patch or not specified patch but is a preRelease or cluster is in a preRelease
 	// Check directly
-	if len(versionSplit) > 2 && versionSplit[2] > 0 || (versionSplit[2] == 0 && isPreRelease) {
+	if len(versionSplit) > 2 && versionSplit[2] > 0 || (versionSplit[2] == 0 && isPreRelease) || fromPreRelease {
 		return a.Equal(b), err
 	}
 

--- a/pkg/ocm/versions_test.go
+++ b/pkg/ocm/versions_test.go
@@ -57,6 +57,18 @@ var _ = Describe("Versions", Ordered, func() {
 			),
 		)
 	})
+
+	Context("when upgrading a hosted control plane", func() {
+		DescribeTable("Should validate the requested version with the available upgrades",
+			func(userRequestedVersion string, supportedVersion string, clusterVersion string, expected bool) {
+				isValid, err := IsValidVersion(userRequestedVersion, supportedVersion, clusterVersion)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(isValid).To(Equal(expected))
+			},
+			Entry("From 4.14.0-rc.4 to 4.14.0", "4.14.0", "4.14.0", "4.14.0-rc.4", true),
+			Entry("From 4.14.0-rc.4 to 4.14.0", "4.14.1", "4.14.0", "4.14.0-rc.4", false),
+		)
+	})
 })
 
 var _ = Describe("Minimal http tokens required version", Ordered, func() {


### PR DESCRIPTION
Fixes version validation on upgrade scenarios where cluster upgrades from a prerelease version:

```
$ ./rosa upgrade cluster -c ying-hcp-b --control-plane
? IAM Roles/Policies upgrade mode: auto
? Version: 4.14.0
E: Expected a valid version to upgrade cluster to.
Valid versions: [4.14.0, 4.14.0-rc.5, 4.14.0-rc.6, 4.14.0-rc.7]
```