### PR TITLE
OCM-5606 | chore: update OWNERS file to reflect current team members

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,29 +1,25 @@
 reviewers:
 - ciaranRoche
 - gdbranco
-- igoihman
+- robpblake
 - oriAdler
 - pvasant
 - renan-campos
-- zgalor
+- hunterkepley
+- thomasmckay
+- den-rgb
+- marcolan018
+- willkutler
+- davidleerh
+- vkareh
 approvers:
 - ciaranRoche
 - gdbranco
-- igoihman
 - oriAdler
 - pvasant
 - renan-campos
 - vkareh
-- zgalor
-maintainers:
-- ciaranRoche
-- gdbranco
-- igoihman
-- oriAdler
-- pvasant
-- renan-campos
-- vkareh
-- zgalor
 emeritus_approvers:
 - jharrington22
-- tbrisker
+- igoihman
+- zgalor


### PR DESCRIPTION
This PR updates the `OWNERS` file in ROSA to reflect the current members of the team. I've taken the following approach:

- All active members of the ROSA squad have been listed as `reviewers`
- I've pruned the `approvers` list to only active members of the ROSA squad
- Inactive members have been moved onto the `emeritus_approvers` list

Reading the docs for Prow OWNERS, I see no mention of the `maintainers` directive: https://www.kubernetes.dev/docs/guide/owners/ . I've therefore removed this from the`OWNERS` file and we can revert this change if it causes any problems.
