### PR TITLE
OCM-5358 | fix: add a warning message when using best effort deletion

### DIFF
--- a/cmd/dlt/cluster/cmd.go
+++ b/cmd/dlt/cluster/cmd.go
@@ -79,6 +79,11 @@ func run(cmd *cobra.Command, _ []string) {
 
 	clusterKey := r.GetClusterKey()
 
+	if args.bestEffort {
+		r.Reporter.Warnf("Deleting cluster '%s' with 'best effort' means that certain resources may be left behind"+
+			" in AWS account '%s'. These resources will need to be deleted manually.", clusterKey, r.Creator.AccountID)
+	}
+
 	if !confirm.Confirm("delete cluster %s", clusterKey) {
 		os.Exit(0)
 	}


### PR DESCRIPTION
Notify the user about cloud resources that may left behind when using the 'best effort' flag.