### PR TITLE
OCM-5024 | fix: update example command for rosa edit cluster

### DIFF
--- a/cmd/edit/cluster/cmd.go
+++ b/cmd/edit/cluster/cmd.go
@@ -58,7 +58,7 @@ var Cmd = &cobra.Command{
 	Short: "Edit cluster",
 	Long:  "Edit cluster.",
 	Example: `  # Edit a cluster named "mycluster" to make it private
-  rosa edit cluster mycluster --private
+  rosa edit cluster -c mycluster --private
 
   # Edit all options interactively
   rosa edit cluster -c mycluster --interactive`,


### PR DESCRIPTION
JIRA : https://issues.redhat.com/browse/OCM-5024 

Validation 
```
 rosa edit cluster -h
Edit cluster.

Usage:
  rosa edit cluster [flags]

Examples:
  # Edit a cluster named "mycluster" to make it private
  rosa edit cluster -c mycluster --private

  # Edit all options interactively
  rosa edit cluster -c mycluster --interactive

Flags:
  -c, --cluster string                        Name or ID of the cluster.
  -y, --yes                                   Automatically answer yes to confirm operation.
      --private                               Restrict master API endpoint to direct, private connectivity.
      --disable-workload-monitoring           Enables you to monitor your own projects in isolation from Red Hat Site Reliability Engineer (SRE) platform metrics.
      --http-proxy string                     A proxy URL to use for creating HTTP connections outside the cluster. The URL scheme must be http.
      --https-proxy string                    A proxy URL to use for creating HTTPS connections outside the cluster.
      --no-proxy strings                      A comma-separated list of destination domain names, domains, IP addresses or other network CIDRs to exclude proxying.
      --additional-trust-bundle-file string   A file contains a PEM-encoded X.509 certificate bundle that will be added to the nodes' trusted certificate store.
      --audit-log-arn string                  The ARN of the role that is used to forward audit logs to AWS CloudWatch.
  -h, --help                                  help for cluster

Global Flags:
      --color string     Surround certain characters with escape sequences to display them in color on the terminal. Allowed options are [auto never always] (default "auto")
      --debug            Enable debug mode.
  -i, --interactive      Enable interactive mode.
      --profile string   Use a specific AWS profile from your credential file.
      --region string    Use a specific AWS region, overriding the AWS_REGION environment variable.
```