### PR TITLE
OCM-4898 | fix: create HCP operator roles by prefix - filter by policy

### DIFF
--- a/cmd/create/oidcconfig/cmd.go
+++ b/cmd/create/oidcconfig/cmd.go
@@ -215,7 +215,7 @@ func run(cmd *cobra.Command, argv []string) {
 			}
 			if mode == aws.ModeAuto && (interactive.Enabled() || (confirm.Yes() && args.installerRoleArn == "")) {
 				args.installerRoleArn = interactiveRoles.
-					GetInstallerRoleArn(r, cmd, args.installerRoleArn, MinorVersionForGetSecret)
+					GetInstallerRoleArn(r, cmd, args.installerRoleArn, MinorVersionForGetSecret, r.AWSClient.FindRoleARNs)
 			}
 			if interactive.Enabled() {
 				prefix, err := interactive.GetString(interactive.Input{

--- a/cmd/create/operatorroles/by_prefix.go
+++ b/cmd/create/operatorroles/by_prefix.go
@@ -58,7 +58,13 @@ func handleOperatorRolesPrefixOptions(r *rosa.Runtime, cmd *cobra.Command) {
 		os.Exit(1)
 	}
 	args.hostedCp = isHostedCP
-	args.installerRoleArn = interactiveRoles.GetInstallerRoleArn(r, cmd, args.installerRoleArn, "")
+	if args.hostedCp {
+		args.installerRoleArn = interactiveRoles.GetInstallerRoleArn(r, cmd, args.installerRoleArn, "",
+			r.AWSClient.FindRoleARNsHostedCp)
+	} else {
+		args.installerRoleArn = interactiveRoles.GetInstallerRoleArn(r, cmd, args.installerRoleArn, "",
+			r.AWSClient.FindRoleARNsClassic)
+	}
 }
 
 func handleOperatorRoleCreationByPrefix(r *rosa.Runtime, env string,

--- a/cmd/register/oidcconfig/cmd.go
+++ b/cmd/register/oidcconfig/cmd.go
@@ -120,7 +120,7 @@ func run(cmd *cobra.Command, argv []string) {
 
 	if !cmd.Flags().Changed(InstallerRoleArnFlag) && (interactive.Enabled() || confirm.Yes()) {
 		args.installerRoleArn = interactiveRoles.
-			GetInstallerRoleArn(r, cmd, args.installerRoleArn, MinorVersionForGetSecret)
+			GetInstallerRoleArn(r, cmd, args.installerRoleArn, MinorVersionForGetSecret, r.AWSClient.FindRoleARNs)
 	}
 	roleName, _ := aws.GetResourceIdFromARN(args.installerRoleArn)
 	if !output.HasFlag() && r.Reporter.IsTerminal() {

--- a/pkg/interactive/roles/roles.go
+++ b/pkg/interactive/roles/roles.go
@@ -14,15 +14,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type findRoleARNs func(string, string) ([]string, error)
+
 func GetInstallerRoleArn(r *rosa.Runtime, cmd *cobra.Command,
-	defaultInstallerRoleArn string, minMinorVersion string) string {
+	defaultInstallerRoleArn string, minMinorVersion string, findRoleARNs findRoleARNs) string {
 	spin := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
 	spin.Start()
-	awsClient := r.AWSClient
 	role := aws.AccountRoles[aws.InstallerAccountRole]
 	roleARN := defaultInstallerRoleArn
 	// Find all installer roles in the current account using AWS resource tags
-	roleARNs, err := awsClient.FindRoleARNs(aws.InstallerAccountRole, minMinorVersion)
+	roleARNs, err := findRoleARNs(aws.InstallerAccountRole, minMinorVersion)
 	if err != nil {
 		r.Reporter.Errorf("Failed to find %s role: %s", role.Name, err)
 		os.Exit(1)


### PR DESCRIPTION
When the user creates operator roles using prefix and provides an installer role ARN in interactive mode, display only account roles with HCP-managed policies.

```
oadler@fedora:rosa (OCM-4898)$ rosa create operator-roles --oidc-config-id 27jpdr1kb66f6fkpkql6b384ckpqs62q --prefix oadler-nov-20 --hosted-cp
? Role creation mode: auto
? Operator roles prefix: oadler-nov-20
? Create hosted control plane operator roles: Yes
W: More than one Installer role found
? Installer role ARN:  [Use arrows to move, type to filter, ? for more help]
  arn:aws:iam::765374464689:role/ming-local-HCP-ROSA-Installer-Role
  arn:aws:iam::765374464689:role/ming-staging-HCP-ROSA-Installer-Role
  arn:aws:iam::765374464689:role/new-prefix-HCP-ROSA-Installer-Role
> arn:aws:iam::765374464689:role/oadler-aug-24-HCP-ROSA-Installer-Role
  arn:aws:iam::765374464689:role/oadler-HCP-ROSA-Installer-Role
  arn:aws:iam::765374464689:role/oadler-nov-14-HCP-ROSA-Installer-Role
  arn:aws:iam::765374464689:role/oadler-nov-16-HCP-ROSA-Installer-Role
```
