### PR TITLE
OCM-5700 | fix: ensure account role creation is not prompted for other role type flag

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -362,7 +362,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	createHostedCP := args.hostedCP
-	if interactive.Enabled() && !cmd.Flags().Changed("hosted-cp") && !r.Creator.IsGovcloud {
+	if interactive.Enabled() && !isHostedCPValueSet && !cmd.Flags().Changed("classic") && !r.Creator.IsGovcloud {
 		createHostedCP, err = interactive.GetBool(interactive.Input{
 			Question: "Create Hosted CP account roles",
 			Help:     cmd.Flags().Lookup("hosted-cp").Usage,


### PR DESCRIPTION
*WHAT*
Part of the UX effort, this change insures when creating account roles, a user is only prompted if they either pass no flags or if they pass `classic` or `hosted-cp` they are not prompted for the flavour they didnt pass 

*VALIDATION*
pass no flags
```
$ rosa create account-roles 
I: Logged in as 'croche_openshift' on 'https://api.stage.openshift.com'
I: Validating AWS credentials...
I: AWS credentials are valid!
I: Validating AWS quota...
I: AWS quota ok. If cluster installation fails, validate actual AWS resource usage against https://docs.openshift.com/rosa/rosa_getting_started/rosa-required-aws-service-quotas.html
I: Verifying whether OpenShift command-line tool is available...
I: Current OpenShift Client Version: 4.12.15
I: Creating account roles
? Role prefix: crochedel
? Permissions boundary ARN (optional): 
? Path (optional): 
? Role creation mode (default = 'auto'): manual
? Create Classic account roles: Yes
? Create Hosted CP account roles: Yes
I: By default, the create account-roles command creates two sets of account roles, one for classic ROSA clusters, and one for Hosted Control Plane clusters.
In order to create a single set, please set one of the following flags: --classic or --hosted-cp
...
```
pass hosted-cp flag
```
$ rosa create account-roles --hosted-cp 
I: Logged in as 'croche_openshift' on 'https://api.stage.openshift.com'
I: Validating AWS credentials...
I: AWS credentials are valid!
I: Validating AWS quota...
I: AWS quota ok. If cluster installation fails, validate actual AWS resource usage against https://docs.openshift.com/rosa/rosa_getting_started/rosa-required-aws-service-quotas.html
I: Verifying whether OpenShift command-line tool is available...
I: Current OpenShift Client Version: 4.12.15
I: Creating account roles
? Role prefix: croche
? Permissions boundary ARN (optional): 
? Path (optional): 
? Role creation mode (default = 'auto'): manual
I: Run the following commands to create the hosted CP account roles and policies:

...
```
pass the classic flag
```
$ rosa create account-roles --classic  
I: Logged in as 'croche_openshift' on 'https://api.stage.openshift.com'
I: Validating AWS credentials...
I: AWS credentials are valid!
I: Validating AWS quota...
I: AWS quota ok. If cluster installation fails, validate actual AWS resource usage against https://docs.openshift.com/rosa/rosa_getting_started/rosa-required-aws-service-quotas.html
I: Verifying whether OpenShift command-line tool is available...
I: Current OpenShift Client Version: 4.12.15
I: Creating account roles
? Role prefix: croche
? Permissions boundary ARN (optional): 
? Path (optional): 
? Role creation mode (default = 'auto'): manual
I: Run the following commands to create the classic account roles and policies:
...
```

*JIRA* https://issues.redhat.com/browse/OCM-5700