### PR TITLE
OCM-4767 | feat: add custom tags flag to rosa verify network

### DIFF
--- a/cmd/verify/network/cmd_test.go
+++ b/cmd/verify/network/cmd_test.go
@@ -333,4 +333,45 @@ INFO: subnet-0f87f640e56934cbc: passed
 		Expect(stderr).To(Equal(""))
 		Expect(stdout).To(Equal(successOutputComplete))
 	})
+	It("Succeeds if custom --tags are supplied", func() {
+		// POST /api/clusters_mgmt/v1/network_verifications
+		apiServer.AppendHandlers(
+			RespondWithJSON(
+				http.StatusOK,
+				subnetsComplete,
+			),
+		)
+		// GET /api/clusters_mgmt/v1/network_verifications/subnetB
+		apiServer.AppendHandlers(
+			RespondWithJSON(
+				http.StatusOK,
+				subnetPassedSuccess,
+			),
+		)
+		// GET /api/clusters_mgmt/v1/network_verifications/subnetB
+		apiServer.AppendHandlers(
+			RespondWithJSON(
+				http.StatusOK,
+				subnetPassedSuccess,
+			),
+		)
+		cmd.Flags().Set(roleArnFlag, "arn:aws:iam::765374464689:role/tomckay-Installer-Role")
+		cmd.Flags().Set("tags", "test val1, test2 val2")
+		cmd.Flags().Set(subnetIDsFlag, "subnet-0b761d44d3d9a4663,subnet-0f87f640e56934cbc")
+		cmd.Flags().Set("region", "us-east-1")
+		stdout, stderr, err := test.RunWithOutputCapture(runWithRuntime, r, cmd)
+		Expect(err).To(BeNil())
+		Expect(stderr).To(Equal(""))
+		Expect(stdout).To(Equal(successOutputComplete))
+	})
+	It("Fails if --tags are formatted incorrectly", func() {
+		cmd.Flags().Set(roleArnFlag, "arn:aws:iam::765374464689:role/tomckay-Installer-Role")
+		cmd.Flags().Set("tags", "test val1 test2 val2")
+		cmd.Flags().Set(subnetIDsFlag, "subnet-0b761d44d3d9a4663,subnet-0f87f640e56934cbc")
+		cmd.Flags().Set("region", "us-east-1")
+		err := runWithRuntime(r, cmd)
+		Expect(err).ToNot(BeNil())
+		Expect(err.Error()).To(
+			ContainSubstring("invalid tag format"))
+	})
 })

--- a/pkg/ocm/verify_network.go
+++ b/pkg/ocm/verify_network.go
@@ -28,10 +28,10 @@ func (c *Client) GetVerifyNetworkSubnet(id string) (*cmv1.SubnetNetworkVerificat
 }
 
 func (c *Client) VerifyNetworkSubnets(awsAccountId string, region string,
-	subnets []string) ([]*cmv1.SubnetNetworkVerification, error) {
+	subnets []string, tags map[string]string) ([]*cmv1.SubnetNetworkVerification, error) {
 
 	body, _ := cmv1.NewNetworkVerification().CloudProviderData(cmv1.NewCloudProviderData().
-		AWS(cmv1.NewAWS().STS(cmv1.NewSTS().RoleARN(awsAccountId))).
+		AWS(cmv1.NewAWS().STS(cmv1.NewSTS().RoleARN(awsAccountId)).Tags(tags)).
 		Subnets(subnets...).
 		Region(cmv1.NewCloudRegion().ID(region))).
 		Build()


### PR DESCRIPTION
Adds a `--tags` flag to `rosa verify network` that allows users to supply custom tags to the on-demand network verification API

https://issues.redhat.com/browse/OCM-4767