### PR TITLE
OCM-4888 | fix: only asks for sgs if not been set in interactive

### DIFF
--- a/cmd/create/machinepool/machinepool.go
+++ b/cmd/create/machinepool/machinepool.go
@@ -291,7 +291,8 @@ func addMachinePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster
 	}
 
 	securityGroupIds := args.securityGroupIds
-	if interactive.Enabled() && isVersionCompatibleComputeSgIds && isByoVpc && !isHcpCluster {
+	if interactive.Enabled() && isVersionCompatibleComputeSgIds &&
+		isByoVpc && !isHcpCluster && !isSecurityGroupIdsSet {
 		availableSubnets, err := r.AWSClient.GetVPCSubnets(cluster.AWS().SubnetIDs()[0])
 		if err != nil {
 			r.Reporter.Errorf("Failed to retrieve available subnets: %v", err)


### PR DESCRIPTION
Related issue: [OCM-4888](https://issues.redhat.com//browse/OCM-4888)