### PR TITLE
OCM-5542 | feat: add `--client` argument to `rosa version` command

### DIFF
--- a/cmd/version/cmd.go
+++ b/cmd/version/cmd.go
@@ -26,6 +26,10 @@ import (
 	"github.com/openshift/rosa/pkg/info"
 )
 
+var args struct {
+	clientOnly bool
+}
+
 var Cmd = &cobra.Command{
 	Use:   "version",
 	Short: "Prints the version of the tool",
@@ -33,7 +37,20 @@ var Cmd = &cobra.Command{
 	Run:   run,
 }
 
+func init() {
+	flags := Cmd.Flags()
+
+	flags.BoolVar(
+		&args.clientOnly,
+		"client",
+		false,
+		"Client version only (no remote version check)",
+	)
+}
+
 func run(cmd *cobra.Command, argv []string) {
 	fmt.Fprintf(os.Stdout, "%s\n", info.Version)
-	rosa.Cmd.Run(rosa.Cmd, []string{})
+	if !args.clientOnly {
+		rosa.Cmd.Run(rosa.Cmd, []string{})
+	}
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-5542

In some restricted environments in might not be desirable to have the version command do a network call

This adds a `--client` argument to `rosa version`. The naming of the argument align with other tools like kubectl/oc. In order to preserve current behavior this defaults to `false`. 