### PR TITLE
OCM-3594 | Feat | Add rhRegion flag to rosa login command

### DIFF
--- a/cmd/list/cmd.go
+++ b/cmd/list/cmd.go
@@ -34,6 +34,7 @@ import (
 	"github.com/openshift/rosa/cmd/list/oidcprovider"
 	"github.com/openshift/rosa/cmd/list/operatorroles"
 	"github.com/openshift/rosa/cmd/list/region"
+	"github.com/openshift/rosa/cmd/list/rhRegion"
 	"github.com/openshift/rosa/cmd/list/service"
 	"github.com/openshift/rosa/cmd/list/tuningconfigs"
 	"github.com/openshift/rosa/cmd/list/upgrade"
@@ -71,6 +72,7 @@ func init() {
 	Cmd.AddCommand(tuningconfigs.Cmd)
 	Cmd.AddCommand(oidcprovider.Cmd)
 	Cmd.AddCommand(dnsdomains.Cmd)
+	Cmd.AddCommand(rhRegion.Cmd)
 	Cmd.AddCommand(externalauthprovider.Cmd)
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)

--- a/cmd/list/rhRegion/cmd.go
+++ b/cmd/list/rhRegion/cmd.go
@@ -1,0 +1,88 @@
+package rhRegion
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/config"
+	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+var (
+	writer = tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', tabwriter.TabIndent)
+	args   struct {
+		discoveryURL string
+	}
+)
+
+var Cmd = NewRhRegionCommand()
+
+func NewRhRegionCommand() *cobra.Command {
+	Cmd := &cobra.Command{
+		Use:   "rh-regions",
+		Short: "List available OCM regions",
+		Long:  "The command lists available OpenShift Cluster Manager regions.",
+		Example: `  # List all supported OCM regions 
+ocm list rh-regions`,
+		Run:    run,
+		Hidden: true,
+		Args:   cobra.NoArgs,
+	}
+
+	flags := Cmd.Flags()
+	flags.StringVar(
+		&args.discoveryURL,
+		"discovery-url",
+		"",
+		"URL of the OCM API gateway. If not provided, will reuse the URL from the configuration "+
+			"file or "+sdk.DefaultURL+" as a last resort. The value should be a complete URL "+
+			"or a valid URL alias: "+strings.Join(ocm.ValidOCMUrlAliases(), ", "),
+	)
+	return Cmd
+}
+
+func run(cmd *cobra.Command, argv []string) {
+	r := rosa.NewRuntime()
+
+	err := ListRhRegions(args.discoveryURL, r)
+	if err != nil {
+		r.Reporter.Errorf("Failed to determine gateway URL: %v", err)
+		os.Exit(1)
+	}
+}
+
+func ListRhRegions(discoveryURL string, r *rosa.Runtime) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("Failed to load config file: %v", err)
+	}
+
+	gatewayURL, err := ocm.ResolveGatewayUrl(discoveryURL, cfg)
+	if err != nil {
+		return fmt.Errorf("Failed to determine gateway URL: %v", err)
+	}
+
+	fmt.Fprintf(writer, "Discovery URL: %s\n\n", gatewayURL)
+	regions, err := sdk.GetRhRegions(gatewayURL)
+	if err != nil {
+		return fmt.Errorf("Failed to get OCM regions: %v", err)
+	}
+
+	// If there are no regions, print a warning message and return early
+	if len(regions) == 0 {
+		r.Reporter.Warnf("No regions found")
+		return nil
+	}
+	fmt.Fprintf(writer, "RH Region\t\tGateway URL\n")
+	for regionName, region := range regions {
+		fmt.Fprintf(writer, "%s\t\t%v\n", regionName, region.URL)
+	}
+	writer.Flush()
+	return nil
+}

--- a/cmd/list/rhRegion/cmd_test.go
+++ b/cmd/list/rhRegion/cmd_test.go
@@ -1,0 +1,44 @@
+package rhRegion
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/rosa/pkg/config"
+	"github.com/openshift/rosa/pkg/ocm"
+)
+
+func TestRhRegionCommand(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "rosa list rh-regions command")
+}
+
+var _ = Describe("Token", Ordered, func() {
+	var tmpdir string
+	var err error
+	var cfg *config.Config
+
+	BeforeAll(func() {
+		tmpdir, err = os.MkdirTemp("/tmp", ".ocm-config-*")
+		Expect(err).To(BeNil())
+		os.Setenv("OCM_CONFIG", tmpdir+"/ocm_config.json")
+		cfg = &config.Config{}
+		cfg.URL = ocm.URLAliases["staging"]
+		err = config.Save(cfg)
+		Expect(err).To(BeNil())
+	})
+
+	AfterAll(func() {
+		os.Setenv("OCM_CONFIG", "")
+	})
+
+	When("Logged in", func() {
+		It("Displays rh-regions", func() {
+			err = ListRhRegions("", nil)
+			Expect(err).To(BeNil())
+		})
+	})
+})

--- a/pkg/arguments/normalize.go
+++ b/pkg/arguments/normalize.go
@@ -13,6 +13,8 @@ const (
 	NewControlPlaneIAMRole         = "controlplane-iam-role-arn"
 	DeprecatedWorkerIAMRole        = "worker-iam-role"
 	NewWorkerIAMRole               = "worker-iam-role-arn"
+	DeprecatedEnvFlag              = "env"
+	NewEnvFlag                     = "url"
 )
 
 func NormalizeFlags(_ *pflag.FlagSet, name string) pflag.NormalizedName {
@@ -25,6 +27,8 @@ func NormalizeFlags(_ *pflag.FlagSet, name string) pflag.NormalizedName {
 		name = NewWorkerIAMRole
 	case DeprecatedControlPlaneIAMRole:
 		name = NewControlPlaneIAMRole
+	case DeprecatedEnvFlag:
+		name = NewEnvFlag
 	}
 	return pflag.NormalizedName(name)
 }

--- a/pkg/arguments/normalize_test.go
+++ b/pkg/arguments/normalize_test.go
@@ -19,6 +19,7 @@ var _ = Describe("Normalize Argument Flags Tests", func() {
 			Entry("controlplane-iam-role to controlplane-iam-role-arn",
 				DeprecatedControlPlaneIAMRole, NewControlPlaneIAMRole),
 			Entry("worker-iam-role to worker-iam-role-arn", DeprecatedWorkerIAMRole, NewWorkerIAMRole),
+			Entry("env to url", DeprecatedEnvFlag, NewEnvFlag),
 		)
 	})
 

--- a/pkg/ocm/config.go
+++ b/pkg/ocm/config.go
@@ -21,7 +21,10 @@ package ocm
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
+
+	sdk "github.com/openshift-online/ocm-sdk-go"
 
 	"github.com/openshift/rosa/pkg/config"
 	"github.com/openshift/rosa/pkg/fedramp"
@@ -39,6 +42,46 @@ var URLAliases = map[string]string{
 	"crc":         "https://clusters-service.apps-crc.testing",
 }
 
+func ValidOCMUrlAliases() []string {
+	keys := make([]string, 0, len(URLAliases))
+	for k := range URLAliases {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// URL Precedent (from highest priority to lowest priority):
+//  1. runtime `--env` cli arg (key found in `urlAliases`)
+//  2. runtime `--env` cli arg (non-empty string)
+//  3. config file `URL` value (non-empty string)
+//  4. sdk.DefaultURL
+//
+// Finally, it will try to url.ParseRequestURI the resolved URL to make sure it's a valid URL.
+func ResolveGatewayUrl(optionalParsedCliFlagValue string, optionalParsedConfig *config.Config) (string, error) {
+	gatewayURL := sdk.DefaultURL
+	source := "default"
+	if optionalParsedCliFlagValue != "" {
+		gatewayURL = optionalParsedCliFlagValue
+		source = "flag"
+		if _, ok := URLAliases[optionalParsedCliFlagValue]; ok {
+			gatewayURL = URLAliases[optionalParsedCliFlagValue]
+		}
+	} else if optionalParsedConfig != nil && optionalParsedConfig.URL != "" {
+		// re-use the URL from the config file
+		gatewayURL = optionalParsedConfig.URL
+		source = "config"
+	}
+
+	url, err := url.ParseRequestURI(gatewayURL)
+	if err != nil {
+		return "", fmt.Errorf(
+			"%w\n\nURL Source: %s\nExpected an absolute URI/path (e.g. %s) or a case-sensitive alias, one of: [%s]",
+			err, source, sdk.DefaultURL, strings.Join(ValidOCMUrlAliases(), ", "))
+	}
+
+	return url.String(), nil
+}
+
 func GetEnv() (string, error) {
 	cfg, err := config.Load()
 	if err != nil {
@@ -50,9 +93,17 @@ func GetEnv() (string, error) {
 		urlAliases = fedramp.URLAliases
 	}
 
-	for env, api := range urlAliases {
-		if api == strings.TrimSuffix(cfg.URL, "/") {
-			return env, nil
+	// Check for OCM environments (including regionalized URLs)
+	if strings.HasSuffix(strings.TrimSuffix(cfg.URL, "/"), "openshift.com") {
+		regionDiscoveryUrl, err := sdk.DetermineRegionDiscoveryUrl(cfg.URL)
+		if err == nil {
+			discoveryGatewayUrl, _ := url.Parse(regionDiscoveryUrl)
+			// Check for URL aliases
+			for env, api := range urlAliases {
+				if api == fmt.Sprintf("%s://%s", discoveryGatewayUrl.Scheme, discoveryGatewayUrl.Host) {
+					return env, nil
+				}
+			}
 		}
 	}
 

--- a/pkg/ocm/config_test.go
+++ b/pkg/ocm/config_test.go
@@ -1,0 +1,176 @@
+package ocm
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	sdk "github.com/openshift-online/ocm-sdk-go"
+
+	"github.com/openshift/rosa/pkg/config"
+)
+
+var _ = Describe("Gateway URL Resolution", func() {
+
+	var nilConfig *config.Config = nil
+	var emptyConfig = &config.Config{}
+	var emptyURLConfig = &config.Config{URL: ""}
+	var nonEmptyURLConfig = &config.Config{URL: "https://api.example.com"}
+	validUrlOverrides := []string{
+		"https://api.example.com", "http://api.example.com", "http://localhost",
+		"http://localhost:8080", "https://localhost:8080/", "unix://my.server.com/tmp/api.socket",
+		"unix+https://my.server.com/tmp/api.socket", "h2c://api.example.com",
+		"unix+h2c://my.server.com/tmp/api.socket",
+	}
+	invalidUrlOverrides := []string{
+		//nolint:misspell // intentional misspellings
+		"productin", "PRod", //alias typo
+		"localhost", "192.168.1.1", "api.openshift.com", //ip address/hostname without protocol
+	}
+	When("Resolving gatewayURL", func() {
+		It("Priority 1 - cli arg valid url aliases", func() {
+			for alias, url := range URLAliases {
+				resolved, err := ResolveGatewayUrl(alias, nilConfig)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resolved).To(Equal(url))
+
+				resolved, err = ResolveGatewayUrl(alias, emptyConfig)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resolved).To(Equal(url))
+
+				resolved, err = ResolveGatewayUrl(alias, emptyURLConfig)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resolved).To(Equal(url))
+
+				resolved, err = ResolveGatewayUrl(alias, nonEmptyURLConfig)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resolved).To(Equal(url))
+			}
+		})
+
+		It("Priority 2 - cli arg valid url", func() {
+			for _, urlOverride := range validUrlOverrides {
+				resolved, err := ResolveGatewayUrl(urlOverride, nilConfig)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resolved).To(Equal(urlOverride))
+
+				resolved, err = ResolveGatewayUrl(urlOverride, emptyConfig)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resolved).To(Equal(urlOverride))
+
+				resolved, err = ResolveGatewayUrl(urlOverride, emptyURLConfig)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resolved).To(Equal(urlOverride))
+
+				resolved, err = ResolveGatewayUrl(urlOverride, nonEmptyURLConfig)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resolved).To(Equal(urlOverride))
+			}
+		})
+
+		It("Priority 3 - valid config url", func() {
+			for _, urlOverride := range validUrlOverrides {
+				resolved, err := ResolveGatewayUrl("", &config.Config{URL: urlOverride})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resolved).To(Equal(urlOverride))
+			}
+		})
+
+		It("Priority 4 - api.openshift.com", func() {
+			resolved, err := ResolveGatewayUrl("", nilConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resolved).To(Equal(sdk.DefaultURL))
+
+			resolved, err = ResolveGatewayUrl("", emptyConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resolved).To(Equal(sdk.DefaultURL))
+
+			resolved, err = ResolveGatewayUrl("", emptyURLConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resolved).To(Equal(sdk.DefaultURL))
+		})
+
+		It("Invalid url alias throws an error", func() {
+			for _, urlOverride := range invalidUrlOverrides {
+				_, err := ResolveGatewayUrl(urlOverride, nilConfig)
+				Expect(err).To(HaveOccurred())
+			}
+		})
+
+		It("Invalid cfg.URL throws an error", func() {
+			for _, urlOverride := range invalidUrlOverrides {
+				_, err := ResolveGatewayUrl("", &config.Config{URL: urlOverride})
+				Expect(err).To(HaveOccurred())
+			}
+		})
+	})
+	When("Getting env", Ordered, func() {
+		BeforeAll(func() {
+			tmpdir, err := os.MkdirTemp("/tmp", ".ocm-config-*")
+			Expect(err).To(BeNil())
+			os.Setenv("OCM_CONFIG", tmpdir+"/ocm_config.json")
+		})
+
+		AfterAll(func() {
+			os.Setenv("OCM_CONFIG", "")
+		})
+
+		It("Returns a valid OCM stage env", func() {
+			url := "https://api.stage.openshift.com"
+			cfg := &config.Config{}
+			cfg.URL = url
+			err := config.Save(cfg)
+			Expect(err).To(BeNil())
+			currentConfig, err := config.Load()
+			Expect(err).To(BeNil())
+			Expect(currentConfig.URL).To(Equal(url))
+
+			env, err := GetEnv()
+			Expect(err).To(BeNil())
+			Expect(env).To(Equal("staging"))
+		})
+
+		It("Returns a valid regionalized env", func() {
+			url := "https://api.aws.ap-southeast-1.integration.openshift.com"
+			cfg := &config.Config{}
+			cfg.URL = url
+			err := config.Save(cfg)
+			Expect(err).To(BeNil())
+			currentConfig, err := config.Load()
+			Expect(err).To(BeNil())
+			Expect(currentConfig.URL).To(Equal(url))
+
+			env, err := GetEnv()
+			Expect(err).To(BeNil())
+			Expect(env).To(Equal("integration"))
+
+			url = "https://api.aws.ap-southeast-1.openshift.com"
+			cfg = &config.Config{}
+			cfg.URL = url
+			err = config.Save(cfg)
+			Expect(err).To(BeNil())
+			currentConfig, err = config.Load()
+			Expect(err).To(BeNil())
+			Expect(currentConfig.URL).To(Equal(url))
+
+			env, err = GetEnv()
+			Expect(err).To(BeNil())
+			Expect(env).To(Equal("production"))
+		})
+
+		It("Fails for invalid URL", func() {
+			url := "https://urlthatfails.com"
+			cfg := &config.Config{}
+			cfg.URL = url
+			err := config.Save(cfg)
+			Expect(err).To(BeNil())
+			currentConfig, err := config.Load()
+			Expect(err).To(BeNil())
+			Expect(currentConfig.URL).To(Equal(url))
+
+			env, err := GetEnv()
+			Expect(err).NotTo(BeNil())
+			Expect(env).To(BeEmpty())
+		})
+	})
+})


### PR DESCRIPTION
Issue : https://issues.redhat.com/browse/OCM-3594

**Changed**
- Add hidden flag rhRegion to rosa login command
- Add list rh-region command to list regions
- Add unit tests

**Tested**
This MR tweaks the `rosa login --env` resolution algorithm to try to reuse `cfg.URL` before falling back to "api.openshift.com". New `--env` resolution algorithm (from highest priority to lowest priority):

1. runtime `--env` cli arg (key found in `URLAliases`)
2. runtime `--env` cli arg (non-empty string)
3. [NEW] config file `URL` value (non-empty string)
4. sdk.DefaultURL

`rosa list rh-region`:
* show discovery URL used
* add optional `--discovery-url` flag with the same url resolution behavior as `ocm login`
* display region name and its associated url rather than just region name