### PR TITLE
OCM-1576 | feat: update link ocm role error message

### DIFF
--- a/cmd/link/ocmrole/cmd.go
+++ b/cmd/link/ocmrole/cmd.go
@@ -144,8 +144,8 @@ func run(cmd *cobra.Command, argv []string) (err error) {
 			}
 
 			r.Reporter.Errorf("%s"+
-				"Only organization admin can run this command. "+
-				"Please ask someone with the organization admin role to run the following command \n\n"+
+				"Only organization member can run this command. "+
+				"Please ask someone with the organization member role to run the following command \n\n"+
 				"\t rosa link ocm-role --role-arn %s --organization-id %s", errMessage, roleArn, orgAccount)
 			return err
 		}


### PR DESCRIPTION
With AMS update also organization member can add/remove OCM organization lables. Update the error message from `admin` to `member`.