### PR TITLE
OCM-4622 | fix: Create HCP account roles with unmanaged policies

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -185,6 +185,7 @@ func run(cmd *cobra.Command, argv []string) {
 	// Hosted cluster roles always use managed policies
 	if cmd.Flags().Changed("hosted-cp") && cmd.Flags().Changed("managed-policies") && !args.managed {
 		r.Reporter.Errorf("Setting `hosted-cp` as unmanaged policies is not supported")
+		os.Exit(1)
 	}
 
 	if cmd.Flags().Changed("hosted-cp") && r.Creator.IsGovcloud {


### PR DESCRIPTION
If the users provides the `managed-policies` flag set to false, alongside the `hosted-cp` flag, exit with the provided error message.

```
oadler@fedora:rosa (OCM-4632)$ rosa create account-roles --hosted-cp --managed-policies=false
I: Logged in as 'oadler.openshift' on 'http://localhost:9000'
E: Setting `hosted-cp` as unmanaged policies is not supported
```