### PR TITLE
OCM-4644 | fix: Create cluster - filter classic ROSA account roles

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1214,7 +1214,12 @@ func run(cmd *cobra.Command, _ []string) {
 		role := aws.AccountRoles[aws.InstallerAccountRole]
 
 		// Find all installer roles in the current account using AWS resource tags
-		roleARNs, err := awsClient.FindRoleARNs(aws.InstallerAccountRole, minor)
+		var roleARNs []string
+		if isHostedCP {
+			roleARNs, err = awsClient.FindRoleARNs(aws.InstallerAccountRole, minor)
+		} else {
+			roleARNs, err = awsClient.FindRoleARNsClassic(aws.InstallerAccountRole, minor)
+		}
 		if err != nil {
 			r.Reporter.Errorf("Failed to find %s role: %s", role.Name, err)
 			os.Exit(1)
@@ -1281,7 +1286,11 @@ func run(cmd *cobra.Command, _ []string) {
 					// Not needed for Hypershift clusters
 					continue
 				}
-				roleARNs, err := awsClient.FindRoleARNs(roleType, minor)
+				if isHostedCP {
+					roleARNs, err = awsClient.FindRoleARNs(roleType, minor)
+				} else {
+					roleARNs, err = awsClient.FindRoleARNsClassic(roleType, minor)
+				}
 				if err != nil {
 					r.Reporter.Errorf("Failed to find %s role: %s", role.Name, err)
 					os.Exit(1)

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -120,6 +120,7 @@ type Client interface {
 	DeleteOpenIDConnectProvider(providerURL string) error
 	HasOpenIDConnectProvider(issuerURL string, accountID string) (bool, error)
 	FindRoleARNs(roleType string, version string) ([]string, error)
+	FindRoleARNsClassic(roleType string, version string) ([]string, error)
 	FindPolicyARN(operator Operator, version string) (string, error)
 	ListUserRoles() ([]Role, error)
 	ListOCMRoles() ([]Role, error)
@@ -185,8 +186,7 @@ type Client interface {
 	PutPublicReadObjectInS3Bucket(bucketName string, body io.ReadSeeker, key string) error
 	CreateSecretInSecretsManager(name string, secret string) (string, error)
 	DeleteSecretInSecretsManager(secretArn string) error
-	ValidateAccountRoleVersionCompatibility(
-		roleName string, roleType string, minVersion string) (bool, error)
+	ValidateAccountRoleVersionCompatibility(roleName string, roleType string, minVersion string) (bool, error)
 	GetDefaultPolicyDocument(policyArn string) (string, error)
 	GetAccountRoleByArn(roleArn string) (*Role, error)
 	GetSecurityGroupIds(vpcId string) ([]*ec2.SecurityGroup, error)

--- a/pkg/aws/policies_test.go
+++ b/pkg/aws/policies_test.go
@@ -1,0 +1,61 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Is Account Role Version Compatible", func() {
+	When("Role isn't an account role", func() {
+		It("Should return not compatible", func() {
+			isCompatible, err := isAccountRoleVersionCompatible([]*iam.Tag{}, InstallerAccountRole, "4.14")
+			Expect(err).To(BeNil())
+			Expect(isCompatible).To(Equal(false))
+		})
+	})
+	When("Role OCP version isn't compatible", func() {
+		It("Should return not compatible", func() {
+			tagsList := []*iam.Tag{
+				{
+					Key:   aws.String("rosa_openshift_version"),
+					Value: aws.String("4.13"),
+				},
+			}
+			isCompatible, err := isAccountRoleVersionCompatible(tagsList, InstallerAccountRole, "4.14")
+			Expect(err).To(BeNil())
+			Expect(isCompatible).To(Equal(false))
+		})
+	})
+	When("Role version is compatible", func() {
+		It("Should return compatible", func() {
+			tagsList := []*iam.Tag{
+				{
+					Key:   aws.String("rosa_openshift_version"),
+					Value: aws.String("4.14"),
+				},
+			}
+			isCompatible, err := isAccountRoleVersionCompatible(tagsList, InstallerAccountRole, "4.14")
+			Expect(err).To(BeNil())
+			Expect(isCompatible).To(Equal(true))
+		})
+	})
+	When("Role has managed policies, ignores openshift version", func() {
+		It("Should return compatible", func() {
+			tagsList := []*iam.Tag{
+				{
+					Key:   aws.String("rosa_openshift_version"),
+					Value: aws.String("4.12"),
+				},
+				{
+					Key:   aws.String("rosa_managed_policies"),
+					Value: aws.String("true"),
+				},
+			}
+			isCompatible, err := isAccountRoleVersionCompatible(tagsList, InstallerAccountRole, "4.14")
+			Expect(err).To(BeNil())
+			Expect(isCompatible).To(Equal(true))
+		})
+	})
+})


### PR DESCRIPTION
When the user creates a cluster in interactive mode and selects classic ROSA topology, the CLI should display only classic account roles. HCP account roles are not compatible with classic ROSA clusters.

```
oadler@fedora:rosa (OCM-4644)$ rosa list account-roles 
I: Fetching account roles
ROLE NAME                                 ROLE TYPE      ROLE ARN                                                                 OPENSHIFT VERSION  AWS Managed
croche-ControlPlane-Role                  Control plane  arn:aws:iam::501358428071:role/croche-ControlPlane-Role                  4.13               No
croche-Installer-Role                     Installer      arn:aws:iam::501358428071:role/croche-Installer-Role                     4.13               No
croche-Support-Role                       Support        arn:aws:iam::501358428071:role/croche-Support-Role                       4.13               No
croche-Worker-Role                        Worker         arn:aws:iam::501358428071:role/croche-Worker-Role                        4.13               No
ManagedOpenShift-ControlPlane-Role        Control plane  arn:aws:iam::501358428071:role/ManagedOpenShift-ControlPlane-Role        4.14               No
ManagedOpenShift-HCP-ROSA-Installer-Role  Installer      arn:aws:iam::501358428071:role/ManagedOpenShift-HCP-ROSA-Installer-Role  4.14               Yes
ManagedOpenShift-HCP-ROSA-Support-Role    Support        arn:aws:iam::501358428071:role/ManagedOpenShift-HCP-ROSA-Support-Role    4.14               Yes
ManagedOpenShift-HCP-ROSA-Worker-Role     Worker         arn:aws:iam::501358428071:role/ManagedOpenShift-HCP-ROSA-Worker-Role     4.14               Yes
marco-ControlPlane-Role                   Control plane  arn:aws:iam::501358428071:role/marco-ControlPlane-Role                   4.13               No
marco-Installer-Role                      Installer      arn:aws:iam::501358428071:role/marco-Installer-Role                      4.13               No
marco-Support-Role                        Support        arn:aws:iam::501358428071:role/marco-Support-Role                        4.13               No
marco-Worker-Role                         Worker         arn:aws:iam::501358428071:role/marco-Worker-Role                         4.13               No
```
HCP account roles are filtered out for a classic cluster:
```
oadler@fedora:rosa (OCM-4644)$ rosa create cluster
I: Enabling interactive mode
? Cluster name: oadler-nov-2
? Deploy cluster with Hosted Control Plane: No
? Create cluster admin user: No
? Deploy cluster using AWS STS: Yes
W: In a future release STS will be the default mode.
W: --sts flag won't be necessary if you wish to use STS.
W: --non-sts/--mint-mode flag will be necessary if you do not wish to use STS.
? OpenShift version: 4.14.1
? Configure the use of IMDSv2 for ec2 instances optional/required: optional
W: No account roles found. You will need to manually set them in the next steps or run 'rosa create account-roles' to create them first.
? Role ARN: [? for help] 
E: Expected a valid ARN: interrupt
```
HCP account roles are always compatible with the OCP version (policies are managed by AWS):
```
oadler@fedora:rosa (OCM-4644)$ rosa create cluster
I: Enabling interactive mode
? Cluster name: oadler-nov-2
? Deploy cluster with Hosted Control Plane: Yes
I: NOTE: Hosted control planes are currently in Technology Preview (https://access.redhat.com/support/offerings/techpreview). Any Technology Preview clusters will need to be destroyed and recreated prior to general availability.
? Billing Account: 765374464689
I: The selected AWS billing account is a different account than your AWS infrastructure account.The AWS billing account will be charged for subscription usage. The AWS infrastructure account will be used for managing the cluster.
? OpenShift version: 4.14.1
I: Using arn:aws:iam::501358428071:role/ManagedOpenShift-HCP-ROSA-Installer-Role for the Installer role
I: Using arn:aws:iam::501358428071:role/ManagedOpenShift-HCP-ROSA-Worker-Role for the Worker role
I: Using arn:aws:iam::501358428071:role/ManagedOpenShift-HCP-ROSA-Support-Role for the Support role
? External ID (optional): [? for help] 
```
