### PR TITLE
OCM-5621 | feat: Add codecov to CI pipeline for ROSA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ test:
 
 .PHONY: coverage
 coverage:
-	go test -coverprofile=cover.out  ./...
+	go test -coverprofile=cover.out -covermode=atomic -p 4 ./...
 
 .PHONY: install
 install:
@@ -63,6 +63,7 @@ commits/check:
 .PHONY: clean
 clean:
 	rm -rf \
+		./cover.out \
 		rosa \
 		*-darwin-amd64 \
 		*-linux-amd64 \
@@ -74,6 +75,10 @@ clean:
 generate:
 	which go-bindata || GO111MODULE=off go get -u github.com/go-bindata/go-bindata/...
 	go-bindata -nometadata -nocompress -pkg assets -o ./assets/bindata.go ./templates/...
+
+.PHONY: codecov
+codecov: coverage
+	@./hack/codecov.sh
 
 mocks:
 	mockgen --build_flags=--mod=mod -package mocks -destination=pkg/aws/mocks/iamapi.go github.com/aws/aws-sdk-go/service/iam/iamiface IAMAPI

--- a/hack/codecov.sh
+++ b/hack/codecov.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+CI_SERVER_URL=https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test
+COVER_PROFILE=${COVER_PROFILE:-cover.out}
+JOB_TYPE=${JOB_TYPE:-"local"}
+
+
+# Configure the git refs and job link based on how the job was triggered via prow
+if [[ "${JOB_TYPE}" == "presubmit" ]]; then
+       echo "detected PR code coverage job for #${PULL_NUMBER}"
+       REF_FLAGS="-P ${PULL_NUMBER} -C ${PULL_PULL_SHA}"
+       JOB_LINK="${CI_SERVER_URL}/pr-logs/pull/${REPO_OWNER}_${REPO_NAME}/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
+elif [[ "${JOB_TYPE}" == "postsubmit" ]]; then
+       echo "detected branch code coverage job for ${PULL_BASE_REF}"
+       REF_FLAGS="-B ${PULL_BASE_REF} -C ${PULL_BASE_SHA}"
+       JOB_LINK="${CI_SERVER_URL}/logs/${JOB_NAME}/${BUILD_ID}"
+elif [[ "${JOB_TYPE}" == "local" ]]; then
+       echo "coverage report available at ${COVER_PROFILE}"
+       exit 0
+else
+       echo "${JOB_TYPE} jobs not supported" >&2
+       exit 1
+fi
+
+# Configure certain internal codecov variables with values from prow.
+export CI_BUILD_URL="${JOB_LINK}"
+export CI_BUILD_ID="${JOB_NAME}"
+export CI_JOB_ID="${BUILD_ID}"
+
+if [[ "${JOB_TYPE}" != "local" ]]; then
+       if [[ -z "${ARTIFACT_DIR:-}" ]] || [[ ! -d "${ARTIFACT_DIR}" ]] || [[ ! -w "${ARTIFACT_DIR}" ]]; then
+              echo '${ARTIFACT_DIR} must be set for non-local jobs, and must point to a writable directory' >&2
+              exit 1
+       fi
+       curl -sS https://codecov.io/bash -o "${ARTIFACT_DIR}/codecov.sh"
+       bash <(cat "${ARTIFACT_DIR}/codecov.sh") -Z -K -f "${COVER_PROFILE}" -r "${REPO_OWNER}/${REPO_NAME}" ${REF_FLAGS}
+else
+       bash <(curl -s https://codecov.io/bash) -Z -K -f "${COVER_PROFILE}" -r "${REPO_OWNER}/${REPO_NAME}" ${REF_FLAGS}
+fi


### PR DESCRIPTION
This PR is the first step for adding CodeCov coverage checking to the ROSA CI pipeline. In this PR I'm simply introducing a `Makefile` target and a bash script to upload results to CodeCov. The bash script has been copied from other projects uploading to CodeCov within the `openshift` org, and then slightly adapated to match our project.

Next steps will be to update our `prow` configuration to run this on each PR and then on merges to `master` so that we have a record of our coverage statistics over time.