### PR TITLE
OCM-5530 | feat: add new parameter to disable CNI at cluster creation for HCP

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -3224,10 +3224,8 @@ func validateNetworkType(r *rosa.Runtime) string {
 		// Parameter not specified, nothing to do
 		return networkType
 	}
-	for _, validType := range ocm.NetworkTypes {
-		if args.networkType == validType {
-			networkType = args.networkType
-		}
+	if helper.Contains(ocm.NetworkTypes, args.networkType) {
+		networkType = args.networkType
 	}
 	if networkType == "" {
 		r.Reporter.Errorf(fmt.Sprintf("Expected a valid network type. Valid values: %v", ocm.NetworkTypes))

--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -135,6 +135,7 @@ type Spec struct {
 	// HyperShift options:
 	Hypershift     Hypershift
 	BillingAccount string
+	NoCni          bool
 
 	// Audit Log Forwarding
 	AuditLogRoleARN *string
@@ -881,7 +882,7 @@ func (c *Client) createClusterSpec(config Spec, awsClient aws.Client) (*cmv1.Clu
 		clusterBuilder = clusterBuilder.Nodes(clusterNodesBuilder)
 	}
 
-	if config.NetworkType != "" ||
+	if config.NetworkType != "" || config.NoCni ||
 		!IsEmptyCIDR(config.MachineCIDR) ||
 		!IsEmptyCIDR(config.ServiceCIDR) ||
 		!IsEmptyCIDR(config.PodCIDR) ||
@@ -889,6 +890,9 @@ func (c *Client) createClusterSpec(config Spec, awsClient aws.Client) (*cmv1.Clu
 		networkBuilder := cmv1.NewNetwork()
 		if config.NetworkType != "" {
 			networkBuilder = networkBuilder.Type(config.NetworkType)
+		}
+		if config.NoCni {
+			networkBuilder = networkBuilder.Type("Other")
 		}
 		if !IsEmptyCIDR(config.MachineCIDR) {
 			networkBuilder = networkBuilder.MachineCIDR(config.MachineCIDR.String())


### PR DESCRIPTION
In Hosted Control Planes, we can disable CNI at creation to let user bring their own.

This change exposes the relevant parameter with a new boolean flag.

There is an existing --network-type parameter, but decision was taken not to reuse this as it is going to be deprecated moving forward and the dedicated parameter is clearer in terms of usage.

Additional validation added in order to ensure the 2 parameters don't collide and are correctly validated.

No breaking change expected compared to the current behavior.

Related: [OCM-5530](https://issues.redhat.com//browse/OCM-5530)