### PR TITLE
OCM-4812 | fix: Provide sensible default for PIDs limit in interactive mode

### DIFF
--- a/pkg/kubeletconfig/config.go
+++ b/pkg/kubeletconfig/config.go
@@ -34,7 +34,7 @@ func GetInteractiveMaxPidsLimitHelp(maxPidsLimit int) string {
 
 func GetInteractiveInput(maxPidsLimit int, kubeletConfig *v1.KubeletConfig) interactive.Input {
 
-	var defaultLimit = PodPidsLimitOptionDefaultValue
+	var defaultLimit = MinPodPidsLimit
 	if kubeletConfig != nil {
 		defaultLimit = kubeletConfig.PodPidsLimit()
 	}

--- a/pkg/kubeletconfig/config_test.go
+++ b/pkg/kubeletconfig/config_test.go
@@ -65,7 +65,7 @@ var _ = Describe("KubeletConfig Config", func() {
 			Expect(input.Question).To(Equal(InteractivePodPidsLimitPrompt))
 			Expect(input.Help).To(Equal(GetInteractiveMaxPidsLimitHelp(5000)))
 			Expect(len(input.Validators)).To(Equal(2))
-			Expect(input.Default).To(Equal(PodPidsLimitOptionDefaultValue))
+			Expect(input.Default).To(Equal(MinPodPidsLimit))
 		})
 	})
 })

--- a/pkg/kubeletconfig/consts.go
+++ b/pkg/kubeletconfig/consts.go
@@ -6,7 +6,7 @@ const (
 	MaxUnsafePodPidsLimit          = 3694303
 	PodPidsLimitOption             = "pod-pids-limit"
 	PodPidsLimitOptionUsage        = "Sets the requested pod_pids_limit for your custom KubeletConfig."
-	PodPidsLimitOptionDefaultValue = -1
+	PodPidsLimitOptionDefaultValue = 0
 	InteractivePodPidsLimitPrompt  = "Pod Pids Limit?"
 	InteractivePodPidsLimitHelp    = "Set the Pod Pids Limit field to a value between 4096 and %d"
 	ByPassPidsLimitCapability      = "capability.organization.bypass_pids_limits"


### PR DESCRIPTION
This PR introduces a sensible default for PIDs limit in interactive mode when creating a `KubeletConfig`.

It also sets the default to `0` on `--pod-pids-limit` to remove the confusing `-1` appearing as a default when running `rosa help create/edit kubeletconfig`.