### PR TITLE
OCM-5018 | Send custom tags when doing network verify for a cluster

### DIFF
--- a/cmd/verify/network/cmd.go
+++ b/cmd/verify/network/cmd.go
@@ -200,7 +200,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 			if cluster == nil {
 				cluster = r.FetchCluster()
 			}
-			_, err := r.OCMClient.VerifyNetworkSubnetsByCluster(cluster.ID())
+			_, err := r.OCMClient.VerifyNetworkSubnetsByCluster(cluster.ID(), tagsList)
 			if err != nil {
 				return fmt.Errorf("Error verifying subnets by cluster: %s", err)
 			}

--- a/pkg/ocm/verify_network.go
+++ b/pkg/ocm/verify_network.go
@@ -45,8 +45,10 @@ func (c *Client) VerifyNetworkSubnets(awsAccountId string, region string,
 	return response.Body().Items(), nil
 }
 
-func (c *Client) VerifyNetworkSubnetsByCluster(clusterId string) ([]*cmv1.SubnetNetworkVerification, error) {
-	body, _ := cmv1.NewNetworkVerification().ClusterId(clusterId).Build()
+func (c *Client) VerifyNetworkSubnetsByCluster(clusterId string, tags map[string]string) (
+	[]*cmv1.SubnetNetworkVerification, error) {
+	body, _ := cmv1.NewNetworkVerification().ClusterId(clusterId).CloudProviderData(
+		cmv1.NewCloudProviderData().AWS(cmv1.NewAWS().Tags(tags))).Build()
 	response, err := c.ocm.ClustersMgmt().V1().NetworkVerifications().Add().
 		Body(body).
 		Send()


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-5018

This issue is caused by the cluster service ignoring the custom tags and by ROSA not sending the custom tags if a cluster is provided. We have a MR in cluster service to process the custom tags properly, and this change fixes ROSA to send the tags if the user provides them.