### PR TITLE
OCM-1323 | fix: Allow users to reset mp taints

### DIFF
--- a/pkg/helper/machinepools/helpers.go
+++ b/pkg/helper/machinepools/helpers.go
@@ -112,7 +112,7 @@ func GetTaints(cmd *cobra.Command, r *rosa.Runtime, existingTaints []*cmv1.Taint
 
 func ParseTaints(taints string) ([]*cmv1.TaintBuilder, error) {
 	taintBuilders := []*cmv1.TaintBuilder{}
-	if taints == "" {
+	if taints == "" || taints == interactiveModeEmptyLabels {
 		return taintBuilders, nil
 	}
 	var errs []error

--- a/pkg/helper/machinepools/helpers_test.go
+++ b/pkg/helper/machinepools/helpers_test.go
@@ -17,6 +17,12 @@ var _ = Describe("MachinePool", func() {
 				Expect(err.Error()).To(ContainSubstring(expectedError))
 			}
 		},
+		Entry("Empty taints are parsed correctly",
+			"", "", 0,
+		),
+		Entry("Resetting taints in interactive mode is parsed correctly",
+			`""`, "", 0,
+		),
 		Entry(
 			"Well formed taint",
 			"node-role.kubernetes.io/infra=val:NoSchedule", "", 1),


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-1323

This PR allows users to remove all existing taints on a MachinePool when using interactive mode on the CLI.