### PR TITLE
OCM-6119 | fix: block users from passing region flag when creating an oidc provider

### DIFF
--- a/cmd/create/oidcprovider/cmd.go
+++ b/cmd/create/oidcprovider/cmd.go
@@ -77,6 +77,12 @@ func run(cmd *cobra.Command, argv []string) {
 	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
 
+	if cmd.Flags().Changed("region") {
+		r.Reporter.Errorf("The '--region' flag is not available when creating the OIDC provider. " +
+			"OIDC provider is a global AWS IAM entity.")
+		os.Exit(1)
+	}
+
 	// Allow the command to be called programmatically
 	isProgmaticallyCalled := false
 	shouldUseClusterKey := true


### PR DESCRIPTION
![image](https://github.com/openshift/rosa/assets/118839428/a5390de3-051b-4916-85c7-850855c3e89a)

Indicate to users that passing / using the region flag is not allowed when creating the OIDC provider.
