### PR TITLE
OCM-5963 | fix: align error messages for billing accounts

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1049,7 +1049,8 @@ func run(cmd *cobra.Command, _ []string) {
 		if !isHcpBillingTechPreview {
 
 			if billingAccount != "" && !ocm.IsValidAWSAccount(billingAccount) {
-				r.Reporter.Errorf("Billing account is invalid. Run the command again with a valid billing account.")
+				r.Reporter.Errorf("Billing account is invalid. Run the command again with a valid billing account. %s",
+					listBillingAccountMessage)
 				os.Exit(1)
 			}
 
@@ -3258,7 +3259,7 @@ func clusterConfigFor(
 
 func validateBillingAccount(billingAccount string) error {
 	if billingAccount == "" || !ocm.IsValidAWSAccount(billingAccount) {
-		return fmt.Errorf("Billing account is invalid. Run the command again with a valid billing account. %s",
+		return fmt.Errorf("billing account is invalid. Run the command again with a valid billing account. %s",
 			listBillingAccountMessage)
 	}
 	return nil

--- a/cmd/create/cluster/cmd_test.go
+++ b/cmd/create/cluster/cmd_test.go
@@ -389,7 +389,7 @@ var _ = Describe("validateBillingAccount()", func() {
 		wrongBillingAccount := "123"
 		err := validateBillingAccount(wrongBillingAccount)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal("Billing account is invalid. Run the command again with a valid billing account." +
+		Expect(err.Error()).To(Equal("billing account is invalid. Run the command again with a valid billing account." +
 			" To see the list of billing account options, you can use interactive mode by passing '-i'."))
 	})
 
@@ -397,7 +397,7 @@ var _ = Describe("validateBillingAccount()", func() {
 		wrongBillingAccount := ""
 		err := validateBillingAccount(wrongBillingAccount)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal("Billing account is invalid. Run the command again with a valid billing account." +
+		Expect(err.Error()).To(Equal("billing account is invalid. Run the command again with a valid billing account." +
 			" To see the list of billing account options, you can use interactive mode by passing '-i'."))
 	})
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-5963

```
./rosa create cluster -c tzhou --hosted-cp --billing-account 123
E: Billing account is invalid. Run the command again with a valid billing account. To see the list of billing account options, you can use interactive mode by passing '-i'.
```