### PR TITLE
OCM-6120 | fix: mark --no-cni flag as hidden

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -709,6 +709,7 @@ func initFlags(cmd *cobra.Command) {
 		false,
 		"Disable CNI creation to let users bring their own CNI.",
 	)
+	flags.MarkHidden("no-cni")
 
 	flags.StringVar(
 		&args.clusterAdminUser,


### PR DESCRIPTION
Mark the --no-cni as hidden as we want to expose it gradually to customers