### PR TITLE
OCM-5715 | fix: add error message when supplying worker disk size on unsupported version

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -70,6 +70,7 @@ import (
 const (
 	OidcConfigIdFlag      = "oidc-config-id"
 	ClassicOidcConfigFlag = "classic-oidc-config"
+	workerDiskSizeFlag    = "worker-disk-size"
 	// #nosec G101
 	Ec2MetadataHttpTokensFlag = "ec2-metadata-http-tokens"
 
@@ -663,7 +664,7 @@ func init() {
 	)
 
 	flags.StringVar(&args.machinePoolRootDiskSize,
-		"worker-disk-size",
+		workerDiskSizeFlag,
 		"",
 		"Default worker machine pool root disk size with a **unit suffix** like GiB or TiB, "+
 			"e.g. 200GiB.")
@@ -2521,8 +2522,26 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
+	isVersionCompatibleMachinePoolRootDisk, err := versions.IsGreaterThanOrEqual(
+		version, ocm.MinVersionForMachinePoolRootDisk)
+	if err != nil {
+		r.Reporter.Errorf("There was a problem checking version compatibility: %v", err)
+		os.Exit(1)
+	}
+	if !isVersionCompatibleMachinePoolRootDisk && cmd.Flags().Changed(workerDiskSizeFlag) {
+		formattedVersion, err := versions.FormatMajorMinorPatch(ocm.MinVersionForMachinePoolRootDisk)
+		if err != nil {
+			r.Reporter.Errorf(versions.MajorMinorPatchFormattedErrorOutput, err)
+			os.Exit(1)
+		}
+		r.Reporter.Errorf(
+			"Updating Worker disk size is not supported for versions prior to '%s'",
+			formattedVersion,
+		)
+		os.Exit(1)
+	}
 	var machinePoolRootDisk *ocm.Volume
-	if !isHostedCP &&
+	if isVersionCompatibleMachinePoolRootDisk && !isHostedCP &&
 		(args.machinePoolRootDiskSize != "" || interactive.Enabled()) {
 		var machinePoolRootDiskSizeStr string
 		if args.machinePoolRootDiskSize == "" {
@@ -2540,7 +2559,7 @@ func run(cmd *cobra.Command, _ []string) {
 			// Also, if nothing is given, we want to display the default value fetched from the OCM API
 			machinePoolRootDiskSizeStr, err = interactive.GetString(interactive.Input{
 				Question: "Machine pool root disk size (GiB or TiB)",
-				Help:     cmd.Flags().Lookup("worker-disk-size").Usage,
+				Help:     cmd.Flags().Lookup(workerDiskSizeFlag).Usage,
 				Default:  machinePoolRootDiskSizeStr,
 				Validators: []interactive.Validator{
 					interactive.MachinePoolRootDiskSizeValidator(version),
@@ -3731,7 +3750,7 @@ func buildCommand(spec ocm.Spec, operatorRolesPrefix string,
 	if spec.MachinePoolRootDisk != nil {
 		machinePoolRootDiskSize := spec.MachinePoolRootDisk.Size
 		if machinePoolRootDiskSize != 0 {
-			command += fmt.Sprintf(" --worker-disk-size %dGiB", machinePoolRootDiskSize)
+			command += fmt.Sprintf(" --%s %dGiB", workerDiskSizeFlag, machinePoolRootDiskSize)
 		}
 	}
 

--- a/cmd/install/addon/cmd.go
+++ b/cmd/install/addon/cmd.go
@@ -18,11 +18,11 @@ package addon
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"os"
 	"regexp"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
 	awsCommonUtils "github.com/openshift-online/ocm-common/pkg/aws/utils"
 	amv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"

--- a/cmd/login/cmd.go
+++ b/cmd/login/cmd.go
@@ -18,12 +18,12 @@ package login
 
 import (
 	"fmt"
-	"github.com/openshift-online/ocm-sdk-go/authentication"
 	"os"
 	"strings"
 
 	"github.com/golang-jwt/jwt/v4"
 	sdk "github.com/openshift-online/ocm-sdk-go"
+	"github.com/openshift-online/ocm-sdk-go/authentication"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/cmd/logout"

--- a/pkg/ocm/versions.go
+++ b/pkg/ocm/versions.go
@@ -36,9 +36,10 @@ const (
 	LowestHttpTokensRequiredSupport = "4.11.0"
 	LowestSTSMinor                  = "4.7"
 	//TODO: Remove the 0.a once stable 4.12 builds are available
-	LowestHostedCpSupport         = "4.12.0-0.a"
-	MinVersionForManagedIngressV2 = "4.14.0-0.a"
-	VersionPrefix                 = "openshift-v"
+	LowestHostedCpSupport            = "4.12.0-0.a"
+	MinVersionForManagedIngressV2    = "4.14.0-0.a"
+	MinVersionForMachinePoolRootDisk = "4.10.0-0.a"
+	VersionPrefix                    = "openshift-v"
 
 	MinVersionForAdditionalComputeSecurityGroupIdsDay1 = "4.14.0-0.a"
 	MinVersionForAdditionalComputeSecurityGroupIdsDay2 = "4.11.0-0.a"
@@ -440,7 +441,8 @@ func (c *Client) IsVersionCloseToEol(daysAwayToCheck int, version string, channe
 			"The version of Red Hat OpenShift Service on AWS that you are installing will no longer be supported after '%s'."+
 				" Red Hat recommends selecting a newer version. For more information,"+
 				" see https://docs.openshift.com/rosa/rosa_policy/rosa-life-cycle.html",
-			ocmVersion.EndOfLifeTimestamp().Format(time.DateOnly))
+			ocmVersion.EndOfLifeTimestamp().Format(time.DateOnly),
+		)
 	}
 	return nil
 }


### PR DESCRIPTION
Related issue: [OCM-5715](https://issues.redhat.com//browse/OCM-5715)