### PR TITLE
OCM-5312 | fix: Output platform and tags

### DIFF
--- a/cmd/verify/network/cmd.go
+++ b/cmd/verify/network/cmd.go
@@ -17,6 +17,7 @@ limitations under the License.
 package network
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -295,7 +296,15 @@ func printStatus(reporter *reporter.Object, spin *spinner.Spinner, subnet string
 	} else if status.State() == string(NetworkVerifyFailed) {
 		reporter.Infof("%s: %s Unable to verify egress to: %v", subnet, status.State(), status.Details())
 	} else {
-		reporter.Infof("%s: %s", subnet, status.State())
+		var tags string
+		if len(status.Tags()) > 0 {
+			tagsList, err := json.Marshal(status.Tags())
+			if err != nil {
+				reporter.Debugf("%s: unable to marshal tags - %s", subnet, err.Error())
+			}
+			tags = string(tagsList)
+		}
+		reporter.Infof("%s, platform: %s, tags: %v: %s", subnet, status.Platform(), tags, status.State())
 	}
 
 	if spin != nil {

--- a/cmd/verify/network/cmd_test.go
+++ b/cmd/verify/network/cmd_test.go
@@ -43,12 +43,16 @@ var _ = Describe("verify network", func() {
 		  {
 			"href": "/api/clusters_mgmt/v1/network_verifications/subnet-0b761d44d3d9a4663/",
 			"id": "subnet-0b761d44d3d9a4663",
-			"state": "pending"
+			"state": "pending",
+			"platform": "aws",
+			"tags": {"t1":"v1"}
 		  },
 		  {
 			"href": "/api/clusters_mgmt/v1/network_verifications/subnet-0f87f640e56934cbc/",
 			"id": "subnet-0f87f640e56934cbc",
-			"state": "passed"
+			"state": "passed",
+			"platform": "aws",
+			"tags": {"t1":"v1"}
 		  }
 		],
 		"cloud_provider_data": {
@@ -65,12 +69,16 @@ var _ = Describe("verify network", func() {
 		  {
 			"href": "/api/clusters_mgmt/v1/network_verifications/subnet-0b761d44d3d9a4663/",
 			"id": "subnet-0b761d44d3d9a4663",
-			"state": "passed"
+			"state": "passed",
+			"platform": "aws",
+			"tags": {"t1":"v1"}
 		  },
 		  {
 			"href": "/api/clusters_mgmt/v1/network_verifications/subnet-0f87f640e56934cbc/",
 			"id": "subnet-0f87f640e56934cbc",
-			"state": "passed"
+			"state": "passed",
+			"platform": "aws",
+			"tags": {"t1":"v1"}
 		  }
 		],
 		"cloud_provider_data": {
@@ -82,35 +90,41 @@ var _ = Describe("verify network", func() {
 	{
 		"href": "/api/clusters_mgmt/v1/network_verifications/subnet-0b761d44d3d9a4663/",
 		"id": "subnet-0b761d44d3d9a4663",
-		"state": "pending"
+		"state": "pending",
+		"platform": "aws",
+		"tags": {"t1":"v1"}
 	}
 	`
 	var subnetRunningSuccess = `
 	{
 		"href": "/api/clusters_mgmt/v1/network_verifications/subnet-0b761d44d3d9a4663/",
 		"id": "subnet-0b761d44d3d9a4663",
-		"state": "running"
+		"state": "running",
+		"platform": "aws",
+		"tags": {"t1":"v1"}
 	}
 	`
 	var subnetPassedSuccess = `
 	{
 		"href": "/api/clusters_mgmt/v1/network_verifications/subnet-0f87f640e56934cbc/",
 		"id": "subnet-0f87f640e56934cbc",
-		"state": "passed"
+		"state": "passed",
+		"platform": "aws",
+		"tags": {"t1":"v1"}
 	}
 	` // #nosec G101
-	var successOutputPendingComplete = `INFO: subnet-0b761d44d3d9a4663: pending
-INFO: subnet-0f87f640e56934cbc: passed
+	var successOutputPendingComplete = `INFO: subnet-0b761d44d3d9a4663, platform: aws, tags: {"t1":"v1"}: pending
+INFO: subnet-0f87f640e56934cbc, platform: aws, tags: {"t1":"v1"}: passed
 INFO: Run the following command to wait for verification to all subnets to complete:
 rosa verify network --watch --status-only --region us-east-1 --subnet-ids subnet-0b761d44d3d9a4663,subnet-0f87f640e56934cbc
 `
-	var successOutputRunningComplete = `INFO: subnet-0b761d44d3d9a4663: running
-INFO: subnet-0f87f640e56934cbc: passed
+	var successOutputRunningComplete = `INFO: subnet-0b761d44d3d9a4663, platform: aws, tags: {"t1":"v1"}: running
+INFO: subnet-0f87f640e56934cbc, platform: aws, tags: {"t1":"v1"}: passed
 INFO: Run the following command to wait for verification to all subnets to complete:
 rosa verify network --watch --status-only --region us-east-1 --subnet-ids subnet-0b761d44d3d9a4663,subnet-0f87f640e56934cbc
 `
-	var successOutputComplete = `INFO: subnet-0b761d44d3d9a4663: passed
-INFO: subnet-0f87f640e56934cbc: passed
+	var successOutputComplete = `INFO: subnet-0b761d44d3d9a4663, platform: aws, tags: {"t1":"v1"}: passed
+INFO: subnet-0f87f640e56934cbc, platform: aws, tags: {"t1":"v1"}: passed
 `
 	BeforeEach(func() {
 


### PR DESCRIPTION
Example output after fix
```
[davidlee@fedora rosa]$ ./rosa verify network --subnet-ids subnet-08cf62aa5b83225ef,subnet-09ae7dd300d7f9e61 --role-arn arn:aws:iam::765374464689:role/dle-stage-Installer-Role --region us-east-1 --hosted-cp --tags v1:t1

I: Verifying the following subnet IDs are configured correctly: [subnet-08cf62aa5b83225ef subnet-09ae7dd300d7f9e61]

I: subnet-08cf62aa5b83225ef, platform: hostedcluster, tags: {"Name":"osd-network-verifier","osd-network-verifier":"owned","red-hat-managed":"true","v1":"t1"}: pending 

I: subnet-09ae7dd300d7f9e61, platform: hostedcluster, tags: {"Name":"osd-network-verifier","osd-network-verifier":"owned","red-hat-managed":"true","v1":"t1"}: passed 

I: Run the following command to wait for verification to all subnets to complete:
rosa verify network --watch --status-only --region us-east-1 --subnet-ids subnet-08cf62aa5b83225ef,subnet-09ae7dd300d7f9e61
```