### PR TITLE
OCM-5384 | fix: show imds param on cluster helper command

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -3559,6 +3559,10 @@ func buildCommand(spec ocm.Spec, operatorRolesPrefix string,
 		command += fmt.Sprintf(" --version %s", commandVersion)
 	}
 
+	if spec.Ec2MetadataHttpTokens != "" {
+		command += fmt.Sprintf(" --ec2-metadata-http-tokens %s", spec.Ec2MetadataHttpTokens)
+	}
+
 	// Only account for expiration duration, as a fixed date may be obsolete if command is re-run later
 	if args.expirationDuration != 0 {
 		command += fmt.Sprintf(" --expiration %s", args.expirationDuration)


### PR DESCRIPTION
Related issue: [OCM-5384](https://issues.redhat.com//browse/OCM-5384)