### PR TITLE
OCM-1352 | fix: Ensure that --etcd-encryption-kms-arn is printed when set and --etcd-encryption is true

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -3693,6 +3693,9 @@ func buildCommand(spec ocm.Spec, operatorRolesPrefix string,
 		command += " --fips"
 	} else if spec.EtcdEncryption {
 		command += " --etcd-encryption"
+		if spec.EtcdEncryptionKMSArn != "" {
+			command += fmt.Sprintf(" --etcd-encryption-kms-arn %s", spec.EtcdEncryptionKMSArn)
+		}
 	}
 
 	if spec.EnableProxy {
@@ -3720,9 +3723,6 @@ func buildCommand(spec ocm.Spec, operatorRolesPrefix string,
 	}
 	if spec.Hypershift.Enabled {
 		command += " --hosted-cp"
-	}
-	if spec.EtcdEncryptionKMSArn != "" {
-		command += fmt.Sprintf(" --etcd-encryption-kms-arn %s", spec.EtcdEncryptionKMSArn)
 	}
 
 	if spec.AuditLogRoleARN != nil && *spec.AuditLogRoleARN != "" {

--- a/cmd/create/cluster/cmd_test.go
+++ b/cmd/create/cluster/cmd_test.go
@@ -32,6 +32,32 @@ var _ = Describe("Validate build command", func() {
 		defaultMachinePoolLabels = "machine-pool-label"
 	})
 	Context("build command", func() {
+
+		When("--etcd-encryption is true", func() {
+			It("prints --etcd-encryption-kms-arn", func() {
+				clusterConfig.EtcdEncryption = true
+				clusterConfig.EtcdEncryptionKMSArn = "my-test-arn"
+				command := buildCommand(clusterConfig, operatorRolesPrefix,
+					expectedOperatorRolePath, userSelectedAvailabilityZones,
+					defaultMachinePoolLabels, argsDotProperties)
+				Expect(command).To(Equal(
+					"rosa create cluster --cluster-name cluster-name --operator-roles-prefix prefix" +
+						" --etcd-encryption --etcd-encryption-kms-arn my-test-arn"))
+			})
+		})
+
+		When("--etcd-encryption is false", func() {
+			It("Does not print --etc-encryption-kms-arn", func() {
+				clusterConfig.EtcdEncryption = false
+				clusterConfig.EtcdEncryptionKMSArn = "my-test-arn"
+				command := buildCommand(clusterConfig, operatorRolesPrefix,
+					expectedOperatorRolePath, userSelectedAvailabilityZones,
+					defaultMachinePoolLabels, argsDotProperties)
+				Expect(command).To(Equal(
+					"rosa create cluster --cluster-name cluster-name --operator-roles-prefix prefix"))
+			})
+		})
+
 		When("--properties is not present", func() {
 			It("should not include --properties", func() {
 				command := buildCommand(clusterConfig, operatorRolesPrefix,


### PR DESCRIPTION
This PR ensures that we print `--etcd-encryption-kms-arn` and it's value in the command output in interactive mode if the user has requested `--etcd-encryption` and passed a value for `--etcd-encryption-kms-arn`