### PR TITLE
OCM-4675 | fix: remove technology preview from command help

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -122,7 +122,7 @@ func init() {
 		&args.hostedCP,
 		"hosted-cp",
 		false,
-		"Technology Preview: Enable the use of Hosted Control Planes",
+		"Enable the use of Hosted Control Planes",
 	)
 
 	flags.BoolVar(


### PR DESCRIPTION
Forgotten in https://github.com/openshift/rosa/pull/1592