### PR TITLE
OCM-4178 | fix: ROSA CLI N/W Verifier Error Message for IPI VPC Clusters

### DIFF
--- a/cmd/create/machinepool/machinepool.go
+++ b/cmd/create/machinepool/machinepool.go
@@ -43,7 +43,7 @@ func addMachinePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster
 
 	// Validate flags that are only allowed for BYOVPC cluster
 	isSubnetSet := cmd.Flags().Changed("subnet")
-	isByoVpc := isBYOVPC(cluster)
+	isByoVpc := helper.IsBYOVPC(cluster)
 	if !isByoVpc && isSubnetSet {
 		r.Reporter.Errorf("Setting the `subnet` flag is only allowed for BYO VPC clusters")
 		os.Exit(1)
@@ -129,7 +129,7 @@ func addMachinePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster
 
 	// Allow the user to select subnet for a single AZ BYOVPC cluster
 	var subnet string
-	if !cluster.MultiAZ() && isBYOVPC(cluster) {
+	if !cluster.MultiAZ() && isByoVpc {
 		subnet = getSubnetFromUser(cmd, r, isSubnetSet, cluster)
 	}
 
@@ -160,7 +160,7 @@ func addMachinePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster
 
 		if !multiAZMachinePool {
 			// Allow to create a single AZ machine pool providing the subnet
-			if isBYOVPC(cluster) && args.availabilityZone == "" {
+			if isByoVpc && args.availabilityZone == "" {
 				subnet = getSubnetFromUser(cmd, r, isSubnetSet, cluster)
 			}
 
@@ -624,8 +624,4 @@ func spotMaxPriceValidator(val interface{}) error {
 		return fmt.Errorf("Spot max price must be positive")
 	}
 	return nil
-}
-
-func isBYOVPC(cluster *cmv1.Cluster) bool {
-	return len(cluster.AWS().SubnetIDs()) > 0
 }

--- a/cmd/verify/network/cmd.go
+++ b/cmd/verify/network/cmd.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/helper"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/rosa"
@@ -155,10 +156,12 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 
 	if !cmd.Flags().Changed(subnetIDsFlag) {
 		if cluster != nil {
-			args.subnetIDs = cluster.AWS().SubnetIDs()
-			if len(args.subnetIDs) == 0 {
-				return fmt.Errorf("No subnets on cluster '%s'", cluster.ID())
+			if !helper.IsBYOVPC(cluster) {
+				return fmt.Errorf(
+					"Running the network verifier is only supported for BYO VPC clusters")
 			}
+
+			args.subnetIDs = cluster.AWS().SubnetIDs()
 		} else {
 			return fmt.Errorf("At least one subnet IDs is required")
 		}

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -14,6 +14,8 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/openshift/rosa/pkg/reporter"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
 var r *rand.Rand
@@ -252,4 +254,8 @@ func ChunkSlice[T any](slice []T, chunkSize int) [][]T {
 	}
 
 	return chunks
+}
+
+func IsBYOVPC(cluster *cmv1.Cluster) bool {
+	return len(cluster.AWS().SubnetIDs()) > 0
 }


### PR DESCRIPTION
`rosa network verify` on a non-BYO VPC cluster will error with "no subnets on cluster xyz" which could be a confusing output. This PR adds a check for BYO VPC and a corresponding error, as well as moving a "IsBYOVPC" function to a common file to avoid code duplication and improve readability. There is also a unit test to verify the fix.

https://issues.redhat.com/browse/OCM-4178