### PR TITLE
OCM-5804 | feat: Add token and config commands

### DIFF
--- a/cmd/config/cmd.go
+++ b/cmd/config/cmd.go
@@ -1,0 +1,76 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/cmd/config/get"
+	"github.com/openshift/rosa/cmd/config/set"
+	"github.com/openshift/rosa/pkg/config"
+)
+
+func configVarDocs() (ret string) {
+	configType := reflect.ValueOf(config.Config{}).Type()
+	fieldHelps := make([]string, configType.NumField())
+	for i := 0; i < len(fieldHelps); i++ {
+		tag := configType.Field(i).Tag
+		name := strings.Split(tag.Get("json"), ",")[0]
+		doc := tag.Get("doc")
+		fieldHelps[i] = fmt.Sprintf("\t%-15s%s", name, doc)
+	}
+	ret = strings.Join(fieldHelps, "\n")
+	return
+}
+
+func longHelp() (ret string) {
+	loc, err := config.Location()
+	if err != nil {
+		// I think this only happens if homedir.Dir() fails, which is unlikely.
+		loc = fmt.Sprintf("UNKNOWN (%s)", err)
+	}
+	ret = fmt.Sprintf(`Get or set variables from a configuration file.
+
+The location of the configuration file is gleaned from the 'OCM_CONFIG' environment variable,
+or ~/.ocm.json if that variable is unset. Currently using: %s
+
+The following variables are supported:
+
+%s
+
+Note that "rosa config get access_token" gives whatever the file contains - may be missing or expired;
+you probably want "rosa token" command instead which will obtain a fresh token if needed.
+`, loc, configVarDocs())
+	return
+}
+
+func NewConfigCommand() *cobra.Command {
+	Cmd := &cobra.Command{
+		Use:   "config COMMAND VARIABLE",
+		Short: "get or set configuration variables",
+		Long:  longHelp(),
+	}
+	Cmd.AddCommand(get.Cmd)
+	Cmd.AddCommand(set.Cmd)
+	return Cmd
+}
+
+var Cmd = NewConfigCommand()

--- a/cmd/config/cmd.go
+++ b/cmd/config/cmd.go
@@ -28,7 +28,7 @@ import (
 	"github.com/openshift/rosa/pkg/config"
 )
 
-func configVarDocs() (ret string) {
+func configVarDocs() string {
 	configType := reflect.ValueOf(config.Config{}).Type()
 	fieldHelps := make([]string, configType.NumField())
 	for i := 0; i < len(fieldHelps); i++ {
@@ -37,17 +37,16 @@ func configVarDocs() (ret string) {
 		doc := tag.Get("doc")
 		fieldHelps[i] = fmt.Sprintf("\t%-15s%s", name, doc)
 	}
-	ret = strings.Join(fieldHelps, "\n")
-	return
+	return strings.Join(fieldHelps, "\n")
 }
 
-func longHelp() (ret string) {
+func longHelp() string {
 	loc, err := config.Location()
 	if err != nil {
 		// I think this only happens if homedir.Dir() fails, which is unlikely.
 		loc = fmt.Sprintf("UNKNOWN (%s)", err)
 	}
-	ret = fmt.Sprintf(`Get or set variables from a configuration file.
+	return fmt.Sprintf(`Get or set variables from a configuration file.
 
 The location of the configuration file is gleaned from the 'OCM_CONFIG' environment variable,
 or ~/.ocm.json if that variable is unset. Currently using: %s
@@ -59,7 +58,6 @@ The following variables are supported:
 Note that "rosa config get access_token" gives whatever the file contains - may be missing or expired;
 you probably want "rosa token" command instead which will obtain a fresh token if needed.
 `, loc, configVarDocs())
-	return
 }
 
 func NewConfigCommand() *cobra.Command {

--- a/cmd/config/cmd_test.go
+++ b/cmd/config/cmd_test.go
@@ -1,0 +1,154 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/rosa/cmd/config/get"
+	"github.com/openshift/rosa/cmd/config/set"
+	"github.com/openshift/rosa/pkg/config"
+	"github.com/openshift/rosa/pkg/test"
+)
+
+func TestConfigCommand(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "rosa token command")
+}
+
+var _ = Describe("Run Command", Ordered, func() {
+	var testRuntime test.TestingRuntime
+	var buf *bytes.Buffer
+	var tmpdir string
+	var err error
+
+	BeforeAll(func() {
+		tmpdir, err = os.MkdirTemp("/tmp", ".ocm-config-*")
+		os.Setenv("OCM_CONFIG", tmpdir+"/ocm_config.json")
+	})
+
+	AfterAll(func() {
+		os.Setenv("OCM_CONFIG", "")
+	})
+
+	BeforeEach(func() {
+		buf = new(bytes.Buffer)
+		get.Writer = buf
+		testRuntime.InitRuntime()
+	})
+
+	It("Saves config", func() {
+		accessToken := "MyTestToken"
+		err = set.SaveConfig("access_token", accessToken)
+		Expect(err).To(BeNil())
+		currentConfig, err := config.Load()
+		Expect(err).To(BeNil())
+		Expect(currentConfig.AccessToken).To(Equal(accessToken))
+
+		clientId := "MyClientId"
+		err = set.SaveConfig("client_id", clientId)
+		Expect(err).To(BeNil())
+		currentConfig, err = config.Load()
+		Expect(err).To(BeNil())
+		Expect(currentConfig.ClientID).To(Equal(clientId))
+
+		insecure := "true"
+		err = set.SaveConfig("insecure", insecure)
+		Expect(err).To(BeNil())
+		currentConfig, err = config.Load()
+		Expect(err).To(BeNil())
+		Expect(strconv.FormatBool(currentConfig.Insecure)).To(Equal(insecure))
+
+		refreshToken := "MyRefreshToken"
+		err = set.SaveConfig("refresh_token", refreshToken)
+		Expect(err).To(BeNil())
+		currentConfig, err = config.Load()
+		Expect(err).To(BeNil())
+		Expect(currentConfig.RefreshToken).To(Equal(refreshToken))
+
+		scopes := "MyScopes"
+		err = set.SaveConfig("scopes", scopes)
+		Expect(err).NotTo(BeNil())
+		Expect(err.Error()).To(Equal("Setting scopes is unsupported"))
+
+		tokenUrl := "MyTokenURL"
+		err = set.SaveConfig("token_url", tokenUrl)
+		Expect(err).To(BeNil())
+		currentConfig, err = config.Load()
+		Expect(err).To(BeNil())
+		Expect(currentConfig.TokenURL).To(Equal(tokenUrl))
+
+		url := "MyURL"
+		err = set.SaveConfig("url", url)
+		Expect(err).To(BeNil())
+		currentConfig, err = config.Load()
+		Expect(err).To(BeNil())
+		Expect(currentConfig.URL).To(Equal(url))
+
+		fedramp := "true"
+		err = set.SaveConfig("fedramp", fedramp)
+		Expect(err).To(BeNil())
+		currentConfig, err = config.Load()
+		Expect(err).To(BeNil())
+		Expect(strconv.FormatBool(currentConfig.FedRAMP)).To(Equal(fedramp))
+
+		insecure = "Incorrect"
+		err = set.SaveConfig("insecure", insecure)
+		Expect(err).NotTo(BeNil())
+		Expect(err.Error()).To(ContainSubstring("Failed to set insecure"))
+
+		randomField := "random value"
+		err = set.SaveConfig("random_field", randomField)
+		Expect(err).NotTo(BeNil())
+		Expect(err.Error()).To(Equal("Unknown setting"))
+	})
+
+	It("Prints config", func() {
+		currentConfig, err := config.Load()
+		Expect(err).To(BeNil())
+		err = get.PrintConfig("access_token")
+		Expect(err).To(BeNil())
+		Expect(buf.String()).To(ContainSubstring(currentConfig.AccessToken))
+
+		err = get.PrintConfig("client_id")
+		Expect(err).To(BeNil())
+		Expect(buf.String()).To(ContainSubstring(currentConfig.ClientID))
+
+		err = get.PrintConfig("client_secret")
+		Expect(err).To(BeNil())
+		Expect(buf.String()).To(ContainSubstring(currentConfig.ClientSecret))
+
+		err = get.PrintConfig("insecure")
+		Expect(err).To(BeNil())
+		Expect(buf.String()).To(ContainSubstring(strconv.FormatBool(currentConfig.Insecure)))
+
+		err = get.PrintConfig("refresh_token")
+		Expect(err).To(BeNil())
+		Expect(buf.String()).To(ContainSubstring(currentConfig.RefreshToken))
+
+		err = get.PrintConfig("scopes")
+		Expect(err).To(BeNil())
+		Expect(buf.String()).To(ContainSubstring(fmt.Sprint(currentConfig.Scopes)))
+
+		err = get.PrintConfig("token_url")
+		Expect(err).To(BeNil())
+		Expect(buf.String()).To(ContainSubstring(currentConfig.TokenURL))
+
+		err = get.PrintConfig("url")
+		Expect(err).To(BeNil())
+		Expect(buf.String()).To(ContainSubstring(currentConfig.URL))
+
+		err = get.PrintConfig("fedramp")
+		Expect(err).To(BeNil())
+		Expect(buf.String()).To(ContainSubstring(strconv.FormatBool(currentConfig.FedRAMP)))
+
+		err = get.PrintConfig("test")
+		Expect(err).NotTo(BeNil())
+		Expect(err.Error()).To(Equal("Unknown setting"))
+	})
+})

--- a/cmd/config/cmd_test.go
+++ b/cmd/config/cmd_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Run Command", Ordered, func() {
 		randomField := "random value"
 		err = set.SaveConfig("random_field", randomField)
 		Expect(err).NotTo(BeNil())
-		Expect(err.Error()).To(Equal("Unknown setting"))
+		Expect(err.Error()).To(Equal("'random_field' is not a supported setting"))
 	})
 
 	It("Prints config", func() {
@@ -149,6 +149,6 @@ var _ = Describe("Run Command", Ordered, func() {
 
 		err = get.PrintConfig("test")
 		Expect(err).NotTo(BeNil())
-		Expect(err.Error()).To(Equal("Unknown setting"))
+		Expect(err.Error()).To(Equal("'test' is not a supported setting"))
 	})
 })

--- a/cmd/config/get/get.go
+++ b/cmd/config/get/get.go
@@ -1,0 +1,107 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package get
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/config"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+var (
+	Writer io.Writer = os.Stdout
+	args   struct {
+		debug bool
+	}
+)
+
+var Cmd = NewConfigCommand()
+
+func NewConfigCommand() *cobra.Command {
+	Cmd := &cobra.Command{
+		Use:   "get [flags] VARIABLE",
+		Short: "Prints the value of a config variable",
+		Long:  "Prints the value of a config variable. See 'rosa config --help' for supported config variables.",
+		Args:  cobra.ExactArgs(1),
+		Run:   run,
+	}
+	flags := Cmd.Flags()
+	flags.BoolVar(
+		&args.debug,
+		"debug",
+		false,
+		"Enable debug mode.",
+	)
+	return Cmd
+}
+
+func run(cmd *cobra.Command, argv []string) {
+	r := rosa.NewRuntime()
+
+	err := PrintConfig(argv[0])
+	if err != nil {
+		r.Reporter.Errorf(err.Error())
+		os.Exit(1)
+	}
+}
+
+func PrintConfig(arg string) error {
+	// Load the configuration file:
+	cfg, err := config.Load()
+	if err != nil {
+		err := fmt.Errorf("Can't load config file: %v", err)
+		return err
+	}
+
+	// If the configuration file doesn't exist yet assume that all the configuration settings
+	// are empty:
+	if cfg == nil {
+		err := fmt.Errorf("Config file doesn't exist yet")
+		return err
+	}
+
+	// Print the value of the requested configuration setting:
+	switch arg {
+	case "access_token":
+		fmt.Fprintf(Writer, "%s\n", cfg.AccessToken)
+	case "client_id":
+		fmt.Fprintf(Writer, "%s\n", cfg.ClientID)
+	case "client_secret":
+		fmt.Fprintf(Writer, "%s\n", cfg.ClientSecret)
+	case "insecure":
+		fmt.Fprintf(Writer, "%v\n", cfg.Insecure)
+	case "refresh_token":
+		fmt.Fprintf(Writer, "%s\n", cfg.RefreshToken)
+	case "scopes":
+		fmt.Fprintf(Writer, "%s\n", cfg.Scopes)
+	case "token_url":
+		fmt.Fprintf(Writer, "%s\n", cfg.TokenURL)
+	case "url":
+		fmt.Fprintf(Writer, "%s\n", cfg.URL)
+	case "fedramp":
+		fmt.Fprintf(Writer, "%v\n", cfg.FedRAMP)
+	default:
+		err := fmt.Errorf("Unknown setting")
+		return err
+	}
+	return nil
+}

--- a/cmd/config/set/set.go
+++ b/cmd/config/set/set.go
@@ -1,0 +1,120 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package set
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/config"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+var args struct {
+	debug bool
+}
+
+var Cmd = NewConfigCommand()
+
+func NewConfigCommand() *cobra.Command {
+	Cmd := &cobra.Command{
+		Use:   "set [flags] VARIABLE VALUE",
+		Short: "Sets the variable's value",
+		Long:  "Sets the value of a config variable. See 'rosa config --help' for supported config variables.",
+		Args:  cobra.ExactArgs(2),
+		Run:   run,
+	}
+	flags := Cmd.Flags()
+	flags.BoolVar(
+		&args.debug,
+		"debug",
+		false,
+		"Enable debug mode.",
+	)
+	return Cmd
+}
+
+func run(cmd *cobra.Command, argv []string) {
+	r := rosa.NewRuntime()
+
+	err := SaveConfig(argv[0], argv[1])
+	if err != nil {
+		r.Reporter.Errorf(err.Error())
+		os.Exit(1)
+	}
+}
+
+func SaveConfig(arg, value string) error {
+	// Load the configuration:
+	cfg, err := config.Load()
+	if err != nil {
+		err := fmt.Errorf("Config file doesn't exist yet")
+		return err
+	}
+
+	// Create an empty configuration if the configuration file doesn't exist:
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+
+	// Copy the value given in the command line to the configuration:
+	switch arg {
+	case "access_token":
+		cfg.AccessToken = value
+	case "client_id":
+		cfg.ClientID = value
+	case "client_secret":
+		cfg.ClientSecret = value
+	case "insecure":
+		cfg.Insecure, err = strconv.ParseBool(value)
+		if err != nil {
+			err := fmt.Errorf("Failed to set insecure: %v", value)
+			return err
+		}
+	case "refresh_token":
+		cfg.RefreshToken = value
+	case "scopes":
+		err := errors.New("Setting scopes is unsupported")
+		return err
+	case "token_url":
+		cfg.TokenURL = value
+	case "url":
+		cfg.URL = value
+	case "fedramp":
+		cfg.FedRAMP, err = strconv.ParseBool(value)
+		if err != nil {
+			err := fmt.Errorf("Failed to set fedramp: %v", value)
+			return err
+		}
+	default:
+		err := errors.New("Unknown setting")
+		return err
+	}
+
+	// Save the configuration:
+	err = config.Save(cfg)
+	if err != nil {
+		err := fmt.Errorf("Can't save config file: %v", err)
+		return err
+	}
+
+	return nil
+}

--- a/cmd/config/set/set.go
+++ b/cmd/config/set/set.go
@@ -21,35 +21,22 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/pkg/config"
 	"github.com/openshift/rosa/pkg/rosa"
 )
 
-var args struct {
-	debug bool
-}
+var Cmd = NewConfigSetCommand()
 
-var Cmd = NewConfigCommand()
-
-func NewConfigCommand() *cobra.Command {
-	Cmd := &cobra.Command{
+func NewConfigSetCommand() *cobra.Command {
+	return &cobra.Command{
 		Use:   "set [flags] VARIABLE VALUE",
 		Short: "Sets the variable's value",
 		Long:  "Sets the value of a config variable. See 'rosa config --help' for supported config variables.",
 		Args:  cobra.ExactArgs(2),
 		Run:   run,
 	}
-	flags := Cmd.Flags()
-	flags.BoolVar(
-		&args.debug,
-		"debug",
-		false,
-		"Enable debug mode.",
-	)
-	return Cmd
 }
 
 func run(cmd *cobra.Command, argv []string) {
@@ -66,8 +53,7 @@ func SaveConfig(arg, value string) error {
 	// Load the configuration:
 	cfg, err := config.Load()
 	if err != nil {
-		err := fmt.Errorf("Config file doesn't exist yet")
-		return err
+		return fmt.Errorf("Config file doesn't exist yet")
 	}
 
 	// Create an empty configuration if the configuration file doesn't exist:
@@ -86,14 +72,12 @@ func SaveConfig(arg, value string) error {
 	case "insecure":
 		cfg.Insecure, err = strconv.ParseBool(value)
 		if err != nil {
-			err := fmt.Errorf("Failed to set insecure: %v", value)
-			return err
+			return fmt.Errorf("Failed to set insecure: %v", value)
 		}
 	case "refresh_token":
 		cfg.RefreshToken = value
 	case "scopes":
-		err := errors.New("Setting scopes is unsupported")
-		return err
+		return fmt.Errorf("Setting scopes is unsupported")
 	case "token_url":
 		cfg.TokenURL = value
 	case "url":
@@ -101,19 +85,16 @@ func SaveConfig(arg, value string) error {
 	case "fedramp":
 		cfg.FedRAMP, err = strconv.ParseBool(value)
 		if err != nil {
-			err := fmt.Errorf("Failed to set fedramp: %v", value)
-			return err
+			return fmt.Errorf("Failed to set fedramp: %v", value)
 		}
 	default:
-		err := errors.New("Unknown setting")
-		return err
+		return fmt.Errorf("'%s' is not a supported setting", arg)
 	}
 
 	// Save the configuration:
 	err = config.Save(cfg)
 	if err != nil {
-		err := fmt.Errorf("Can't save config file: %v", err)
-		return err
+		return fmt.Errorf("Can't save config file: %v", err)
 	}
 
 	return nil

--- a/cmd/rosa/main.go
+++ b/cmd/rosa/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/cmd/completion"
+	"github.com/openshift/rosa/cmd/config"
 	"github.com/openshift/rosa/cmd/create"
 	"github.com/openshift/rosa/cmd/describe"
 	"github.com/openshift/rosa/cmd/dlt"
@@ -42,6 +43,7 @@ import (
 	"github.com/openshift/rosa/cmd/register"
 	"github.com/openshift/rosa/cmd/resume"
 	"github.com/openshift/rosa/cmd/revoke"
+	"github.com/openshift/rosa/cmd/token"
 	"github.com/openshift/rosa/cmd/uninstall"
 	"github.com/openshift/rosa/cmd/unlink"
 	"github.com/openshift/rosa/cmd/upgrade"
@@ -92,6 +94,8 @@ func init() {
 	root.AddCommand(resume.GenerateCommand())
 	root.AddCommand(link.Cmd)
 	root.AddCommand(unlink.Cmd)
+	root.AddCommand(token.Cmd)
+	root.AddCommand(config.Cmd)
 }
 
 func main() {

--- a/cmd/token/cmd.go
+++ b/cmd/token/cmd.go
@@ -1,0 +1,173 @@
+package token
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/config"
+	"github.com/openshift/rosa/pkg/output"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+var (
+	writer io.Writer = os.Stdout
+	args   struct {
+		header    bool
+		payload   bool
+		signature bool
+		refresh   bool
+		generate  bool
+	}
+)
+
+var Cmd = NewTokenCommand()
+
+func NewTokenCommand() *cobra.Command {
+	Cmd := &cobra.Command{
+		Use:   "token",
+		Short: "Generates a token",
+		Long:  "Uses the stored credentials to generate a token.",
+		Args:  cobra.NoArgs,
+		Run:   run,
+	}
+	flags := Cmd.Flags()
+	flags.BoolVar(
+		&args.payload,
+		"payload",
+		false,
+		"Print the JSON payload.",
+	)
+	flags.BoolVar(
+		&args.header,
+		"header",
+		false,
+		"Print the JSON header.",
+	)
+	flags.BoolVar(
+		&args.signature,
+		"signature",
+		false,
+		"Print the signature.",
+	)
+	flags.BoolVar(
+		&args.refresh,
+		"refresh",
+		false,
+		"Print the refresh token instead of the access token.",
+	)
+	flags.BoolVar(
+		&args.generate,
+		"generate",
+		false,
+		"Generate a new token.",
+	)
+	output.AddFlag(Cmd)
+	return Cmd
+}
+
+func run(cmd *cobra.Command, argv []string) {
+	r := rosa.NewRuntime().WithOCM()
+	defer r.Cleanup()
+	var accessToken string
+	var refreshToken string
+	var err error
+	// Check the options:
+	count := 0
+	if args.header {
+		count++
+	}
+	if args.payload {
+		count++
+	}
+	if args.signature {
+		count++
+	}
+	if args.generate {
+		count++
+	}
+
+	if count > 1 {
+		r.Reporter.Errorf("Options '--payload', '--header', '--signature', and '--generate' are mutually exclusive")
+		os.Exit(1)
+	}
+
+	if args.generate {
+		// Get new tokens:
+		accessToken, refreshToken, err = r.OCMClient.GetConnectionTokens(15 * time.Minute)
+		if err != nil {
+			r.Reporter.Errorf("Can't get new tokens: %v", err)
+			os.Exit(1)
+		}
+	} else {
+		// Get the tokens:
+		accessToken, refreshToken, err = r.OCMClient.GetConnectionTokens()
+		if err != nil {
+			r.Reporter.Errorf("Can't get token: %v", err)
+			os.Exit(1)
+		}
+	}
+
+	// Select the token according to the options:
+	selectedToken := accessToken
+	if args.refresh {
+		selectedToken = refreshToken
+	}
+
+	// Parse the token:
+	parser := new(jwt.Parser)
+	fmt.Println(refreshToken)
+	_, parts, err := parser.ParseUnverified(selectedToken, jwt.MapClaims{})
+	if err != nil {
+		r.Reporter.Errorf("Can't parse token: %v", err)
+		os.Exit(1)
+	}
+	encoding := base64.RawURLEncoding
+	header, err := encoding.DecodeString(parts[0])
+	if err != nil {
+		r.Reporter.Errorf("Can't decode header: %v", err)
+		os.Exit(1)
+	}
+	payload, err := encoding.DecodeString(parts[1])
+	if err != nil {
+		r.Reporter.Errorf("Can't decode payload: %v", err)
+		os.Exit(1)
+	}
+	signature, err := encoding.DecodeString(parts[2])
+	if err != nil {
+		r.Reporter.Errorf("Can't decode signature: %v", err)
+		os.Exit(1)
+	}
+
+	// Print the data:
+	if args.header {
+		fmt.Fprintf(writer, "%s\n", header)
+	} else if args.payload {
+		fmt.Fprintf(writer, "%s\n", payload)
+	} else if args.signature {
+		fmt.Fprintf(writer, "%s\n", signature)
+	} else {
+		fmt.Fprintf(writer, "%s\n", selectedToken)
+	}
+
+	// Load the configuration file:
+	cfg, err := config.Load()
+	if err != nil {
+		r.Reporter.Errorf("Can't load config file: %v", err)
+		os.Exit(1)
+	}
+
+	// Save the configuration:
+	cfg.AccessToken = accessToken
+	cfg.RefreshToken = refreshToken
+	err = config.Save(cfg)
+	if err != nil {
+		r.Reporter.Errorf("Can't save config file: %v", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/token/cmd_test.go
+++ b/cmd/token/cmd_test.go
@@ -1,0 +1,78 @@
+package token
+
+import (
+	"bytes"
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/ghttp"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+
+	"github.com/openshift/rosa/cmd/config/set"
+)
+
+func TestTokenCommand(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "rosa token command")
+}
+
+var _ = Describe("Token", Ordered, func() {
+	var buf *bytes.Buffer
+	var tmpdir string
+	var err error
+	var ssoServer *Server
+
+	BeforeAll(func() {
+		tmpdir, err = os.MkdirTemp("/tmp", ".ocm-config-*")
+		Expect(err).To(BeNil())
+		os.Setenv("OCM_CONFIG", tmpdir+"/ocm_config.json")
+	})
+
+	AfterAll(func() {
+		os.Setenv("OCM_CONFIG", "")
+	})
+
+	BeforeEach(func() {
+		// Create the server
+		ssoServer = MakeTCPServer()
+	})
+
+	AfterEach(func() {
+		ssoServer.Close()
+	})
+
+	When("Logged in", func() {
+		var accessToken string
+		var refreshToken string
+
+		BeforeEach(func() {
+			buf = new(bytes.Buffer)
+			writer = buf
+			// Create the tokens:
+			accessToken = MakeTokenString("Bearer", 10*time.Minute)
+			refreshToken = MakeTokenString("Refresh", 10*time.Hour)
+			ssoServer.AppendHandlers(RespondWithAccessToken(accessToken))
+
+			err = set.SaveConfig("access_token", accessToken)
+			Expect(err).To(BeNil())
+			err = set.SaveConfig("refresh_token", refreshToken)
+			Expect(err).To(BeNil())
+			err = set.SaveConfig("token_url", ssoServer.URL())
+			Expect(err).To(BeNil())
+		})
+
+		It("Displays current access token", func() {
+			Cmd.Run(Cmd, []string{})
+			Expect(buf.String()).To(ContainSubstring(accessToken))
+		})
+
+		It("Displays current refresh token", func() {
+			args.refresh = true
+			Cmd.Run(Cmd, []string{})
+			Expect(buf.String()).To(ContainSubstring(refreshToken))
+		})
+	})
+})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,15 +35,15 @@ import (
 
 // Config is the type used to store the configuration of the client.
 type Config struct {
-	AccessToken  string   `json:"access_token,omitempty"`
-	ClientID     string   `json:"client_id,omitempty"`
-	ClientSecret string   `json:"client_secret,omitempty"`
-	Insecure     bool     `json:"insecure,omitempty"`
-	RefreshToken string   `json:"refresh_token,omitempty"`
-	Scopes       []string `json:"scopes,omitempty"`
-	TokenURL     string   `json:"token_url,omitempty"`
-	URL          string   `json:"url,omitempty"`
-	FedRAMP      bool     `json:"fedramp,omitempty"`
+	AccessToken  string   `json:"access_token,omitempty" doc:"Bearer access token."`
+	ClientID     string   `json:"client_id,omitempty" doc:"OpenID client identifier."`
+	ClientSecret string   `json:"client_secret,omitempty" doc:"OpenID client secret."`
+	Insecure     bool     `json:"insecure,omitempty" doc:"Enables insecure communication with the server."`
+	RefreshToken string   `json:"refresh_token,omitempty" doc:"Offline or refresh token."`
+	Scopes       []string `json:"scopes,omitempty" doc:"OpenID scope."`
+	TokenURL     string   `json:"token_url,omitempty" doc:"OpenID token URL."`
+	URL          string   `json:"url,omitempty" doc:"URL of the API gateway."`
+	FedRAMP      bool     `json:"fedramp,omitempty" doc:"Indicates FedRAMP."`
 }
 
 // Load loads the configuration from the configuration file. If the configuration file doesn't exist

--- a/pkg/ocm/client.go
+++ b/pkg/ocm/client.go
@@ -169,6 +169,6 @@ func (c *Client) GetConnectionURL() string {
 	return c.ocm.URL()
 }
 
-func (c *Client) GetConnectionTokens() (string, string, error) {
-	return c.ocm.Tokens()
+func (c *Client) GetConnectionTokens(expiresIn ...time.Duration) (string, string, error) {
+	return c.ocm.Tokens(expiresIn...)
 }


### PR DESCRIPTION
**Changed**
- Add token command (similar to [OCM CLI](https://github.com/openshift-online/ocm-cli/blob/main/cmd/ocm/token/cmd.go))
- Add config command with get and set subcommands (similar to [OCM CLI](https://github.com/openshift-online/ocm-cli/blob/main/cmd/ocm/config/cmd.go))