### PR TITLE
OCM-6243 | fix: validate aws region within .WithAWS

### DIFF
--- a/pkg/rosa/runtime.go
+++ b/pkg/rosa/runtime.go
@@ -42,6 +42,13 @@ func (r *Runtime) WithOCM() *Runtime {
 
 // Adds an AWS client to the runtime
 func (r *Runtime) WithAWS() *Runtime {
+	// dependency to ocm client to validate the region
+	r.WithOCM()
+	err := r.OCMClient.ValidateAwsClientRegion()
+	if err != nil {
+		r.Reporter.Errorf("%v", err)
+		os.Exit(1)
+	}
 	if r.AWSClient == nil {
 		r.AWSClient = aws.CreateNewClientOrExit(r.Logger, r.Reporter)
 	}


### PR DESCRIPTION
Related issue: [OCM-6243](https://issues.redhat.com//browse/OCM-6243)

```
rosa list cluster --region avocado
E: Unsupported region 'avocado', available regions: [ap-east-1, eu-west-1, eu-west-2, eu-west-3, sa-east-1, us-east-1, us-east-2, us-west-1, us-west-2, af-south-1, ap-south-1, ap-south-2, eu-north-1, eu-south-1, eu-south-2, me-south-1, ca-central-1, eu-central-1, eu-central-2, il-central-1, me-central-1, us-gov-east-1, us-gov-west-1, ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-southeast-1, ap-southeast-2, ap-southeast-3, ap-southeast-4]
```