### PR TITLE
OCM-5862 | fix: default version computation should be done only once

### DIFF
--- a/pkg/helper/versions/helpers_test.go
+++ b/pkg/helper/versions/helpers_test.go
@@ -103,16 +103,16 @@ var _ = Describe("Get default version", func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	DescribeTable("Validates entries",
-		func(val *v1.Version, expected string) {
+		func(val *v1.Version, expected bool) {
 			isHostedCP := true
-			result := getDefaultVersion(val, isHostedCP)
+			result := isDefaultVersion(val, isHostedCP)
 			Expect(result).To(Equal(expected))
 		},
 		Entry("Hosted default", versionHostedDefault,
-			"4.14.9"),
+			true),
 		Entry("Classic default", versionClassicDefault,
-			"4.14.8"),
+			true),
 		Entry("Not default", notDefault,
-			""),
+			false),
 	)
 })

--- a/pkg/helper/versions/helpers_test.go
+++ b/pkg/helper/versions/helpers_test.go
@@ -1,11 +1,15 @@
 package versions
 
 import (
+	"net/http"
+
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/ginkgo/v2/dsl/decorators"
 	. "github.com/onsi/ginkgo/v2/dsl/table"
 	. "github.com/onsi/gomega"
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+	"github.com/openshift/rosa/pkg/test"
 )
 
 var _ = Describe("Version Helpers", Ordered, func() {
@@ -103,16 +107,122 @@ var _ = Describe("Get default version", func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	DescribeTable("Validates entries",
-		func(val *v1.Version, expected bool) {
-			isHostedCP := true
+		func(val *v1.Version, isHostedCP, expected bool) {
 			result := isDefaultVersion(val, isHostedCP)
 			Expect(result).To(Equal(expected))
 		},
-		Entry("Hosted default", versionHostedDefault,
+		Entry("Hosted default", versionHostedDefault, true,
 			true),
-		Entry("Classic default", versionClassicDefault,
+		Entry("Classic default", versionClassicDefault, false,
 			true),
-		Entry("Not default", notDefault,
+		Entry("Not default", notDefault, false,
 			false),
 	)
 })
+
+var _ = Describe("computeVersionListAndDefault", func() {
+
+	versionHostedDefault, err := v1.NewVersion().ROSAEnabled(true).
+		RawID("4.14.9").Enabled(true).ChannelGroup("stable").
+		HostedControlPlaneDefault(true).HostedControlPlaneEnabled(true).Build()
+	Expect(err).NotTo(HaveOccurred())
+
+	versionClassicDefault, err := v1.NewVersion().ROSAEnabled(true).
+		RawID("4.14.8").Enabled(true).ChannelGroup("stable").Default(true).Build()
+	Expect(err).NotTo(HaveOccurred())
+
+	versionHostedNotDefault, err := v1.NewVersion().ROSAEnabled(true).
+		RawID("4.14.7").Enabled(true).ChannelGroup("stable").
+		HostedControlPlaneDefault(true).HostedControlPlaneEnabled(true).Build()
+	Expect(err).NotTo(HaveOccurred())
+
+	versionClassicNotDefault, err := v1.NewVersion().ROSAEnabled(true).
+		RawID("4.14.6").Enabled(true).ChannelGroup("stable").Default(true).Build()
+	Expect(err).NotTo(HaveOccurred())
+
+	notROSAEnabled, err := v1.NewVersion().ROSAEnabled(false).
+		RawID("4.14.0").Enabled(true).ChannelGroup("stable").Build()
+	Expect(err).NotTo(HaveOccurred())
+
+	// This is older than minimum supported
+	notSTS, err := v1.NewVersion().ROSAEnabled(false).
+		RawID("4.5.0").Enabled(true).ChannelGroup("stable").Build()
+	Expect(err).NotTo(HaveOccurred())
+
+	versionList := make([]*v1.Version, 3)
+	versionList = append(versionList, versionHostedDefault, versionClassicDefault, versionHostedNotDefault,
+		versionClassicNotDefault, notROSAEnabled, notSTS)
+
+	DescribeTable("compute",
+		func(versions []*v1.Version, isHostedCP, isSTS, filterHostedCP bool, expectedDefault string,
+			expectedVersions []string) {
+			defaultVersion, versionList, err := computeVersionListAndDefault(versions, isHostedCP,
+				isSTS, filterHostedCP)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(defaultVersion).To(Equal(expectedDefault))
+			Expect(versionList).To(Equal(expectedVersions))
+		},
+		Entry("HCP", versionList, true, true, true, "4.14.9", []string{"4.14.9", "4.14.7"}),
+		Entry("Classic", versionList, false, true, false, "4.14.8", []string{"4.14.9", "4.14.8",
+			"4.14.7", "4.14.6", "4.14.0"}),
+	)
+})
+
+var _ = Describe("GetVersionList", func() {
+	var testRuntime test.TestingRuntime
+	versionHCPDefault, err := v1.NewVersion().ID("4.14.1").RawID("openshift-4.14.1").
+		HostedControlPlaneDefault(true).ROSAEnabled(true).Build()
+	Expect(err).NotTo(HaveOccurred())
+	versionHCPClassicDefault, err := v1.NewVersion().ID("4.14.2").RawID("openshift-4.14.2").
+		HostedControlPlaneDefault(false).ROSAEnabled(true).Default(true).Build()
+	Expect(err).NotTo(HaveOccurred())
+
+	BeforeEach(func() {
+		testRuntime.InitRuntime()
+	})
+
+	It("Expects no version found", func() {
+		testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK,
+			test.FormatVersionList([]*v1.Version{})))
+		_, vs, err := GetVersionList(testRuntime.RosaRuntime, "stable",
+			true, true, true, false)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("Could not find versions for the provided channel-group"))
+		Expect(len(vs)).To(Equal(0))
+	})
+
+	It("Expects a single version", func() {
+		testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK,
+			test.FormatVersionList([]*v1.Version{versionHCPDefault})))
+		defaultVersion, vs, err := GetVersionList(testRuntime.RosaRuntime,
+			"stable", true, true, false, false)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(vs)).To(Equal(1))
+		Expect(defaultVersion).To(Equal("openshift-4.14.1"))
+	})
+
+	It("Expects a version list and a default", func() {
+		testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK,
+			test.FormatVersionList([]*v1.Version{versionHCPDefault, versionHCPClassicDefault})))
+		defaultVersion, vs, err := GetVersionList(testRuntime.RosaRuntime,
+			"stable", true, true, false, false)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(vs)).To(Equal(2))
+		Expect(defaultVersion).To(Equal("openshift-4.14.1"))
+	})
+})
+
+var _ = DescribeTable("IsGreaterThanOrEqual", func(version1, version2 string, expectedResult bool,
+	expectedError string) {
+	result, err := IsGreaterThanOrEqual(version1, version2)
+	if expectedError != "" {
+		Expect(err.Error()).To(ContainSubstring(expectedError))
+	}
+	Expect(result).To(Equal(expectedResult))
+},
+	Entry("Not greater", "openshift-v4.14.1", "openshift-v4.14.2", false, ""),
+	Entry("Equal", "openshift-v4.14.1", "openshift-v4.14.1", true, ""),
+	Entry("Greater", "openshift-v4.14.2", "openshift-v4.14.1", true, ""),
+	Entry("Invalid arg 1", "invalid", "openshift-v4.14.1", false, "Malformed version: invalid"),
+	Entry("Invalid arg 2", "openshift-v4.14.2", "invalid2", false, "Malformed version: invalid2"),
+)

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -128,6 +128,21 @@ func FormatIngressList(ingresses []*v1.Ingress) string {
 	}`, len(ingresses), len(ingresses), ingressJson.String())
 }
 
+func FormatVersionList(versions []*v1.Version) string {
+	var versionJson bytes.Buffer
+
+	v1.MarshalVersionList(versions, &versionJson)
+
+	return fmt.Sprintf(`
+	{
+		"kind": "VersionList",
+		"page": 1,
+		"size": %d,
+		"total": %d,
+		"items": %s
+	}`, len(versions), len(versions), versionJson.String())
+}
+
 func FormatNodePoolUpgradePolicyList(upgrades []*v1.NodePoolUpgradePolicy) string {
 	var outputJson bytes.Buffer
 


### PR DESCRIPTION
Fix a panic caused by the default version being reinitialized at every loop. Add also a safety fallback in case the default version can't be computed.

Related: [OCM-5862](https://issues.redhat.com//browse/OCM-5862)