### PR TITLE
OCM-5826 | fix: refactor awsClient calls to include spinner

### DIFF
--- a/cmd/list/cluster/cmd.go
+++ b/cmd/list/cluster/cmd.go
@@ -71,13 +71,6 @@ func run(_ *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
 
-	for i := 0; i < 1000; i++ {
-
-		r.AWSClient.DetachRolePolicies("dle-audit-test-role")
-
-		r.AWSClient.AttachRolePolicy("dle-audit-test-role", "arn:aws:iam::765374464689:policy/dle-audit-log-forwarding-policy")
-	}
-
 	// Retrieve the list of clusters:
 	var creator *aws.Creator
 	if args.listAll {

--- a/cmd/list/cluster/cmd.go
+++ b/cmd/list/cluster/cmd.go
@@ -71,6 +71,13 @@ func run(_ *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
 
+	for i := 0; i < 1000; i++ {
+
+		r.AWSClient.DetachRolePolicies("dle-audit-test-role")
+
+		r.AWSClient.AttachRolePolicy("dle-audit-test-role", "arn:aws:iam::765374464689:policy/dle-audit-log-forwarding-policy")
+	}
+
 	// Retrieve the list of clusters:
 	var creator *aws.Creator
 	if args.listAll {

--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -241,10 +241,8 @@ func run(cmd *cobra.Command, argv []string) error {
 	case aws.ModeAuto:
 		if isUpgradeNeedForAccountRolePolicies {
 			reporter.Infof("Starting to upgrade the policies")
-			err = r.WithSpinner(func() error {
-				return upgradeAccountRolePolicies(reporter, awsClient, prefix, creator.AccountID, policies,
-					policyVersion, policyPath, isVersionChosen)
-			})
+			err = upgradeAccountRolePolicies(reporter, awsClient, prefix, creator.AccountID, policies,
+				policyVersion, policyPath, isVersionChosen)
 			if err != nil {
 				LogError(roles.RosaUpgradeAccRolesModeAuto, ocmClient, policyVersion, err, reporter)
 				reporter.Errorf("Error upgrading the role polices: %s", err)

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -232,14 +232,8 @@ type awsClient struct {
 	spinner             *spinner.Spinner
 }
 
-func CreateNewClientOrExit(logger *logrus.Logger, reporter *reporter.Object) Client {
-
-	clientBuild := NewClient().Logger(logger)
-	if reporter.IsTerminal() {
-		spinner := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-		clientBuild.Spinner(spinner)
-	}
-	awsClient, err := clientBuild.Build()
+func CreateNewClientOrExit(logger *logrus.Logger, reporter *reporter.Object, spinner *spinner.Spinner) Client {
+	awsClient, err := NewClient().Logger(logger).Spinner(spinner).Build()
 	if err != nil {
 		reporter.Errorf("Failed to create AWS client: %v", err)
 		os.Exit(1)
@@ -436,6 +430,7 @@ func (b *ClientBuilder) Build() (Client, error) {
 		servicequotasClient: servicequotas.New(sess),
 		awsSession:          sess,
 		useLocalCredentials: b.useLocalCredentials,
+		spinner:             b.spinner,
 	}
 
 	_, root, err := getClientDetails(c)
@@ -1275,7 +1270,7 @@ func (c *awsClient) WithSpinner(fn func() (interface{}, error)) (interface{}, er
 	if c.spinner != nil {
 		c.spinner.Start()
 		returnValue, err := fn() // arbitrary function
-		c.spinner.Stop()         // stops spinner after the function completes
+		c.spinner.Stop()
 		return returnValue, err
 	}
 	return fn()

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -1063,7 +1063,9 @@ func (c *awsClient) DetachRolePolicies(roleName string) error {
 }
 
 func (c *awsClient) detachRolePolicy(policyArn string, roleName string) error {
-	_, err := c.iamClient.DetachRolePolicy(&iam.DetachRolePolicyInput{PolicyArn: &policyArn, RoleName: &roleName})
+	_, err := c.WithSpinner(func() (interface{}, error) {
+		return c.iamClient.DetachRolePolicy(&iam.DetachRolePolicyInput{PolicyArn: &policyArn, RoleName: &roleName})
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/aws/client_test.go
+++ b/pkg/aws/client_test.go
@@ -59,6 +59,7 @@ var _ = Describe("Client", func() {
 			&session.Session{},
 			&AccessKey{},
 			false,
+			nil,
 		)
 	})
 

--- a/pkg/rosa/runtime.go
+++ b/pkg/rosa/runtime.go
@@ -2,9 +2,7 @@ package rosa
 
 import (
 	"os"
-	"time"
 
-	"github.com/briandowns/spinner"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/sirupsen/logrus"
 
@@ -22,14 +20,12 @@ type Runtime struct {
 	Creator    *aws.Creator
 	ClusterKey string
 	Cluster    *cmv1.Cluster
-	Spinner    *spinner.Spinner
 }
 
 func NewRuntime() *Runtime {
 	reporter := reporter.CreateReporterOrExit()
 	logger := logging.NewLogger()
-	spinner := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-	return &Runtime{Reporter: reporter, Logger: logger, Spinner: spinner}
+	return &Runtime{Reporter: reporter, Logger: logger}
 }
 
 // Adds an OCM client to the runtime. Requires a deferred call to `.Cleanup()` to close connections.
@@ -100,14 +96,4 @@ func (r *Runtime) FetchCluster() *cmv1.Cluster {
 	}
 	r.Cluster = cluster
 	return cluster
-}
-
-func (r *Runtime) WithSpinner(fn func() error) error {
-	if r.Reporter.IsTerminal() {
-		r.Spinner.Start()
-		err := fn()      // arbitrary function
-		r.Spinner.Stop() // stops spinner after the function completes
-		return err
-	}
-	return fn()
 }

--- a/pkg/rosa/runtime.go
+++ b/pkg/rosa/runtime.go
@@ -2,7 +2,9 @@ package rosa
 
 import (
 	"os"
+	"time"
 
+	"github.com/briandowns/spinner"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/sirupsen/logrus"
 
@@ -38,8 +40,13 @@ func (r *Runtime) WithOCM() *Runtime {
 
 // Adds an AWS client to the runtime
 func (r *Runtime) WithAWS() *Runtime {
+	var spin *spinner.Spinner
+	if r.Reporter.IsTerminal() {
+		spin = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+	}
+
 	if r.AWSClient == nil {
-		r.AWSClient = aws.CreateNewClientOrExit(r.Logger, r.Reporter)
+		r.AWSClient = aws.CreateNewClientOrExit(r.Logger, r.Reporter, spin)
 	}
 	if r.Creator == nil {
 		var err error

--- a/pkg/rosa/runtime.go
+++ b/pkg/rosa/runtime.go
@@ -42,7 +42,7 @@ func (r *Runtime) WithOCM() *Runtime {
 func (r *Runtime) WithAWS() *Runtime {
 	var spin *spinner.Spinner
 	if r.Reporter.IsTerminal() {
-		spin = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+		spin = spinner.New(spinner.CharSets[9], 200*time.Millisecond)
 	}
 
 	if r.AWSClient == nil {


### PR DESCRIPTION
TEST