### PR TITLE
OCM-4675 | feat: show dynamically technology preview messages for hcp

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -652,7 +652,7 @@ func init() {
 		&args.hostedClusterEnabled,
 		"hosted-cp",
 		false,
-		"Technology Preview: Enable the use of Hosted Control Planes",
+		"Enable the use of Hosted Control Planes",
 	)
 
 	flags.StringVar(&args.machinePoolRootDiskSize,
@@ -912,11 +912,15 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 	}
 
-	// FIXME: Remove before GA
 	if isHostedCP && r.Reporter.IsTerminal() {
-		//nolint
-		r.Reporter.Infof("NOTE: Hosted control planes are currently in Technology Preview (https://access.redhat.com/support/offerings/techpreview)." +
-			" Any Technology Preview clusters will need to be destroyed and recreated prior to general availability.")
+		techPreviewMsg, err := r.OCMClient.GetTechnologyPreviewMessage(ocm.HcpProduct, time.Now())
+		if err != nil {
+			r.Reporter.Errorf("%s", err)
+			os.Exit(1)
+		}
+		if techPreviewMsg != "" {
+			r.Reporter.Infof(techPreviewMsg)
+		}
 	}
 
 	if isHostedCP && args.ec2MetadataHttpTokens != "" {

--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -90,7 +90,7 @@ func init() {
 		&args.hostedCP,
 		"hosted-cp",
 		false,
-		"Technology Preview: Enable the use of Hosted Control Planes",
+		"Enable the use of Hosted Control Planes",
 	)
 
 	confirm.AddFlag(flags)

--- a/pkg/ocm/products.go
+++ b/pkg/ocm/products.go
@@ -1,0 +1,38 @@
+package ocm
+
+import (
+	"time"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+)
+
+const RosaProductId = "rosa"
+
+func (c *Client) GetTechnologyPreview(id string) (*cmv1.ProductTechnologyPreview, bool, error) {
+	response, err := c.ocm.ClustersMgmt().V1().
+		Products().Product(RosaProductId).
+		TechnologyPreviews().TechnologyPreview(id).
+		Get().
+		Send()
+	if response.Status() == 404 {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, handleErr(response.Error(), err)
+	}
+	return response.Body(), true, nil
+}
+
+func (c *Client) GetTechnologyPreviewMessage(id string, forTime time.Time) (string, error) {
+	techPreview, exists, err := c.GetTechnologyPreview(id)
+	if err != nil {
+		return "", err
+	}
+	// It assumes that the technology_preview endpoint will be available in CS before the ROSA CLI 1.2.30 is out
+	// If no technology preview found, a feature should be considered GA
+	// If there is a technology preview for HCP and it's active we'll show the message
+	if exists && techPreview.EndDate().After(forTime) {
+		return techPreview.AdditionalText(), nil
+	}
+	return "", nil
+}

--- a/pkg/ocm/products_test.go
+++ b/pkg/ocm/products_test.go
@@ -1,0 +1,131 @@
+package ocm
+
+import (
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	"github.com/openshift-online/ocm-sdk-go/logging"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+)
+
+// nolint
+const hcpTechnologyPreviewBody = `{
+	"kind": "ProductTechnologyPreview",
+ 	"href": "/api/clusters_mgmt/v1/products/rosa/technology_previews/hcp",
+	"start_date": "2022-12-01T00:01:00Z",
+	"end_date": "2023-12-05T00:01:00Z",
+	"additional_text": "Tech preview message"
+}`
+
+var _ = Describe("Technology preview features", func() {
+	var ssoServer, apiServer *ghttp.Server
+	var ocmClient *Client
+
+	BeforeEach(func() {
+		// Create the servers:
+		ssoServer = MakeTCPServer()
+		apiServer = MakeTCPServer()
+		apiServer.SetAllowUnhandledRequests(true)
+		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+
+		// Create the token:
+		accessToken := MakeTokenString("Bearer", 15*time.Minute)
+
+		// Prepare the server:
+		ssoServer.AppendHandlers(
+			RespondWithAccessToken(accessToken),
+		)
+		// Prepare the logger:
+		logger, err := logging.NewGoLoggerBuilder().
+			Debug(true).
+			Build()
+		Expect(err).To(BeNil())
+		// Set up the connection with the fake config
+		connection, err := sdk.NewConnectionBuilder().
+			Logger(logger).
+			Tokens(accessToken).
+			URL(apiServer.URL()).
+			Build()
+		// Initialize client object
+		Expect(err).To(BeNil())
+		ocmClient = &Client{ocm: connection}
+	})
+
+	AfterEach(func() {
+		// Close the servers:
+		ssoServer.Close()
+		apiServer.Close()
+		Expect(ocmClient.Close()).To(Succeed())
+	})
+
+	It("Expects a message for hcp in tech preview", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(
+				http.StatusOK,
+				hcpTechnologyPreviewBody,
+			),
+		)
+
+		beforeRelease, err := time.Parse(time.RFC3339, "2023-12-03T00:01:00Z")
+		Expect(err).ToNot(HaveOccurred())
+
+		message, err := ocmClient.GetTechnologyPreviewMessage("hcp", beforeRelease)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(message).To(Equal("Tech preview message"))
+	})
+
+	It("Expects no message for hcp in GA", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(
+				http.StatusOK,
+				hcpTechnologyPreviewBody,
+			),
+		)
+
+		afterRelease, err := time.Parse(time.RFC3339, "2023-12-06T00:01:00Z")
+		Expect(err).ToNot(HaveOccurred())
+
+		message, err := ocmClient.GetTechnologyPreviewMessage("hcp", afterRelease)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(message).To(BeEmpty())
+	})
+
+	It("Expects no message if no technology preview", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(
+				http.StatusNotFound,
+				"",
+			),
+		)
+
+		beforeRelease, err := time.Parse(time.RFC3339, "2023-12-03T00:01:00Z")
+		Expect(err).ToNot(HaveOccurred())
+
+		message, err := ocmClient.GetTechnologyPreviewMessage("hcp", beforeRelease)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(message).To(BeEmpty())
+	})
+
+	It("Expects an error if bad product", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(
+				http.StatusBadRequest,
+				"Product 'bad-product' doesn't exist",
+			),
+		)
+
+		beforeRelease, err := time.Parse(time.RFC3339, "2023-12-03T00:01:00Z")
+		Expect(err).ToNot(HaveOccurred())
+
+		message, err := ocmClient.GetTechnologyPreviewMessage("bad-product", beforeRelease)
+		Expect(err).To(HaveOccurred())
+		Expect(message).To(BeEmpty())
+	})
+
+})


### PR DESCRIPTION
This PR shows the technology preview messages for hcp dynamically.

Two open questions:
- I don't find a good solution for the "Tech preview" messages in the init(), so, I guess the simple solution is to remove them as it is expected this feature will be part of the 1.2.30 release.
- I think we have to decide if the technology preview should be "explicit" meaning that if there is no entry, it can be considered GA (that would simplify the logic).

cc @andreadecorte 