### PR TITLE
OCM-5983 | chore: clean up old TODO

### DIFF
--- a/pkg/ocm/idps.go
+++ b/pkg/ocm/idps.go
@@ -175,8 +175,6 @@ func getIDPListWithoutAuthURLSupport() []string {
 func BuildOAuthURL(cluster *cmv1.Cluster, idpType cmv1.IdentityProviderType) (string, error) {
 	var oauthURL string
 	if cluster.Hypershift().Enabled() {
-		// TODO(adecorte): this logic is not valid if ExternalDNS is not configured. This should be the case only in
-		// local env. We should either align local or have a specific logic for this case
 		// https://api.example.com:443 -> https://oauth.example.com
 		apiURL := cluster.API().URL()
 		if OAuthURLNeedsPort(idpType) {


### PR DESCRIPTION
OAuth in HCP local dev now behaves like all the other environments. So ROSA CLI is able to compute it correctly.

Relevant TODO should be removed from ROSA CLI.

Related: [OCM-5983](https://issues.redhat.com//browse/OCM-5983)