### PR TITLE
OCM-4782 | fix: Ensure we display what the user entered for '-c' flag on KubeletConfig command output

### DIFF
--- a/cmd/create/kubeletconfig/cmd.go
+++ b/cmd/create/kubeletconfig/cmd.go
@@ -109,7 +109,7 @@ func run(_ *cobra.Command, _ []string) {
 
 		if err != nil {
 			r.Reporter.Errorf("Failed creating KubeletConfig for cluster '%s': '%s'",
-				cluster.ID(), err)
+				clusterKey, err)
 			os.Exit(1)
 		}
 
@@ -122,7 +122,7 @@ func run(_ *cobra.Command, _ []string) {
 	}
 
 	prompt := fmt.Sprintf("Creating the custom KubeletConfig for cluster '%s' will cause all non-Control Plane "+
-		"nodes to reboot. This may cause outages to your applications. Do you wish to continue?", cluster.ID())
+		"nodes to reboot. This may cause outages to your applications. Do you wish to continue?", clusterKey)
 
 	if confirm.ConfirmRaw(prompt) {
 
@@ -132,13 +132,13 @@ func run(_ *cobra.Command, _ []string) {
 		_, err = r.OCMClient.CreateKubeletConfig(cluster.ID(), kubeletConfigArgs)
 		if err != nil {
 			r.Reporter.Errorf("Failed creating custom KubeletConfig for cluster '%s': '%s'",
-				cluster.ID(), err)
+				clusterKey, err)
 			os.Exit(1)
 		}
 
-		r.Reporter.Infof("Successfully created custom KubeletConfig for cluster '%s'", cluster.ID())
+		r.Reporter.Infof("Successfully created custom KubeletConfig for cluster '%s'", clusterKey)
 		os.Exit(0)
 	}
 
-	r.Reporter.Infof("Creation of custom KubeletConfig for cluster '%s' aborted.", cluster.ID())
+	r.Reporter.Infof("Creation of custom KubeletConfig for cluster '%s' aborted.", clusterKey)
 }

--- a/cmd/dlt/kubeletconfig/cmd.go
+++ b/cmd/dlt/kubeletconfig/cmd.go
@@ -52,19 +52,19 @@ func run(_ *cobra.Command, _ []string) {
 	r.Reporter.Debugf("Deleting KubeletConfig for cluster '%s'", clusterKey)
 
 	prompt := fmt.Sprintf("Deleting the custom KubeletConfig for cluster '%s' will cause all non-Control Plane "+
-		"nodes to reboot. This may cause outages to your applications. Do you wish to continue?", cluster.ID())
+		"nodes to reboot. This may cause outages to your applications. Do you wish to continue?", clusterKey)
 
 	if confirm.ConfirmRaw(prompt) {
 
 		err := r.OCMClient.DeleteKubeletConfig(cluster.ID())
 		if err != nil {
 			r.Reporter.Errorf("Failed to delete custom KubeletConfig for cluster '%s': '%s'",
-				cluster.ID(), err)
+				clusterKey, err)
 			os.Exit(1)
 		}
-		r.Reporter.Infof("Successfully deleted custom KubeletConfig for cluster '%s'", cluster.ID())
+		r.Reporter.Infof("Successfully deleted custom KubeletConfig for cluster '%s'", clusterKey)
 		os.Exit(0)
 	}
 
-	r.Reporter.Infof("Delete of custom KubeletConfig for cluster '%s' aborted.", cluster.ID())
+	r.Reporter.Infof("Delete of custom KubeletConfig for cluster '%s' aborted.", clusterKey)
 }

--- a/cmd/edit/kubeletconfig/cmd.go
+++ b/cmd/edit/kubeletconfig/cmd.go
@@ -80,7 +80,7 @@ func run(_ *cobra.Command, _ []string) {
 	kubeletconfig, err := r.OCMClient.GetClusterKubeletConfig(cluster.ID())
 	if err != nil {
 		r.Reporter.Errorf("Failed to fetch existing KubeletConfig configuration for cluster '%s': %s",
-			cluster.ID(), err)
+			clusterKey, err)
 		os.Exit(1)
 	}
 
@@ -113,7 +113,7 @@ func run(_ *cobra.Command, _ []string) {
 
 		if err != nil {
 			r.Reporter.Errorf("Failed updating KubeletConfig for cluster '%s': '%s'",
-				cluster.ID(), err)
+				clusterKey, err)
 			os.Exit(1)
 		}
 	}
@@ -125,7 +125,7 @@ func run(_ *cobra.Command, _ []string) {
 	}
 
 	prompt := fmt.Sprintf("Updating the custom KubeletConfig for cluster '%s' will cause all non-Control Plane "+
-		"nodes to reboot. This may cause outages to your applications. Do you wish to continue?", cluster.ID())
+		"nodes to reboot. This may cause outages to your applications. Do you wish to continue?", clusterKey)
 
 	if confirm.ConfirmRaw(prompt) {
 		r.Reporter.Debugf("Updating KubeletConfig for cluster '%s'", clusterKey)
@@ -136,9 +136,9 @@ func run(_ *cobra.Command, _ []string) {
 			os.Exit(1)
 		}
 
-		r.Reporter.Infof("Successfully updated custom KubeletConfig for cluster '%s'", cluster.ID())
+		r.Reporter.Infof("Successfully updated custom KubeletConfig for cluster '%s'", clusterKey)
 		os.Exit(0)
 	}
 
-	r.Reporter.Infof("Update of custom KubeletConfig for cluster '%s' aborted.", cluster.ID())
+	r.Reporter.Infof("Update of custom KubeletConfig for cluster '%s' aborted.", clusterKey)
 }


### PR DESCRIPTION
This PR ensures that we are consistent across all `rosa kubeletconfig` commands to output what the user has entered for the `-c` flag when printing command output. We were previously switching between cluster name e.g `rblake-test` and cluster id, which is slightly confusing.