### PR TITLE
OCM-5060 | fix:Validate min replicas for hosted cp clusters

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -3348,6 +3348,11 @@ func minReplicaValidator(multiAZ bool, isHostedCP bool, privateSubnetsCount int)
 			return err
 		}
 
+		if isHostedCP && minReplicas < 2 {
+			return fmt.Errorf("hosted Control Plane clusters require a minimum of 2 nodes, "+
+				"but %d was requested", minReplicas)
+		}
+
 		return clustervalidations.MinReplicasValidator(minReplicas, multiAZ, isHostedCP, privateSubnetsCount)
 	}
 }


### PR DESCRIPTION
When creating a hosted CP cluster, the user must set the nodes/replicas to a minimal value of 2.
Improve the UX and provide feedback to the client.