### PR TITLE
OCM-5571 | fix: adjust message when operator roles already exists

### DIFF
--- a/cmd/create/oidcprovider/cmd.go
+++ b/cmd/create/oidcprovider/cmd.go
@@ -183,7 +183,7 @@ func run(cmd *cobra.Command, argv []string) {
 			os.Exit(1)
 		}
 		// Returns so that when called from create cluster does not interrupt flow
-		r.Reporter.Infof("OIDC provider already exists.")
+		r.Reporter.Infof("OIDC provider already exists")
 		return
 	}
 

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -12,10 +12,9 @@ import (
 
 	"github.com/briandowns/spinner"
 	"github.com/google/uuid"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 
 	"github.com/openshift/rosa/pkg/reporter"
-
-	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
 var r *rand.Rand


### PR DESCRIPTION
Related issue: [OCM-5571](https://issues.redhat.com//browse/OCM-5571)