### PR TITLE
OCM-824 | fix: Align usage of -arn suffix on role parameters to create cluster command

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -292,7 +292,7 @@ func init() {
 
 	flags.StringVar(
 		&args.controlPlaneRoleARN,
-		"controlplane-iam-role",
+		"controlplane-iam-role-arn",
 		"",
 		"The IAM role ARN that will be attached to control plane instances.",
 	)
@@ -303,11 +303,11 @@ func init() {
 		"",
 		"The IAM role ARN that will be attached to master instances.",
 	)
-	flags.MarkDeprecated("master-iam-role", "use --controlplane-iam-role instead")
+	flags.MarkDeprecated("master-iam-role", "use --controlplane-iam-role-arn instead")
 
 	flags.StringVar(
 		&args.workerRoleARN,
-		"worker-iam-role",
+		"worker-iam-role-arn",
 		"",
 		"The IAM role ARN that will be attached to worker instances.",
 	)

--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -283,7 +283,7 @@ func run(cmd *cobra.Command, argv []string) {
 
 	if cluster.AWS().STS().RoleARN() != "" {
 		str = fmt.Sprintf("%s"+
-			"STS Role ARN:               %s\n", str,
+			"Role (STS) ARN:             %s\n", str,
 			cluster.AWS().STS().RoleARN())
 		if cluster.AWS().STS().ExternalID() != "" {
 			str = fmt.Sprintf("%s"+

--- a/pkg/arguments/normalize.go
+++ b/pkg/arguments/normalize.go
@@ -9,14 +9,22 @@ const (
 	newInstallerRoleArnFlag        = "role-arn"
 	DeprecatedDefaultMPLabelsFlag  = "default-mp-labels"
 	NewDefaultMPLabelsFlag         = "worker-mp-labels"
+	DeprecatedControlPlaneIAMRole  = "controlplane-iam-role"
+	NewControlPlaneIAMRole         = "controlplane-iam-role-arn"
+	DeprecatedWorkerIAMRole        = "worker-iam-role"
+	NewWorkerIAMRole               = "worker-iam-role-arn"
 )
 
-func NormalizeFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
+func NormalizeFlags(_ *pflag.FlagSet, name string) pflag.NormalizedName {
 	switch name {
 	case deprecatedInstallerRoleArnFlag:
 		name = newInstallerRoleArnFlag
 	case DeprecatedDefaultMPLabelsFlag:
 		name = NewDefaultMPLabelsFlag
+	case DeprecatedWorkerIAMRole:
+		name = NewWorkerIAMRole
+	case DeprecatedControlPlaneIAMRole:
+		name = NewControlPlaneIAMRole
 	}
 	return pflag.NormalizedName(name)
 }

--- a/pkg/arguments/normalize_test.go
+++ b/pkg/arguments/normalize_test.go
@@ -16,6 +16,9 @@ var _ = Describe("Normalize Argument Flags Tests", func() {
 			},
 			Entry("installer-role-arn to role-arn", deprecatedInstallerRoleArnFlag, newInstallerRoleArnFlag),
 			Entry("default-mp-labels to worker-mp-labels", DeprecatedDefaultMPLabelsFlag, NewDefaultMPLabelsFlag),
+			Entry("controlplane-iam-role to controlplane-iam-role-arn",
+				DeprecatedControlPlaneIAMRole, NewControlPlaneIAMRole),
+			Entry("worker-iam-role to worker-iam-role-arn", DeprecatedWorkerIAMRole, NewWorkerIAMRole),
 		)
 	})
 


### PR DESCRIPTION
This PR updates the flags for the `rosa create cluster` command that relate to roles to use the `--arn` suffix for consistency. Support for the old flag names remains as they are mapped to the new flag name via the normalize function, to ensure that we do not break existing users of the ROSA CLI.

Additionally there is a minor modification to the output of the `rosa describe cluster` command to add the `(STS)` to `Role Arn` output.