### PR TITLE
OCM-3618 | feat: Automate grouping of imports in Go source files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,4 +39,14 @@ linters:
 linters-settings:
   staticcheck:
     go: "1.20"
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(k8s)
+      - prefix(sigs.k8s)
+      - prefix(github.com)
+      - prefix(gitlab)
+      - prefix(github.com/openshift/rosa)
+    custom-order: true
 

--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,17 @@ coverage:
 install:
 	go install ./cmd/rosa
 
+.PHONY: gci-install
+gci-install:
+	go install github.com/daixiang0/gci@v0.10.1
+
 .PHONY: fmt
-fmt:
+fmt: fmt-imports
 	gofmt -s -l -w cmd pkg
+
+.PHONY: fmt-imports
+fmt-imports: gci-install
+	find . -name '*.go' -not -path './vendor/*' | xargs gci write -s standard -s default -s "prefix(k8s)" -s "prefix(sigs.k8s)" -s "prefix(github.com)" -s "prefix(gitlab)" -s "prefix(github.com/openshift/rosa)" --custom-order --skip-generated
 
 .PHONY: lint
 lint:

--- a/cmd/create/accountroles/creators.go
+++ b/cmd/create/accountroles/creators.go
@@ -3,13 +3,13 @@ package accountroles
 import (
 	"fmt"
 
+	common "github.com/openshift-online/ocm-common/pkg/aws/validations"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
 	"github.com/openshift/rosa/pkg/aws"
 	awscb "github.com/openshift/rosa/pkg/aws/commandbuilder"
 	"github.com/openshift/rosa/pkg/aws/tags"
 	"github.com/openshift/rosa/pkg/rosa"
-
-	common "github.com/openshift-online/ocm-common/pkg/aws/validations"
 )
 
 type creator interface {

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -27,9 +27,6 @@ import (
 	"time"
 
 	awssdk "github.com/aws/aws-sdk-go/aws"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-
 	"github.com/aws/aws-sdk-go/service/ec2"
 	clustervalidations "github.com/openshift-online/ocm-common/pkg/cluster/validations"
 	passwordValidator "github.com/openshift-online/ocm-common/pkg/idp/validations"
@@ -37,6 +34,9 @@ import (
 	kmsArnRegexpValidator "github.com/openshift-online/ocm-common/pkg/resource/validations"
 	accountsv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
 	"github.com/openshift/rosa/cmd/create/admin"
 	"github.com/openshift/rosa/cmd/create/idp"
 	"github.com/openshift/rosa/cmd/create/oidcprovider"

--- a/cmd/create/cluster/cmd_test.go
+++ b/cmd/create/cluster/cmd_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
+
 	"github.com/openshift/rosa/pkg/logging"
 	"github.com/openshift/rosa/pkg/ocm"
 )

--- a/cmd/create/cluster/shared_vpc.go
+++ b/cmd/create/cluster/shared_vpc.go
@@ -3,11 +3,12 @@ package cluster
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+	errors "github.com/zgalor/weberr"
+
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/rosa"
-	"github.com/spf13/cobra"
-	errors "github.com/zgalor/weberr"
 )
 
 // nolint:lll

--- a/cmd/create/dnsdomains/cmd.go
+++ b/cmd/create/dnsdomains/cmd.go
@@ -20,8 +20,9 @@ import (
 	// nolint:gosec
 	"os"
 
-	"github.com/openshift/rosa/pkg/rosa"
 	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/rosa"
 )
 
 var Cmd = &cobra.Command{

--- a/cmd/create/idp/gitlab.go
+++ b/cmd/create/idp/gitlab.go
@@ -23,11 +23,11 @@ import (
 	"os"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	"github.com/openshift/rosa/pkg/helper"
-	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/rosa/pkg/helper"
 	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/ocm"
 )
 
 func buildGitlabIdp(cmd *cobra.Command,

--- a/cmd/create/idp/htpasswd.go
+++ b/cmd/create/idp/htpasswd.go
@@ -22,10 +22,10 @@ import (
 	"os"
 	"strings"
 
+	passwordValidator "github.com/openshift-online/ocm-common/pkg/idp/validations"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
-	passwordValidator "github.com/openshift-online/ocm-common/pkg/idp/validations"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/rosa"
 )

--- a/cmd/create/machinepool/cmd.go
+++ b/cmd/create/machinepool/cmd.go
@@ -21,15 +21,15 @@ import (
 	"regexp"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
 	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/interactive/securitygroups"
+	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/properties"
 	"github.com/openshift/rosa/pkg/rosa"
-	"github.com/spf13/cobra"
-
-	"github.com/openshift/rosa/pkg/interactive"
-	"github.com/openshift/rosa/pkg/ocm"
 )
 
 // Regular expression to used to make sure that the identifier given by the

--- a/cmd/create/machinepool/helper.go
+++ b/cmd/create/machinepool/helper.go
@@ -4,10 +4,11 @@ import (
 	"os"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/rosa"
-	"github.com/spf13/cobra"
 )
 
 func getSubnetFromUser(cmd *cobra.Command, r *rosa.Runtime, isSubnetSet bool, cluster *cmv1.Cluster) string {

--- a/cmd/create/machinepool/machinepool.go
+++ b/cmd/create/machinepool/machinepool.go
@@ -12,6 +12,8 @@ import (
 	"github.com/openshift-online/ocm-common/pkg"
 	diskValidator "github.com/openshift-online/ocm-common/pkg/machinepool/validations"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
 	"github.com/openshift/rosa/pkg/helper"
 	mpHelpers "github.com/openshift/rosa/pkg/helper/machinepools"
 	"github.com/openshift/rosa/pkg/helper/versions"
@@ -22,7 +24,6 @@ import (
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/rosa"
-	"github.com/spf13/cobra"
 )
 
 func addMachinePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster, r *rosa.Runtime) {

--- a/cmd/create/ocmrole/cmd.go
+++ b/cmd/create/ocmrole/cmd.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"os"
 
+	common "github.com/openshift-online/ocm-common/pkg/aws/validations"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
 	linkocmrole "github.com/openshift/rosa/cmd/link/ocmrole"
@@ -31,9 +33,6 @@ import (
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
-
-	common "github.com/openshift-online/ocm-common/pkg/aws/validations"
-	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
 var args struct {

--- a/cmd/create/oidcconfig/cmd.go
+++ b/cmd/create/oidcconfig/cmd.go
@@ -17,10 +17,6 @@ limitations under the License.
 package oidcconfig
 
 import (
-	// nolint:gosec
-
-	//#nosec GSC-G505 -- Import blacklist: crypto/sha1
-
 	"bytes"
 	"fmt"
 	"os"
@@ -29,6 +25,9 @@ import (
 
 	"github.com/briandowns/spinner"
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+	"github.com/zgalor/weberr"
+
 	"github.com/openshift/rosa/cmd/create/oidcprovider"
 	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
@@ -42,8 +41,6 @@ import (
 	interactiveRoles "github.com/openshift/rosa/pkg/interactive/roles"
 	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/rosa"
-	"github.com/spf13/cobra"
-	"github.com/zgalor/weberr"
 )
 
 var args struct {

--- a/cmd/create/operatorroles/by_clusterkey.go
+++ b/cmd/create/operatorroles/by_clusterkey.go
@@ -7,6 +7,7 @@ import (
 
 	common "github.com/openshift-online/ocm-common/pkg/aws/validations"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
 	"github.com/openshift/rosa/pkg/aws"
 	awscb "github.com/openshift/rosa/pkg/aws/commandbuilder"
 	"github.com/openshift/rosa/pkg/aws/tags"

--- a/cmd/create/operatorroles/by_prefix.go
+++ b/cmd/create/operatorroles/by_prefix.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
+	common "github.com/openshift-online/ocm-common/pkg/aws/validations"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
-	common "github.com/openshift-online/ocm-common/pkg/aws/validations"
 	"github.com/openshift/rosa/pkg/aws"
 	awscb "github.com/openshift/rosa/pkg/aws/commandbuilder"
 	"github.com/openshift/rosa/pkg/aws/tags"

--- a/cmd/create/operatorroles/common_utils.go
+++ b/cmd/create/operatorroles/common_utils.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 
 	"github.com/openshift-online/ocm-common/pkg"
+	errors "github.com/zgalor/weberr"
+
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/rosa"
-	errors "github.com/zgalor/weberr"
 )
 
 const assumePolicyAction = "sts:AssumeRole"

--- a/cmd/create/service/cmd.go
+++ b/cmd/create/service/cmd.go
@@ -23,11 +23,11 @@ import (
 	"regexp"
 	"strings"
 
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	awssdk "github.com/aws/aws-sdk-go/aws"
-	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/helper"

--- a/cmd/create/tuningconfigs/cmd.go
+++ b/cmd/create/tuningconfigs/cmd.go
@@ -21,11 +21,12 @@ import (
 	"os"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
 	"github.com/openshift/rosa/pkg/input"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
-	"github.com/spf13/cobra"
 )
 
 var args struct {

--- a/cmd/create/userrole/cmd.go
+++ b/cmd/create/userrole/cmd.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
 	linkuser "github.com/openshift/rosa/cmd/link/userrole"
@@ -32,8 +33,6 @@ import (
 	"github.com/openshift/rosa/pkg/ocm"
 	rprtr "github.com/openshift/rosa/pkg/reporter"
 	"github.com/openshift/rosa/pkg/rosa"
-
-	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
 var args struct {

--- a/cmd/describe/addon/cmd.go
+++ b/cmd/describe/addon/cmd.go
@@ -23,8 +23,9 @@ import (
 	"strings"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	"github.com/openshift/rosa/pkg/rosa"
 	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/rosa"
 )
 
 var Cmd = &cobra.Command{

--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -24,9 +24,9 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/arn"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
-	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/rosa/pkg/ocm"
 	ocmOutput "github.com/openshift/rosa/pkg/ocm/output"
 	"github.com/openshift/rosa/pkg/output"

--- a/cmd/describe/cluster/cmd_test.go
+++ b/cmd/describe/cluster/cmd_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/ginkgo/v2/dsl/decorators"
 	. "github.com/onsi/ginkgo/v2/dsl/table"
 	. "github.com/onsi/gomega"
-
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 

--- a/cmd/describe/installation/cmd.go
+++ b/cmd/describe/installation/cmd.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"os"
 
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
-	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
 )

--- a/cmd/describe/machinepool/cmd.go
+++ b/cmd/describe/machinepool/cmd.go
@@ -21,10 +21,11 @@ import (
 	"os"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/rosa"
-	"github.com/spf13/cobra"
 )
 
 var Cmd = &cobra.Command{

--- a/cmd/describe/machinepool/cmd_test.go
+++ b/cmd/describe/machinepool/cmd_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/onsi/gomega/format"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	. "github.com/openshift-online/ocm-sdk-go/testing"
+
 	"github.com/openshift/rosa/pkg/test"
 )
 

--- a/cmd/describe/machinepool/machinepool.go
+++ b/cmd/describe/machinepool/machinepool.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
 	ocmOutput "github.com/openshift/rosa/pkg/ocm/output"
 	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/rosa"

--- a/cmd/describe/machinepool/nodepool.go
+++ b/cmd/describe/machinepool/nodepool.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
 	ocmOutput "github.com/openshift/rosa/pkg/ocm/output"
 	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/rosa"

--- a/cmd/describe/tuningconfigs/cmd.go
+++ b/cmd/describe/tuningconfigs/cmd.go
@@ -21,11 +21,12 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spf13/cobra"
+
 	"github.com/openshift/rosa/pkg/input"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/rosa"
-	"github.com/spf13/cobra"
 )
 
 var Cmd = &cobra.Command{

--- a/cmd/describe/upgrade/cmd.go
+++ b/cmd/describe/upgrade/cmd.go
@@ -22,10 +22,11 @@ import (
 	"strings"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
-	"github.com/spf13/cobra"
 )
 
 var Cmd = &cobra.Command{

--- a/cmd/describe/upgrade/cmd_test.go
+++ b/cmd/describe/upgrade/cmd_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/onsi/gomega/format"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	. "github.com/openshift-online/ocm-sdk-go/testing"
+
 	"github.com/openshift/rosa/pkg/test"
 )
 

--- a/cmd/dlt/accountroles/cmd.go
+++ b/cmd/dlt/accountroles/cmd.go
@@ -23,13 +23,14 @@ import (
 	"strings"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
 	"github.com/openshift/rosa/pkg/aws"
 	awscb "github.com/openshift/rosa/pkg/aws/commandbuilder"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
-	"github.com/spf13/cobra"
 )
 
 var args struct {

--- a/cmd/dlt/autoscaler/cmd.go
+++ b/cmd/dlt/autoscaler/cmd.go
@@ -19,10 +19,11 @@ package autoscaler
 import (
 	"os"
 
+	"github.com/spf13/cobra"
+
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
-	"github.com/spf13/cobra"
 )
 
 var Cmd = &cobra.Command{

--- a/cmd/dlt/machinepool/machinepool.go
+++ b/cmd/dlt/machinepool/machinepool.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/rosa"
 )

--- a/cmd/dlt/machinepool/nodepool.go
+++ b/cmd/dlt/machinepool/nodepool.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/rosa"
 )

--- a/cmd/dlt/oidcprovider/cmd.go
+++ b/cmd/dlt/oidcprovider/cmd.go
@@ -21,6 +21,9 @@ import (
 	"net/url"
 	"os"
 
+	"github.com/spf13/cobra"
+	errors "github.com/zgalor/weberr"
+
 	"github.com/openshift/rosa/pkg/aws"
 	awscb "github.com/openshift/rosa/pkg/aws/commandbuilder"
 	"github.com/openshift/rosa/pkg/helper"
@@ -29,8 +32,6 @@ import (
 	interactiveOidc "github.com/openshift/rosa/pkg/interactive/oidc"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
-	"github.com/spf13/cobra"
-	errors "github.com/zgalor/weberr"
 )
 
 var Cmd = &cobra.Command{

--- a/cmd/dlt/service/cmd.go
+++ b/cmd/dlt/service/cmd.go
@@ -21,9 +21,9 @@ import (
 	"os"
 	"strings"
 
+	msv1 "github.com/openshift-online/ocm-sdk-go/servicemgmt/v1"
 	"github.com/spf13/cobra"
 
-	msv1 "github.com/openshift-online/ocm-sdk-go/servicemgmt/v1"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"

--- a/cmd/dlt/tuningconfigs/cmd.go
+++ b/cmd/dlt/tuningconfigs/cmd.go
@@ -20,11 +20,12 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spf13/cobra"
+
 	"github.com/openshift/rosa/pkg/input"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
-	"github.com/spf13/cobra"
 )
 
 var Cmd = &cobra.Command{

--- a/cmd/dlt/upgrade/cmd.go
+++ b/cmd/dlt/upgrade/cmd.go
@@ -21,10 +21,11 @@ import (
 	"os"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
-	"github.com/spf13/cobra"
 )
 
 var args struct {

--- a/cmd/dlt/upgrade/cmd_test.go
+++ b/cmd/dlt/upgrade/cmd_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	. "github.com/openshift-online/ocm-sdk-go/testing"
+
 	"github.com/openshift/rosa/pkg/test"
 )
 

--- a/cmd/download/oc/cmd.go
+++ b/cmd/download/oc/cmd.go
@@ -23,10 +23,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/rosa/cmd/verify/oc"
 	helper "github.com/openshift/rosa/pkg/helper/download"
 	rprtr "github.com/openshift/rosa/pkg/reporter"
-
-	"github.com/openshift/rosa/cmd/verify/oc"
 )
 
 var Cmd = &cobra.Command{

--- a/cmd/edit/autoscaler/cmd.go
+++ b/cmd/edit/autoscaler/cmd.go
@@ -20,10 +20,10 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/openshift-online/ocm-common/pkg"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
-	"github.com/openshift-online/ocm-common/pkg"
 	"github.com/openshift/rosa/pkg/clusterautoscaler"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/ocm"

--- a/cmd/edit/cluster/cmd.go
+++ b/cmd/edit/cluster/cmd.go
@@ -24,13 +24,14 @@ import (
 	"time"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/helper"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
-	"github.com/spf13/cobra"
 )
 
 const doubleQuotesToRemove = "\"\""

--- a/cmd/edit/cluster/cmd_test.go
+++ b/cmd/edit/cluster/cmd_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	. "github.com/openshift-online/ocm-sdk-go/testing"
+
 	"github.com/openshift/rosa/pkg/test"
 )
 

--- a/cmd/edit/machinepool/machinepool.go
+++ b/cmd/edit/machinepool/machinepool.go
@@ -5,11 +5,12 @@ import (
 	"regexp"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
 	mpHelpers "github.com/openshift/rosa/pkg/helper/machinepools"
 	"github.com/openshift/rosa/pkg/interactive"
 	rprtr "github.com/openshift/rosa/pkg/reporter"
 	"github.com/openshift/rosa/pkg/rosa"
-	"github.com/spf13/cobra"
 )
 
 // Regular expression to used to make sure that the identifier given by the

--- a/cmd/edit/machinepool/nodepool.go
+++ b/cmd/edit/machinepool/nodepool.go
@@ -5,12 +5,13 @@ import (
 	"strings"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
 	"github.com/openshift/rosa/pkg/helper/machinepools"
 	mpHelpers "github.com/openshift/rosa/pkg/helper/machinepools"
 	"github.com/openshift/rosa/pkg/interactive"
 	rprtr "github.com/openshift/rosa/pkg/reporter"
 	"github.com/openshift/rosa/pkg/rosa"
-	"github.com/spf13/cobra"
 )
 
 func editNodePool(cmd *cobra.Command, nodePoolID string, clusterKey string, cluster *cmv1.Cluster, r *rosa.Runtime) {

--- a/cmd/edit/service/cmd.go
+++ b/cmd/edit/service/cmd.go
@@ -19,9 +19,9 @@ package service
 import (
 	"os"
 
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
-	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"

--- a/cmd/edit/tuningconfigs/cmd.go
+++ b/cmd/edit/tuningconfigs/cmd.go
@@ -21,11 +21,12 @@ import (
 	"os"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
 	"github.com/openshift/rosa/pkg/input"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
-	"github.com/spf13/cobra"
 )
 
 var args struct {

--- a/cmd/hibernate/cluster/cmd.go
+++ b/cmd/hibernate/cluster/cmd.go
@@ -19,9 +19,9 @@ package cluster
 import (
 	"os"
 
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
-	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"

--- a/cmd/initialize/cmd.go
+++ b/cmd/initialize/cmd.go
@@ -27,7 +27,6 @@ import (
 	"github.com/openshift/rosa/cmd/verify/oc"
 	"github.com/openshift/rosa/cmd/verify/permissions"
 	"github.com/openshift/rosa/cmd/verify/quota"
-
 	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/aws/region"

--- a/cmd/install/addon/cmd.go
+++ b/cmd/install/addon/cmd.go
@@ -24,12 +24,12 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/openshift-online/ocm-common/pkg"
 	amv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 	errors "github.com/zgalor/weberr"
 
-	"github.com/openshift-online/ocm-common/pkg"
 	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/aws/tags"

--- a/cmd/list/gates/cmd.go
+++ b/cmd/list/gates/cmd.go
@@ -23,11 +23,10 @@ import (
 	"text/tabwriter"
 
 	semver "github.com/hashicorp/go-version"
-
+	"github.com/nathan-fiscaletti/consolesize-go"
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
-	"github.com/nathan-fiscaletti/consolesize-go"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/rosa"

--- a/cmd/list/machinepool/machinepool.go
+++ b/cmd/list/machinepool/machinepool.go
@@ -6,6 +6,7 @@ import (
 	"text/tabwriter"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
 	ocmOutput "github.com/openshift/rosa/pkg/ocm/output"
 	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/rosa"

--- a/cmd/list/machinepool/nodepool.go
+++ b/cmd/list/machinepool/nodepool.go
@@ -6,6 +6,7 @@ import (
 	"text/tabwriter"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
 	ocmOutput "github.com/openshift/rosa/pkg/ocm/output"
 	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/rosa"

--- a/cmd/list/ocmroles/cmd.go
+++ b/cmd/list/ocmroles/cmd.go
@@ -23,12 +23,12 @@ import (
 	"time"
 
 	"github.com/briandowns/spinner"
+	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/helper"
 	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/rosa"
-	"github.com/spf13/cobra"
 )
 
 var Cmd = &cobra.Command{

--- a/cmd/list/region/cmd.go
+++ b/cmd/list/region/cmd.go
@@ -22,9 +22,10 @@ import (
 	"text/tabwriter"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
 	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/rosa"
-	"github.com/spf13/cobra"
 )
 
 var args struct {

--- a/cmd/list/service/cmd.go
+++ b/cmd/list/service/cmd.go
@@ -22,9 +22,10 @@ import (
 	"text/tabwriter"
 
 	msv1 "github.com/openshift-online/ocm-sdk-go/servicemgmt/v1"
+	"github.com/spf13/cobra"
+
 	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/rosa"
-	"github.com/spf13/cobra"
 )
 
 var Cmd = &cobra.Command{

--- a/cmd/list/tuningconfigs/cmd.go
+++ b/cmd/list/tuningconfigs/cmd.go
@@ -21,11 +21,12 @@ import (
 	"os"
 	"text/tabwriter"
 
+	"github.com/spf13/cobra"
+
 	"github.com/openshift/rosa/pkg/input"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/rosa"
-	"github.com/spf13/cobra"
 )
 
 var Cmd = &cobra.Command{

--- a/cmd/list/upgrade/cmd.go
+++ b/cmd/list/upgrade/cmd.go
@@ -24,9 +24,9 @@ import (
 	"text/tabwriter"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/rosa"

--- a/cmd/list/upgrade/cmd_test.go
+++ b/cmd/list/upgrade/cmd_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/onsi/gomega/format"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	. "github.com/openshift-online/ocm-sdk-go/testing"
+
 	"github.com/openshift/rosa/pkg/test"
 )
 

--- a/cmd/list/userroles/cmd.go
+++ b/cmd/list/userroles/cmd.go
@@ -20,12 +20,12 @@ import (
 	"time"
 
 	"github.com/briandowns/spinner"
+	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/helper"
 	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/rosa"
-	"github.com/spf13/cobra"
 )
 
 var Cmd = &cobra.Command{

--- a/cmd/register/oidcconfig/cmd.go
+++ b/cmd/register/oidcconfig/cmd.go
@@ -17,15 +17,13 @@ limitations under the License.
 package oidcconfig
 
 import (
-	// nolint:gosec
-
-	//#nosec GSC-G505 -- Import blacklist: crypto/sha1
-
 	"fmt"
 	"os"
 
 	"github.com/briandowns/spinner"
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
 	"github.com/openshift/rosa/cmd/create/oidcprovider"
 	"github.com/openshift/rosa/pkg/aws"
 	. "github.com/openshift/rosa/pkg/constants"
@@ -34,7 +32,6 @@ import (
 	interactiveRoles "github.com/openshift/rosa/pkg/interactive/roles"
 	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/rosa"
-	"github.com/spf13/cobra"
 )
 
 var args struct {

--- a/cmd/resume/cluster/cmd.go
+++ b/cmd/resume/cluster/cmd.go
@@ -19,9 +19,9 @@ package cluster
 import (
 	"os"
 
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
-	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"

--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/briandowns/spinner"
+	common "github.com/openshift-online/ocm-common/pkg/aws/validations"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
@@ -36,8 +37,6 @@ import (
 	"github.com/openshift/rosa/pkg/ocm"
 	rprtr "github.com/openshift/rosa/pkg/reporter"
 	"github.com/openshift/rosa/pkg/rosa"
-
-	common "github.com/openshift-online/ocm-common/pkg/aws/validations"
 )
 
 var args struct {

--- a/cmd/upgrade/cluster/cmd.go
+++ b/cmd/upgrade/cluster/cmd.go
@@ -24,13 +24,14 @@ import (
 
 	"github.com/openshift-online/ocm-common/pkg"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
 	"github.com/openshift/rosa/cmd/upgrade/roles"
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
-	"github.com/spf13/cobra"
 )
 
 var args struct {

--- a/cmd/upgrade/cluster/cmd_test.go
+++ b/cmd/upgrade/cluster/cmd_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	. "github.com/openshift-online/ocm-sdk-go/testing"
+
 	"github.com/openshift/rosa/pkg/test"
 )
 

--- a/cmd/upgrade/cmd.go
+++ b/cmd/upgrade/cmd.go
@@ -17,6 +17,8 @@ limitations under the License.
 package upgrade
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/openshift/rosa/cmd/upgrade/accountroles"
 	"github.com/openshift/rosa/cmd/upgrade/cluster"
 	"github.com/openshift/rosa/cmd/upgrade/machinepool"
@@ -24,7 +26,6 @@ import (
 	"github.com/openshift/rosa/cmd/upgrade/roles"
 	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/interactive"
-	"github.com/spf13/cobra"
 )
 
 var Cmd = &cobra.Command{

--- a/cmd/upgrade/machinepool/cmd.go
+++ b/cmd/upgrade/machinepool/cmd.go
@@ -21,13 +21,14 @@ import (
 	"os"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
 	"github.com/openshift/rosa/pkg/input"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
 )
 
 var args struct {

--- a/cmd/upgrade/machinepool/cmd_test.go
+++ b/cmd/upgrade/machinepool/cmd_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	. "github.com/openshift-online/ocm-sdk-go/testing"
+
 	"github.com/openshift/rosa/pkg/test"
 )
 

--- a/cmd/upgrade/operatorroles/cmd.go
+++ b/cmd/upgrade/operatorroles/cmd.go
@@ -22,15 +22,15 @@ import (
 	"strings"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	"github.com/openshift/rosa/pkg/helper/roles"
-	"github.com/openshift/rosa/pkg/rosa"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/pkg/aws"
 	awscb "github.com/openshift/rosa/pkg/aws/commandbuilder"
+	"github.com/openshift/rosa/pkg/helper/roles"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/rosa"
 )
 
 var args struct {

--- a/cmd/upgrade/roles/cmd.go
+++ b/cmd/upgrade/roles/cmd.go
@@ -24,11 +24,11 @@ import (
 
 	"github.com/briandowns/spinner"
 	semver "github.com/hashicorp/go-version"
+	common "github.com/openshift-online/ocm-common/pkg/aws/validations"
+	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 	"github.com/zgalor/weberr"
 
-	common "github.com/openshift-online/ocm-common/pkg/aws/validations"
-	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/rosa/pkg/aws"
 	awscb "github.com/openshift/rosa/pkg/aws/commandbuilder"
 	awscbRoles "github.com/openshift/rosa/pkg/aws/commandbuilder/helper/roles"

--- a/cmd/verify/network/cmd.go
+++ b/cmd/verify/network/cmd.go
@@ -23,9 +23,9 @@ import (
 	"time"
 
 	"github.com/briandowns/spinner"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
-	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/ocm"

--- a/cmd/verify/network/cmd_test.go
+++ b/cmd/verify/network/cmd_test.go
@@ -12,11 +12,12 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift-online/ocm-sdk-go/logging"
 	. "github.com/openshift-online/ocm-sdk-go/testing"
+	"github.com/spf13/cobra"
+
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
 	"github.com/openshift/rosa/pkg/test"
-	"github.com/spf13/cobra"
 )
 
 //nolint:lll

--- a/cmd/verify/rosa/cmd.go
+++ b/cmd/verify/rosa/cmd.go
@@ -23,10 +23,11 @@ import (
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/hashicorp/go-version"
-	"github.com/openshift/rosa/pkg/info"
-	"github.com/openshift/rosa/pkg/reporter"
 	"github.com/spf13/cobra"
 	"github.com/zgalor/weberr"
+
+	"github.com/openshift/rosa/pkg/info"
+	"github.com/openshift/rosa/pkg/reporter"
 )
 
 var Cmd = &cobra.Command{

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -50,16 +50,16 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	"github.com/openshift/rosa/pkg/fedramp"
-	"github.com/openshift/rosa/pkg/reporter"
 	"github.com/sirupsen/logrus"
 	"github.com/zgalor/weberr"
 
 	"github.com/openshift/rosa/pkg/aws/profile"
 	regionflag "github.com/openshift/rosa/pkg/aws/region"
 	"github.com/openshift/rosa/pkg/aws/tags"
+	"github.com/openshift/rosa/pkg/fedramp"
 	"github.com/openshift/rosa/pkg/info"
 	"github.com/openshift/rosa/pkg/logging"
+	"github.com/openshift/rosa/pkg/reporter"
 )
 
 // Name of the AWS user that will be used to create all the resources of the cluster:

--- a/pkg/aws/client_test.go
+++ b/pkg/aws/client_test.go
@@ -2,20 +2,20 @@ package aws_test
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/openshift-online/ocm-sdk-go/helpers"
 
 	awsSdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	common "github.com/openshift-online/ocm-common/pkg/aws/validations"
+	"github.com/openshift-online/ocm-sdk-go/helpers"
 	"github.com/sirupsen/logrus"
 
-	common "github.com/openshift-online/ocm-common/pkg/aws/validations"
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/aws/mocks"
 	rosaTags "github.com/openshift/rosa/pkg/aws/tags"

--- a/pkg/aws/commandbuilder/helper/roles/roles.go
+++ b/pkg/aws/commandbuilder/helper/roles/roles.go
@@ -5,6 +5,7 @@ import (
 
 	common "github.com/openshift-online/ocm-common/pkg/aws/validations"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
 	awscb "github.com/openshift/rosa/pkg/aws/commandbuilder"
 	"github.com/openshift/rosa/pkg/aws/tags"
 )

--- a/pkg/aws/flag.go
+++ b/pkg/aws/flag.go
@@ -18,8 +18,10 @@ package aws
 
 import (
 	"fmt"
-	"github.com/openshift/rosa/pkg/arguments"
+
 	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/arguments"
 )
 
 var mode string

--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -8,9 +8,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/sirupsen/logrus"
-	"github.com/zgalor/weberr"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
@@ -18,12 +15,14 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/sts"
-	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	awscb "github.com/openshift/rosa/pkg/aws/commandbuilder"
-
 	"github.com/openshift-online/ocm-common/pkg"
 	common "github.com/openshift-online/ocm-common/pkg/aws/validations"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/sirupsen/logrus"
+	"github.com/zgalor/weberr"
+
 	"github.com/openshift/rosa/pkg/arguments"
+	awscb "github.com/openshift/rosa/pkg/aws/commandbuilder"
 	"github.com/openshift/rosa/pkg/aws/tags"
 	"github.com/openshift/rosa/pkg/constants"
 	"github.com/openshift/rosa/pkg/fedramp"

--- a/pkg/aws/idps.go
+++ b/pkg/aws/idps.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
+
 	"github.com/openshift/rosa/pkg/aws/tags"
 )
 

--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -26,10 +26,10 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
 	semver "github.com/hashicorp/go-version"
+	common "github.com/openshift-online/ocm-common/pkg/aws/validations"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	errors "github.com/zgalor/weberr"
 
-	common "github.com/openshift-online/ocm-common/pkg/aws/validations"
 	"github.com/openshift/rosa/pkg/aws/tags"
 	"github.com/openshift/rosa/pkg/helper"
 )

--- a/pkg/aws/region/flag.go
+++ b/pkg/aws/region/flag.go
@@ -21,8 +21,9 @@ package region
 import (
 	"os"
 
-	"github.com/openshift/rosa/pkg/helper"
 	"github.com/spf13/pflag"
+
+	"github.com/openshift/rosa/pkg/helper"
 )
 
 // AddFlag adds the debug flag to the given set of command line flags.

--- a/pkg/aws/sts.go
+++ b/pkg/aws/sts.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	common "github.com/openshift-online/ocm-common/pkg/aws/validations"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
 	awscbRoles "github.com/openshift/rosa/pkg/aws/commandbuilder/helper/roles"
 	"github.com/openshift/rosa/pkg/aws/tags"
 	rprtr "github.com/openshift/rosa/pkg/reporter"

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/briandowns/spinner"
 	"github.com/google/uuid"
+
 	"github.com/openshift/rosa/pkg/reporter"
 )
 

--- a/pkg/helper/machinepools/helpers.go
+++ b/pkg/helper/machinepools/helpers.go
@@ -6,12 +6,14 @@ import (
 	"strconv"
 	"strings"
 
-	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	"github.com/openshift/rosa/pkg/interactive"
-	"github.com/openshift/rosa/pkg/rosa"
-	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/validation"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/rosa"
 )
 
 // To clear existing labels in interactive mode, the user enters "" as an empty list value

--- a/pkg/helper/roles/helpers.go
+++ b/pkg/helper/roles/helpers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift-online/ocm-common/pkg"
 	common "github.com/openshift-online/ocm-common/pkg/aws/validations"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
 	"github.com/openshift/rosa/pkg/aws"
 	awscb "github.com/openshift/rosa/pkg/aws/commandbuilder"
 	awscbRoles "github.com/openshift/rosa/pkg/aws/commandbuilder/helper/roles"

--- a/pkg/helper/versions/helpers.go
+++ b/pkg/helper/versions/helpers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/go-version"
 	ver "github.com/hashicorp/go-version"
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
 )

--- a/pkg/input/input_validation.go
+++ b/pkg/input/input_validation.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
 )

--- a/pkg/interactive/interactive.go
+++ b/pkg/interactive/interactive.go
@@ -25,8 +25,8 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/core"
 	"github.com/AlecAivazis/survey/v2/terminal"
-
 	"github.com/openshift-online/ocm-common/pkg"
+
 	"github.com/openshift/rosa/pkg/color"
 	"github.com/openshift/rosa/pkg/helper"
 	"github.com/openshift/rosa/pkg/interactive/consts"

--- a/pkg/interactive/oidc/oidc.go
+++ b/pkg/interactive/oidc/oidc.go
@@ -5,9 +5,10 @@ import (
 	"os"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	. "github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/rosa"
-	"github.com/spf13/cobra"
 )
 
 func GetOidcConfigID(r *rosa.Runtime, cmd *cobra.Command) string {

--- a/pkg/interactive/roles/roles.go
+++ b/pkg/interactive/roles/roles.go
@@ -6,12 +6,13 @@ import (
 	"time"
 
 	"github.com/briandowns/spinner"
+	"github.com/spf13/cobra"
+
 	"github.com/openshift/rosa/pkg/aws"
 	. "github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/rosa"
-	"github.com/spf13/cobra"
 )
 
 type findRoleARNs func(string, string) ([]string, error)

--- a/pkg/interactive/securitygroups/security_groups.go
+++ b/pkg/interactive/securitygroups/security_groups.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spf13/cobra"
+
 	"github.com/openshift/rosa/pkg/aws"
 	. "github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/rosa"
-	"github.com/spf13/cobra"
 )
 
 const (

--- a/pkg/kubeletconfig/config.go
+++ b/pkg/kubeletconfig/config.go
@@ -2,10 +2,11 @@ package kubeletconfig
 
 import (
 	"fmt"
+
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	"github.com/openshift/rosa/pkg/rosa"
 
 	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/rosa"
 )
 
 //go:generate mockgen -source=config.go -package=kubeletconfig -destination=mock_capability_checker.go

--- a/pkg/logging/round_tripper.go
+++ b/pkg/logging/round_tripper.go
@@ -31,6 +31,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+
 	"gitlab.com/c0b/go-ordered-json"
 )
 

--- a/pkg/ocm/billing.go
+++ b/pkg/ocm/billing.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	v1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
+
 	"github.com/openshift/rosa/pkg/helper"
 )
 

--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -28,6 +28,8 @@ import (
 	amv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	errors "github.com/zgalor/weberr"
+
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/helper"
 	"github.com/openshift/rosa/pkg/info"
@@ -35,7 +37,6 @@ import (
 	"github.com/openshift/rosa/pkg/logging"
 	"github.com/openshift/rosa/pkg/properties"
 	rprtr "github.com/openshift/rosa/pkg/reporter"
-	errors "github.com/zgalor/weberr"
 )
 
 const (

--- a/pkg/ocm/clusters_test.go
+++ b/pkg/ocm/clusters_test.go
@@ -4,6 +4,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
 	"github.com/openshift/rosa/pkg/aws"
 )
 

--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -28,23 +28,22 @@ import (
 	"strconv"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	semver "github.com/hashicorp/go-version"
-	"github.com/openshift/rosa/pkg/aws"
-	"github.com/openshift/rosa/pkg/output"
-	"github.com/openshift/rosa/pkg/reporter"
-	errors "github.com/zgalor/weberr"
-	"k8s.io/apimachinery/pkg/api/resource"
-
+	common "github.com/openshift-online/ocm-common/pkg/ocm/validations"
 	amsv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
+	errors "github.com/zgalor/weberr"
 
+	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/helper"
-
-	common "github.com/openshift-online/ocm-common/pkg/ocm/validations"
+	"github.com/openshift/rosa/pkg/output"
+	"github.com/openshift/rosa/pkg/reporter"
 )
 
 const (

--- a/pkg/ocm/idps.go
+++ b/pkg/ocm/idps.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
 	"github.com/openshift/rosa/pkg/helper"
 )
 

--- a/pkg/ocm/kubeletconfig_test.go
+++ b/pkg/ocm/kubeletconfig_test.go
@@ -9,7 +9,6 @@ import (
 	. "github.com/onsi/ginkgo/v2/dsl/decorators"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
-
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift-online/ocm-sdk-go/logging"

--- a/pkg/ocm/machines.go
+++ b/pkg/ocm/machines.go
@@ -23,6 +23,7 @@ import (
 
 	amsv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
 	"github.com/openshift/rosa/pkg/aws"
 )
 

--- a/pkg/ocm/output/machinepools.go
+++ b/pkg/ocm/output/machinepools.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
 	"github.com/openshift/rosa/pkg/helper"
 )
 

--- a/pkg/ocm/output/nodepools.go
+++ b/pkg/ocm/output/nodepools.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
 	"github.com/openshift/rosa/pkg/ocm"
 )
 

--- a/pkg/ocm/regions.go
+++ b/pkg/ocm/regions.go
@@ -21,9 +21,10 @@ import (
 	"fmt"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/zgalor/weberr"
+
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/logging"
-	"github.com/zgalor/weberr"
 )
 
 // GetFilteredRegionsByVersion fetches a list of regions. The 'version' argument is optional for filtering.

--- a/pkg/ocm/validators.go
+++ b/pkg/ocm/validators.go
@@ -2,9 +2,10 @@ package ocm
 
 import (
 	"fmt"
-	"github.com/openshift-online/ocm-common/pkg"
 	"strconv"
 	"time"
+
+	"github.com/openshift-online/ocm-common/pkg"
 )
 
 func IntValidator(val interface{}) error {

--- a/pkg/ocm/versions_test.go
+++ b/pkg/ocm/versions_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/ginkgo/v2/dsl/decorators"
 	. "github.com/onsi/ginkgo/v2/dsl/table"
 	. "github.com/onsi/gomega"
-
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -28,8 +28,10 @@ import (
 	"github.com/ghodss/yaml"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	msv1 "github.com/openshift-online/ocm-sdk-go/servicemgmt/v1"
-	"github.com/openshift/rosa/pkg/aws"
+
 	"gitlab.com/c0b/go-ordered-json"
+
+	"github.com/openshift/rosa/pkg/aws"
 )
 
 // When ocm-sdk-go encounters an empty resource list, it marshals it as a

--- a/pkg/rosa/runtime.go
+++ b/pkg/rosa/runtime.go
@@ -4,11 +4,12 @@ import (
 	"os"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/logging"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/reporter"
-	"github.com/sirupsen/logrus"
 )
 
 type Runtime struct {

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -16,10 +16,11 @@ import (
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift-online/ocm-sdk-go/logging"
 	. "github.com/openshift-online/ocm-sdk-go/testing"
+	"github.com/spf13/cobra"
+
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
-	"github.com/spf13/cobra"
 )
 
 func RunWithOutputCapture(runWithRuntime func(*rosa.Runtime, *cobra.Command) error,


### PR DESCRIPTION
1. Add a new target `gci-install` to install `gci`.
2. Add a new target `fmt-imports` to format the imports.
3. Format existing imports - Running the command `make fmt`.

This PR is similar to the auto grouping of imports in the CS project https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/blob/master/Makefile?ref_type=heads#L296.

**Note: a follow up PR will enforce formating as part of the PR pipeline**