### PR TITLE
OCM-4505 | fix: elaborate on --best-effort help description

### DIFF
--- a/cmd/dlt/cluster/cmd.go
+++ b/cmd/dlt/cluster/cmd.go
@@ -59,7 +59,9 @@ func init() {
 		&args.bestEffort,
 		"best-effort",
 		false,
-		"Delete cluster in best-effort mode.",
+		"Deleting a cluster with \"best effort\" means that certain resources "+
+			"may be left behind in the cloud account and will need manual cleanup. "+
+			"This option should be used with care.",
 	)
 
 	flags.BoolVarP(


### PR DESCRIPTION
https://source.redhat.com/groups/public/ocm_team/ocm_blog/using_the_best_effort_flag_for_enabling_problematic_cluster_deletion