### PR TITLE
OCM-6279 | fix: Temporarily remove build output from rosa version command

### DIFF
--- a/cmd/version/cmd.go
+++ b/cmd/version/cmd.go
@@ -80,7 +80,7 @@ func run(cmd *cobra.Command, _ []string) {
 }
 
 func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
-	fmt.Fprintf(os.Stdout, "%s (Build: %s)\n", info.Version, info.Build)
+	fmt.Fprintf(os.Stdout, "%s\n", info.Version)
 	if args.verbose {
 		fmt.Fprintf(os.Stdout, "Information and download locations:\n\t%s\n\t%s\n",
 			verify.ConsoleLatestFolder,

--- a/cmd/version/cmd_test.go
+++ b/cmd/version/cmd_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Run Command", func() {
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(stderr).To(BeEmpty())
-		Expect(stdout).To(ContainSubstring("%s (Build: %s)\n", info.Version, info.Build))
+		Expect(stdout).To(ContainSubstring("%s\n", info.Version))
 		Expect(delegateInvokeCount).To(Equal(0))
 	})
 
@@ -55,7 +55,7 @@ var _ = Describe("Run Command", func() {
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(stderr).To(BeEmpty())
-		Expect(stdout).To(ContainSubstring("%s (Build: %s)\n", info.Version, info.Build))
+		Expect(stdout).To(ContainSubstring("%s\n", info.Version))
 		Expect(delegateInvokeCount).To(Equal(1))
 	})
 
@@ -67,9 +67,9 @@ var _ = Describe("Run Command", func() {
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(stderr).To(BeEmpty())
-		Expect(stdout).To(ContainSubstring("%s (Build: %s)\n"+
+		Expect(stdout).To(ContainSubstring("%s\n"+
 			"Information and download locations:\n\t%s\n\t%s\n",
-			info.Version, info.Build,
+			info.Version,
 			verify.ConsoleLatestFolder,
 			verify.DownloadLatestMirrorFolder,
 		))


### PR DESCRIPTION
This PR temporarily removes the `(Build: $GIT_SHA)` output from the `rosa version` command due to the fact that we are not reliably setting this on internal build systems for productised releases. We need to align on our approach throughout all build systems to ensure this is applied consistently, but for now, we remove the output from `rosa version` to reduce confusion for our customers.