### PR TITLE
OCM-4877 | fix: Return versions when create cluster in fedramp

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1161,7 +1161,7 @@ func run(cmd *cobra.Command, _ []string) {
 	// OpenShift version:
 	version := args.version
 	channelGroup := args.channelGroup
-	versionList, err := versions.GetVersionList(r, channelGroup, isSTS, isHostedCP, true, true)
+	versionList, err := versions.GetVersionList(r, channelGroup, isSTS, isHostedCP, isHostedCP, true)
 	if err != nil {
 		r.Reporter.Errorf("%s", err)
 		os.Exit(1)


### PR DESCRIPTION
Fedramp was filtering out both non-HCP and HCP versions when using stable as the channel-group

This fix only filters out non-HCP when not creating an HCP cluster