### PR TITLE
OCM-4896 | fix: skip permission policies creation for HCP

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -406,7 +406,7 @@ func run(cmd *cobra.Command, argv []string) {
 			ocm.Version:  policyVersion,
 		})
 	case aws.ModeManual:
-		err = aws.GeneratePolicyFiles(r.Reporter, env, true, false, policies, nil, managedPolicies, "")
+		err = aws.GeneratePolicyFiles(r.Reporter, env, true, false, policies, nil, rolesCreator.skipPermissionFiles(), "")
 		if err != nil {
 			r.Reporter.Errorf("There was an error generating the policy files: %s", err)
 			r.OCMClient.LogEvent("ROSACreateAccountRolesModeManual", map[string]string{

--- a/cmd/create/accountroles/creators.go
+++ b/cmd/create/accountroles/creators.go
@@ -16,6 +16,7 @@ type creator interface {
 	createRoles(*rosa.Runtime, *accountRolesCreationInput) error
 	getRoleTags(string, *accountRolesCreationInput) map[string]string
 	printCommands(*rosa.Runtime, *accountRolesCreationInput) error
+	skipPermissionFiles() bool
 }
 
 func initCreator(r *rosa.Runtime, managedPolicies bool, classic bool, hostedCP bool, isClassicValueSet bool,
@@ -155,6 +156,10 @@ func (mp *managedPoliciesCreator) getRoleTags(roleType string, input *accountRol
 	return tagsList
 }
 
+func (mp *managedPoliciesCreator) skipPermissionFiles() bool {
+	return true
+}
+
 type unmanagedPoliciesCreator struct{}
 
 func (up *unmanagedPoliciesCreator) createRoles(r *rosa.Runtime, input *accountRolesCreationInput) error {
@@ -205,6 +210,10 @@ func (up *unmanagedPoliciesCreator) getRoleTags(roleType string, input *accountR
 	return getBaseRoleTags(roleType, input)
 }
 
+func (up *unmanagedPoliciesCreator) skipPermissionFiles() bool {
+	return false
+}
+
 type doubleRolesCreator struct{}
 
 func (db *doubleRolesCreator) createRoles(r *rosa.Runtime, input *accountRolesCreationInput) error {
@@ -236,6 +245,10 @@ func (db *doubleRolesCreator) printCommands(r *rosa.Runtime, input *accountRoles
 // getRoleTags is not needed, but here to satisfy the interface
 func (db *doubleRolesCreator) getRoleTags(roleType string, input *accountRolesCreationInput) map[string]string {
 	return nil
+}
+
+func (db *doubleRolesCreator) skipPermissionFiles() bool {
+	return false
 }
 
 func createRoleUnmanagedPolicy(r *rosa.Runtime, input *accountRolesCreationInput, accRoleName string,
@@ -342,6 +355,10 @@ func (hcp *hcpManagedPoliciesCreator) getRoleTags(roleType string, input *accoun
 	tagsList[tags.HypershiftPolicies] = tags.True
 
 	return tagsList
+}
+
+func (hcp *hcpManagedPoliciesCreator) skipPermissionFiles() bool {
+	return true
 }
 
 func getBaseRoleTags(roleType string, input *accountRolesCreationInput) map[string]string {

--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -637,7 +637,7 @@ func GetInstallerAccountRoleName(cluster *cmv1.Cluster) (string, error) {
 
 func GeneratePolicyFiles(reporter *rprtr.Object, env string, generateAccountRolePolicies bool,
 	generateOperatorRolePolicies bool, policies map[string]*cmv1.AWSSTSPolicy,
-	credRequests map[string]*cmv1.STSOperator, managedPolicies bool, sharedVpcRoleArn string) error {
+	credRequests map[string]*cmv1.STSOperator, skipPermissionFiles bool, sharedVpcRoleArn string) error {
 	if generateAccountRolePolicies {
 		for file := range AccountRoles {
 			//Get trust policy
@@ -655,7 +655,7 @@ func GeneratePolicyFiles(reporter *rprtr.Object, env string, generateAccountRole
 			}
 
 			//Get the permission policy
-			if !managedPolicies {
+			if !skipPermissionFiles {
 				err = generatePermissionPolicyFile(reporter, file, policies)
 				if err != nil {
 					return err
@@ -663,7 +663,7 @@ func GeneratePolicyFiles(reporter *rprtr.Object, env string, generateAccountRole
 			}
 		}
 	}
-	if generateOperatorRolePolicies {
+	if generateOperatorRolePolicies && !skipPermissionFiles {
 		isSharedVpc := sharedVpcRoleArn != ""
 		for credrequest := range credRequests {
 			filename := GetOperatorPolicyKey(credrequest, false, isSharedVpc)


### PR DESCRIPTION
When creating roles in manual mode, the CLI saves permission files locally. 
In the case of HCP account roles or operator roles, skip the file creation, as the roles are using managed policies.

Creating operator and account roles locally, only trust policies are created, used both for unmanaged and managed:

```
oadler@fedora:rosa (OCM-4896)$ rosa create operator-roles --oidc-config-id 27jpdr1kb66f6fkpkql6b384ckpqs62q --prefix oadler-nov-19
? Role creation mode: manual
? Operator roles prefix: oadler-nov-19
? Create hosted control plane operator roles: Yes
W: More than one Installer role found
? Installer role ARN: arn:aws:iam::765374464689:role/oadler-HCP-ROSA-Installer-Role
? Permissions boundary ARN (optional): 
I: Reusable OIDC Configuration detected. Validating trusted relationships to operator roles: 
I: All policy files saved to the current directory
I: Run the following commands to create the operator roles:

aws iam create-role \
        --assume-role-policy-document file://operator_cluster_csi_drivers_ebs_cloud_credentials_policy.json \
        --role-name oadler-nov-19-openshift-cluster-csi-drivers-ebs-cloud-credential \
	--tags Key=red-hat-managed,Value=true Key=rosa_hcp_policies,Value=true Key=rosa_managed_policies,Value=true Key=operator_name,Value=ebs-cloud-credentials Key=operator_namespace,Value=openshift-cluster-csi-drivers

aws iam attach-role-policy \
	--policy-arn arn:aws:iam::aws:policy/service-role/ROSAAmazonEBSCSIDriverOperatorPolicy \
	--role-name oadler-nov-19-openshift-cluster-csi-drivers-ebs-cloud-credential

aws iam create-role \
	--assume-role-policy-document file://operator_cloud_network_config_controller_cloud_credentials_policy.json \
	--role-name oadler-nov-19-openshift-cloud-network-config-controller-cloud-cr \
	--tags Key=red-hat-managed,Value=true Key=rosa_hcp_policies,Value=true Key=rosa_managed_policies,Value=true Key=operator_name,Value=cloud-credentials Key=operator_namespace,Value=openshift-cloud-network-config-controller

aws iam attach-role-policy \
	--policy-arn arn:aws:iam::aws:policy/service-role/ROSACloudNetworkConfigOperatorPolicy \
	--role-name oadler-nov-19-openshift-cloud-network-config-controller-cloud-cr

aws iam create-role \
	--assume-role-policy-document file://operator_image_registry_installer_cloud_credentials_policy.json \
	--role-name oadler-nov-19-openshift-image-registry-installer-cloud-credentia \
	--tags Key=red-hat-managed,Value=true Key=rosa_hcp_policies,Value=true Key=rosa_managed_policies,Value=true Key=operator_name,Value=installer-cloud-credentials Key=operator_namespace,Value=openshift-image-registry

aws iam attach-role-policy \
	--policy-arn arn:aws:iam::aws:policy/service-role/ROSAImageRegistryOperatorPolicy \
	--role-name oadler-nov-19-openshift-image-registry-installer-cloud-credentia

aws iam create-role \
	--assume-role-policy-document file://operator_ingress_operator_cloud_credentials_policy.json \
	--role-name oadler-nov-19-openshift-ingress-operator-cloud-credentials \
	--tags Key=red-hat-managed,Value=true Key=rosa_hcp_policies,Value=true Key=rosa_managed_policies,Value=true Key=operator_name,Value=cloud-credentials Key=operator_namespace,Value=openshift-ingress-operator

aws iam attach-role-policy \
	--policy-arn arn:aws:iam::aws:policy/service-role/ROSAIngressOperatorPolicy \
	--role-name oadler-nov-19-openshift-ingress-operator-cloud-credentials

aws iam create-role \
	--assume-role-policy-document file://operator_kube_controller_manager_credentials_policy.json \
	--role-name oadler-nov-19-kube-system-kube-controller-manager \
	--tags Key=red-hat-managed,Value=true Key=rosa_hcp_policies,Value=true Key=rosa_managed_policies,Value=true Key=operator_namespace,Value=kube-system Key=operator_name,Value=kube-controller-manager

aws iam attach-role-policy \
	--policy-arn arn:aws:iam::aws:policy/service-role/ROSAKubeControllerPolicy \
	--role-name oadler-nov-19-kube-system-kube-controller-manager

aws iam create-role \
	--assume-role-policy-document file://operator_capa_controller_manager_credentials_policy.json \
	--role-name oadler-nov-19-kube-system-capa-controller-manager \
	--tags Key=red-hat-managed,Value=true Key=rosa_hcp_policies,Value=true Key=rosa_managed_policies,Value=true Key=operator_namespace,Value=kube-system Key=operator_name,Value=capa-controller-manager

aws iam attach-role-policy \
	--policy-arn arn:aws:iam::aws:policy/service-role/ROSANodePoolManagementPolicy \
	--role-name oadler-nov-19-kube-system-capa-controller-manager

aws iam create-role \
	--assume-role-policy-document file://operator_control_plane_operator_credentials_policy.json \
	--role-name oadler-nov-19-kube-system-control-plane-operator \
	--tags Key=red-hat-managed,Value=true Key=rosa_hcp_policies,Value=true Key=rosa_managed_policies,Value=true Key=operator_namespace,Value=kube-system Key=operator_name,Value=control-plane-operator

aws iam attach-role-policy \
	--policy-arn arn:aws:iam::aws:policy/service-role/ROSAControlPlaneOperatorPolicy \
	--role-name oadler-nov-19-kube-system-control-plane-operator

aws iam create-role \
	--assume-role-policy-document file://operator_kms_provider_credentials_policy.json \
	--role-name oadler-nov-19-kube-system-kms-provider \
	--tags Key=red-hat-managed,Value=true Key=rosa_hcp_policies,Value=true Key=operator_name,Value=kms-provider Key=rosa_managed_policies,Value=true Key=operator_namespace,Value=kube-system

aws iam attach-role-policy \
	--policy-arn arn:aws:iam::aws:policy/service-role/ROSAKMSProviderPolicy \
	--role-name oadler-nov-19-kube-system-kms-provider
oadler@fedora:rosa (OCM-4896)$ ls | grep json
operator_capa_controller_manager_credentials_policy.json
operator_cloud_network_config_controller_cloud_credentials_policy.json
operator_cluster_csi_drivers_ebs_cloud_credentials_policy.json
operator_control_plane_operator_credentials_policy.json
operator_image_registry_installer_cloud_credentials_policy.json
operator_ingress_operator_cloud_credentials_policy.json
operator_kms_provider_credentials_policy.json
operator_kube_controller_manager_credentials_policy.json
```

```
oadler@fedora:rosa (OCM-4896)$ ls | grep json
oadler@fedora:rosa (OCM-4896)$ rosa create account-roles --mode manual -y --hosted-cp
I: Logged in as 'oadler.openshift' on 'https://api.stage.openshift.com'
I: Validating AWS credentials...
I: AWS credentials are valid!
I: Validating AWS quota...
I: AWS quota ok. If cluster installation fails, validate actual AWS resource usage against https://docs.openshift.com/rosa/rosa_getting_started/rosa-required-aws-service-quotas.html
I: Verifying whether OpenShift command-line tool is available...
I: Current OpenShift Client Version: 4.11.0
I: Creating account roles
I: Run the following commands to create the hosted CP account roles and policies:

aws iam create-role \
	--assume-role-policy-document file://sts_installer_trust_policy.json \
	--role-name ManagedOpenShift-HCP-ROSA-Installer-Role \
	--tags Key=red-hat-managed,Value=true Key=rosa_hcp_policies,Value=true Key=rosa_role_type,Value=installer Key=rosa_managed_policies,Value=true Key=rosa_openshift_version,Value=4.14 Key=rosa_role_prefix,Value=ManagedOpenShift

aws iam attach-role-policy \
	--policy-arn arn:aws:iam::aws:policy/service-role/ROSAInstallerPolicy \
	--role-name ManagedOpenShift-HCP-ROSA-Installer-Role

aws iam create-role \
	--assume-role-policy-document file://sts_support_trust_policy.json \
	--role-name ManagedOpenShift-HCP-ROSA-Support-Role \
	--tags Key=red-hat-managed,Value=true Key=rosa_hcp_policies,Value=true Key=rosa_role_type,Value=support Key=rosa_managed_policies,Value=true Key=rosa_openshift_version,Value=4.14 Key=rosa_role_prefix,Value=ManagedOpenShift

aws iam attach-role-policy \
	--policy-arn arn:aws:iam::aws:policy/service-role/ROSASRESupportPolicy \
	--role-name ManagedOpenShift-HCP-ROSA-Support-Role

aws iam create-role \
	--assume-role-policy-document file://sts_instance_worker_trust_policy.json \
	--role-name ManagedOpenShift-HCP-ROSA-Worker-Role \
	--tags Key=red-hat-managed,Value=true Key=rosa_hcp_policies,Value=true Key=rosa_managed_policies,Value=true Key=rosa_openshift_version,Value=4.14 Key=rosa_role_type,Value=instance_worker Key=rosa_role_prefix,Value=ManagedOpenShift

aws iam attach-role-policy \
	--policy-arn arn:aws:iam::aws:policy/service-role/ROSAWorkerInstancePolicy \
	--role-name ManagedOpenShift-HCP-ROSA-Worker-Role

I: All policy files saved to the current directory
oadler@fedora:rosa (OCM-4896)$ ls | grep json
sts_installer_trust_policy.json
sts_instance_controlplane_trust_policy.json
sts_instance_worker_trust_policy.json
sts_support_trust_policy.json
```
