### PR TITLE
OCM-5978 | fix: Ensure rosa is the default Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@
 
 include .bingo/Variables.mk
 
+.DEFAULT_TARGET := rosa
+
 # Ensure go modules are enabled:
 export GO111MODULE=on
 export GOPROXY=https://proxy.golang.org


### PR DESCRIPTION
This PR ensures that `rosa` remains the default Makefile target which is the main workflow for the vast majority of people working on the project.