### PR TITLE
OCM-4924 | fix: improve info message for create operator roles

### DIFF
--- a/cmd/create/operatorroles/by_prefix.go
+++ b/cmd/create/operatorroles/by_prefix.go
@@ -192,9 +192,13 @@ func handleOperatorRoleCreationByPrefix(r *rosa.Runtime, env string,
 			if args.hostedCp {
 				hostedCpOutputParam = fmt.Sprintf(" --%s", HostedCpFlag)
 			}
+			installerRoleArnParam := ""
+			if args.installerRoleArn != "" && path != "" {
+				installerRoleArnParam = fmt.Sprintf(" --role-arn %s", args.installerRoleArn)
+			}
 			r.Reporter.Infof(fmt.Sprintf("To create a cluster with these roles, run the following command:\n"+
-				"\trosa create cluster --sts --oidc-config-id %s --operator-roles-prefix %s%s",
-				args.oidcConfigId, args.prefix, hostedCpOutputParam))
+				"\trosa create cluster --sts --oidc-config-id %s --operator-roles-prefix %s%s%s",
+				args.oidcConfigId, args.prefix, hostedCpOutputParam, installerRoleArnParam))
 		}
 		r.OCMClient.LogEvent("ROSACreateOperatorRolesModeAuto", map[string]string{
 			ocm.OperatorRolesPrefix: operatorRolesPrefix,


### PR DESCRIPTION
Add an info message guiding the user to use the same installer role for cluster creation.

e.g.
```
oadler@dhcp-0-129:rosa (OCM-4924)$ rosa create operator-roles --prefix oadler-nov-22
? Role creation mode: auto
? Operator roles prefix: oadler-nov-22
? OIDC Configuration ID: 25mar6dtg943vg319du08o2k5bcnmb61 | https://d3gt1gce2zmg3d.cloudfront.net/25mar6dtg943vg319du08o2k5bcnmb61
? Create hosted control plane operator roles: No
W: More than one Installer role found
? Installer role ARN: arn:aws:iam::765374464689:role/bla/oadler-nov-22-Installer-Role
? Permissions boundary ARN (optional): 
I: ARN path '/bla/' detected in installer role 'arn:aws:iam::765374464689:role/bla/oadler-nov-22-Installer-Role'. This ARN path will be used for subsequent created operator roles and policies.
I: Reusable OIDC Configuration detected. Validating trusted relationships to operator roles: 
I: Creating roles using 'arn:aws:iam::765374464689:user/oadler'
I: Created role 'oadler-nov-22-openshift-ingress-operator-cloud-credentials' with ARN 'arn:aws:iam::765374464689:role/bla/oadler-nov-22-openshift-ingress-operator-cloud-credentials'
I: Created role 'oadler-nov-22-openshift-cluster-csi-drivers-ebs-cloud-credential' with ARN 'arn:aws:iam::765374464689:role/bla/oadler-nov-22-openshift-cluster-csi-drivers-ebs-cloud-credential'
I: Created role 'oadler-nov-22-openshift-cloud-network-config-controller-cloud-cr' with ARN 'arn:aws:iam::765374464689:role/bla/oadler-nov-22-openshift-cloud-network-config-controller-cloud-cr'
I: Created role 'oadler-nov-22-openshift-machine-api-aws-cloud-credentials' with ARN 'arn:aws:iam::765374464689:role/bla/oadler-nov-22-openshift-machine-api-aws-cloud-credentials'
I: Created role 'oadler-nov-22-openshift-cloud-credential-operator-cloud-credenti' with ARN 'arn:aws:iam::765374464689:role/bla/oadler-nov-22-openshift-cloud-credential-operator-cloud-credenti'
I: Created role 'oadler-nov-22-openshift-image-registry-installer-cloud-credentia' with ARN 'arn:aws:iam::765374464689:role/bla/oadler-nov-22-openshift-image-registry-installer-cloud-credentia'
I: To create a cluster with these roles, run the following command:
	rosa create cluster --sts --oidc-config-id 25mar6dtg943vg319du08o2k5bcnmb61 --operator-roles-prefix oadler-nov-22 --role-arn arn:aws:iam::765374464689:role/bla/oadler-nov-22-Installer-Role
```