### PR TITLE
OCM-6322 | feat: Create cluster with additional SGs

### DIFF
--- a/cmd/create/cluster/cmd_test.go
+++ b/cmd/create/cluster/cmd_test.go
@@ -13,6 +13,7 @@ import (
 	v1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/rosa/pkg/interactive/securitygroups"
 	"github.com/openshift/rosa/pkg/logging"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
@@ -401,6 +402,35 @@ var _ = Describe("validateBillingAccount()", func() {
 			" To see the list of billing account options, you can use interactive mode by passing '-i'."))
 	})
 
+})
+
+var _ = Describe("Validate machine type for additional security groups based on topology", func() {
+	It("Allows setting security groups for compute kind", func() {
+		err := validateKindForHcp(securitygroups.ComputeKind, true)
+		Expect(err).ToNot(HaveOccurred())
+	})
+	It("Rejects updating kind for control plane kind", func() {
+		err := validateKindForHcp(securitygroups.ControlPlaneKind, true)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("is not supported for Hosted Control Plane clusters"))
+	})
+	It("Rejects updating kind for infra kind", func() {
+		err := validateKindForHcp(securitygroups.InfraKind, true)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("is not supported for Hosted Control Plane clusters"))
+	})
+	It("Allows setting kind for compute kind for classic", func() {
+		err := validateKindForHcp(securitygroups.ComputeKind, false)
+		Expect(err).ToNot(HaveOccurred())
+	})
+	It("Allows setting kind for infra kind for classic", func() {
+		err := validateKindForHcp(securitygroups.InfraKind, false)
+		Expect(err).ToNot(HaveOccurred())
+	})
+	It("Allows setting kind for control plane kind for classic", func() {
+		err := validateKindForHcp(securitygroups.ControlPlaneKind, false)
+		Expect(err).ToNot(HaveOccurred())
+	})
 })
 
 func mustParseCIDR(s string) *net.IPNet {


### PR DESCRIPTION
Move topology check to the backend, to keep the client as lean as possible.

```
oadler@fedora:rosa (OCM-6322)$ rosa create cluster --cluster-name oadler-feb-22 --sts --role-arn arn:aws:iam::765374464689:role/ManagedOpenShift-HCP-ROSA-Installer-Role --support-role-arn arn:aws:iam::765374464689:role/ManagedOpenShift-HCP-ROSA-Support-Role --worker-iam-role arn:aws:iam::765374464689:role/ManagedOpenShift-HCP-ROSA-Worker-Role --operator-roles-prefix oadler-feb-22-g2p5 --oidc-config-id 26letu8scfhqd739be7h2fugkteidqpk --region us-west-2 --version 4.14.6 --replicas 2 --compute-machine-type m5.xlarge --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23 --subnet-ids subnet-0147b43f80bd4a1a4,subnet-0c4066fd979eceb8a --hosted-cp --additional-compute-security-group-ids 123 --billing-account 765374464689
I: Creating cluster 'oadler-feb-22'
I: To view a list of clusters and their status, run 'rosa list clusters'
E: Failed to create cluster: Setting 'Additional Security Groups' is not supported for Hosted Control Plane clusters
```
