### PR TITLE
OCM-4588 | fix: remove suggestion to 'create oidc-config' 

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -401,10 +401,6 @@ func run(cmd *cobra.Command, argv []string) {
 			})
 			os.Exit(1)
 		}
-		if r.Reporter.IsTerminal() {
-			r.Reporter.Infof("To create an OIDC Config, run the following command:\n" +
-				"\trosa create oidc-config")
-		}
 		r.OCMClient.LogEvent("ROSACreateAccountRolesModeAuto", map[string]string{
 			ocm.Response: ocm.Success,
 			ocm.Version:  policyVersion,


### PR DESCRIPTION
[OCM-4588](https://issues.redhat.com//browse/OCM-4588) | fix: remove suggestion to 'create oidc-config' during 'create account-roles'

Suggestion was to remove prompt to create oidc-config