### PR TITLE
OCM-1305 | feat: UX fix for invalid flag showing up in rosa edit addon error

### DIFF
--- a/cmd/edit/addon/cmd.go
+++ b/cmd/edit/addon/cmd.go
@@ -42,14 +42,16 @@ var Cmd = &cobra.Command{
 	Run:                run,
 	DisableFlagParsing: true,
 	Args: func(cmd *cobra.Command, argv []string) error {
-		err := arguments.ParseUnknownFlags(cmd, argv)
-		if err != nil {
-			return err
-		}
 
 		if len(cmd.Flags().Args()) != 1 {
 			return fmt.Errorf("Expected exactly one command line parameter containing the id of the add-on")
 		}
+
+		err := arguments.ParseUnknownFlags(cmd, argv)
+		if err != nil {
+			return err
+		}
+		
 		return nil
 	},
 }

--- a/cmd/edit/addon/cmd.go
+++ b/cmd/edit/addon/cmd.go
@@ -42,16 +42,19 @@ var Cmd = &cobra.Command{
 	Run:                run,
 	DisableFlagParsing: true,
 	Args: func(cmd *cobra.Command, argv []string) error {
-
-		if len(cmd.Flags().Args()) != 1 {
-			return fmt.Errorf("Expected exactly one command line parameter containing the id of the add-on")
-		}
-
-		err := arguments.ParseUnknownFlags(cmd, argv)
+		err := cmd.ParseFlags(argv)
 		if err != nil {
 			return err
 		}
-		
+		if len(argv) > 0 && (strings.HasPrefix(argv[0], "--") || strings.HasPrefix(argv[0], "-")) {
+			return fmt.Errorf("Expected exactly one command line parameter containing the id of the add-on")
+		}
+
+		err = arguments.ParseUnknownFlags(cmd, argv)
+		if err != nil {
+			return err
+		}
+
 		return nil
 	},
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-1305

Invalid flag (`--billing-model`) shows up in `rosa edit addon` error relating to not including the addon ID. This MR makes the help/error message identical to the `rosa edit addon -h` message