### PR TITLE
OCM-4896 | fix: Create HCP trust policies in manual mode

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -406,7 +406,8 @@ func run(cmd *cobra.Command, argv []string) {
 			ocm.Version:  policyVersion,
 		})
 	case aws.ModeManual:
-		err = aws.GenerateAccountRolePolicyFiles(r.Reporter, env, policies, rolesCreator.skipPermissionFiles())
+		err = aws.GenerateAccountRolePolicyFiles(r.Reporter, env, policies, rolesCreator.skipPermissionFiles(),
+			rolesCreator.getAccountRolesMap())
 		if err != nil {
 			r.Reporter.Errorf("There was an error generating the policy files: %s", err)
 			r.OCMClient.LogEvent("ROSACreateAccountRolesModeManual", map[string]string{

--- a/cmd/create/accountroles/creators.go
+++ b/cmd/create/accountroles/creators.go
@@ -17,6 +17,7 @@ type creator interface {
 	getRoleTags(string, *accountRolesCreationInput) map[string]string
 	printCommands(*rosa.Runtime, *accountRolesCreationInput) error
 	skipPermissionFiles() bool
+	getAccountRolesMap() map[string]aws.AccountRole
 }
 
 func initCreator(r *rosa.Runtime, managedPolicies bool, classic bool, hostedCP bool, isClassicValueSet bool,
@@ -160,6 +161,10 @@ func (mp *managedPoliciesCreator) skipPermissionFiles() bool {
 	return true
 }
 
+func (mp *managedPoliciesCreator) getAccountRolesMap() map[string]aws.AccountRole {
+	return aws.AccountRoles
+}
+
 type unmanagedPoliciesCreator struct{}
 
 func (up *unmanagedPoliciesCreator) createRoles(r *rosa.Runtime, input *accountRolesCreationInput) error {
@@ -214,6 +219,10 @@ func (up *unmanagedPoliciesCreator) skipPermissionFiles() bool {
 	return false
 }
 
+func (up *unmanagedPoliciesCreator) getAccountRolesMap() map[string]aws.AccountRole {
+	return aws.AccountRoles
+}
+
 type doubleRolesCreator struct{}
 
 func (db *doubleRolesCreator) createRoles(r *rosa.Runtime, input *accountRolesCreationInput) error {
@@ -249,6 +258,10 @@ func (db *doubleRolesCreator) getRoleTags(roleType string, input *accountRolesCr
 
 func (db *doubleRolesCreator) skipPermissionFiles() bool {
 	return false
+}
+
+func (db *doubleRolesCreator) getAccountRolesMap() map[string]aws.AccountRole {
+	return aws.AccountRoles
 }
 
 func createRoleUnmanagedPolicy(r *rosa.Runtime, input *accountRolesCreationInput, accRoleName string,
@@ -359,6 +372,10 @@ func (hcp *hcpManagedPoliciesCreator) getRoleTags(roleType string, input *accoun
 
 func (hcp *hcpManagedPoliciesCreator) skipPermissionFiles() bool {
 	return true
+}
+
+func (hcp *hcpManagedPoliciesCreator) getAccountRolesMap() map[string]aws.AccountRole {
+	return aws.HCPAccountRoles
 }
 
 func getBaseRoleTags(roleType string, input *accountRolesCreationInput) map[string]string {

--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -251,7 +251,7 @@ func run(cmd *cobra.Command, argv []string) error {
 		}
 	case aws.ModeManual:
 		if isUpgradeNeedForAccountRolePolicies {
-			err = aws.GenerateAccountRolePolicyFiles(reporter, env, policies, false)
+			err = aws.GenerateAccountRolePolicyFiles(reporter, env, policies, false, aws.AccountRoles)
 			if err != nil {
 				reporter.Errorf("There was an error generating the policy files: %s", err)
 				os.Exit(1)

--- a/cmd/upgrade/roles/cmd.go
+++ b/cmd/upgrade/roles/cmd.go
@@ -304,7 +304,8 @@ func run(cmd *cobra.Command, argv []string) error {
 			}
 		case aws.ModeManual:
 			if isUpgradeNeedForAccountRolePolicies {
-				err = aws.GenerateAccountRolePolicyFiles(reporter, env, accountRolePolicies, false)
+				err = aws.GenerateAccountRolePolicyFiles(reporter, env, accountRolePolicies, false,
+					aws.AccountRoles)
 				if err != nil {
 					reporter.Errorf("There was an error generating the policy files: %s", err)
 					os.Exit(1)

--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -661,8 +661,8 @@ func GenerateOperatorRolePolicyFiles(reporter *rprtr.Object, policies map[string
 }
 
 func GenerateAccountRolePolicyFiles(reporter *rprtr.Object, env string, policies map[string]*cmv1.AWSSTSPolicy,
-	skipPermissionFiles bool) error {
-	for file := range AccountRoles {
+	skipPermissionFiles bool, accountRoles map[string]AccountRole) error {
+	for file := range accountRoles {
 		//Get trust policy
 		filename := fmt.Sprintf("sts_%s_trust_policy", file)
 		policyDetail := GetPolicyDetails(policies, filename)


### PR DESCRIPTION
Pass the map of the account roles to the generate policies function. HCP requires only three account roles (excluding control plane) while classic requires all four account roles.

e.g.
```
oadler@dhcp-0-129:rosa (OCM-4896)$ rosa create account-roles --hosted-cp --mode manual -y --prefix oadler-nov-29
I: Logged in as 'oadler.openshift' on 'https://api.stage.openshift.com'
I: Validating AWS credentials...
I: AWS credentials are valid!
I: Validating AWS quota...
I: AWS quota ok. If cluster installation fails, validate actual AWS resource usage against https://docs.openshift.com/rosa/rosa_getting_started/rosa-required-aws-service-quotas.html
I: Verifying whether OpenShift command-line tool is available...
I: Current OpenShift Client Version: 4.11.0
I: Creating account roles
I: Run the following commands to create the hosted CP account roles and policies:

aws iam create-role \
	--assume-role-policy-document file://sts_installer_trust_policy.json \
	--role-name oadler-nov-29-HCP-ROSA-Installer-Role \
	--tags Key=red-hat-managed,Value=true Key=rosa_hcp_policies,Value=true Key=rosa_role_type,Value=installer Key=rosa_managed_policies,Value=true Key=rosa_openshift_version,Value=4.14 Key=rosa_role_prefix,Value=oadler-nov-29

aws iam attach-role-policy \
	--policy-arn arn:aws:iam::aws:policy/service-role/ROSAInstallerPolicy \
	--role-name oadler-nov-29-HCP-ROSA-Installer-Role

aws iam create-role \
	--assume-role-policy-document file://sts_support_trust_policy.json \
	--role-name oadler-nov-29-HCP-ROSA-Support-Role \
	--tags Key=red-hat-managed,Value=true Key=rosa_hcp_policies,Value=true Key=rosa_role_type,Value=support Key=rosa_managed_policies,Value=true Key=rosa_openshift_version,Value=4.14 Key=rosa_role_prefix,Value=oadler-nov-29

aws iam attach-role-policy \
	--policy-arn arn:aws:iam::aws:policy/service-role/ROSASRESupportPolicy \
	--role-name oadler-nov-29-HCP-ROSA-Support-Role

aws iam create-role \
	--assume-role-policy-document file://sts_instance_worker_trust_policy.json \
	--role-name oadler-nov-29-HCP-ROSA-Worker-Role \
	--tags Key=red-hat-managed,Value=true Key=rosa_hcp_policies,Value=true Key=rosa_managed_policies,Value=true Key=rosa_openshift_version,Value=4.14 Key=rosa_role_prefix,Value=oadler-nov-29 Key=rosa_role_type,Value=instance_worker

aws iam attach-role-policy \
	--policy-arn arn:aws:iam::aws:policy/service-role/ROSAWorkerInstancePolicy \
	--role-name oadler-nov-29-HCP-ROSA-Worker-Role

I: All policy files saved to the current directory
oadler@dhcp-0-129:rosa (OCM-4896)$ ls | grep json
sts_installer_trust_policy.json
sts_instance_worker_trust_policy.json
sts_support_trust_policy.json
```
