### PR TITLE
OCM-4165 | fix: update default-mp-labels arg to worker-mp-labels

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -544,9 +544,10 @@ func init() {
 		"Maximum number of compute nodes.",
 	)
 
+	flags.SetNormalizeFunc(arguments.NormalizeFlags)
 	flags.StringVar(
 		&args.defaultMachinePoolLabels,
-		"default-mp-labels",
+		arguments.NewDefaultMPLabelsFlag,
 		"",
 		"Labels for the worker machine pool. Format should be a comma-separated list of 'key=value'. "+
 			"This list will overwrite any modifications made to Node labels on an ongoing basis.",
@@ -1010,7 +1011,7 @@ func run(cmd *cobra.Command, _ []string) {
 		outputClusterAdminDetails(r, isClusterAdmin, clusterAdminPassword)
 	}
 
-	if isHostedCP && cmd.Flags().Changed("default-mp-labels") {
+	if isHostedCP && cmd.Flags().Changed(arguments.NewDefaultMPLabelsFlag) {
 		r.Reporter.Errorf("Setting the worker machine pool labels is not supported for hosted clusters")
 		os.Exit(1)
 	}
@@ -2436,7 +2437,7 @@ func run(cmd *cobra.Command, _ []string) {
 	if interactive.Enabled() && !isHostedCP {
 		labels, err = interactive.GetString(interactive.Input{
 			Question: "Worker machine pool labels",
-			Help:     cmd.Flags().Lookup("default-mp-labels").Usage,
+			Help:     cmd.Flags().Lookup(arguments.NewDefaultMPLabelsFlag).Usage,
 			Default:  labels,
 			Validators: []interactive.Validator{
 				mpHelpers.LabelValidator,
@@ -3658,7 +3659,7 @@ func buildCommand(spec ocm.Spec, operatorRolesPrefix string,
 	}
 
 	if len(spec.ComputeLabels) != 0 {
-		command += fmt.Sprintf(" --default-mp-labels \"%s\"", labels)
+		command += fmt.Sprintf(" --%s \"%s\"", arguments.NewDefaultMPLabelsFlag, labels)
 	}
 
 	if spec.NetworkType != "" {

--- a/pkg/arguments/normalize.go
+++ b/pkg/arguments/normalize.go
@@ -7,12 +7,16 @@ import (
 const (
 	deprecatedInstallerRoleArnFlag = "installer-role-arn"
 	newInstallerRoleArnFlag        = "role-arn"
+	DeprecatedDefaultMPLabelsFlag  = "default-mp-labels"
+	NewDefaultMPLabelsFlag         = "worker-mp-labels"
 )
 
 func NormalizeFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
 	switch name {
 	case deprecatedInstallerRoleArnFlag:
 		name = newInstallerRoleArnFlag
+	case DeprecatedDefaultMPLabelsFlag:
+		name = NewDefaultMPLabelsFlag
 	}
 	return pflag.NormalizedName(name)
 }

--- a/pkg/arguments/normalize_test.go
+++ b/pkg/arguments/normalize_test.go
@@ -8,14 +8,15 @@ import (
 
 var _ = Describe("Normalize Argument Flags Tests", func() {
 	When("when flags have been deprecated", func() {
-		It("should normalize --installer-role-arn to --role-arn", func() {
-			f := pflag.NewFlagSet("test", pflag.ContinueOnError)
-			flagName := deprecatedInstallerRoleArnFlag
-
-			normalized := NormalizeFlags(f, flagName)
-
-			Expect(string(normalized)).To(Equal(newInstallerRoleArnFlag))
-		})
+		DescribeTable("should normalize flag names",
+			func(flagName, expectedNormalized string) {
+				f := pflag.NewFlagSet("test", pflag.ContinueOnError)
+				normalized := NormalizeFlags(f, flagName)
+				Expect(string(normalized)).To(Equal(expectedNormalized))
+			},
+			Entry("installer-role-arn to role-arn", deprecatedInstallerRoleArnFlag, newInstallerRoleArnFlag),
+			Entry("default-mp-labels to worker-mp-labels", DeprecatedDefaultMPLabelsFlag, NewDefaultMPLabelsFlag),
+		)
 	})
 
 	When("Flags that have not been deprecated", func() {


### PR DESCRIPTION
*WHAT*
Adds default-mp-labels to normalize args to worker-mp-labels, this insures both arguements work as expected for adding day 1 labels to the worker pool

*VALIDATION* 
create a cluster with arg `--worker-mp-labels`
```
$ rosa create cluster --cluster-name croche --sts --role-arn arn:aws:iam::765374464689:role/ManagedOpenShift-Installer-Role --support-role-arn arn:aws:iam::765374464689:role/ManagedOpenShift-Support-Role --controlplane-iam-role arn:aws:iam::765374464689:role/ManagedOpenShift-ControlPlane-Role --worker-iam-role arn:aws:iam::765374464689:role/ManagedOpenShift-Worker-Role --operator-roles-prefix cr-del --region eu-west-1 --version 4.14.1 --replicas 3 --compute-machine-type m5.8xlarge --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23 --worker-mp-labels noop=boop
W: In a future release STS will be the default mode.
W: --sts flag won't be necessary if you wish to use STS.
W: --non-sts/--mint-mode flag will be necessary if you do not wish to use STS.
I: Creating cluster 'croche'
I: To view a list of clusters and their status, run 'rosa list clusters'
I: Cluster 'croche' has been created.
I: Once the cluster is installed you will need to add an Identity Provider before you can login into the cluster. See 'rosa create idp --help' for more information.

Name:                       croche
Display Name:               croche
ID:                         28u3cap4d8sko1jug1t8j28hjbolvs55
```
get the labels for compute nodes on day 1 cluster spec
```
$ ocm get cluster 28u3cap4d8sko1jug1t8j28hjbolvs55 | jq .nodes.compute_labels                                                                                                         127 ↵
{
  "noop": "boop"
}

```
get labels from machine pool worker spec
```
$ ocm get /api/clusters_mgmt/v1/clusters/28u3cap4d8sko1jug1t8j28hjbolvs55/machine_pools/worker | jq .labels
{
  "noop": "boop"
}
```

create cluster with`--default-mp-labels`
```
$ rosa create cluster --cluster-name croche --sts --role-arn arn:aws:iam::765374464689:role/ManagedOpenShift-Installer-Role --support-role-arn arn:aws:iam::765374464689:role/ManagedOpenShift-Support-Role --controlplane-iam-role arn:aws:iam::765374464689:role/ManagedOpenShift-ControlPlane-Role --worker-iam-role arn:aws:iam::765374464689:role/ManagedOpenShift-Worker-Role --operator-roles-prefix cr-del --region eu-west-1 --version 4.14.1 --replicas 3 --compute-machine-type m5.8xlarge --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23 --default-mp-labels noop=boop
W: In a future release STS will be the default mode.
W: --sts flag won't be necessary if you wish to use STS.
W: --non-sts/--mint-mode flag will be necessary if you do not wish to use STS.
I: Creating cluster 'croche'
I: To view a list of clusters and their status, run 'rosa list clusters'
I: Cluster 'croche' has been created.
I: Once the cluster is installed you will need to add an Identity Provider before you can login into the cluster. See 'rosa create idp --help' for more information.

Name:                       croche
Display Name:               croche
ID:                         28u3frnstk2hf7id3968o5smm6t6jhsj
```
get the labels for compute nodes on day 1 cluster spec
```
$ ocm get cluster 28u3frnstk2hf7id3968o5smm6t6jhsj | jq .nodes.compute_labels                                                                                                         130 ↵
{
  "noop": "boop"
}

```
get labels from machine pool worker spec
```
$ ocm get /api/clusters_mgmt/v1/clusters/28u3frnstk2hf7id3968o5smm6t6jhsj/machine_pools/worker | jq .labels
{
  "noop": "boop"
}

```

*JIRA* https://issues.redhat.com/browse/OCM-4165
