### PR TITLE
OCM-4771 | fix: Added -y flag to rosa edit kubeletconfig command

### DIFF
--- a/cmd/edit/cmd.go
+++ b/cmd/edit/cmd.go
@@ -29,6 +29,7 @@ import (
 	"github.com/openshift/rosa/cmd/edit/tuningconfigs"
 	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/interactive/confirm"
 )
 
 var Cmd = &cobra.Command{
@@ -52,4 +53,5 @@ func init() {
 	arguments.AddProfileFlag(flags)
 	arguments.AddRegionFlag(flags)
 	interactive.AddFlag(flags)
+	confirm.AddFlag(flags)
 }


### PR DESCRIPTION
This PR adds the `-y` flag to `rosa edit` commands (in particular the `rosa edit kubeletconfig` command) which allows users to automatically accept prompts rather than having to manually acknowledge them.