### PR TITLE
version, verify rosa-client: Support --debug

### DIFF
--- a/cmd/verify/rosa/cmd.go
+++ b/cmd/verify/rosa/cmd.go
@@ -23,10 +23,12 @@ import (
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/hashicorp/go-version"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/zgalor/weberr"
 
 	"github.com/openshift/rosa/pkg/info"
+	"github.com/openshift/rosa/pkg/logging"
 	"github.com/openshift/rosa/pkg/reporter"
 )
 
@@ -71,7 +73,18 @@ func run(_ *cobra.Command, _ []string) {
 }
 
 func retrievePossibleVersionsFromMirror() ([]string, error) {
-	resp, err := http.Get(baseReleasesFolder)
+	logger := logging.NewLogger()
+	transport := http.DefaultTransport
+	if logger.IsLevelEnabled(logrus.DebugLevel) {
+		dumper, err := logging.NewRoundTripper().Logger(logger).Next(transport).Build()
+		if err != nil {
+			return nil, err
+		}
+		transport = dumper
+	}
+	client := &http.Client{Transport: transport}
+
+	resp, err := client.Get(baseReleasesFolder)
 	if err != nil {
 		return []string{}, weberr.Wrapf(err, "Error setting up request for latest released rosa cli")
 	}
@@ -96,6 +109,7 @@ func retrievePossibleVersionsFromMirror() ([]string, error) {
 			}
 		})
 	})
+	logger.Debugf("Versions available for download: %v", possibleVersions)
 	return possibleVersions, nil
 }
 


### PR DESCRIPTION
Allow inspecting how `rosa version` and `verify rosa-client` check available versions.
Previously --debug did nothing for these commands.

```
> rosa version --debug
1.2.31
time=2023-12-04T12:09:03+02:00 level=debug msg=Request method is GET
time=2023-12-04T12:09:03+02:00 level=debug msg=Request URL is 'https://mirror.openshift.com/pub/openshift-v4/clients/rosa/'
time=2023-12-04T12:09:04+02:00 level=debug msg=Response status is '200 OK'
time=2023-12-04T12:09:04+02:00 level=debug msg=Response header 'Cache-Control' is 'max-age=0'
time=2023-12-04T12:09:04+02:00 level=debug msg=Response header 'Content-Length' is '29044'
time=2023-12-04T12:09:04+02:00 level=debug msg=Response header 'Content-Type' is 'text/html'
time=2023-12-04T12:09:04+02:00 level=debug msg=Response header 'Date' is 'Mon, 04 Dec 2023 10:09:04 GMT'
time=2023-12-04T12:09:04+02:00 level=debug msg=Response header 'Server' is 'CloudFront'
time=2023-12-04T12:09:04+02:00 level=debug msg=Response header 'Vary' is 'Accept-Encoding'
time=2023-12-04T12:09:04+02:00 level=debug msg=Response header 'Via' is '1.1 0d0af2eea2f20e46e2262385b289cbae.cloudfront.net (CloudFront)'
time=2023-12-04T12:09:04+02:00 level=debug msg=Response header 'X-Amz-Cf-Id' is 'oSzAzTwd_pjlPEjRx5UwYwUW_YaK30GdjSMUmojCk9CeeqZH6RAk4Q=='
time=2023-12-04T12:09:04+02:00 level=debug msg=Response header 'X-Amz-Cf-Pop' is 'TLV50-C2'
time=2023-12-04T12:09:04+02:00 level=debug msg=Response header 'X-Cache' is 'Miss from cloudfront'
time=2023-12-04T12:09:04+02:00 level=debug msg=Response body follows
<!DOCTYPE html>
...
        <tr class="file">
            <td></td>
            <td>
                <a href="1.0.1/">
...
time=2023-12-04T12:09:04+02:00 level=debug msg=Versions available for download: [1.0.1 1.0.2 1.0.4 1.0.5 1.0.8 1.0.9 1.1.0 1.1.1 1.1.11 1.1.12 1.1.2 1.1.3 1.1.5 1.1.7 1.1.9 1.2.0 1.2.10 1.2.11 1.2.15 1.2.2 1.2.21 1.2.22 1.2.23 1.2.24 1.2.25 1.2.26 1.2.27 1.2.28 1.2.29 1.2.3 1.2.30 1.2.31 1.2.5 1.2.6 1.2.8]
I: Your ROSA CLI is up to date.
```