### PR TITLE
OCM-4985 | fix: align role-arn flag across commands

### DIFF
--- a/cmd/create/oidcconfig/cmd.go
+++ b/cmd/create/oidcconfig/cmd.go
@@ -96,6 +96,8 @@ func init() {
 		"Indicates whether it is a Red Hat managed or unmanaged (Customer hosted) OIDC Configuration.",
 	)
 
+	// normalizing installer role argument to support deprecated flag
+	flags.SetNormalizeFunc(arguments.NormalizeFlags)
 	flags.StringVar(
 		&args.installerRoleArn,
 		InstallerRoleArnFlag,
@@ -407,7 +409,7 @@ func (s *CreateUnmanagedOidcConfigAutoStrategy) execute(r *rosa.Runtime) {
 		}
 		r.Reporter.Errorf("There was a problem building your unmanaged OIDC Configuration %v.\n"+
 			"Please refer to documentation and try again through:\n"+
-			"\trosa register oidc-config --issuer-url %s --secret-arn %s --installer-role-arn %s",
+			"\trosa register oidc-config --issuer-url %s --secret-arn %s --role-arn %s",
 			err, bucketUrl, secretARN, installerRoleArn)
 		os.Exit(1)
 	}

--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -22,6 +22,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
@@ -33,7 +34,7 @@ const (
 	PrefixFlag           = "prefix"
 	HostedCpFlag         = "hosted-cp"
 	OidcConfigIdFlag     = "oidc-config-id"
-	InstallerRoleArnFlag = "installer-role-arn"
+	InstallerRoleArnFlag = "role-arn"
 )
 
 var args struct {
@@ -80,6 +81,8 @@ func init() {
 			"Not to be used alongside --cluster flag.",
 	)
 
+	// normalizing installer role argument to support deprecated flag
+	flags.SetNormalizeFunc(arguments.NormalizeFlags)
 	flags.StringVar(
 		&args.installerRoleArn,
 		InstallerRoleArnFlag,

--- a/cmd/create/operatorroles/common_utils.go
+++ b/cmd/create/operatorroles/common_utils.go
@@ -51,7 +51,7 @@ func validateIngressOperatorPolicyOverride(r *rosa.Runtime, policyArn string, sh
 					"[Expected: '%s', Provided '%s'].\n"+
 					"The policy is associated with the installer role with the prefix '%s'.\n"+
 					"To create operator roles with shared VPC role ARN '%s', please provide a different value for "+
-					"'--installer-role-arn'", policyArn, assumePolicyAction, statement.Resource, sharedVpcRoleArn,
+					"'--role-arn'", policyArn, assumePolicyAction, statement.Resource, sharedVpcRoleArn,
 					installerRolePrefix, sharedVpcRoleArn)
 			}
 		}

--- a/cmd/register/oidcconfig/cmd.go
+++ b/cmd/register/oidcconfig/cmd.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/cmd/create/oidcprovider"
+	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
 	. "github.com/openshift/rosa/pkg/constants"
 	"github.com/openshift/rosa/pkg/interactive"
@@ -53,6 +54,8 @@ var Cmd = &cobra.Command{
 func init() {
 	flags := Cmd.Flags()
 
+	// normalizing installer role argument to support deprecated flag
+	flags.SetNormalizeFunc(arguments.NormalizeFlags)
 	flags.StringVar(
 		&args.installerRoleArn,
 		InstallerRoleArnFlag,

--- a/pkg/arguments/arguments_suite_test.go
+++ b/pkg/arguments/arguments_suite_test.go
@@ -1,0 +1,13 @@
+package arguments
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestArguments(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Arguments Suite")
+}

--- a/pkg/arguments/normalize.go
+++ b/pkg/arguments/normalize.go
@@ -1,0 +1,18 @@
+package arguments
+
+import (
+	"github.com/spf13/pflag"
+)
+
+const (
+	deprecatedInstallerRoleArnFlag = "installer-role-arn"
+	newInstallerRoleArnFlag        = "role-arn"
+)
+
+func NormalizeFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
+	switch name {
+	case deprecatedInstallerRoleArnFlag:
+		name = newInstallerRoleArnFlag
+	}
+	return pflag.NormalizedName(name)
+}

--- a/pkg/arguments/normalize_test.go
+++ b/pkg/arguments/normalize_test.go
@@ -1,0 +1,31 @@
+package arguments
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/pflag"
+)
+
+var _ = Describe("Normalize Argument Flags Tests", func() {
+	When("when flags have been deprecated", func() {
+		It("should normalize --installer-role-arn to --role-arn", func() {
+			f := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			flagName := deprecatedInstallerRoleArnFlag
+
+			normalized := NormalizeFlags(f, flagName)
+
+			Expect(string(normalized)).To(Equal(newInstallerRoleArnFlag))
+		})
+	})
+
+	When("Flags that have not been deprecated", func() {
+		It("should return unchanged flag name if not deprecatedInstallerRoleArnFlag", func() {
+			f := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			flagName := "some_other_flag"
+
+			normalized := NormalizeFlags(f, flagName)
+
+			Expect(string(normalized)).To(Equal(flagName))
+		})
+	})
+})

--- a/pkg/constants/oidc_config.go
+++ b/pkg/constants/oidc_config.go
@@ -1,7 +1,7 @@
 package constants
 
 const (
-	InstallerRoleArnFlag = "installer-role-arn"
+	InstallerRoleArnFlag = "role-arn"
 	IssuerUrlFlag        = "issuer-url"
 	SecretArnFlag        = "secret-arn"
 

--- a/pkg/interactive/roles/roles.go
+++ b/pkg/interactive/roles/roles.go
@@ -52,7 +52,7 @@ func GetInstallerRoleArn(r *rosa.Runtime, cmd *cobra.Command,
 			}
 			roleARN, err = GetOption(Input{
 				Question: fmt.Sprintf("%s role ARN", role.Name),
-				Help:     cmd.Flags().Lookup("installer-role-arn").Usage,
+				Help:     cmd.Flags().Lookup("role-arn").Usage,
 				Options:  roleARNs,
 				Default:  defaultRoleARN,
 				Required: true,


### PR DESCRIPTION
Uses the `SetNormalizeFunc` to support both aligned and depreciated flags.

Validations
```
╭─croche@fedora ~/Work/ocm/rosa ‹OCM-4958●› 
╰─$ rosa create operator-roles --role-arn arn:aws:iam::765374464689:role/15nov-HCP-ROSA-Installer-Role --prefix crtest --oidc-config-id 27meq1dc0i7h6n98fablivf90s686pa1

? Role creation mode: manual
? Operator roles prefix: crtest
? Create hosted control plane operator roles: No
W: More than one Installer role found
? Installer role ARN:  [Use arrows to move, type to filter, ? for more help]
> arn:aws:iam::765374464689:role/15nov-Installer-Role
  arn:aws:iam::765374464689:role/adecorte/ad-path-Installer-Role
  arn:aws:iam::765374464689:role/crs3-Installer-Role
  arn:aws:iam::765374464689:role/CSE2ETests-Installer-Role
  arn:aws:iam::765374464689:role/dle-iso-Installer-Role
  arn:aws:iam::765374464689:role/dle-pa-Installer-Role
  arn:aws:iam::765374464689:role/dle-wa-Installer-Role
E: Expected a valid role ARN: interrupt
╭─croche@fedora ~/Work/ocm/rosa ‹OCM-4958●› 
╰─$ rosa create operator-roles --prefix crtest --oidc-config-id 27meq1dc0i7h6n98fablivf90s686pa1         

? Role creation mode: manual
? Operator roles prefix: crtest
? Create hosted control plane operator roles: No
W: More than one Installer role found
? Installer role ARN:  [Use arrows to move, type to filter, ? for more help]
  arn:aws:iam::765374464689:role/dle-wa-Installer-Role
  arn:aws:iam::765374464689:role/jbriones-Installer-Role
  arn:aws:iam::765374464689:role/magchen-upgrade-Installer-Role
> arn:aws:iam::765374464689:role/ManagedOpenShift-Installer-Role
  arn:aws:iam::765374464689:role/msoriano-localdev-Installer-Role
  arn:aws:iam::765374464689:role/new-prefix-Installer-Role
  arn:aws:iam::765374464689:role/oadler-nov-16-Installer-Role
E: Expected a valid role ARN: interrupt
╭─croche@fedora ~/Work/ocm/rosa ‹OCM-4958●› 
╰─$ rosa create operator-roles --installer-role-arn arn:aws:iam::765374464689:role/15nov-HCP-ROSA-Installer-Role --prefix crtest --oidc-config-id 27meq1dc0i7h6n98fablivf90s686pa1

? Role creation mode: auto
? Operator roles prefix: crtest
? Create hosted control plane operator roles: No
W: More than one Installer role found
? Installer role ARN:  [Use arrows to move, type to filter, ? for more help]
> arn:aws:iam::765374464689:role/15nov-Installer-Role
  arn:aws:iam::765374464689:role/adecorte/ad-path-Installer-Role
  arn:aws:iam::765374464689:role/crs3-Installer-Role
  arn:aws:iam::765374464689:role/CSE2ETests-Installer-Role
  arn:aws:iam::765374464689:role/dle-iso-Installer-Role
  arn:aws:iam::765374464689:role/dle-pa-Installer-Role
  arn:aws:iam::765374464689:role/dle-wa-Installer-Role
E: Expected a valid role ARN: interrupt
```
```
╭─croche@fedora ~/Work/ocm/rosa ‹OCM-4958●› 
╰─$ rosa register oidc-config --installer-role-arn arn:aws:iam::765374464689:role/15nov-HCP-ROSA-Installer-Role
? OIDC Provider creation mode: manual
I: Using arn:aws:iam::765374464689:role/15nov-HCP-ROSA-Installer-Role for the installer role
? Issuer URL (please include 'https://'): [? for help] 
E: Expected an issuer URL: interrupt
╭─croche@fedora ~/Work/ocm/rosa ‹OCM-4958●› 
╰─$ rosa register oidc-config --role-arn arn:aws:iam::765374464689:role/15nov-HCP-ROSA-Installer-Role     
? OIDC Provider creation mode: manual
I: Using arn:aws:iam::765374464689:role/15nov-HCP-ROSA-Installer-Role for the installer role
? Issuer URL (please include 'https://'): [? for help] 
E: Expected an issuer URL: interrupt

```

https://issues.redhat.com/browse/OCM-4985