### PR TITLE
OCM-5829 | feat: Supressing help message when error is thrown

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,12 @@ configured in https://github.com/openshift/release repo.
 `.golangciversion` file is read by the `lint` job commands there:
 https://github.com/openshift/release/blob/master/ci-operator/config/openshift/rosa/openshift-rosa-master.yaml
 
+## Contributing and Error Handling in Cobra
+
+1. If you are contributing code, please ensure that you are handling errors
+   properly. Please use `Run: run` instead of `RunE: runE` when writing commands,
+   in order to stop the **usage info** being printed when an error is returned.
+
 ## GitHub Workflows
 
 This repository also uses GitHub actions which are configured at `./github/workflows`

--- a/cmd/dlt/ocmrole/cmd.go
+++ b/cmd/dlt/ocmrole/cmd.go
@@ -43,7 +43,7 @@ var Cmd = &cobra.Command{
 	Long:    "Delete OCM role from the current AWS organization",
 	Example: ` # Delete OCM role
 rosa delete ocm-role --role-arn arn:aws:iam::123456789012:role/xxx-OCM-Role-1223456778`,
-	RunE: run,
+	Run: run,
 }
 
 func init() {
@@ -61,7 +61,7 @@ func init() {
 	interactive.AddFlag(flags)
 }
 
-func run(cmd *cobra.Command, argv []string) error {
+func run(cmd *cobra.Command, argv []string) {
 	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
 
@@ -74,7 +74,7 @@ func run(cmd *cobra.Command, argv []string) error {
 	orgID, _, err := r.OCMClient.GetCurrentOrganization()
 	if err != nil {
 		r.Reporter.Errorf("Error getting organization account: %v", err)
-		return err
+		os.Exit(1)
 	}
 
 	if len(argv) > 0 {
@@ -216,8 +216,6 @@ func run(cmd *cobra.Command, argv []string) error {
 		r.Reporter.Errorf("Invalid mode. Allowed values are %s", aws.Modes)
 		os.Exit(1)
 	}
-
-	return nil
 }
 
 func buildCommands(roleName string, roleARN string, isLinked bool, awsClient aws.Client,

--- a/cmd/link/userrole/cmd.go
+++ b/cmd/link/userrole/cmd.go
@@ -41,7 +41,7 @@ var Cmd = &cobra.Command{
 	Long:    "Link user role to specific OCM account before create your cluster.",
 	Example: ` # Link user roles
   rosa link user-role --role-arn arn:aws:iam::{accountid}:role/{prefix}-User-{username}-Role`,
-	RunE: run,
+	Run: run,
 }
 
 func init() {
@@ -64,7 +64,8 @@ func init() {
 	interactive.AddFlag(flags)
 }
 
-func run(cmd *cobra.Command, argv []string) (err error) {
+func run(cmd *cobra.Command, argv []string) {
+	var err error
 	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
 
@@ -143,5 +144,4 @@ func run(cmd *cobra.Command, argv []string) (err error) {
 		os.Exit(1)
 	}
 	r.Reporter.Infof("Successfully linked role ARN '%s' with account '%s'", roleArn, accountID)
-	return nil
 }

--- a/cmd/unlink/ocmrole/cmd.go
+++ b/cmd/unlink/ocmrole/cmd.go
@@ -38,7 +38,7 @@ var Cmd = &cobra.Command{
 	Long:    "Unlink ocm role from a specific OCM organization",
 	Example: ` #Unlink ocm role
 rosa unlink ocm-role --role-arn arn:aws:iam::123456789012:role/ManagedOpenshift-OCM-Role`,
-	RunE: run,
+	Run: run,
 }
 
 func init() {
@@ -61,7 +61,7 @@ func init() {
 	interactive.AddFlag(flags)
 }
 
-func run(cmd *cobra.Command, argv []string) (err error) {
+func run(cmd *cobra.Command, argv []string) {
 	r := rosa.NewRuntime().WithOCM()
 	defer r.Cleanup()
 
@@ -130,6 +130,4 @@ func run(cmd *cobra.Command, argv []string) (err error) {
 		os.Exit(1)
 	}
 	r.Reporter.Infof("Successfully unlinked role-arn '%s' from organization account '%s'", roleArn, orgID)
-
-	return nil
 }

--- a/cmd/unlink/userrole/cmd.go
+++ b/cmd/unlink/userrole/cmd.go
@@ -38,7 +38,7 @@ var Cmd = &cobra.Command{
 	Long:    "Unlink user role from a specific OCM account",
 	Example: ` # Unlink user role
 rosa unlink user-role --role-arn arn:aws:iam::{accountid}:role/{prefix}-User-{username}-Role`,
-	RunE: run,
+	Run: run,
 }
 
 func init() {
@@ -61,7 +61,8 @@ func init() {
 	interactive.AddFlag(flags)
 }
 
-func run(cmd *cobra.Command, argv []string) (err error) {
+func run(cmd *cobra.Command, argv []string) {
+	var err error
 	r := rosa.NewRuntime().WithOCM()
 	defer r.Cleanup()
 
@@ -129,5 +130,4 @@ func run(cmd *cobra.Command, argv []string) (err error) {
 		os.Exit(1)
 	}
 	r.Reporter.Infof("Successfully unlinked role ARN '%s' from account '%s'", roleArn, accountID)
-	return nil
 }

--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -53,7 +53,7 @@ var Cmd = &cobra.Command{
 	Long:    "Upgrade account-wide IAM roles to the latest version before upgrading your cluster.",
 	Example: `  # Upgrade account roles for ROSA STS clusters
   rosa upgrade account-roles`,
-	RunE: run,
+	Run: run,
 }
 
 func init() {
@@ -96,7 +96,7 @@ func init() {
 	interactive.AddFlag(flags)
 }
 
-func run(cmd *cobra.Command, argv []string) error {
+func run(cmd *cobra.Command, argv []string) {
 	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
 	reporter := r.Reporter
@@ -172,7 +172,7 @@ func run(cmd *cobra.Command, argv []string) error {
 
 		r.Reporter.Infof("Account roles with the prefix '%s' have attached managed policies. "+
 			"An upgrade isn't needed", prefix)
-		return nil
+		os.Exit(0)
 	}
 
 	creator, err := awsClient.GetCreator()
@@ -272,7 +272,6 @@ func run(cmd *cobra.Command, argv []string) error {
 		reporter.Errorf("Invalid mode. Allowed values are %s", aws.Modes)
 		os.Exit(1)
 	}
-	return err
 }
 
 func LogError(key string, ocmClient *ocm.Client, defaultPolicyVersion string, err error, reporter *rprtr.Object) {

--- a/cmd/verify/quota/cmd.go
+++ b/cmd/verify/quota/cmd.go
@@ -18,6 +18,7 @@ package quota
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -36,7 +37,7 @@ var Cmd = &cobra.Command{
 
   # Verify AWS quotas in a different region
   rosa verify quota --region=us-west-2`,
-	RunE: run,
+	Run: run,
 }
 
 func init() {
@@ -46,7 +47,7 @@ func init() {
 	arguments.AddProfileFlag(flags)
 }
 
-func run(cmd *cobra.Command, _ []string) (err error) {
+func run(cmd *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithOCM()
 	defer r.Cleanup()
 
@@ -54,7 +55,7 @@ func run(cmd *cobra.Command, _ []string) (err error) {
 	region, err := aws.GetRegion(arguments.GetRegion())
 	if err != nil {
 		r.Reporter.Errorf("Error getting region: %v", err)
-		return err
+		os.Exit(1)
 	}
 
 	// Create the AWS client:
@@ -68,7 +69,7 @@ func run(cmd *cobra.Command, _ []string) (err error) {
 			r.OCMClient.LogEvent("ROSAInitCredentialsSTS", nil)
 		}
 		r.Reporter.Errorf("Error creating AWS client: %v", err)
-		return err
+		os.Exit(1)
 	}
 
 	if r.Reporter.IsTerminal() {
@@ -79,12 +80,11 @@ func run(cmd *cobra.Command, _ []string) (err error) {
 		r.OCMClient.LogEvent("ROSAVerifyQuotaInsufficient", nil)
 		r.Reporter.Errorf("Insufficient AWS quotas")
 		r.Reporter.Errorf("%v", err)
-		return err
+		os.Exit(1)
 	}
 	if r.Reporter.IsTerminal() {
 		r.Reporter.Infof("AWS quota ok. " +
 			"If cluster installation fails, validate actual AWS resource usage against " +
 			"https://docs.openshift.com/rosa/rosa_getting_started/rosa-required-aws-service-quotas.html")
 	}
-	return nil
 }


### PR DESCRIPTION
[JIRA](https://issues.redhat.com/browse/OCM-5829) Suppressing help message when error is shown from linking multiple roles to the same org