### PR TITLE
OCM-5782 | feat: Add Git SHA of built binary to version output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ unexport GOFLAGS
 
 .PHONY: rosa
 rosa:
-	go build ./cmd/rosa
+	go build -ldflags="-X github.com/openshift/rosa/pkg/info.Build=$(shell git rev-parse --short HEAD)" ./cmd/rosa
 
 .PHONY: test
 test:

--- a/cmd/version/cmd.go
+++ b/cmd/version/cmd.go
@@ -18,6 +18,7 @@ package version
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -26,16 +27,20 @@ import (
 	"github.com/openshift/rosa/pkg/info"
 )
 
-var args struct {
-	clientOnly bool
-}
+var (
+	writer io.Writer = os.Stdout
+	args   struct {
+		clientOnly bool
+	}
 
-var Cmd = &cobra.Command{
-	Use:   "version",
-	Short: "Prints the version of the tool",
-	Long:  "Prints the version number of the tool.",
-	Run:   run,
-}
+	Cmd = &cobra.Command{
+		Use:   "version",
+		Short: "Prints the version of the tool",
+		Long:  "Prints the version number of the tool.",
+		Run:   run,
+	}
+	delegateCommand = rosa.Cmd.Run
+)
 
 func init() {
 	flags := Cmd.Flags()
@@ -48,9 +53,9 @@ func init() {
 	)
 }
 
-func run(cmd *cobra.Command, argv []string) {
-	fmt.Fprintf(os.Stdout, "%s\n", info.Version)
+func run(_ *cobra.Command, _ []string) {
+	fmt.Fprintf(writer, "%s (Build: %s)\n", info.Version, info.Build)
 	if !args.clientOnly {
-		rosa.Cmd.Run(rosa.Cmd, []string{})
+		delegateCommand(rosa.Cmd, []string{})
 	}
 }

--- a/cmd/version/cmd_test.go
+++ b/cmd/version/cmd_test.go
@@ -1,0 +1,54 @@
+package version
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/openshift/rosa/pkg/info"
+	"github.com/spf13/cobra"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestVersionCommand(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "rosa version command")
+}
+
+var _ = Describe("Run Command", func() {
+
+	var delegateInvokeCount int
+	var buf *bytes.Buffer
+
+	BeforeEach(func() {
+		buf = new(bytes.Buffer)
+		writer = buf
+		delegateInvokeCount = 0
+		delegateCommand = func(cmd *cobra.Command, args []string) {
+			delegateInvokeCount++
+		}
+	})
+
+	When("Run in client-only mode", func() {
+		It("It only prints version and build information", func() {
+			args.clientOnly = true
+
+			Cmd.Execute()
+
+			Expect(buf.String()).To(Equal(fmt.Sprintf("%s (Build: %s)\n", info.Version, info.Build)))
+			Expect(delegateInvokeCount).To(Equal(0))
+		})
+	})
+
+	When("Run without client-only", func() {
+
+		It("Prints version information and invokes delegate command", func() {
+			args.clientOnly = false
+			Cmd.Execute()
+
+			Expect(buf.String()).To(Equal(fmt.Sprintf("%s (Build: %s)\n", info.Version, info.Build)))
+			Expect(delegateInvokeCount).To(Equal(1))
+		})
+	})
+})

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -20,4 +20,7 @@ package info
 
 const Version = "1.2.34"
 
+// Build contains the short Git SHA of the CLI at the point it was build. Set via `-ldflags` at build time
+var Build = "local"
+
 const UserAgent = "ROSACLI"


### PR DESCRIPTION
This PR adds the short Git SHA as a build property into the ROSA CLI. This is then printed as part of the version information when the user runs `rosa version`. This allows us to identify the exact build that the user is working with as we only set the version in `version.go` at the point of release and builds from `master` of our repository can masquerade as the released artifact.

The `build` is set via the `make rosa` command and the use of `-ldflags`. If the user builds the `rosa` binary directly via `go build`, this will default to `local`, again allowing us to determine how the binary a user is working with has been built.

The rationale for this was working with QE when they had not rebuilt their ROSA CLI binary to pickup the latest changes. The version information continued to report `1.2.34` even though there were newer changes in the binary.