### PR TITLE
OCM-5978 | fix: Make rosa the default goal in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 
 include .bingo/Variables.mk
 
-.DEFAULT_TARGET := rosa
+.DEFAULT_GOAL := rosa
 
 # Ensure go modules are enabled:
 export GO111MODULE=on


### PR DESCRIPTION
This PR fixes my previous PR 🙄 #1766  It should be `DEFAULT_GOAL` and not `DEFAULT_TARGET`