### PR TITLE
OCM-5231 | fix: use spaces instead of \t

### DIFF
--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -621,13 +621,13 @@ func clusterInfraConfig(cluster *cmv1.Cluster, clusterKey string, r *rosa.Runtim
 		nodeConfig += " - Additional Security Group IDs:\n"
 		if hasSgsControlPlane {
 			nodeConfig += fmt.Sprintf(
-				"\t- Control Plane:	%s\n",
+				"   - Control Plane:	%s\n",
 				ocmOutput.PrintStringSlice(
 					cluster.AWS().AdditionalControlPlaneSecurityGroupIds()))
 		}
 		if hasSgsInfra {
 			nodeConfig += fmt.Sprintf(
-				"\t- Infra:		%s\n",
+				"   - Infra:		%s\n",
 				ocmOutput.PrintStringSlice(
 					cluster.AWS().AdditionalInfraSecurityGroupIds()))
 		}


### PR DESCRIPTION
Related issue: [OCM-5231](https://issues.redhat.com//browse/OCM-5231)