### PR TITLE
OCM-4644 | fix: Create cluster - filter classic ROSA account roles

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1214,7 +1214,12 @@ func run(cmd *cobra.Command, _ []string) {
 		role := aws.AccountRoles[aws.InstallerAccountRole]
 
 		// Find all installer roles in the current account using AWS resource tags
-		roleARNs, err := awsClient.FindRoleARNs(aws.InstallerAccountRole, minor)
+		var roleARNs []string
+		if isHostedCP {
+			roleARNs, err = awsClient.FindRoleARNs(aws.InstallerAccountRole, minor)
+		} else {
+			roleARNs, err = awsClient.FindRoleARNsClassic(aws.InstallerAccountRole, minor)
+		}
 		if err != nil {
 			r.Reporter.Errorf("Failed to find %s role: %s", role.Name, err)
 			os.Exit(1)
@@ -1281,7 +1286,11 @@ func run(cmd *cobra.Command, _ []string) {
 					// Not needed for Hypershift clusters
 					continue
 				}
-				roleARNs, err := awsClient.FindRoleARNs(roleType, minor)
+				if isHostedCP {
+					roleARNs, err = awsClient.FindRoleARNs(roleType, minor)
+				} else {
+					roleARNs, err = awsClient.FindRoleARNsClassic(roleType, minor)
+				}
 				if err != nil {
 					r.Reporter.Errorf("Failed to find %s role: %s", role.Name, err)
 					os.Exit(1)

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -120,6 +120,7 @@ type Client interface {
 	DeleteOpenIDConnectProvider(providerURL string) error
 	HasOpenIDConnectProvider(issuerURL string, accountID string) (bool, error)
 	FindRoleARNs(roleType string, version string) ([]string, error)
+	FindRoleARNsClassic(roleType string, version string) ([]string, error)
 	FindPolicyARN(operator Operator, version string) (string, error)
 	ListUserRoles() ([]Role, error)
 	ListOCMRoles() ([]Role, error)
@@ -185,8 +186,7 @@ type Client interface {
 	PutPublicReadObjectInS3Bucket(bucketName string, body io.ReadSeeker, key string) error
 	CreateSecretInSecretsManager(name string, secret string) (string, error)
 	DeleteSecretInSecretsManager(secretArn string) error
-	ValidateAccountRoleVersionCompatibility(
-		roleName string, roleType string, minVersion string) (bool, error)
+	ValidateAccountRoleVersionCompatibility(roleName string, roleType string, minVersion string) (bool, error)
 	GetDefaultPolicyDocument(policyArn string) (string, error)
 	GetAccountRoleByArn(roleArn string) (*Role, error)
 	GetSecurityGroupIds(vpcId string) ([]*ec2.SecurityGroup, error)

--- a/pkg/aws/policies_test.go
+++ b/pkg/aws/policies_test.go
@@ -1,0 +1,61 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Is Account Role Version Compatible", func() {
+	When("Role isn't an account role", func() {
+		It("Should return not compatible", func() {
+			isCompatible, err := isAccountRoleVersionCompatible([]*iam.Tag{}, InstallerAccountRole, "4.14")
+			Expect(err).To(BeNil())
+			Expect(isCompatible).To(Equal(false))
+		})
+	})
+	When("Role OCP version isn't compatible", func() {
+		It("Should return not compatible", func() {
+			tagsList := []*iam.Tag{
+				{
+					Key:   aws.String("rosa_openshift_version"),
+					Value: aws.String("4.13"),
+				},
+			}
+			isCompatible, err := isAccountRoleVersionCompatible(tagsList, InstallerAccountRole, "4.14")
+			Expect(err).To(BeNil())
+			Expect(isCompatible).To(Equal(false))
+		})
+	})
+	When("Role version is compatible", func() {
+		It("Should return compatible", func() {
+			tagsList := []*iam.Tag{
+				{
+					Key:   aws.String("rosa_openshift_version"),
+					Value: aws.String("4.14"),
+				},
+			}
+			isCompatible, err := isAccountRoleVersionCompatible(tagsList, InstallerAccountRole, "4.14")
+			Expect(err).To(BeNil())
+			Expect(isCompatible).To(Equal(true))
+		})
+	})
+	When("Role has managed policies, ignores openshift version", func() {
+		It("Should return compatible", func() {
+			tagsList := []*iam.Tag{
+				{
+					Key:   aws.String("rosa_openshift_version"),
+					Value: aws.String("4.12"),
+				},
+				{
+					Key:   aws.String("rosa_managed_policies"),
+					Value: aws.String("true"),
+				},
+			}
+			isCompatible, err := isAccountRoleVersionCompatible(tagsList, InstallerAccountRole, "4.14")
+			Expect(err).To(BeNil())
+			Expect(isCompatible).To(Equal(true))
+		})
+	})
+})


### PR DESCRIPTION
When the user creates a cluster in interactive mode and selecting classic ROSA topology, the CLI should display only classic account-roles. HCP account roles are not compatible with classic ROSA clusters.

(cherry picked from commit 5a522b6c4c0a0bddcb43c1ff86d429071ef354f5)