### PR TITLE
pkg/ocm: remove dependency on AWS client for cluster fetch

### DIFF
--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -444,9 +444,8 @@ func (c *Client) GetCluster(clusterKey string, creator *aws.Creator) (*cmv1.Clus
 	return c.getCluster(clusterKey, creator)
 }
 
-func (c *Client) GetClusterByID(clusterKey string, creator *aws.Creator) (*cmv1.Cluster, error) {
-	query := fmt.Sprintf("%s AND id = '%s'",
-		getClusterFilter(creator),
+func (c *Client) GetClusterByID(clusterKey string) (*cmv1.Cluster, error) {
+	query := fmt.Sprintf("id = '%s'",
 		clusterKey,
 	)
 	response, err := c.ocm.ClustersMgmt().V1().Clusters().List().

--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -739,6 +739,24 @@ func (c *Client) DeleteCluster(clusterKey string, bestEffort bool,
 	return cluster, nil
 }
 
+func (c *Client) DeleteClusterByID(clusterID string, bestEffort bool) (*cmv1.Cluster, error) {
+	cluster, err := c.GetClusterByID(clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := c.ocm.ClustersMgmt().V1().Clusters().
+		Cluster(cluster.ID()).
+		Delete().
+		BestEffort(bestEffort).
+		Send()
+	if err != nil {
+		return nil, handleErr(response.Error(), err)
+	}
+
+	return cluster, nil
+}
+
 func (c *Client) createClusterSpec(config Spec, awsClient aws.Client) (*cmv1.Cluster, error) {
 	reporter, err := rprtr.New().
 		Build()


### PR DESCRIPTION
It looks like the AWS-account-specific filters that are exposed in the GetClusterByID() may be a historical side-effect of a previous filtering approach. No futher filtering is necessary today when fetching a cluster by ID.