### PR TITLE
OCM-4375 | feat: Added `rosa edit kubeletconfig` sub-command

### DIFF
--- a/cmd/edit/cmd.go
+++ b/cmd/edit/cmd.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openshift/rosa/cmd/edit/autoscaler"
 	"github.com/openshift/rosa/cmd/edit/cluster"
 	"github.com/openshift/rosa/cmd/edit/ingress"
+	"github.com/openshift/rosa/cmd/edit/kubeletconfig"
 	"github.com/openshift/rosa/cmd/edit/machinepool"
 	"github.com/openshift/rosa/cmd/edit/service"
 	"github.com/openshift/rosa/cmd/edit/tuningconfigs"
@@ -45,6 +46,7 @@ func init() {
 	Cmd.AddCommand(service.Cmd)
 	Cmd.AddCommand(tuningconfigs.Cmd)
 	Cmd.AddCommand(autoscaler.Cmd)
+	Cmd.AddCommand(kubeletconfig.Cmd)
 
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)

--- a/pkg/kubeletconfig/consts.go
+++ b/pkg/kubeletconfig/consts.go
@@ -1,5 +1,12 @@
 package kubeletconfig
 
 const (
-	MinPodPidsLimit = 4096
+	MinPodPidsLimit         = 4096
+	PodPidsLimitOption      = "pod-pids-limit"
+	PodPidsLimitOptionUsage = "Sets the requested pod_pids_limit for your custom KubeletConfig." +
+		" Must be an integer in the range 4096 - 16,384."
+	PodPidsLimitOptionDefaultValue = -1
+
+	InteractivePodPidsLimitPrompt = "Pod Pids Limit?"
+	InteractivePodPidsLimitHelp   = "Set the Pod Pids Limit field to a value between 4096 and 16,384"
 )

--- a/pkg/ocm/kubeletconfig.go
+++ b/pkg/ocm/kubeletconfig.go
@@ -32,16 +32,41 @@ func (c *Client) DeleteKubeletConfig(clusterID string) error {
 	return nil
 }
 
-func (c *Client) CreateKubeletConfig(clusterID string, args KubeletConfigArgs) (*cmv1.KubeletConfig, error) {
-
+func toOCMKubeletConfig(args KubeletConfigArgs) (*cmv1.KubeletConfig, error) {
 	builder := &cmv1.KubeletConfigBuilder{}
 	kubeletConfig, err := builder.PodPidsLimit(args.PodPidsLimit).Build()
 	if err != nil {
 		return nil, err
 	}
 
+	return kubeletConfig, nil
+}
+
+func (c *Client) CreateKubeletConfig(clusterID string, args KubeletConfigArgs) (*cmv1.KubeletConfig, error) {
+
+	kubeletConfig, err := toOCMKubeletConfig(args)
+	if err != nil {
+		return nil, err
+	}
+
 	response, err := c.ocm.ClustersMgmt().V1().Clusters().Cluster(clusterID).
 		KubeletConfig().Post().Request(kubeletConfig).Send()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return response.Body(), nil
+}
+
+func (c *Client) UpdateKubeletConfig(clusterID string, args KubeletConfigArgs) (*cmv1.KubeletConfig, error) {
+	kubeletConfig, err := toOCMKubeletConfig(args)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := c.ocm.ClustersMgmt().V1().Clusters().Cluster(clusterID).
+		KubeletConfig().Update().Body(kubeletConfig).Send()
 
 	if err != nil {
 		return nil, err

--- a/pkg/ocm/kubeletconfig_test.go
+++ b/pkg/ocm/kubeletconfig_test.go
@@ -150,6 +150,34 @@ var _ = Describe("KubeletConfig", Ordered, func() {
 		Expect(err).To(HaveOccurred())
 	})
 
+	It("Updates KubeletConfig", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(
+				http.StatusOK,
+				body,
+			),
+		)
+
+		args := KubeletConfigArgs{podPidsLimit}
+		kubeletConfig, err := ocmClient.UpdateKubeletConfig(clusterId, args)
+
+		Expect(kubeletConfig).NotTo(BeNil())
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Fails to update KubeletConfig", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(
+				http.StatusBadRequest,
+				body,
+			),
+		)
+
+		args := KubeletConfigArgs{podPidsLimit}
+		_, err := ocmClient.UpdateKubeletConfig(clusterId, args)
+		Expect(err).To(HaveOccurred())
+	})
+
 })
 
 func createKubeletConfig() (string, error) {


### PR DESCRIPTION
This PR introduces the `rosa edit kubeletconfig` sub-command.