### PR TITLE
OCM-5480 | fix: add billing-account param to last command

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -3731,6 +3731,10 @@ func buildCommand(spec ocm.Spec, operatorRolesPrefix string,
 			strings.Join(spec.AdditionalControlPlaneSecurityGroupIds, ","))
 	}
 
+	if spec.BillingAccount != "" {
+		command += fmt.Sprintf(" --billing-account %s", spec.BillingAccount)
+	}
+
 	for _, p := range properties {
 		command += fmt.Sprintf(" --properties \"%s\"", p)
 	}


### PR DESCRIPTION
In rosa interactive mode, add the billing-account parameter for the future command to recreate the same cluster.