### PR TITLE
OCM-5508 | fix: remove condition that checks cluster state when creating oidc provider

### DIFF
--- a/cmd/create/oidcprovider/cmd.go
+++ b/cmd/create/oidcprovider/cmd.go
@@ -189,11 +189,6 @@ func run(cmd *cobra.Command, argv []string) {
 
 	switch mode {
 	case aws.ModeAuto:
-		if cluster != nil && cluster.State() != cmv1.ClusterStateWaiting && cluster.State() != cmv1.ClusterStatePending {
-			r.Reporter.Infof("Cluster '%s' is %s and does not need additional configuration.",
-				clusterKey, cluster.State())
-			os.Exit(0)
-		}
 		if !output.HasFlag() || r.Reporter.IsTerminal() {
 			r.Reporter.Infof("Creating OIDC provider using '%s'", r.Creator.ARN)
 		}


### PR DESCRIPTION
Related issue: [OCM-5508](https://issues.redhat.com//browse/OCM-5508)

Currently there's a check if the actual provider already exists or not. Due to that there's no reason to have this condition anymore, also it is blocking customers that mistakenly delete the provider for their account