### PR TITLE
OCM-5828 | fix: Correct the message shown in interactive mode when creating a MachinePool

### DIFF
--- a/cmd/create/machinepool/machinepool.go
+++ b/cmd/create/machinepool/machinepool.go
@@ -325,7 +325,7 @@ func addMachinePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster
 		spin = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
 	}
 	if spin != nil {
-		r.Reporter.Infof("Checking available instance types for machine pool '%s'", args.name)
+		r.Reporter.Infof("Checking available instance types for machine pool '%s'", name)
 		spin.Start()
 	}
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+coverage:
+  status:
+    project:
+      default:
+        paths:
+          - "cmd"
+          - "pkg"
+        only_pulls: true
+    patch:
+      default:
+        paths:
+          - "cmd"
+          - "pkg"
+        informational: true
+        only_pulls: true


### PR DESCRIPTION
Tiny fix to ensure we're using the correct parameter in the log message when fetching instance types for creation of a Machine Pool.