### PR TITLE
OCM-5034 | fix: Do not ask user about HCP account-roles when on fedramp + always classic on fedramp

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -345,7 +345,9 @@ func run(cmd *cobra.Command, argv []string) {
 	isHostedCPValueSet := cmd.Flags().Changed("hosted-cp")
 
 	createClassic := args.classic
-	if interactive.Enabled() && !cmd.Flags().Changed("classic") {
+	if r.Creator.IsGovcloud {
+		createClassic = true
+	} else if interactive.Enabled() && !cmd.Flags().Changed("classic") {
 		createClassic, err = interactive.GetBool(interactive.Input{
 			Question: "Create Classic account roles",
 			Help:     cmd.Flags().Lookup("classic").Usage,

--- a/cmd/create/operatorroles/by_prefix.go
+++ b/cmd/create/operatorroles/by_prefix.go
@@ -46,16 +46,25 @@ func handleOperatorRolesPrefixOptions(r *rosa.Runtime, cmd *cobra.Command) {
 		args.oidcConfigId = interactiveOidc.GetOidcConfigID(r, cmd)
 	}
 
-	isHostedCP := args.hostedCp
-	isHostedCP, err = interactive.GetBool(interactive.Input{
-		Question: "Create hosted control plane operator roles",
-		Help:     cmd.Flags().Lookup("hosted-cp").Usage,
-		Default:  isHostedCP,
-		Required: false,
-	})
-	if err != nil {
-		r.Reporter.Errorf("Expected a valid --hosted-cp value: %s", err)
+	if cmd.Flags().Changed("hosted-cp") && r.Creator.IsGovcloud {
+		r.Reporter.Errorf("Setting `hosted-cp` is not supported for Govcloud AWS accounts")
 		os.Exit(1)
+	}
+
+	isHostedCP := args.hostedCp
+	if r.Creator.IsGovcloud {
+		isHostedCP = false
+	} else {
+		isHostedCP, err = interactive.GetBool(interactive.Input{
+			Question: "Create hosted control plane operator roles",
+			Help:     cmd.Flags().Lookup("hosted-cp").Usage,
+			Default:  isHostedCP,
+			Required: false,
+		})
+		if err != nil {
+			r.Reporter.Errorf("Expected a valid --hosted-cp value: %s", err)
+			os.Exit(1)
+		}
 	}
 	args.hostedCp = isHostedCP
 	if args.installerRoleArn == "" {

--- a/cmd/dlt/accountroles/cmd.go
+++ b/cmd/dlt/accountroles/cmd.go
@@ -108,6 +108,11 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
+	if cmd.Flags().Changed("hosted-cp") && r.Creator.IsGovcloud {
+		r.Reporter.Errorf("Setting `hosted-cp` is not supported for Govcloud AWS accounts")
+		os.Exit(1)
+	}
+
 	prefix := args.prefix
 	if interactive.Enabled() && prefix == "" {
 		prefix, err = interactive.GetString(interactive.Input{
@@ -156,7 +161,9 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 	}
 
-	if interactive.Enabled() && !cmd.Flags().Changed("hosted-cp") && !cmd.Flags().Changed("classic") {
+	if r.Creator.IsGovcloud {
+		deleteHostedCP = false
+	} else if interactive.Enabled() && !cmd.Flags().Changed("hosted-cp") && !cmd.Flags().Changed("classic") {
 		deleteHostedCP, err = interactive.GetBool(interactive.Input{
 			Question: "Delete hosted CP account roles",
 			Help:     cmd.Flags().Lookup("hosted-cp").Usage,


### PR DESCRIPTION
User was prompted about HCP roles upon account-role deletion when using fedramp, this has been disabled for fedramp only

User was prompted about whether or not to use Classic roles when on fedramp, this has been defaulted to `Yes` and disabled for fedramp

Now role creation & deletion only deals with classic on fedramp

```
./rosa create roles --profile gov --region us-gov-west-1
I: Logged in as '<REDACTED>' on 'https://<REDACTED>.com'
I: Validating AWS credentials...
I: AWS credentials are valid!
I: Validating AWS quota...
I: AWS quota ok. If cluster installation fails, validate actual AWS resource usage against https://docs.openshift.com/rosa/rosa_getting_started/rosa-required-aws-service-quotas.html
I: Verifying whether OpenShift command-line tool is available...
I: Current OpenShift Client Version: 4.11.6
I: Creating account roles
? Role prefix: hk
? Permissions boundary ARN (optional): 
? Path (optional): 
? Role creation mode: auto
I: Creating classic account roles using 'user/hkepley'
I: Created role 'hk-Installer-Role' with ARN 'role/hk-Installer-Role'
I: Created role 'hk-ControlPlane-Role' with ARN 'role/hk-ControlPlane-Role'
I: Created role 'hk-Worker-Role' with ARN 'role/hk-Worker-Role'
I: Created role 'hk-Support-Role' with ARN 'role/hk-Support-Role'

./rosa delete accountroles hk --profile gov --region us-gov-west-1
? Role prefix: hk
? Account role deletion mode: auto
I: Deleting classic account roles
? Delete the account role 'hk-Support-Role'? Yes
I: Deleting account role 'hk-Support-Role'

? Delete the account role 'hk-Installer-Role'? Yes
I: Deleting account role 'hk-Installer-Role'
? Delete the account role 'hk-ControlPlane-Role'? Yes
I: Deleting account role 'hk-ControlPlane-Role'
? Delete the account role 'hk-Worker-Role'? Yes
I: Deleting account role 'hk-Worker-Role'
I: Successfully deleted the classic account roles

```