### PR TITLE
OCM-6055 | feat: describe node pools with additional security groups

### DIFF
--- a/cmd/describe/machinepool/cmd_test.go
+++ b/cmd/describe/machinepool/cmd_test.go
@@ -11,6 +11,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	. "github.com/openshift-online/ocm-sdk-go/testing"
 
+	"github.com/openshift/rosa/pkg/ocm/output"
 	"github.com/openshift/rosa/pkg/test"
 )
 
@@ -31,6 +32,7 @@ Version:                    4.12.24
 Autorepair:                 No
 Tuning configs:             
 Message:                    
+Security Group IDs:         
 `
 	describeStringWithUpgradeOutput = `
 ID:                         nodepool85
@@ -47,6 +49,7 @@ Version:                    4.12.24
 Autorepair:                 No
 Tuning configs:             
 Message:                    
+Security Group IDs:         
 Scheduled upgrade:          scheduled 4.12.25 on 2023-08-07 15:22 UTC
 `
 
@@ -237,6 +240,21 @@ var _ = Describe("Upgrade machine pool", func() {
 				Expect(err).To(BeNil())
 				Expect(stdout).To(Equal(describeClassicStringOutput))
 				Expect(stderr).To(BeEmpty())
+			})
+			It("Format AWS additional security groups if exist", func() {
+				securityGroupsIds := []string{"123", "321"}
+				awsNodePool, err := cmv1.NewAWSNodePool().AdditionalSecurityGroupIds(securityGroupsIds...).Build()
+				Expect(err).ToNot(HaveOccurred())
+
+				securityGroupsOutput := output.PrintNodePoolAdditionalSecurityGroups(awsNodePool)
+				Expect(securityGroupsOutput).To(Equal("123, 321"))
+			})
+			It("Return an empty list for additional security groups if empty AWS node pool is passed", func() {
+				awsNodePool, err := cmv1.NewAWSNodePool().Build()
+				Expect(err).ToNot(HaveOccurred())
+
+				securityGroupsOutput := output.PrintNodePoolAdditionalSecurityGroups(awsNodePool)
+				Expect(securityGroupsOutput).To(Equal(""))
 			})
 			It("Pass a machine pool name through parameter and it is found. yaml output", func() {
 				args.machinePool = nodePoolName

--- a/cmd/describe/machinepool/nodepool.go
+++ b/cmd/describe/machinepool/nodepool.go
@@ -51,7 +51,8 @@ func describeNodePool(r *rosa.Runtime, cluster *cmv1.Cluster, clusterKey string,
 		"Version:                    %s\n"+
 		"Autorepair:                 %s\n"+
 		"Tuning configs:             %s\n"+
-		"Message:                    %s\n",
+		"Message:                    %s\n"+
+		"Security Group IDs:         %s\n",
 		nodePool.ID(),
 		cluster.ID(),
 		ocmOutput.PrintNodePoolAutoscaling(nodePool.Autoscaling()),
@@ -66,6 +67,7 @@ func describeNodePool(r *rosa.Runtime, cluster *cmv1.Cluster, clusterKey string,
 		ocmOutput.PrintNodePoolAutorepair(nodePool.AutoRepair()),
 		ocmOutput.PrintNodePoolTuningConfigs(nodePool.TuningConfigs()),
 		ocmOutput.PrintNodePoolMessage(nodePool.Status()),
+		ocmOutput.PrintNodePoolAdditionalSecurityGroups(nodePool.AWSNodePool()),
 	)
 
 	// Print scheduled upgrades if existing

--- a/pkg/ocm/output/nodepools.go
+++ b/pkg/ocm/output/nodepools.go
@@ -48,6 +48,14 @@ func PrintNodePoolInstanceType(aws *cmv1.AWSNodePool) string {
 	return aws.InstanceType()
 }
 
+func PrintNodePoolAdditionalSecurityGroups(aws *cmv1.AWSNodePool) string {
+	if aws == nil {
+		return ""
+	}
+
+	return PrintStringSlice(aws.AdditionalSecurityGroupIds())
+}
+
 func PrintNodePoolCurrentReplicas(status *cmv1.NodePoolStatus) string {
 	if status != nil {
 		return fmt.Sprintf("%d", status.CurrentReplicas())


### PR DESCRIPTION
Print additional security group IDs if available.

e.g.
```
oadler@fedora:rosa (OCM-6055)$ rosa describe machinepool -c 29id32fv1u4mjav5jqkd4d9n6k7o9e9v test10

ID:                         test10
Cluster ID:                 29id32fv1u4mjav5jqkd4d9n6k7o9e9v
Autoscaling:                No
Desired replicas:           1
Current replicas:           1
Instance type:              m5.xlarge
Labels:                     
Taints:                     
Availability zone:          us-west-2a
Subnet:                     subnet-0e3a4046c1c2f1078
Version:                    4.14.6
Autorepair:                 Yes
Tuning configs:             
Message:                    
Security Group IDs:         sg-099ede74e05b84790, sg-0061db738d1f88702, sg-0087541ff27d09d6b
```
