### PR TITLE
OCM-1012 | feat: Add filtering by config ID for `list oidc-providers`

### DIFF
--- a/cmd/list/oidcprovider/cmd.go
+++ b/cmd/list/oidcprovider/cmd.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/briandowns/spinner"
+	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/pkg/aws"
@@ -41,11 +42,23 @@ var Cmd = &cobra.Command{
 	Run: run,
 }
 
+var args struct {
+	oidcConfigId string
+}
+
 func init() {
 	flags := Cmd.Flags()
 	flags.SortFlags = false
 	output.AddFlag(Cmd)
 	ocm.AddOptionalClusterFlag(Cmd)
+
+	flags.StringVarP(
+		&args.oidcConfigId,
+		"oidc-config-id",
+		"i",
+		"",
+		"Filter by OIDC Config ID, returns one provider linked to the config ID.",
+	)
 }
 
 func run(cmd *cobra.Command, _ []string) {
@@ -66,8 +79,16 @@ func run(cmd *cobra.Command, _ []string) {
 		clusterKey := r.GetClusterKey()
 		clusterId = clusterKey
 	}
-
-	providers, err := r.AWSClient.ListOidcProviders(clusterId)
+	var config *v1.OidcConfig
+	var err error
+	if args.oidcConfigId != "" {
+		config, err = r.OCMClient.GetOidcConfig(args.oidcConfigId)
+		if err != nil {
+			r.Reporter.Errorf("Failed to get OIDC config: %v", err)
+			os.Exit(1)
+		}
+	}
+	providers, err := r.AWSClient.ListOidcProviders(clusterId, config)
 
 	if spin != nil {
 		spin.Stop()
@@ -117,17 +138,21 @@ func run(cmd *cobra.Command, _ []string) {
 	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	fmt.Fprintf(writer, "OIDC PROVIDER ARN\tCluster ID\tIn Use\n")
 	for _, provider := range providers {
-		providerInUse := "No"
-		if ok := providersInUse[provider.Arn]; ok {
-			providerInUse = "Yes"
-		}
-		fmt.Fprintf(
-			writer,
-			"%s\t%s\t%v\n",
-			provider.Arn,
-			provider.ClusterId,
-			providerInUse,
-		)
+		printProvider(writer, providersInUse, provider)
 	}
 	writer.Flush()
+}
+
+func printProvider(writer *tabwriter.Writer, providersInUse map[string]bool, provider aws.OidcProviderOutput) {
+	providerInUse := "No"
+	if ok := providersInUse[provider.Arn]; ok {
+		providerInUse = "Yes"
+	}
+	fmt.Fprintf(
+		writer,
+		"%s\t%s\t%v\n",
+		provider.Arn,
+		provider.ClusterId,
+		providerInUse,
+	)
 }

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -137,7 +137,7 @@ type Client interface {
 	ListOCMRoles() ([]Role, error)
 	ListAccountRoles(version string) ([]Role, error)
 	ListOperatorRoles(version string, clusterID string) (map[string][]OperatorRoleDetail, error)
-	ListOidcProviders(targetClusterId string) ([]OidcProviderOutput, error)
+	ListOidcProviders(targetClusterId string, config *cmv1.OidcConfig) ([]OidcProviderOutput, error)
 	GetRoleByARN(roleARN string) (*iam.Role, error)
 	DeleteOperatorRole(roles string, managedPolicies bool) error
 	GetOperatorRolesFromAccountByClusterID(

--- a/pkg/aws/mock_client.go
+++ b/pkg/aws/mock_client.go
@@ -1120,18 +1120,18 @@ func (mr *MockClientMockRecorder) ListOCMRoles() *gomock.Call {
 }
 
 // ListOidcProviders mocks base method.
-func (m *MockClient) ListOidcProviders(targetClusterId string) ([]OidcProviderOutput, error) {
+func (m *MockClient) ListOidcProviders(targetClusterId string, config *v1.OidcConfig) ([]OidcProviderOutput, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListOidcProviders", targetClusterId)
+	ret := m.ctrl.Call(m, "ListOidcProviders", targetClusterId, config)
 	ret0, _ := ret[0].([]OidcProviderOutput)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListOidcProviders indicates an expected call of ListOidcProviders.
-func (mr *MockClientMockRecorder) ListOidcProviders(targetClusterId interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) ListOidcProviders(targetClusterId, config interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOidcProviders", reflect.TypeOf((*MockClient)(nil).ListOidcProviders), targetClusterId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOidcProviders", reflect.TypeOf((*MockClient)(nil).ListOidcProviders), targetClusterId, config)
 }
 
 // ListOperatorRoles mocks base method.

--- a/pkg/aws/sts.go
+++ b/pkg/aws/sts.go
@@ -19,6 +19,7 @@ package aws
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
@@ -216,8 +217,8 @@ type OidcProviderOutput struct {
 	ClusterId string
 }
 
-func (c *awsClient) ListOidcProviders(targetClusterId string) ([]OidcProviderOutput, error) {
-	providers := []OidcProviderOutput{}
+func (c *awsClient) ListOidcProviders(targetClusterId string, config *cmv1.OidcConfig) ([]OidcProviderOutput, error) {
+	var providers []OidcProviderOutput
 	output, err := c.iamClient.ListOpenIDConnectProviders(&iam.ListOpenIDConnectProvidersInput{})
 	if err != nil {
 		return providers, err
@@ -257,6 +258,15 @@ func (c *awsClient) ListOidcProviders(targetClusterId string) ([]OidcProviderOut
 						ClusterId: clusterId,
 					})
 					return providers, nil
+				}
+			}
+			if config != nil {
+				resourceId, err := GetResourceIdFromOidcProviderARN(*provider.Arn)
+				if err != nil {
+					return nil, fmt.Errorf("unable to get resource ID from OIDC Provider's ARN. Error: '%v'", err)
+				}
+				if config == nil || !strings.Contains(config.IssuerUrl(), resourceId) {
+					skip = true
 				}
 			}
 			if skip {

--- a/pkg/aws/test_helpers.go
+++ b/pkg/aws/test_helpers.go
@@ -1,0 +1,10 @@
+package aws
+
+import cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
+func MockOidcConfig(id string, issuerUrl string) (*cmv1.OidcConfig, error) {
+	mock := cmv1.NewOidcConfig().
+		ID(id).IssuerUrl(issuerUrl)
+
+	return mock.Build()
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-1012

Lists OIDC providers by config ID (as long as that config exists in OCM)

Below are examples of the new flag:

![image](https://github.com/openshift/rosa/assets/9747105/7a5c1345-ec2d-4a4f-a1ea-316e229086f9)

