### PR TITLE
OCM-6057 | fix: Ensure codecov reports are being published for master

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,11 +5,9 @@ coverage:
         paths:
           - "cmd"
           - "pkg"
-        only_pulls: true
     patch:
       default:
         paths:
           - "cmd"
           - "pkg"
         informational: true
-        only_pulls: true


### PR DESCRIPTION
This PR ensures our codecov reporting is being generated for `master` branch.