### PR TITLE
OCM-5023 | feat: Refactor `GeneratePolicyFiles` to simplify code

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -406,7 +406,7 @@ func run(cmd *cobra.Command, argv []string) {
 			ocm.Version:  policyVersion,
 		})
 	case aws.ModeManual:
-		err = aws.GeneratePolicyFiles(r.Reporter, env, true, false, policies, nil, rolesCreator.skipPermissionFiles(), "")
+		err = aws.GenerateAccountRolePolicyFiles(r.Reporter, env, policies, rolesCreator.skipPermissionFiles())
 		if err != nil {
 			r.Reporter.Errorf("There was an error generating the policy files: %s", err)
 			r.OCMClient.LogEvent("ROSACreateAccountRolesModeManual", map[string]string{

--- a/cmd/create/operatorroles/by_clusterkey.go
+++ b/cmd/create/operatorroles/by_clusterkey.go
@@ -268,11 +268,12 @@ func buildCommands(r *rosa.Runtime, env string,
 	sharedVpcRoleArn := cluster.AWS().PrivateHostedZoneRoleARN()
 	isSharedVpc := sharedVpcRoleArn != ""
 
-	err := aws.GeneratePolicyFiles(r.Reporter, env, false,
-		true, policies, credRequests, managedPolicies, sharedVpcRoleArn)
-	if err != nil {
-		r.Reporter.Errorf("There was an error generating the policy files: %s", err)
-		os.Exit(1)
+	if !managedPolicies {
+		err := aws.GenerateOperatorRolePolicyFiles(r.Reporter, policies, credRequests, sharedVpcRoleArn)
+		if err != nil {
+			r.Reporter.Errorf("There was an error generating the policy files: %s", err)
+			os.Exit(1)
+		}
 	}
 
 	commands := []string{}

--- a/cmd/create/operatorroles/by_prefix.go
+++ b/cmd/create/operatorroles/by_prefix.go
@@ -390,11 +390,12 @@ func buildCommandsFromPrefix(r *rosa.Runtime, env string,
 	managedPolicies bool, path string,
 	operatorIAMRoleList []*cmv1.OperatorIAMRole,
 	oidcEndpointUrl string, hostedCPPolicies bool, sharedVpcRoleArn string) (string, error) {
-	err := aws.GeneratePolicyFiles(r.Reporter, env, false,
-		true, policies, credRequests, managedPolicies, sharedVpcRoleArn)
-	if err != nil {
-		r.Reporter.Errorf("There was an error generating the policy files: %s", err)
-		os.Exit(1)
+	if !managedPolicies {
+		err := aws.GenerateOperatorRolePolicyFiles(r.Reporter, policies, credRequests, sharedVpcRoleArn)
+		if err != nil {
+			r.Reporter.Errorf("There was an error generating the policy files: %s", err)
+			os.Exit(1)
+		}
 	}
 
 	isSharedVpc := sharedVpcRoleArn != ""

--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -251,11 +251,12 @@ func run(cmd *cobra.Command, argv []string) error {
 			}
 		}
 	case aws.ModeManual:
-		err = aws.GeneratePolicyFiles(reporter, env, isUpgradeNeedForAccountRolePolicies,
-			false, policies, nil, false, "")
-		if err != nil {
-			reporter.Errorf("There was an error generating the policy files: %s", err)
-			os.Exit(1)
+		if isUpgradeNeedForAccountRolePolicies {
+			err = aws.GenerateAccountRolePolicyFiles(reporter, env, policies, false)
+			if err != nil {
+				reporter.Errorf("There was an error generating the policy files: %s", err)
+				os.Exit(1)
+			}
 		}
 		if reporter.IsTerminal() {
 			reporter.Infof("All policy files saved to the current directory")

--- a/cmd/upgrade/operatorroles/cmd.go
+++ b/cmd/upgrade/operatorroles/cmd.go
@@ -261,8 +261,8 @@ func upgradeOperatorPolicies(mode string, r *rosa.Runtime,
 		}
 		return nil
 	case aws.ModeManual:
-		err := aws.GeneratePolicyFiles(r.Reporter, env, false,
-			true, policies, credRequests, false, cluster.AWS().PrivateHostedZoneRoleARN())
+		err := aws.GenerateOperatorRolePolicyFiles(r.Reporter, policies, credRequests,
+			cluster.AWS().PrivateHostedZoneRoleARN())
 		if err != nil {
 			r.Reporter.Errorf("There was an error generating the policy files: %s", err)
 			os.Exit(1)

--- a/cmd/upgrade/roles/cmd.go
+++ b/cmd/upgrade/roles/cmd.go
@@ -303,11 +303,12 @@ func run(cmd *cobra.Command, argv []string) error {
 				}
 			}
 		case aws.ModeManual:
-			err = aws.GeneratePolicyFiles(reporter, env, isUpgradeNeedForAccountRolePolicies,
-				false, accountRolePolicies, nil, false, "")
-			if err != nil {
-				reporter.Errorf("There was an error generating the policy files: %s", err)
-				os.Exit(1)
+			if isUpgradeNeedForAccountRolePolicies {
+				err = aws.GenerateAccountRolePolicyFiles(reporter, env, accountRolePolicies, false)
+				if err != nil {
+					reporter.Errorf("There was an error generating the policy files: %s", err)
+					os.Exit(1)
+				}
 			}
 			if reporter.IsTerminal() {
 				reporter.Infof("All policy files saved to the current directory")
@@ -738,8 +739,8 @@ func upgradeOperatorPolicies(
 		}
 		return nil
 	case aws.ModeManual:
-		err := aws.GeneratePolicyFiles(r.Reporter, env, false,
-			true, policies, credRequests, false, cluster.AWS().PrivateHostedZoneRoleARN())
+		err := aws.GenerateOperatorRolePolicyFiles(r.Reporter, policies, credRequests,
+			cluster.AWS().PrivateHostedZoneRoleARN())
 		if err != nil {
 			r.Reporter.Errorf("There was an error generating the policy files: %s", err)
 			os.Exit(1)


### PR DESCRIPTION
Separate the function into two new functions, `generateOperatorRolePolicies` and `generateAccountRolePolicies`.
Reduce the number of parameters passed to the function.

**Note:** Previously two booleans were passed to `GeneratePolicyFiles` to generate operator or account roles files, always one of the booleans was set to false.

e.g. 
```
func GeneratePolicyFiles(reporter *rprtr.Object, env string, generateAccountRolePolicies bool,
	generateOperatorRolePolicies bool...
```