### PR TITLE
OCM-4612 | fix: `list users` can list `cluster-admin` user

### DIFF
--- a/cmd/list/user/cmd.go
+++ b/cmd/list/user/cmd.go
@@ -26,7 +26,6 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
-	"github.com/openshift/rosa/cmd/create/idp"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/rosa"
@@ -68,12 +67,6 @@ func run(_ *cobra.Command, _ []string) {
 	if err != nil {
 		r.Reporter.Errorf("Failed to get cluster-admins for cluster '%s': %v", clusterKey, err)
 		os.Exit(1)
-	}
-	// Remove cluster-admin user
-	for i, user := range clusterAdmins {
-		if user.ID() == idp.ClusterAdminUsername {
-			clusterAdmins = append(clusterAdmins[:i], clusterAdmins[i+1:]...)
-		}
 	}
 
 	// Load dedicated-admins for this cluster


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-4612

In the current code, the `cluster-admin` user is filtered out in `list users` output. That will lead to confusing since user selects to create that user, but cannot find it. The code is 3 years old and is used to avoid explicitly grant `cluster-admin` user to `cluster-admins` group.
But in latest implementation, the `cluster-admin` user is created and will be injected into `cluster-admins` group by default. And `grant user` command is prevented to update `cluster-admin` user's group. It's better to display `cluster-admin` user to `rosa list users` now.

Signed-off-by: marcolan018 <llan@redhat.com>