### PR TITLE
OCM-4883 | fix: fetch passed arn in all roles

### DIFF
--- a/cmd/create/operatorroles/by_prefix.go
+++ b/cmd/create/operatorroles/by_prefix.go
@@ -58,12 +58,17 @@ func handleOperatorRolesPrefixOptions(r *rosa.Runtime, cmd *cobra.Command) {
 		os.Exit(1)
 	}
 	args.hostedCp = isHostedCP
-	if args.hostedCp {
-		args.installerRoleArn = interactiveRoles.GetInstallerRoleArn(r, cmd, args.installerRoleArn, "",
-			r.AWSClient.FindRoleARNsHostedCp)
+	if args.installerRoleArn == "" {
+		if args.hostedCp {
+			args.installerRoleArn = interactiveRoles.GetInstallerRoleArn(r, cmd, args.installerRoleArn, "",
+				r.AWSClient.FindRoleARNsHostedCp)
+		} else {
+			args.installerRoleArn = interactiveRoles.GetInstallerRoleArn(r, cmd, args.installerRoleArn, "",
+				r.AWSClient.FindRoleARNsClassic)
+		}
 	} else {
 		args.installerRoleArn = interactiveRoles.GetInstallerRoleArn(r, cmd, args.installerRoleArn, "",
-			r.AWSClient.FindRoleARNsClassic)
+			r.AWSClient.FindRoleARNs)
 	}
 }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-4883

There was an issue where if a use creates a cluster using classic role, but using operator roles that uses hcp roles. There will be a mismatch between managed/unmanaged policies, thus upgrade will fail.

This change will allow the user to create operator roles with classic role if passes '--installer-role-arn string'