### PR TITLE
OCM-4376 | feat: Added the `rosa delete kubeletconfig` sub-command

### DIFF
--- a/cmd/dlt/cmd.go
+++ b/cmd/dlt/cmd.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift/rosa/cmd/dlt/dnsdomains"
 	"github.com/openshift/rosa/cmd/dlt/idp"
 	"github.com/openshift/rosa/cmd/dlt/ingress"
+	"github.com/openshift/rosa/cmd/dlt/kubeletconfig"
 	"github.com/openshift/rosa/cmd/dlt/machinepool"
 	"github.com/openshift/rosa/cmd/dlt/ocmrole"
 	"github.com/openshift/rosa/cmd/dlt/oidcconfig"
@@ -63,6 +64,7 @@ func init() {
 	Cmd.AddCommand(tuningconfigs.Cmd)
 	Cmd.AddCommand(dnsdomains.Cmd)
 	Cmd.AddCommand(autoscaler.Cmd)
+	Cmd.AddCommand(kubeletconfig.Cmd)
 
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)

--- a/cmd/dlt/kubeletconfig/cmd.go
+++ b/cmd/dlt/kubeletconfig/cmd.go
@@ -1,0 +1,70 @@
+/*
+Copyright (c) 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeletconfig
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/interactive/confirm"
+	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+var Cmd = &cobra.Command{
+	Use:     "kubeletconfig",
+	Aliases: []string{"kubelet-config"},
+	Short:   "Delete the custom kubeletconfig for a cluster",
+	Long:    "Delete the custom kubeletconfig for a cluster",
+	Example: `  # Delete the custom kubeletconfig for cluster 'foo'
+  rosa delete kubeletconfig --cluster foo`,
+	Run: run,
+}
+
+func init() {
+	ocm.AddClusterFlag(Cmd)
+	confirm.AddFlag(Cmd.Flags())
+}
+
+func run(_ *cobra.Command, _ []string) {
+	r := rosa.NewRuntime().WithOCM()
+	defer r.Cleanup()
+
+	clusterKey := r.GetClusterKey()
+	cluster := r.FetchCluster()
+
+	r.Reporter.Debugf("Deleting KubeletConfig for cluster '%s'", clusterKey)
+
+	prompt := fmt.Sprintf("Deleting the custom KubeletConfig for cluster '%s' will cause all non-Control Plane "+
+		"nodes to reboot. This may cause outages to your applications. Do you wish to continue?", cluster.ID())
+
+	if confirm.ConfirmRaw(prompt) {
+
+		err := r.OCMClient.DeleteKubeletConfig(cluster.ID())
+		if err != nil {
+			r.Reporter.Errorf("Failed to delete custom KubeletConfig for cluster '%s': '%s'",
+				cluster.ID(), err)
+			os.Exit(1)
+		}
+		r.Reporter.Infof("Successfully deleted custom KubeletConfig for cluster '%s'", cluster.ID())
+		os.Exit(0)
+	}
+
+	r.Reporter.Infof("Delete of custom KubeletConfig for cluster '%s' aborted.", cluster.ID())
+}

--- a/pkg/interactive/confirm/confirm.go
+++ b/pkg/interactive/confirm/confirm.go
@@ -40,9 +40,14 @@ func Yes() bool {
 	return yes
 }
 
+// Asks the user to confirm the operation, using the specified string as the message
+func ConfirmRaw(q string) bool {
+	return Prompt(false, q)
+}
+
 func Confirm(q string, v ...interface{}) bool {
 	msg := fmt.Sprintf("Are you sure you want to %s?", fmt.Sprintf(q, v...))
-	return Prompt(false, msg)
+	return ConfirmRaw(msg)
 }
 
 func Prompt(dflt bool, q string, v ...interface{}) bool {

--- a/pkg/ocm/kubeletconfig.go
+++ b/pkg/ocm/kubeletconfig.go
@@ -19,3 +19,11 @@ func (c *Client) GetClusterKubeletConfig(clusterID string) (*cmv1.KubeletConfig,
 
 	return response.Body(), nil
 }
+
+func (c *Client) DeleteKubeletConfig(clusterID string) error {
+	response, err := c.ocm.ClustersMgmt().V1().Clusters().Cluster(clusterID).KubeletConfig().Delete().Send()
+	if err != nil {
+		return handleErr(response.Error(), err)
+	}
+	return nil
+}

--- a/pkg/ocm/kubeletconfig_test.go
+++ b/pkg/ocm/kubeletconfig_test.go
@@ -98,6 +98,29 @@ var _ = Describe("KubeletConfig", Ordered, func() {
 		Expect(err).To(BeNil())
 		Expect(kubeletConfig).To(BeNil())
 	})
+
+	It("Deletes KubeletConfig", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusNoContent, ""),
+		)
+
+		err := ocmClient.DeleteKubeletConfig(clusterId)
+		Expect(err).To(BeNil())
+	})
+
+	It("Fails to Delete KubeletConfig if none exists", func() {
+
+		apiServer.AppendHandlers(
+			RespondWithJSON(
+				http.StatusNotFound,
+				body,
+			),
+		)
+
+		err := ocmClient.DeleteKubeletConfig(clusterId)
+		Expect(err).NotTo(BeNil())
+	})
+
 })
 
 func createKubeletConfig() (string, error) {


### PR DESCRIPTION
This PR adds support for the `rosa delete kubeletconfig` sub-command.