### PR TITLE
OCM-1012 | feat: Oidc Config filter + unit tests

### DIFF
--- a/cmd/list/oidcconfig/cmd.go
+++ b/cmd/list/oidcconfig/cmd.go
@@ -37,8 +37,20 @@ var Cmd = &cobra.Command{
 	Run: run,
 }
 
+var args struct {
+	oidcConfigId string
+}
+
 func init() {
 	output.AddFlag(Cmd)
+
+	Cmd.Flags().StringVarP(
+		&args.oidcConfigId,
+		"oidc-config-id",
+		"i",
+		"",
+		"Filter oidc configs by ID, or, if unmanaged, issuer URL.",
+	)
 }
 
 func run(_ *cobra.Command, _ []string) {
@@ -47,7 +59,7 @@ func run(_ *cobra.Command, _ []string) {
 
 	// Load any existing ingresses for this cluster
 	r.Reporter.Debugf("Loading oidc configs for current org id")
-	oidcConfigs, err := r.OCMClient.ListOidcConfigs(r.Creator.AccountID)
+	oidcConfigs, err := r.OCMClient.ListOidcConfigs(r.Creator.AccountID, args.oidcConfigId)
 	if err != nil {
 		r.Reporter.Errorf("Failed to list OIDC Configurations: %v", err)
 		os.Exit(1)

--- a/pkg/interactive/oidc/oidc.go
+++ b/pkg/interactive/oidc/oidc.go
@@ -12,7 +12,7 @@ import (
 )
 
 func GetOidcConfigID(r *rosa.Runtime, cmd *cobra.Command) string {
-	oidcConfigs, err := r.OCMClient.ListOidcConfigs(r.Creator.AccountID)
+	oidcConfigs, err := r.OCMClient.ListOidcConfigs(r.Creator.AccountID, "")
 	if err != nil {
 		r.Reporter.Warnf("There was a problem retrieving OIDC Configurations "+
 			"for your organization: %v", err)

--- a/pkg/ocm/oidc_config_test.go
+++ b/pkg/ocm/oidc_config_test.go
@@ -1,0 +1,48 @@
+package ocm
+
+import (
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+)
+
+var _ = Describe("Test oidc config filtering", func() {
+	var configs []*v1.OidcConfig
+
+	BeforeEach(func() {
+		c1, err := v1.NewOidcConfig().ID("292929ssti8i2beq6vivt256bj0ju15dm").
+			IssuerUrl("https://test.org/292929ssti8i2beq6vivt256bj0ju15dm").Managed(true).Build()
+		Expect(err).ToNot(HaveOccurred())
+		c2, err := v1.NewOidcConfig().ID("212121ssti8i2beq6vivt256bj0ju15dm").
+			IssuerUrl("https://test2.org/212121ssti8i2beq6vivt256bj0ju15dm").Managed(true).Build()
+		Expect(err).ToNot(HaveOccurred())
+		c3, err := v1.NewOidcConfig().ID("202020ssti8i2beq6vivt256bj0ju15dm").
+			IssuerUrl("https://test3.org/202020ssti8i2beq6vivt256bj0ju15dm").Managed(false).Build()
+		Expect(err).ToNot(HaveOccurred())
+		c4, err := v1.NewOidcConfig().ID("151515ssti8i2beq6vivt256bj0ju15dm").
+			IssuerUrl("https://test4.org/151515ssti8i2beq6vivt256bj0ju15dm").Managed(false).Build()
+		Expect(err).ToNot(HaveOccurred())
+		configs = []*v1.OidcConfig{c1, c2, c3, c4}
+	})
+
+	It("Managed filter", func() {
+		resp := filterOidcConfigs(configs, "292929")
+		Expect(len(resp)).To(Equal(1))
+		resp = filterOidcConfigs(configs, "212121")
+		Expect(len(resp)).To(Equal(1))
+		resp = filterOidcConfigs(configs, "ssti8i")
+		Expect(len(resp)).To(Equal(4))
+	})
+	It("Unmanaged filter", func() {
+		resp := filterOidcConfigs(configs, "test3")
+		Expect(len(resp)).To(Equal(1))
+		resp = filterOidcConfigs(configs, "test4")
+		Expect(len(resp)).To(Equal(1))
+		resp = filterOidcConfigs(configs, "test")
+		Expect(len(resp)).To(Equal(2))
+	})
+	It("No filter", func() {
+		resp := filterOidcConfigs(configs, "")
+		Expect(len(resp)).To(Equal(4))
+	})
+})


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-1012

Filters based on OCM UUID if managed, and if unmanaged, filters based on issuer URL

Automatically determines which one to filter depending on each individual oidc config, so you can search both managed and unmanaged with the same flag.