### PR TITLE
OCM-4724 | feat: allow non sts clusters to verify network

### DIFF
--- a/cmd/verify/network/cmd.go
+++ b/cmd/verify/network/cmd.go
@@ -157,9 +157,6 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 			if cluster == nil {
 				cluster = r.FetchCluster()
 			}
-			if args.roleArn = cluster.AWS().STS().RoleARN(); args.roleArn == "" {
-				return fmt.Errorf("Network verification is only available for STS clusters")
-			}
 		} else {
 			return fmt.Errorf("%s is required", roleArnFlag)
 		}


### PR DESCRIPTION
Related issue: [OCM-4724](https://issues.redhat.com//browse/OCM-4724)