### PR TITLE
OCM-5100 | chore: bump to v1.2.33

### DIFF
--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,6 +18,6 @@ limitations under the License.
 
 package info
 
-const Version = "1.2.32"
+const Version = "1.2.33"
 
 const UserAgent = "ROSACLI"


### PR DESCRIPTION
Related issue: [OCM-5100](https://issues.redhat.com//browse/OCM-5100)