### PR TITLE
OCM-5522 | fix: add confirmation prompt to deleting cluster autoscaler

### DIFF
--- a/cmd/dlt/autoscaler/cmd.go
+++ b/cmd/dlt/autoscaler/cmd.go
@@ -52,6 +52,10 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
+	if !confirm.Confirm("delete cluster autoscaler?") {
+		os.Exit(0)
+	}
+
 	r.Reporter.Debugf("Deleting autoscaler for cluster '%s''", clusterKey)
 
 	err := r.OCMClient.DeleteClusterAutoscaler(cluster.ID())


### PR DESCRIPTION
*WHAT*
Adds a confirmation to deleting cluster autoscaler

*VALIDATION*
```
# getting prompt
$ rosa delete autoscaler -c croche  
? Are you sure you want to delete the cluster autoscaler? Yes
I: Successfully deleted autoscaler configuration for cluster '28q7v5kffen949h6fmvdl755ist8vvmq'

# passing `-y` to skip prompt
$ rosa delete autoscaler -c croche -y                                                   
I: Successfully deleted autoscaler configuration for cluster '28q7v5kffen949h6fmvdl755ist8vvmq'

```

JIRA - https://issues.redhat.com/browse/OCM-5522