### PR TITLE
cmd/create/cluster: reduce use of globals

### DIFF
--- a/cmd/create/autoscaler/cmd.go
+++ b/cmd/create/autoscaler/cmd.go
@@ -58,7 +58,7 @@ func init() {
 
 	ocm.AddClusterFlag(Cmd)
 	interactive.AddFlag(flags)
-	autoscalerArgs = clusterautoscaler.AddClusterAutoscalerFlags(Cmd, argsPrefix)
+	autoscalerArgs = clusterautoscaler.AddClusterAutoscalerFlags(Cmd.Flags(), argsPrefix)
 }
 
 func run(cmd *cobra.Command, _ []string) {

--- a/cmd/create/cluster/cmd_test.go
+++ b/cmd/create/cluster/cmd_test.go
@@ -21,6 +21,9 @@ var _ = Describe("Validate build command", func() {
 	var userSelectedAvailabilityZones bool
 	var defaultMachinePoolLabels string
 	var argsDotProperties []string
+	var clusterAdminPassword string
+	var classicOidcConfig bool
+	var expirationDuration time.Duration
 
 	BeforeEach(func() {
 		clusterConfig = ocm.Spec{
@@ -39,7 +42,8 @@ var _ = Describe("Validate build command", func() {
 				clusterConfig.EtcdEncryptionKMSArn = "my-test-arn"
 				command := buildCommand(clusterConfig, operatorRolesPrefix,
 					expectedOperatorRolePath, userSelectedAvailabilityZones,
-					defaultMachinePoolLabels, argsDotProperties)
+					defaultMachinePoolLabels, argsDotProperties,
+					clusterAdminPassword, classicOidcConfig, expirationDuration)
 				Expect(command).To(Equal(
 					"rosa create cluster --cluster-name cluster-name --operator-roles-prefix prefix" +
 						" --etcd-encryption --etcd-encryption-kms-arn my-test-arn"))
@@ -52,7 +56,8 @@ var _ = Describe("Validate build command", func() {
 				clusterConfig.EtcdEncryptionKMSArn = "my-test-arn"
 				command := buildCommand(clusterConfig, operatorRolesPrefix,
 					expectedOperatorRolePath, userSelectedAvailabilityZones,
-					defaultMachinePoolLabels, argsDotProperties)
+					defaultMachinePoolLabels, argsDotProperties,
+					clusterAdminPassword, classicOidcConfig, expirationDuration)
 				Expect(command).To(Equal(
 					"rosa create cluster --cluster-name cluster-name --operator-roles-prefix prefix"))
 			})
@@ -62,7 +67,8 @@ var _ = Describe("Validate build command", func() {
 			It("should not include --properties", func() {
 				command := buildCommand(clusterConfig, operatorRolesPrefix,
 					expectedOperatorRolePath, userSelectedAvailabilityZones,
-					defaultMachinePoolLabels, argsDotProperties)
+					defaultMachinePoolLabels, argsDotProperties,
+					clusterAdminPassword, classicOidcConfig, expirationDuration)
 				// nolint:lll
 				Expect(command).To(Equal("rosa create cluster --cluster-name cluster-name --operator-roles-prefix prefix"))
 			})
@@ -72,7 +78,8 @@ var _ = Describe("Validate build command", func() {
 				argsDotProperties = []string{"prop1", "prop2"}
 				command := buildCommand(clusterConfig, operatorRolesPrefix,
 					expectedOperatorRolePath, userSelectedAvailabilityZones,
-					defaultMachinePoolLabels, argsDotProperties)
+					defaultMachinePoolLabels, argsDotProperties,
+					clusterAdminPassword, classicOidcConfig, expirationDuration)
 				// nolint:lll
 				Expect(command).To(Equal("rosa create cluster --cluster-name cluster-name --operator-roles-prefix prefix --properties \"prop1\" --properties \"prop2\""))
 			})

--- a/cmd/create/cmd.go
+++ b/cmd/create/cmd.go
@@ -48,7 +48,7 @@ var Cmd = &cobra.Command{
 func init() {
 	Cmd.AddCommand(accountroles.Cmd)
 	Cmd.AddCommand(admin.Cmd)
-	Cmd.AddCommand(cluster.Cmd)
+	Cmd.AddCommand(cluster.Cmd())
 	Cmd.AddCommand(idp.Cmd)
 	Cmd.AddCommand(machinepool.Cmd)
 	Cmd.AddCommand(oidcconfig.Cmd)

--- a/cmd/edit/autoscaler/cmd.go
+++ b/cmd/edit/autoscaler/cmd.go
@@ -60,7 +60,7 @@ func init() {
 
 	ocm.AddClusterFlag(Cmd)
 	interactive.AddFlag(flags)
-	autoscalerArgs = clusterautoscaler.AddClusterAutoscalerFlags(Cmd, argsPrefix)
+	autoscalerArgs = clusterautoscaler.AddClusterAutoscalerFlags(Cmd.Flags(), argsPrefix)
 }
 
 func run(cmd *cobra.Command, _ []string) {


### PR DESCRIPTION
Instead of using package-global variables and init() to drive control flow, use values of types.