### PR TITLE
OCM-1109 | feat: Improve create op-role UX by not checking for account role version on manual mode

### DIFF
--- a/cmd/create/operatorroles/by_clusterkey.go
+++ b/cmd/create/operatorroles/by_clusterkey.go
@@ -68,13 +68,7 @@ func handleOperatorRoleCreationByClusterKey(r *rosa.Runtime, env string,
 			path, cluster.AWS().STS().RoleARN())
 	}
 	var accountRoleVersion string
-	if mode == aws.ModeAuto {
-		accountRoleVersion, err = r.AWSClient.GetAccountRoleVersion(roleName)
-		if err != nil {
-			r.Reporter.Errorf("Error getting account role version %s", err)
-			os.Exit(1)
-		}
-	}
+
 	managedPolicies := cluster.AWS().STS().ManagedPolicies()
 	if args.forcePolicyCreation && managedPolicies {
 		r.Reporter.Warnf("Forcing creation of policies only works for unmanaged policies")
@@ -97,6 +91,11 @@ func handleOperatorRoleCreationByClusterKey(r *rosa.Runtime, env string,
 	case aws.ModeAuto:
 		if !output.HasFlag() || r.Reporter.IsTerminal() {
 			r.Reporter.Infof("Creating roles using '%s'", r.Creator.ARN)
+		}
+		accountRoleVersion, err = r.AWSClient.GetAccountRoleVersion(roleName)
+		if err != nil {
+			r.Reporter.Errorf("Error getting account role version %s", err)
+			os.Exit(1)
 		}
 		err = createRoles(r, operatorRolePolicyPrefix, permissionsBoundary, cluster,
 			accountRoleVersion, policies, defaultPolicyVersion, credRequests, managedPolicies, hostedCPPolicies)

--- a/cmd/create/operatorroles/by_clusterkey.go
+++ b/cmd/create/operatorroles/by_clusterkey.go
@@ -67,10 +67,13 @@ func handleOperatorRoleCreationByClusterKey(r *rosa.Runtime, env string,
 			"This ARN path will be used for subsequent created operator roles and policies.",
 			path, cluster.AWS().STS().RoleARN())
 	}
-	accountRoleVersion, err := r.AWSClient.GetAccountRoleVersion(roleName)
-	if err != nil {
-		r.Reporter.Errorf("Error getting account role version %s", err)
-		os.Exit(1)
+	var accountRoleVersion string
+	if mode == aws.ModeAuto {
+		accountRoleVersion, err = r.AWSClient.GetAccountRoleVersion(roleName)
+		if err != nil {
+			r.Reporter.Errorf("Error getting account role version %s", err)
+			os.Exit(1)
+		}
 	}
 	managedPolicies := cluster.AWS().STS().ManagedPolicies()
 	if args.forcePolicyCreation && managedPolicies {


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-1109

Steps to Reproduce:
1. Login with the latest roascli 
2. Create rosa sts cluster in manual mode by `rosa create cluster --sts --mode manual`
3. Create operator-roles in the manual mode with the aws account which has no enough permission
rosa create operator-roles -c <cluster_id> --mode manual --profile sdqe-no-permission

Actual results:
3. It fails with error message like bellow,
E: Error getting account role version AccessDenied: User: arn:aws:iam::301721915996:user/sdqe-no-permission is not authorized to perform: iam:GetRole on resource: role QEAuto-sts-20221020-Installer-Role because no identity-based policy allows the iam:GetRole action
        status code: 403, request id: 27e93c76-7535-40f0-890a-5809f7102d28

Expected results:
3. It should work without error and the aws commands should be prompted


To boil it down, creating operator roles only requires the account role version when using `--mode auto`

When using `--mode manual`, we do not even use this data. So we can safely skip when on manual.