### PR TITLE
OCM-4571 | fix: Fix CheckAndParseVersion when coming from preRelease

### DIFF
--- a/cmd/upgrade/cluster/cmd.go
+++ b/cmd/upgrade/cluster/cmd.go
@@ -317,7 +317,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 
 	// Validate version
 	if !currentUpgradeScheduling.AutomaticUpgrades {
-		version, err = ocm.CheckAndParseVersion(availableUpgrades, version)
+		version, err = ocm.CheckAndParseVersion(availableUpgrades, version, cluster)
 		if err != nil {
 			return fmt.Errorf("Error parsing version to upgrade to")
 		}


### PR DESCRIPTION
Fixing another helper for version validation:

https://issues.redhat.com/browse/OCM-4571?focusedId=23365966&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-23365966