### PR TITLE
OCM-3854 | feat: Added `rosa create kubeletconfig` sub-command

### DIFF
--- a/cmd/create/cmd.go
+++ b/cmd/create/cmd.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift/rosa/cmd/create/dnsdomains"
 	"github.com/openshift/rosa/cmd/create/idp"
 	"github.com/openshift/rosa/cmd/create/ingress"
+	"github.com/openshift/rosa/cmd/create/kubeletconfig"
 	"github.com/openshift/rosa/cmd/create/machinepool"
 	"github.com/openshift/rosa/cmd/create/ocmrole"
 	"github.com/openshift/rosa/cmd/create/oidcconfig"
@@ -34,7 +35,6 @@ import (
 	"github.com/openshift/rosa/cmd/create/service"
 	"github.com/openshift/rosa/cmd/create/tuningconfigs"
 	"github.com/openshift/rosa/cmd/create/userrole"
-
 	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 )
@@ -62,6 +62,7 @@ func init() {
 	Cmd.AddCommand(tuningconfigs.Cmd)
 	Cmd.AddCommand(dnsdomains.Cmd)
 	Cmd.AddCommand(autoscaler.Cmd)
+	Cmd.AddCommand(kubeletconfig.Cmd)
 
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)

--- a/cmd/create/kubeletconfig/cmd.go
+++ b/cmd/create/kubeletconfig/cmd.go
@@ -1,0 +1,147 @@
+/*
+Copyright (c) 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeletconfig
+
+import (
+	"fmt"
+	"os"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/interactive/confirm"
+	"github.com/openshift/rosa/pkg/kubeletconfig"
+	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+const unassigned int = -1
+
+var Cmd = &cobra.Command{
+	Use:     "kubeletconfig",
+	Aliases: []string{"kubelet-config"},
+	Short:   "Create a custom kubeletconfig for a cluster",
+	Long:    "Create a custom kubeletconfig for a cluster",
+	Example: `  # Create a custom kubeletconfig with a pod-pids-limit of 5000
+  rosa create kubeletconfig --cluster=mycluster --pod-pids-limit=5000
+  `,
+	Run: run,
+}
+
+var args struct {
+	podPidsLimit int
+}
+
+func init() {
+	flags := Cmd.Flags()
+	flags.SortFlags = false
+	flags.IntVar(
+		&args.podPidsLimit,
+		"pod-pids-limit",
+		unassigned,
+		"Sets the requested pod_pids_limit for your custom KubeletConfig. Must be an integer in the range "+
+			"4096 - 16,384.")
+
+	ocm.AddClusterFlag(Cmd)
+	interactive.AddFlag(flags)
+}
+
+func run(_ *cobra.Command, _ []string) {
+	r := rosa.NewRuntime().WithOCM()
+	defer r.Cleanup()
+
+	clusterKey := r.GetClusterKey()
+	cluster := r.FetchCluster()
+
+	if cluster.Hypershift().Enabled() {
+		r.Reporter.Errorf("Hosted Control Plane clusters do not support custom KubeletConfig configuration.")
+		os.Exit(1)
+	}
+
+	if cluster.State() != cmv1.ClusterStateReady {
+		r.Reporter.Errorf("Cluster '%s' is not yet ready. Current state is '%s'", clusterKey, cluster.State())
+		os.Exit(1)
+	}
+
+	kubeletConfig, err := r.OCMClient.GetClusterKubeletConfig(cluster.ID())
+	if err != nil {
+		r.Reporter.Errorf("Failed getting KubeletConfig for cluster '%s': %s",
+			cluster.ID(), err)
+		os.Exit(1)
+	}
+
+	if kubeletConfig != nil {
+		r.Reporter.Errorf("A custom KubeletConfig for cluster '%s' already exists. "+
+			"You should edit it via 'rosa edit kubeletconfig'", clusterKey)
+		os.Exit(1)
+	}
+
+	if args.podPidsLimit == unassigned && !interactive.Enabled() {
+		interactive.Enable()
+		r.Reporter.Infof("Enabling interactive mode")
+	}
+
+	if interactive.Enabled() {
+		args.podPidsLimit, err = interactive.GetInt(interactive.Input{
+			Question: "Pod Pids Limit?",
+			Help:     "Set the Pod Pids Limit field to a value between 4096 and 16,384",
+			Options:  nil,
+			Default:  nil,
+			Required: true,
+			Validators: []interactive.Validator{
+				// We only validate the minimum as some customers have capability to exceed maximum
+				// We rely on backend validation for that
+				interactive.Min(kubeletconfig.MinPodPidsLimit),
+			},
+		})
+
+		if err != nil {
+			r.Reporter.Errorf("Failed creating KubeletConfig for cluster '%s': '%s'",
+				cluster.ID(), err)
+			os.Exit(1)
+		}
+
+	}
+
+	if args.podPidsLimit < kubeletconfig.MinPodPidsLimit {
+		r.Reporter.Errorf("The minimum value for --pod-pids-limit is '%d'. You have supplied '%d'",
+			kubeletconfig.MinPodPidsLimit, args.podPidsLimit)
+		os.Exit(1)
+	}
+
+	prompt := fmt.Sprintf("Creating the custom KubeletConfig for cluster '%s' will cause all non-Control Plane "+
+		"nodes to reboot. This may cause outages to your applications. Do you wish to continue?", cluster.ID())
+
+	if confirm.ConfirmRaw(prompt) {
+
+		r.Reporter.Debugf("Creating KubeletConfig for cluster '%s'", clusterKey)
+		kubeletConfigArgs := ocm.KubeletConfigArgs{PodPidsLimit: args.podPidsLimit}
+
+		_, err = r.OCMClient.CreateKubeletConfig(cluster.ID(), kubeletConfigArgs)
+		if err != nil {
+			r.Reporter.Errorf("Failed creating custom KubeletConfig for cluster '%s': '%s'",
+				cluster.ID(), err)
+			os.Exit(1)
+		}
+
+		r.Reporter.Infof("Successfully created custom KubeletConfig for cluster '%s'", cluster.ID())
+		os.Exit(0)
+	}
+
+	r.Reporter.Infof("Creation of custom KubeletConfig for cluster '%s' aborted.", cluster.ID())
+}

--- a/pkg/interactive/validation.go
+++ b/pkg/interactive/validation.go
@@ -24,11 +24,13 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"strconv"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/core"
 	clustervalidations "github.com/openshift-online/ocm-common/pkg/cluster/validations"
 	diskValidator "github.com/openshift-online/ocm-common/pkg/machinepool/validations"
+
 	"github.com/openshift/rosa/pkg/helper"
 	"github.com/openshift/rosa/pkg/ocm"
 )
@@ -120,6 +122,25 @@ func IsCIDR(val interface{}) error {
 		return nil
 	}
 	return fmt.Errorf("can only validate strings, got %v", val)
+}
+
+func Min(min int) Validator {
+	return func(ans interface{}) error {
+		if i, ok := ans.(string); ok {
+			val, err := strconv.Atoi(i)
+			if err != nil {
+				return fmt.Errorf("please enter an integer value, you entered '%s'", i)
+			}
+			if val < min {
+				return fmt.Errorf(
+					"'%d' is less than the permitted minimum of '%d'", val, min)
+			}
+
+			return nil
+		}
+
+		return fmt.Errorf("can only validate strings, got %v", ans)
+	}
 }
 
 func RegExp(restr string) Validator {

--- a/pkg/interactive/validation_test.go
+++ b/pkg/interactive/validation_test.go
@@ -1,0 +1,44 @@
+package interactive
+
+import (
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Validation", func() {
+	Context("Min", func() {
+		It("Fails validation if the answer is less than the minimum", func() {
+			validator := Min(50)
+			err := validator("25")
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("'25' is less than the permitted minimum of '50'"))
+		})
+
+		It("Fails validation if the answer is not an integer", func() {
+			validator := Min(50)
+			err := validator("hello")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("please enter an integer value, you entered 'hello'"))
+		})
+
+		It("Fails validation if the answer is not a string", func() {
+			validator := Min(50)
+			err := validator(45)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("can only validate strings, got int"))
+		})
+
+		It("Passes validation if the answer is greater than the min", func() {
+			validator := Min(50)
+			err := validator("55")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Passes validation if the answer is equal to the min", func() {
+			validator := Min(50)
+			err := validator("50")
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/pkg/kubeletconfig/consts.go
+++ b/pkg/kubeletconfig/consts.go
@@ -1,0 +1,5 @@
+package kubeletconfig
+
+const (
+	MinPodPidsLimit = 4096
+)

--- a/pkg/ocm/kubeletconfig.go
+++ b/pkg/ocm/kubeletconfig.go
@@ -6,6 +6,10 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
+type KubeletConfigArgs struct {
+	PodPidsLimit int
+}
+
 func (c *Client) GetClusterKubeletConfig(clusterID string) (*cmv1.KubeletConfig, error) {
 	response, err := c.ocm.ClustersMgmt().V1().Clusters().Cluster(clusterID).KubeletConfig().Get().Send()
 
@@ -26,4 +30,22 @@ func (c *Client) DeleteKubeletConfig(clusterID string) error {
 		return handleErr(response.Error(), err)
 	}
 	return nil
+}
+
+func (c *Client) CreateKubeletConfig(clusterID string, args KubeletConfigArgs) (*cmv1.KubeletConfig, error) {
+
+	builder := &cmv1.KubeletConfigBuilder{}
+	kubeletConfig, err := builder.PodPidsLimit(args.PodPidsLimit).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := c.ocm.ClustersMgmt().V1().Clusters().Cluster(clusterID).
+		KubeletConfig().Post().Request(kubeletConfig).Send()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return response.Body(), nil
 }

--- a/pkg/ocm/kubeletconfig_test.go
+++ b/pkg/ocm/kubeletconfig_test.go
@@ -121,6 +121,35 @@ var _ = Describe("KubeletConfig", Ordered, func() {
 		Expect(err).NotTo(BeNil())
 	})
 
+	It("Creates KubeletConfig", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(
+				http.StatusCreated,
+				body,
+			),
+		)
+
+		args := KubeletConfigArgs{podPidsLimit}
+		kubeletConfig, err := ocmClient.CreateKubeletConfig(clusterId, args)
+
+		Expect(kubeletConfig).NotTo(BeNil())
+		Expect(err).NotTo(HaveOccurred())
+
+	})
+
+	It("Fails to create KubeletConfig if one exists", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(
+				http.StatusBadRequest,
+				body,
+			),
+		)
+
+		args := KubeletConfigArgs{podPidsLimit}
+		_, err := ocmClient.CreateKubeletConfig(clusterId, args)
+		Expect(err).To(HaveOccurred())
+	})
+
 })
 
 func createKubeletConfig() (string, error) {


### PR DESCRIPTION
This PR adds support for the `rosa create kubeletconfig` sub-command.