### PR TITLE
OCM-4792 | fix: do not ask billingAccount for hcp before GA

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -659,6 +659,7 @@ func init() {
 		"",
 		"Account used for billing subscriptions purchased via the AWS marketplace",
 	)
+	flags.MarkHidden("billing-account")
 
 	flags.BoolVar(
 		&args.createAdminUser,
@@ -974,83 +975,16 @@ func run(cmd *cobra.Command, _ []string) {
 		outputClusterAdminDetails(r, isClusterAdmin, clusterAdminPassword)
 	}
 
+	if isHostedCP && cmd.Flags().Changed("default-mp-labels") {
+		r.Reporter.Errorf("Setting the worker machine pool labels is not supported for hosted clusters")
+		os.Exit(1)
+	}
+
 	// Billing Account
 	billingAccount := args.billingAccount
-	if isHostedCP {
-		if billingAccount != "" && !ocm.IsValidAWSAccount(billingAccount) {
-			r.Reporter.Errorf("Billing account is invalid. Run the command again with a valid billing account.")
-			os.Exit(1)
-		}
-
-		cloudAccounts, err := r.OCMClient.GetBillingAccounts()
-		if err != nil {
-			r.Reporter.Errorf("%s", err)
-			os.Exit(1)
-		}
-
-		billingAccounts := ocm.GenerateBillingAccountsList(cloudAccounts)
-
-		if billingAccount == "" && !interactive.Enabled() {
-			// if a billing account is not provided we will try to use the infrastructure account as default
-			if helper.ContainsPrefix(billingAccounts, awsCreator.AccountID) {
-				billingAccount = awsCreator.AccountID
-				r.Reporter.Infof("Using '%s' as billing account", billingAccount)
-				r.Reporter.Infof("To use a different billing account, add --billing-account xxxxxxxxxx to previous command")
-			} else {
-				r.Reporter.Errorf("A billing account is required for Hosted Control Plane clusters.")
-			}
-		}
-
-		if interactive.Enabled() {
-			if len(billingAccounts) > 0 {
-				billingAccount, err = interactive.GetOption(interactive.Input{
-					Question: "Billing Account",
-					Help:     cmd.Flags().Lookup("billing-account").Usage,
-					Default:  billingAccount,
-					Required: true,
-					Options:  billingAccounts,
-				})
-
-				if err != nil {
-					r.Reporter.Errorf("Expected a valid billing account: '%s'", err)
-					os.Exit(1)
-				}
-
-				billingAccount = aws.ParseOption(billingAccount)
-			}
-
-			if billingAccount == "" || !ocm.IsValidAWSAccount(billingAccount) {
-				r.Reporter.Errorf("Expected a valid billing account")
-				os.Exit(1)
-			}
-
-			// Get contract info
-			contracts, isContractEnabled := GetBillingAccountContracts(cloudAccounts, billingAccount)
-
-			if billingAccount != awsCreator.AccountID {
-				r.Reporter.Infof("The selected AWS billing account is a different account than your AWS infrastructure account." +
-					"The AWS billing account will be charged for subscription usage. " +
-					"The AWS infrastructure account will be used for managing the cluster.")
-			} else {
-				r.Reporter.Infof("Using '%s' as billing account.",
-					billingAccount)
-			}
-
-			if isContractEnabled && len(contracts) > 0 {
-				//currently, an AWS account will have only one ROSA HCP active contract at a time
-				contractDisplay := GenerateContractDisplay(contracts[0])
-				r.Reporter.Infof(contractDisplay)
-			}
-		}
-		if cmd.Flags().Changed("default-mp-labels") {
-			r.Reporter.Errorf("Setting the worker machine pool labels is not supported for hosted clusters")
-			os.Exit(1)
-		}
-	} else {
-		if billingAccount != "" {
-			r.Reporter.Errorf("Billing accounts are only supported for Hosted Control Plane clusters")
-			os.Exit(1)
-		}
+	if !isHostedCP && billingAccount != "" {
+		r.Reporter.Errorf("Billing accounts are only supported for Hosted Control Plane clusters")
+		os.Exit(1)
 	}
 
 	etcdEncryptionKmsARN := args.etcdEncryptionKmsARN


### PR DESCRIPTION
This is a hotfix for the ROSA CLI version.

Before the HCP GA, the "--billing-account" should be optional and not requested.

Note that this logic is not removed from master branch, as the 1.2.31 version should be available for HCP GA.

