### PR TITLE
OCM-5400 | fix: --output flag for 'rosa verify network'

### DIFF
--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -124,6 +124,10 @@ func Print(resource interface{}) error {
 		if users, ok := resource.([]*cmv1.User); ok {
 			cmv1.MarshalUserList(users, &b)
 		}
+	case "*v1.SubnetNetworkVerification":
+		if subnetNetworkVerification, ok := resource.(*cmv1.SubnetNetworkVerification); ok {
+			cmv1.MarshalSubnetNetworkVerification(subnetNetworkVerification, &b)
+		}
 	case "[]aws.Role", "[]aws.OidcProviderOutput":
 		{
 			err := defaultEncode(resource, &b)


### PR DESCRIPTION
Allow --output flag for  'rosa verify network' :

JSON
![image](https://github.com/openshift/rosa/assets/118839428/1ae8e338-9b44-446f-b9c3-73b46a5ff226)

YAML
![image](https://github.com/openshift/rosa/assets/118839428/b4e911d9-2094-41c4-89f5-717e702de41b)
