### PR TITLE
OCM-4687 | feat:Create HCP cluster - filter classic roles

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1240,7 +1240,7 @@ func run(cmd *cobra.Command, _ []string) {
 		// Find all installer roles in the current account using AWS resource tags
 		var roleARNs []string
 		if isHostedCP {
-			roleARNs, err = awsClient.FindRoleARNs(aws.InstallerAccountRole, minor)
+			roleARNs, err = awsClient.FindRoleARNsHostedCp(aws.InstallerAccountRole, minor)
 		} else {
 			roleARNs, err = awsClient.FindRoleARNsClassic(aws.InstallerAccountRole, minor)
 		}
@@ -1312,7 +1312,7 @@ func run(cmd *cobra.Command, _ []string) {
 					continue
 				}
 				if isHostedCP {
-					roleARNs, err = awsClient.FindRoleARNs(roleType, minor)
+					roleARNs, err = awsClient.FindRoleARNsHostedCp(roleType, minor)
 				} else {
 					roleARNs, err = awsClient.FindRoleARNsClassic(roleType, minor)
 				}

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -121,6 +121,7 @@ type Client interface {
 	HasOpenIDConnectProvider(issuerURL string, accountID string) (bool, error)
 	FindRoleARNs(roleType string, version string) ([]string, error)
 	FindRoleARNsClassic(roleType string, version string) ([]string, error)
+	FindRoleARNsHostedCp(roleType string, version string) ([]string, error)
 	FindPolicyARN(operator Operator, version string) (string, error)
 	ListUserRoles() ([]Role, error)
 	ListOCMRoles() ([]Role, error)

--- a/pkg/aws/policies_test.go
+++ b/pkg/aws/policies_test.go
@@ -58,4 +58,44 @@ var _ = Describe("Is Account Role Version Compatible", func() {
 			Expect(isCompatible).To(Equal(true))
 		})
 	})
+	When("Role has HCP managed policies when trying to create classic cluster", func() {
+		It("Should return incompatible", func() {
+			tagsList := []*iam.Tag{
+				{
+					Key:   aws.String("rosa_openshift_version"),
+					Value: aws.String("4.12"),
+				},
+				{
+					Key:   aws.String("rosa_managed_policies"),
+					Value: aws.String("true"),
+				},
+				{
+					Key:   aws.String("rosa_hcp_policies"),
+					Value: aws.String("true"),
+				},
+			}
+			isCompatible, err := validateAccountRoleVersionCompatibilityClassic(InstallerAccountRole, "4.12",
+				tagsList)
+			Expect(err).To(BeNil())
+			Expect(isCompatible).To(Equal(false))
+		})
+	})
+	When("Role has classic policies when trying to create an HCP cluster", func() {
+		It("Should return incompatible", func() {
+			tagsList := []*iam.Tag{
+				{
+					Key:   aws.String("rosa_openshift_version"),
+					Value: aws.String("4.12"),
+				},
+				{
+					Key:   aws.String("rosa_managed_policies"),
+					Value: aws.String("true"),
+				},
+			}
+			isCompatible, err := validateAccountRoleVersionCompatibilityHostedCp(InstallerAccountRole, "4.12",
+				tagsList)
+			Expect(err).To(BeNil())
+			Expect(isCompatible).To(Equal(false))
+		})
+	})
 })


### PR DESCRIPTION
When the user is creating an HCP cluster in interactive mode, display only roles with HCP-managed policies.

**Note:** The user can still provide classic role ARNs via flags (will be enabled for some organizations in the backend).

```
oadler@fedora:rosa (OCM-4687)$ rosa create cluster --hosted-cp
I: Enabling interactive mode
? Cluster name: oadler-nov-6
? Deploy cluster with Hosted Control Plane: Yes
I: NOTE: Hosted control planes are currently in Technology Preview (https://access.redhat.com/support/offerings/techpreview). Any Technology Preview clusters will need to be destroyed and recreated prior to general availability.
? Billing Account: 765374464689
I: Using '765374464689' as billing account.
? OpenShift version: 4.13.18
W: More than one Installer role found
? Installer role ARN:  [Use arrows to move, type to filter, ? for more help]
  arn:aws:iam::765374464689:role/hcp1-HCP-ROSA-Installer-Role
  arn:aws:iam::765374464689:role/hcp2-HCP-ROSA-Installer-Role
  arn:aws:iam::765374464689:role/int-HCP-ROSA-Installer-Role
> arn:aws:iam::765374464689:role/jbriones-HCP-ROSA-Installer-Role
  arn:aws:iam::765374464689:role/local-HCP-ROSA-Installer-Role
  arn:aws:iam::765374464689:role/lponce-local-HCP-ROSA-Installer-Role
  arn:aws:iam::765374464689:role/lponce-prod-HCP-ROSA-Installer-Role
```
