### PR TITLE
OCM-1007 | fix: Improve list account-roles runtime

### DIFF
--- a/pkg/aws/client_test.go
+++ b/pkg/aws/client_test.go
@@ -225,10 +225,6 @@ var _ = Describe("Client", func() {
 				Tags: tags,
 			}, nil)
 
-			mockIamAPI.EXPECT().ListRolePolicies(gomock.Any()).Return(&iam.ListRolePoliciesOutput{
-				PolicyNames: make([]*string, 0),
-			}, nil)
-
 			role, err := client.GetAccountRoleByArn(testArn)
 
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
It seems like there is a redundant API call to `listPolicies`, the role's policies are fetched from AWS but not used. Removing the policies API call and the `Policy` field from the role struct.

**Note:** This change introduces an improvement when listing the roles in our AWS dev account `real	0m21.995s
 -> real	0m15.018s`, we might need another iteration on this ticket.