### PR TITLE
OCM-1469 | fix: Fail commands when unknown arguments are passed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ verify: fmt
 clean:
 	rm -rf \
 		./cover.out \
+		rosa \
 		rosa-darwin-amd64 \
 		rosa-darwin-arm64 \
 		rosa-linux-amd64 \

--- a/cmd/config/cmd.go
+++ b/cmd/config/cmd.go
@@ -65,6 +65,7 @@ func NewConfigCommand() *cobra.Command {
 		Use:   "config COMMAND VARIABLE",
 		Short: "get or set configuration variables",
 		Long:  longHelp(),
+		Args:  cobra.NoArgs,
 	}
 	Cmd.AddCommand(get.Cmd)
 	Cmd.AddCommand(set.Cmd)

--- a/cmd/config/get/get.go
+++ b/cmd/config/get/get.go
@@ -43,7 +43,7 @@ func NewConfigGetCommand() *cobra.Command {
 	}
 }
 
-func run(cmd *cobra.Command, argv []string) {
+func run(_ *cobra.Command, argv []string) {
 	r := rosa.NewRuntime()
 
 	err := PrintConfig(argv[0])

--- a/cmd/config/set/set.go
+++ b/cmd/config/set/set.go
@@ -39,7 +39,7 @@ func NewConfigSetCommand() *cobra.Command {
 	}
 }
 
-func run(cmd *cobra.Command, argv []string) {
+func run(_ *cobra.Command, argv []string) {
 	r := rosa.NewRuntime()
 
 	err := SaveConfig(argv[0], argv[1])

--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -54,7 +54,8 @@ var Cmd = &cobra.Command{
 
   # Create account roles with a specific permissions boundary
   rosa create account-roles --permissions-boundary arn:aws:iam::123456789012:policy/perm-boundary`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/create/admin/cmd.go
+++ b/cmd/create/admin/cmd.go
@@ -40,7 +40,8 @@ var Cmd = &cobra.Command{
 	Long:  "Creates a cluster-admin user with an auto-generated password to login to the cluster",
 	Example: `  # Create an admin user to login to the cluster
   rosa create admin -c mycluster -p MasterKey123`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 var args struct {
@@ -60,7 +61,7 @@ func init() {
 	output.AddFlag(Cmd)
 }
 
-func run(cmd *cobra.Command, _ []string) {
+func run(_ *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
 

--- a/cmd/create/autoscaler/cmd.go
+++ b/cmd/create/autoscaler/cmd.go
@@ -47,7 +47,8 @@ var Cmd = &cobra.Command{
 
   # Create a cluster-autoscaler with total CPU constraints
   rosa create autoscaler --cluster=mycluster --min-cores 10 --max-cores 100`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 var autoscalerArgs *clusterautoscaler.AutoscalerArgs

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -234,7 +234,8 @@ func makeCmd() *cobra.Command {
 
   # Create a cluster in the us-east-2 region
   rosa create cluster --cluster-name=mycluster --region=us-east-2`,
-		Run: run,
+		Run:  run,
+		Args: cobra.NoArgs,
 	}
 }
 

--- a/cmd/create/cmd.go
+++ b/cmd/create/cmd.go
@@ -43,6 +43,7 @@ var Cmd = &cobra.Command{
 	Aliases: []string{"add"},
 	Short:   "Create a resource from stdin",
 	Long:    "Create a resource from stdin",
+	Args:    cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/create/dnsdomains/cmd.go
+++ b/cmd/create/dnsdomains/cmd.go
@@ -32,10 +32,11 @@ var Cmd = &cobra.Command{
 	Long:    "Create DNS Domain.",
 	Example: `  # Create DNS Domain
 	rosa create dns-domain`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
-func run(cmd *cobra.Command, _ []string) {
+func run(_ *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithOCM()
 	defer r.Cleanup()
 

--- a/cmd/create/idp/cmd.go
+++ b/cmd/create/idp/cmd.go
@@ -96,7 +96,8 @@ var Cmd = &cobra.Command{
 
   # Add an identity provider following interactive prompts
   rosa create idp --cluster=mycluster --interactive`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/create/kubeletconfig/cmd.go
+++ b/cmd/create/kubeletconfig/cmd.go
@@ -38,7 +38,8 @@ var Cmd = &cobra.Command{
 	Example: `  # Create a custom kubeletconfig with a pod-pids-limit of 5000
   rosa create kubeletconfig --cluster=mycluster --pod-pids-limit=5000
   `,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 var args struct {

--- a/cmd/create/machinepool/cmd.go
+++ b/cmd/create/machinepool/cmd.go
@@ -79,7 +79,8 @@ var Cmd = &cobra.Command{
   # Add a machine pool with spot instances to a cluster
   rosa create machinepool -c mycluster --name=mp-1 --replicas=2 --instance-type=r5.2xlarge --use-spot-instances \
     --spot-max-price=0.5`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/create/ocmrole/cmd.go
+++ b/cmd/create/ocmrole/cmd.go
@@ -53,7 +53,8 @@ var Cmd = &cobra.Command{
 
   # Create ocm role with a specific permissions boundary
   rosa create ocm-role --permissions-boundary arn:aws:iam::123456789012:policy/perm-boundary`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {
@@ -107,7 +108,7 @@ func init() {
 	interactive.AddFlag(flags)
 }
 
-func run(cmd *cobra.Command, argv []string) {
+func run(cmd *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
 

--- a/cmd/create/oidcconfig/cmd.go
+++ b/cmd/create/oidcconfig/cmd.go
@@ -60,7 +60,8 @@ var Cmd = &cobra.Command{
 		"It also creates a Secret in Secrets Manager containing the private key.",
 	Example: `  # Create OIDC config
 	rosa create oidc-config`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 const (
@@ -133,7 +134,7 @@ func checkInteractiveModeNeeded(cmd *cobra.Command) {
 	}
 }
 
-func run(cmd *cobra.Command, argv []string) {
+func run(cmd *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
 

--- a/cmd/create/oidcprovider/cmd.go
+++ b/cmd/create/oidcprovider/cmd.go
@@ -43,7 +43,8 @@ var Cmd = &cobra.Command{
 	Long:    "Create OIDC provider for operators to authenticate against in an STS cluster.",
 	Example: `  # Create OIDC provider for cluster named "mycluster"
   rosa create oidc-provider --cluster=mycluster`,
-	Run: run,
+	Run:  run,
+	Args: cobra.MaximumNArgs(3),
 }
 
 const (

--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -58,7 +58,8 @@ var Cmd = &cobra.Command{
 
   # Create operator roles with a specific permissions boundary
   rosa create operator-roles -c mycluster --permissions-boundary arn:aws:iam::123456789012:policy/perm-boundary`,
-	Run: run,
+	Run:  run,
+	Args: cobra.MaximumNArgs(3),
 }
 
 func init() {

--- a/cmd/create/tuningconfigs/cmd.go
+++ b/cmd/create/tuningconfigs/cmd.go
@@ -41,7 +41,8 @@ var Cmd = &cobra.Command{
 	Long:    "Add a tuning config to a cluster.",
 	Example: `  # Add a tuning config with name "tuned1" and spec from a file "file1" to a cluster named "mycluster"
  rosa create tuning-config --name=tuned1 --spec-path=file1 --cluster=mycluster"`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/create/userrole/cmd.go
+++ b/cmd/create/userrole/cmd.go
@@ -52,7 +52,8 @@ var Cmd = &cobra.Command{
 
   # Create user role with a specific permissions boundary
   rosa create user-role --permissions-boundary arn:aws:iam::123456789012:policy/perm-boundary`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {
@@ -82,7 +83,7 @@ func init() {
 	interactive.AddFlag(flags)
 }
 
-func run(cmd *cobra.Command, argv []string) {
+func run(cmd *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
 

--- a/cmd/describe/admin/cmd.go
+++ b/cmd/describe/admin/cmd.go
@@ -33,14 +33,15 @@ var Cmd = &cobra.Command{
 	Long:  "Show details of the cluster-admin user and a command to login to the cluster",
 	Example: `  # Describe cluster-admin user of a cluster named mycluster
   rosa describe admin -c mycluster`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {
 	ocm.AddClusterFlag(Cmd)
 }
 
-func run(cmd *cobra.Command, _ []string) {
+func run(_ *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
 

--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -50,7 +50,8 @@ var Cmd = &cobra.Command{
 	Long:  "Show details of a cluster",
 	Example: `  # Describe a cluster named "mycluster"
   rosa describe cluster --cluster=mycluster`,
-	Run: run,
+	Run:  run,
+	Args: cobra.MaximumNArgs(1),
 }
 
 func init() {

--- a/cmd/describe/cmd.go
+++ b/cmd/describe/cmd.go
@@ -35,6 +35,7 @@ var Cmd = &cobra.Command{
 	Use:   "describe",
 	Short: "Show details of a specific resource",
 	Long:  "Show details of a specific resource",
+	Args:  cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/describe/installation/cmd.go
+++ b/cmd/describe/installation/cmd.go
@@ -34,7 +34,8 @@ var Cmd = &cobra.Command{
 	Long:    "Show details of an add-on installation",
 	Example: `  # Describe the 'bar' add-on installation on cluster 'foo'
   rosa describe addon-installation --cluster foo --addon bar`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 var args struct {
@@ -61,7 +62,7 @@ func init() {
 	)
 }
 
-func run(_ *cobra.Command, argv []string) {
+func run(_ *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
 

--- a/cmd/describe/kubeletconfig/cmd.go
+++ b/cmd/describe/kubeletconfig/cmd.go
@@ -34,7 +34,8 @@ var Cmd = &cobra.Command{
 	Long:    "Show details of the custom kubeletconfig for a cluster.",
 	Example: `  # Describe the custom kubeletconfig for cluster 'foo'
   rosa describe kubeletconfig --cluster foo`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {
@@ -42,7 +43,7 @@ func init() {
 	output.AddFlag(Cmd)
 }
 
-func run(_ *cobra.Command, argv []string) {
+func run(_ *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithOCM()
 	defer r.Cleanup()
 

--- a/cmd/describe/machinepool/cmd.go
+++ b/cmd/describe/machinepool/cmd.go
@@ -35,7 +35,8 @@ var Cmd = &cobra.Command{
 	Long:    "Show details of a machine pool on a cluster.",
 	Example: `  # Show details of a machine pool named "mymachinepool"" on a cluster named "mycluster"
   rosa describe machinepool --cluster=mycluster --machinepool=mymachinepool`,
-	Run: run,
+	Run:  run,
+	Args: cobra.MaximumNArgs(1),
 }
 
 var args struct {

--- a/cmd/describe/service/cmd.go
+++ b/cmd/describe/service/cmd.go
@@ -37,6 +37,7 @@ var Cmd = &cobra.Command{
   rosa describe managed-service --id=aaabbbccc`,
 	Run:    run,
 	Hidden: true,
+	Args:   cobra.NoArgs,
 }
 
 func init() {
@@ -50,7 +51,7 @@ func init() {
 	)
 }
 
-func run(cmd *cobra.Command, argv []string) {
+func run(cmd *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithOCM()
 	defer r.Cleanup()
 

--- a/cmd/describe/upgrade/cmd.go
+++ b/cmd/describe/upgrade/cmd.go
@@ -38,6 +38,7 @@ var Cmd = &cobra.Command{
   rosa describe upgrade`,
 	Run:    run,
 	Hidden: false,
+	Args:   cobra.NoArgs,
 }
 
 var args struct {

--- a/cmd/dlt/accountroles/cmd.go
+++ b/cmd/dlt/accountroles/cmd.go
@@ -46,7 +46,8 @@ var Cmd = &cobra.Command{
 	Long:    "Cleans up account roles from the current AWS account.",
 	Example: `  # Delete Account roles"
   rosa delete account-roles -p prefix`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/dlt/admin/cmd.go
+++ b/cmd/dlt/admin/cmd.go
@@ -89,14 +89,15 @@ var Cmd = &cobra.Command{
 	Long:  "Deletes the cluster-admin user used to login to the cluster",
 	Example: `  # Delete the admin user
   rosa delete admin --cluster=mycluster`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {
 	ocm.AddClusterFlag(Cmd)
 }
 
-func run(cmd *cobra.Command, _ []string) {
+func run(_ *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
 

--- a/cmd/dlt/autoscaler/cmd.go
+++ b/cmd/dlt/autoscaler/cmd.go
@@ -32,7 +32,8 @@ var Cmd = &cobra.Command{
 	Long:  "Delete autoscaler configuration for a given cluster.",
 	Example: `  # Delete the autoscaler config for cluster named "mycluster"
   rosa delete autoscaler --cluster=mycluster`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {
@@ -40,7 +41,7 @@ func init() {
 	confirm.AddFlag(Cmd.Flags())
 }
 
-func run(cmd *cobra.Command, _ []string) {
+func run(_ *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
 

--- a/cmd/dlt/cluster/cmd.go
+++ b/cmd/dlt/cluster/cmd.go
@@ -46,7 +46,8 @@ var Cmd = &cobra.Command{
 	Long:  "Delete cluster.",
 	Example: `  # Delete a cluster named "mycluster"
   rosa delete cluster --cluster=mycluster`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {
@@ -73,7 +74,7 @@ func init() {
 	)
 }
 
-func run(cmd *cobra.Command, _ []string) {
+func run(_ *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
 

--- a/cmd/dlt/cmd.go
+++ b/cmd/dlt/cmd.go
@@ -45,6 +45,7 @@ var Cmd = &cobra.Command{
 	Aliases: []string{"remove"},
 	Short:   "Delete a specific resource",
 	Long:    "Delete a specific resource",
+	Args:    cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/dlt/kubeletconfig/cmd.go
+++ b/cmd/dlt/kubeletconfig/cmd.go
@@ -34,7 +34,8 @@ var Cmd = &cobra.Command{
 	Long:    "Delete the custom kubeletconfig for a cluster",
 	Example: `  # Delete the custom kubeletconfig for cluster 'foo'
   rosa delete kubeletconfig --cluster foo`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/dlt/ocmrole/cmd.go
+++ b/cmd/dlt/ocmrole/cmd.go
@@ -43,7 +43,8 @@ var Cmd = &cobra.Command{
 	Long:    "Delete OCM role from the current AWS organization",
 	Example: ` # Delete OCM role
 rosa delete ocm-role --role-arn arn:aws:iam::123456789012:role/xxx-OCM-Role-1223456778`,
-	Run: run,
+	Args: cobra.MaximumNArgs(1),
+	Run:  run,
 }
 
 func init() {

--- a/cmd/dlt/oidcconfig/cmd.go
+++ b/cmd/dlt/oidcconfig/cmd.go
@@ -44,7 +44,8 @@ var Cmd = &cobra.Command{
 	Long:    "Cleans up OIDC config based on registered OIDC Config ID.",
 	Example: `  # Delete OIDC config based on registered OIDC Config ID that has been supplied
 	rosa delete oidc-config --oidc-config-id <oidc_config_id>`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 const (
@@ -74,7 +75,7 @@ func init() {
 	confirm.AddFlag(flags)
 }
 
-func run(cmd *cobra.Command, argv []string) {
+func run(cmd *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
 

--- a/cmd/dlt/oidcprovider/cmd.go
+++ b/cmd/dlt/oidcprovider/cmd.go
@@ -41,7 +41,8 @@ var Cmd = &cobra.Command{
 	Long:    "Cleans up OIDC provider of deleted STS cluster.",
 	Example: `  # Delete OIDC provider for cluster named "mycluster"
   rosa delete oidc-provider --cluster=mycluster`,
-	Run: run,
+	Run:  run,
+	Args: cobra.MaximumNArgs(3),
 }
 
 const (

--- a/cmd/dlt/operatorrole/cmd.go
+++ b/cmd/dlt/operatorrole/cmd.go
@@ -49,7 +49,8 @@ var Cmd = &cobra.Command{
 	Long:    "Cleans up operator roles of deleted STS cluster.",
 	Example: `  # Delete Operator roles for cluster named "mycluster"
   rosa delete operator-roles --cluster=mycluster`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {
@@ -71,7 +72,7 @@ const (
 	hypershiftSubscriptionPlanId = "MOA-HostedControlPlane"
 )
 
-func run(cmd *cobra.Command, argv []string) {
+func run(cmd *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
 

--- a/cmd/dlt/service/cmd.go
+++ b/cmd/dlt/service/cmd.go
@@ -43,6 +43,7 @@ var Cmd = &cobra.Command{
   rosa delete managed-service --id=aabbcc`,
 	Run:    run,
 	Hidden: true,
+	Args:   cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/dlt/upgrade/cmd.go
+++ b/cmd/dlt/upgrade/cmd.go
@@ -38,6 +38,7 @@ var Cmd = &cobra.Command{
 	Short:   "Cancel cluster upgrade",
 	Long:    "Cancel scheduled cluster upgrade",
 	Run:     run,
+	Args:    cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/dlt/userrole/cmd.go
+++ b/cmd/dlt/userrole/cmd.go
@@ -42,7 +42,8 @@ var Cmd = &cobra.Command{
 	Long:    "Delete user role from the current AWS account",
 	Example: ` # Delete user role
 rosa delete user-role --role-arn {prefix}-User-{username}-Role`,
-	Run: run,
+	Run:  run,
+	Args: cobra.MaximumNArgs(1),
 }
 
 func init() {

--- a/cmd/docs/cmd.go
+++ b/cmd/docs/cmd.go
@@ -18,10 +18,13 @@ package docs
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
+
+	"github.com/openshift/rosa/pkg/rosa"
 )
 
 var args struct {
@@ -33,7 +36,8 @@ var Cmd = &cobra.Command{
 	Use:    "docs",
 	Short:  "Generates documentation files",
 	Hidden: true,
-	RunE:   run,
+	Run:    run,
+	Args:   cobra.NoArgs,
 }
 
 func init() {
@@ -56,8 +60,9 @@ func init() {
 	)
 }
 
-func run(cmd *cobra.Command, _ []string) (err error) {
+func run(cmd *cobra.Command, _ []string) {
 	cmd.Root().DisableAutoGenTag = true
+	var err error
 
 	switch args.format {
 	case "markdown":
@@ -74,11 +79,11 @@ func run(cmd *cobra.Command, _ []string) (err error) {
 		err = doc.GenReSTTree(cmd.Root(), args.dir)
 	}
 
+	r := rosa.NewRuntime()
 	if err != nil {
-		return err
+		r.Reporter.Errorf("Failed to generate documents: %v", err)
+		os.Exit(1)
 	}
 
-	fmt.Println("Documents generated successfully on", args.dir)
-
-	return
+	r.Reporter.Infof("Documents generated successfully on '%s'", args.dir)
 }

--- a/cmd/download/cmd.go
+++ b/cmd/download/cmd.go
@@ -27,6 +27,7 @@ var Cmd = &cobra.Command{
 	Use:   "download",
 	Short: "Download necessary tools for using your cluster",
 	Long:  "Download necessary tools for using your cluster",
+	Args:  cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/download/oc/cmd.go
+++ b/cmd/download/oc/cmd.go
@@ -35,7 +35,8 @@ var Cmd = &cobra.Command{
 	Long:    "Downloads to latest compatible version of the OpenShift client tools.",
 	Example: `  # Download oc client tools
   rosa download oc`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func run(cmd *cobra.Command, argv []string) {

--- a/cmd/download/rosa/cmd.go
+++ b/cmd/download/rosa/cmd.go
@@ -35,10 +35,11 @@ var Cmd = &cobra.Command{
 	Long:    "Downloads to latest compatible version of the ROSA client tools.",
 	Example: `  # Download rosa client tools
   rosa download rosa`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
-func run(cmd *cobra.Command, argv []string) {
+func run(_ *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
 
 	platform := getPlatform()

--- a/cmd/edit/autoscaler/cmd.go
+++ b/cmd/edit/autoscaler/cmd.go
@@ -49,7 +49,8 @@ var Cmd = &cobra.Command{
 
   # Edit a cluster-autoscaler with total CPU constraints
   rosa edit autoscaler --cluster=mycluster --min-cores 10 --max-cores 100`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 var autoscalerArgs *clusterautoscaler.AutoscalerArgs

--- a/cmd/edit/cluster/cmd.go
+++ b/cmd/edit/cluster/cmd.go
@@ -62,7 +62,8 @@ var Cmd = &cobra.Command{
 
   # Edit all options interactively
   rosa edit cluster -c mycluster --interactive`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/edit/cmd.go
+++ b/cmd/edit/cmd.go
@@ -37,6 +37,7 @@ var Cmd = &cobra.Command{
 	Aliases: []string{"update"},
 	Short:   "Edit a specific resource",
 	Long:    "Edit a specific resource",
+	Args:    cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/edit/kubeletconfig/cmd.go
+++ b/cmd/edit/kubeletconfig/cmd.go
@@ -38,7 +38,8 @@ var Cmd = &cobra.Command{
 	Example: `  # Edit a custom kubeletconfig to have a pod-pids-limit of 10000
   rosa edit kubeletconfig --cluster=mycluster --pod-pids-limit=10000
   `,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 var args struct {

--- a/cmd/edit/service/cmd.go
+++ b/cmd/edit/service/cmd.go
@@ -39,6 +39,7 @@ var Cmd = &cobra.Command{
 	Run:                run,
 	Hidden:             true,
 	DisableFlagParsing: true,
+	Args:               cobra.ArbitraryArgs, // Args are checked by the arguments.ParseKnownFlags function
 }
 
 func init() {

--- a/cmd/grant/cmd.go
+++ b/cmd/grant/cmd.go
@@ -27,6 +27,7 @@ var Cmd = &cobra.Command{
 	Use:   "grant",
 	Short: "Grant role to a specific resource",
 	Long:  "Grant role to a specific resource",
+	Args:  cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/hibernate/cluster/cmd.go
+++ b/cmd/hibernate/cluster/cmd.go
@@ -34,14 +34,15 @@ func GenerateCommand() *cobra.Command {
 		Long:  "Hibernate cluster.",
 		Example: `  # Hibernate the cluster
   rosa hibernate cluster -c mycluster`,
-		Run: run,
+		Run:  run,
+		Args: cobra.NoArgs,
 	}
 	ocm.AddClusterFlag(Cmd)
 	confirm.AddFlag(Cmd.Flags())
 	return Cmd
 }
 
-func run(cmd *cobra.Command, _ []string) {
+func run(_ *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
 

--- a/cmd/hibernate/cmd.go
+++ b/cmd/hibernate/cmd.go
@@ -29,6 +29,7 @@ func GenerateCommand() *cobra.Command {
 		Short:  "Hibernate cluster",
 		Long:   "Hibernate a ready cluster",
 		Hidden: true,
+		Args:   cobra.NoArgs,
 	}
 	Cmd.AddCommand(cluster.GenerateCommand())
 	flags := Cmd.PersistentFlags()

--- a/cmd/initialize/cmd.go
+++ b/cmd/initialize/cmd.go
@@ -55,7 +55,8 @@ var Cmd = &cobra.Command{
 
   # Configure a new AWS account using pre-existing OCM credentials
   rosa init --token=$OFFLINE_ACCESS_TOKEN`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/install/cmd.go
+++ b/cmd/install/cmd.go
@@ -29,6 +29,7 @@ var Cmd = &cobra.Command{
 	Use:   "install",
 	Short: "Installs a resource into a cluster",
 	Long:  "Installs a resource into a cluster",
+	Args:  cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/link/cmd.go
+++ b/cmd/link/cmd.go
@@ -31,6 +31,7 @@ var Cmd = &cobra.Command{
 	Short:   "Link OCM role to specific OCM organization",
 	Long:    "Link OCM role to specific OCM organization",
 	Hidden:  false,
+	Args:    cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/link/ocmrole/cmd.go
+++ b/cmd/link/ocmrole/cmd.go
@@ -39,7 +39,8 @@ var Cmd = &cobra.Command{
 	Long:    "Link OCM role to specific OCM organization before you create your cluster.",
 	Example: ` # Link OCM role
   rosa link ocm-role --role-arn arn:aws:iam::123456789012:role/ManagedOpenshift-OCM-Role`,
-	Run: run,
+	Run:  run,
+	Args: cobra.MaximumNArgs(1),
 }
 
 func init() {

--- a/cmd/link/userrole/cmd.go
+++ b/cmd/link/userrole/cmd.go
@@ -41,7 +41,8 @@ var Cmd = &cobra.Command{
 	Long:    "Link user role to specific OCM account before create your cluster.",
 	Example: ` # Link user roles
   rosa link user-role --role-arn arn:aws:iam::{accountid}:role/{prefix}-User-{username}-Role`,
-	Run: run,
+	Run:  run,
+	Args: cobra.MaximumNArgs(1),
 }
 
 func init() {

--- a/cmd/list/accountroles/cmd.go
+++ b/cmd/list/accountroles/cmd.go
@@ -41,7 +41,8 @@ var Cmd = &cobra.Command{
 	Long:    "List account roles and policies for the current AWS account.",
 	Example: `  # List all account roles
   rosa list account-roles`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/list/addon/cmd.go
+++ b/cmd/list/addon/cmd.go
@@ -40,7 +40,8 @@ var Cmd = &cobra.Command{
 	Long:    "List add-ons installed on a cluster.",
 	Example: `  # List all add-on installations on a cluster named "mycluster"
   rosa list addons --cluster=mycluster`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/list/cmd.go
+++ b/cmd/list/cmd.go
@@ -46,6 +46,7 @@ var Cmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all resources of a specific type",
 	Long:  "List all resources of a specific type",
+	Args:  cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/list/dnsdomains/cmd.go
+++ b/cmd/list/dnsdomains/cmd.go
@@ -39,7 +39,8 @@ var Cmd = &cobra.Command{
 	Long:    "List DNS Domains",
 	Example: `  # List all DNS Domains tied to your organization ID"
   rosa list dns-domain`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/list/gates/cmd.go
+++ b/cmd/list/gates/cmd.go
@@ -54,7 +54,9 @@ var Cmd = &cobra.Command{
 
   # List available gates for cluster upgrade version
   rosa list gates -c <cluster_id> --version 4.9.15`,
-	Run: run}
+	Run:  run,
+	Args: cobra.NoArgs,
+}
 
 func init() {
 	flags := Cmd.Flags()
@@ -96,7 +98,7 @@ var (
 	versionGates = []*v1.VersionGate{}
 )
 
-func run(cmd *cobra.Command, _ []string) {
+func run(_ *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithOCM()
 	defer r.Cleanup()
 

--- a/cmd/list/idp/cmd.go
+++ b/cmd/list/idp/cmd.go
@@ -36,7 +36,8 @@ var Cmd = &cobra.Command{
 	Long:    "List identity providers for a cluster.",
 	Example: `  # List all identity providers on a cluster named "mycluster"
   rosa list idps --cluster=mycluster`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/list/ingress/cmd.go
+++ b/cmd/list/ingress/cmd.go
@@ -38,7 +38,8 @@ var Cmd = &cobra.Command{
 	Long:    "List API and ingress endpoints for a cluster.",
 	Example: `  # List all routes on a cluster named "mycluster"
   rosa list ingresses --cluster=mycluster`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/list/instancetypes/cmd.go
+++ b/cmd/list/instancetypes/cmd.go
@@ -41,7 +41,8 @@ func makeCmd() *cobra.Command {
 		Long:    "List Instance types that are available for use with ROSA.",
 		Example: `  # List all instance types
 	rosa list instance-types`,
-		Run: run,
+		Run:  run,
+		Args: cobra.NoArgs,
 	}
 
 	return cmd

--- a/cmd/list/machinepool/cmd.go
+++ b/cmd/list/machinepool/cmd.go
@@ -34,7 +34,8 @@ var Cmd = &cobra.Command{
 	Long:    "List machine pools configured on a cluster.",
 	Example: `  # List all machine pools on a cluster named "mycluster"
   rosa list machinepools --cluster=mycluster`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/list/ocmroles/cmd.go
+++ b/cmd/list/ocmroles/cmd.go
@@ -38,7 +38,8 @@ var Cmd = &cobra.Command{
 	Long:    "List ocm roles for the current AWS account.",
 	Example: ` # List all ocm roles
 rosa list ocm-roles`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/list/oidcconfig/cmd.go
+++ b/cmd/list/oidcconfig/cmd.go
@@ -34,7 +34,8 @@ var Cmd = &cobra.Command{
 	Long:    "List OIDC Configuration resources",
 	Example: `  # List all OIDC Configurations tied to your organization ID"
   rosa list oidc-config`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/list/oidcprovider/cmd.go
+++ b/cmd/list/oidcprovider/cmd.go
@@ -39,7 +39,8 @@ var Cmd = &cobra.Command{
 	Long:    "List OIDC providers for the current AWS account.",
 	Example: `  # List all oidc providers
   rosa list oidc-providers`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 var args struct {

--- a/cmd/list/operatorroles/cmd.go
+++ b/cmd/list/operatorroles/cmd.go
@@ -46,7 +46,8 @@ var Cmd = &cobra.Command{
 	Long:    "List operator roles and policies for the current AWS account.",
 	Example: `  # List all operator roles
   rosa list operator-roles`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 const (

--- a/cmd/list/region/cmd.go
+++ b/cmd/list/region/cmd.go
@@ -42,7 +42,8 @@ var Cmd = &cobra.Command{
 	Long:    "List regions that are available for the current AWS account.",
 	Example: `  # List all available regions
   rosa list regions`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/list/tuningconfigs/cmd.go
+++ b/cmd/list/tuningconfigs/cmd.go
@@ -36,7 +36,8 @@ var Cmd = &cobra.Command{
 	Long:    "List tuning configuration resources for a cluster.",
 	Example: `  # List all tuning configuration for a cluster named 'mycluster'"
   rosa list tuning-configs -c mycluster`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/list/upgrade/cmd.go
+++ b/cmd/list/upgrade/cmd.go
@@ -42,6 +42,7 @@ var Cmd = &cobra.Command{
 	Short:   "List available cluster upgrades",
 	Long:    "List available and scheduled cluster version upgrades",
 	Run:     run,
+	Args:    cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/list/user/cmd.go
+++ b/cmd/list/user/cmd.go
@@ -38,7 +38,8 @@ var Cmd = &cobra.Command{
 	Long:    "List administrative cluster users.",
 	Example: `  # List all users on a cluster named "mycluster"
   rosa list users --cluster=mycluster`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/list/userroles/cmd.go
+++ b/cmd/list/userroles/cmd.go
@@ -35,7 +35,8 @@ var Cmd = &cobra.Command{
 	Long:    "List user roles for current AWS account",
 	Example: `# List all user roles
 rosa list user-roles`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/list/version/cmd.go
+++ b/cmd/list/version/cmd.go
@@ -43,7 +43,8 @@ var Cmd = &cobra.Command{
 	Long:    "List versions of OpenShift that are available for creating clusters.",
 	Example: `  # List all OpenShift versions
   rosa list versions`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {
@@ -62,7 +63,7 @@ func init() {
 	output.AddFlag(Cmd)
 }
 
-func run(cmd *cobra.Command, _ []string) {
+func run(_ *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithOCM()
 	defer r.Cleanup()
 	isHostedCp := args.hostedCp

--- a/cmd/login/cmd.go
+++ b/cmd/login/cmd.go
@@ -72,7 +72,8 @@ var Cmd = &cobra.Command{
 		"\t5. Command-line prompt\n", uiTokenPage),
 	Example: fmt.Sprintf(`  # Login to the OpenShift API with an existing token generated from %s
   rosa login --token=$OFFLINE_ACCESS_TOKEN`, uiTokenPage),
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/logout/cmd.go
+++ b/cmd/logout/cmd.go
@@ -30,9 +30,10 @@ var Cmd = &cobra.Command{
 	Short: "Log out",
 	Long:  "Log out, removing the configuration file.",
 	Run:   run,
+	Args:  cobra.NoArgs,
 }
 
-func run(cmd *cobra.Command, argv []string) {
+func run(_ *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
 	// Remove the configuration file:
 	err := config.Remove()

--- a/cmd/logs/cmd.go
+++ b/cmd/logs/cmd.go
@@ -34,6 +34,7 @@ var Cmd = &cobra.Command{
 
   # Show uninstall logs for a cluster named 'mycluster'
   rosa logs uninstall --cluster=mycluster`,
+	Args: cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/logs/install/cmd.go
+++ b/cmd/logs/install/cmd.go
@@ -45,7 +45,8 @@ var Cmd = &cobra.Command{
 
   # Show install logs for a cluster using the --cluster flag
   rosa logs install --cluster=mycluster`,
-	Run: run,
+	Run:  run,
+	Args: cobra.MaximumNArgs(1),
 }
 
 func init() {

--- a/cmd/logs/uninstall/cmd.go
+++ b/cmd/logs/uninstall/cmd.go
@@ -45,7 +45,8 @@ var Cmd = &cobra.Command{
 
   # Show uninstall logs for a cluster using the --cluster flag
   rosa logs uninstall --cluster=mycluster`,
-	Run: run,
+	Run:  run,
+	Args: cobra.MaximumNArgs(1),
 }
 
 func init() {

--- a/cmd/register/cmd.go
+++ b/cmd/register/cmd.go
@@ -29,6 +29,7 @@ var Cmd = &cobra.Command{
 	Aliases: []string{"registers"},
 	Short:   "Registers a specific resource",
 	Long:    "Registers a specific resource",
+	Args:    cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/register/oidcconfig/cmd.go
+++ b/cmd/register/oidcconfig/cmd.go
@@ -48,7 +48,8 @@ var Cmd = &cobra.Command{
 	Long:    "Registers unmanaged OIDC config with Openshift Clusters Manager.",
 	Example: `  # Register OIDC config
 	rosa register oidc-config`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {
@@ -93,7 +94,7 @@ func checkInteractiveModeNeeded(cmd *cobra.Command) {
 	}
 }
 
-func run(cmd *cobra.Command, argv []string) {
+func run(cmd *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
 

--- a/cmd/resume/cluster/cmd.go
+++ b/cmd/resume/cluster/cmd.go
@@ -34,14 +34,15 @@ func GenerateCommand() *cobra.Command {
 		Long:  "Resume cluster.",
 		Example: `  # Resume the cluster
   rosa resume cluster -c mycluster`,
-		Run: run,
+		Run:  run,
+		Args: cobra.NoArgs,
 	}
 	ocm.AddClusterFlag(Cmd)
 	confirm.AddFlag(Cmd.Flags())
 	return Cmd
 }
 
-func run(cmd *cobra.Command, _ []string) {
+func run(_ *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
 

--- a/cmd/resume/cmd.go
+++ b/cmd/resume/cmd.go
@@ -29,6 +29,7 @@ func GenerateCommand() *cobra.Command {
 		Short:  "Resume cluster",
 		Long:   "Resume a hibernating cluster",
 		Hidden: true,
+		Args:   cobra.NoArgs,
 	}
 	Cmd.AddCommand(cluster.GenerateCommand())
 	flags := Cmd.PersistentFlags()

--- a/cmd/revoke/cmd.go
+++ b/cmd/revoke/cmd.go
@@ -28,6 +28,7 @@ var Cmd = &cobra.Command{
 	Use:   "revoke",
 	Short: "Revoke role from a specific resource",
 	Long:  "Revoke role from a specific resource",
+	Args:  cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/rosa/main.go
+++ b/cmd/rosa/main.go
@@ -60,6 +60,7 @@ var root = &cobra.Command{
 	Long: "Command line tool for Red Hat OpenShift Service on AWS.\n" +
 		"For further documentation visit " +
 		"https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws\n",
+	Args: cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/rosa/main_test.go
+++ b/cmd/rosa/main_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+)
+
+func TestCommandStructure(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "rosa command structure")
+}
+
+var _ = Describe("ROSA Commands", func() {
+	It("Have all basic fields defined correctly", func() {
+		assertCommand(root)
+	})
+})
+
+func assertCommand(command *cobra.Command) {
+	Expect(command.Use).NotTo(BeNil(), fmt.Sprintf("Use cannot be nil on command '%s'", command.CommandPath()))
+	Expect(command.Short).NotTo(
+		BeNil(), fmt.Sprintf("Short description is not set on command '%s'", command.CommandPath()))
+	Expect(command.Long).NotTo(
+		BeNil(), fmt.Sprintf("Long description is not set on command '%s'", command.CommandPath()))
+	Expect(command.Example).NotTo(
+		BeNil(), fmt.Sprintf("Example is not set on command '%s'", command.CommandPath()))
+	Expect(command.Args).NotTo(
+		BeNil(), fmt.Sprintf("command.Args function is not set on command '%s'", command.CommandPath()))
+
+	if len(command.Commands()) == 0 {
+		Expect(command.Run).NotTo(
+			BeNil(), fmt.Sprintf("The run function is not defined on command '%s'", command.CommandPath()))
+	} else {
+		for _, c := range command.Commands() {
+			assertCommand(c)
+		}
+	}
+}

--- a/cmd/uninstall/cmd.go
+++ b/cmd/uninstall/cmd.go
@@ -28,6 +28,7 @@ var Cmd = &cobra.Command{
 	Use:   "uninstall",
 	Short: "Uninstalls a resource from a cluster",
 	Long:  "Uninstalls a resource from a cluster",
+	Args:  cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/unlink/cmd.go
+++ b/cmd/unlink/cmd.go
@@ -28,6 +28,7 @@ var Cmd = &cobra.Command{
 	Short:   "UnLink a ocm/user role from stdin",
 	Long:    "UnLink a ocm/user role from stdin",
 	Hidden:  false,
+	Args:    cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/unlink/ocmrole/cmd.go
+++ b/cmd/unlink/ocmrole/cmd.go
@@ -38,7 +38,8 @@ var Cmd = &cobra.Command{
 	Long:    "Unlink ocm role from a specific OCM organization",
 	Example: ` #Unlink ocm role
 rosa unlink ocm-role --role-arn arn:aws:iam::123456789012:role/ManagedOpenshift-OCM-Role`,
-	Run: run,
+	Args: cobra.MaximumNArgs(1),
+	Run:  run,
 }
 
 func init() {

--- a/cmd/unlink/userrole/cmd.go
+++ b/cmd/unlink/userrole/cmd.go
@@ -38,7 +38,8 @@ var Cmd = &cobra.Command{
 	Long:    "Unlink user role from a specific OCM account",
 	Example: ` # Unlink user role
 rosa unlink user-role --role-arn arn:aws:iam::{accountid}:role/{prefix}-User-{username}-Role`,
-	Run: run,
+	Run:  run,
+	Args: cobra.MaximumNArgs(1),
 }
 
 func init() {

--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -53,7 +53,8 @@ var Cmd = &cobra.Command{
 	Long:    "Upgrade account-wide IAM roles to the latest version before upgrading your cluster.",
 	Example: `  # Upgrade account roles for ROSA STS clusters
   rosa upgrade account-roles`,
-	Run: run,
+	Args: cobra.NoArgs,
+	Run:  run,
 }
 
 func init() {
@@ -96,7 +97,7 @@ func init() {
 	interactive.AddFlag(flags)
 }
 
-func run(cmd *cobra.Command, argv []string) {
+func run(cmd *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
 	reporter := r.Reporter

--- a/cmd/upgrade/cluster/cmd.go
+++ b/cmd/upgrade/cluster/cmd.go
@@ -63,7 +63,8 @@ var Cmd = &cobra.Command{
 
   # Schedule a cluster upgrade within the hour
   rosa upgrade cluster -c mycluster --version 4.12.20`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/upgrade/cmd.go
+++ b/cmd/upgrade/cmd.go
@@ -32,6 +32,7 @@ var Cmd = &cobra.Command{
 	Use:   "upgrade",
 	Short: "Upgrade a resource",
 	Long:  "Upgrade a resource",
+	Args:  cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/upgrade/operatorroles/cmd.go
+++ b/cmd/upgrade/operatorroles/cmd.go
@@ -44,7 +44,8 @@ var Cmd = &cobra.Command{
 	Long:    "Upgrade cluster-specific operator IAM roles to latest version.",
 	Example: `  # Upgrade cluster-specific operator IAM roles
   rosa upgrade operators-roles`,
-	Run: run,
+	Args: cobra.NoArgs,
+	Run:  run,
 }
 
 func init() {
@@ -64,7 +65,7 @@ func init() {
 	interactive.AddFlag(flags)
 }
 
-func run(cmd *cobra.Command, argv []string) {
+func run(cmd *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
 

--- a/cmd/upgrade/roles/cmd.go
+++ b/cmd/upgrade/roles/cmd.go
@@ -57,7 +57,8 @@ var Cmd = &cobra.Command{
 	Long:    "Upgrade cluster-specific IAM roles to the latest version before upgrading your cluster.",
 	Example: `  # Upgrade cluster roles for ROSA STS clusters
 		rosa upgrade roles -c <cluster_key>`,
-	Run: run,
+	Args: cobra.MaximumNArgs(2),
+	Run:  run,
 }
 
 const (

--- a/cmd/verify/cmd.go
+++ b/cmd/verify/cmd.go
@@ -30,6 +30,7 @@ var Cmd = &cobra.Command{
 	Use:   "verify",
 	Short: "Verify resources are configured correctly for cluster install",
 	Long:  "Verify resources are configured correctly for cluster install",
+	Args:  cobra.NoArgs,
 }
 
 func init() {

--- a/cmd/verify/network/cmd.go
+++ b/cmd/verify/network/cmd.go
@@ -54,7 +54,8 @@ func makeCmd() *cobra.Command {
 		Long:  "Verify that the VPC subnets are configured correctly.",
 		Example: `  # Verify two subnets
 	rosa verify network --subnet-ids subnet-03046a9b92b5014fb,subnet-03046a9c92b5014fb`,
-		Run: run,
+		Run:  run,
+		Args: cobra.NoArgs,
 	}
 }
 

--- a/cmd/verify/oc/cmd.go
+++ b/cmd/verify/oc/cmd.go
@@ -33,7 +33,8 @@ var Cmd = &cobra.Command{
 	Long:    "Verify that the OpenShift client tools is installed and compatible.",
 	Example: `  # Verify oc client tools
   rosa verify oc`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func run(_ *cobra.Command, _ []string) {

--- a/cmd/verify/permissions/cmd.go
+++ b/cmd/verify/permissions/cmd.go
@@ -38,7 +38,8 @@ var Cmd = &cobra.Command{
 
   # Verify AWS permissions in a different region
   rosa verify permissions --region=us-west-2`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {
@@ -48,7 +49,7 @@ func init() {
 	arguments.AddRegionFlag(flags)
 }
 
-func run(cmd *cobra.Command, _ []string) {
+func run(_ *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithOCM()
 	defer r.Cleanup()
 

--- a/cmd/verify/quota/cmd.go
+++ b/cmd/verify/quota/cmd.go
@@ -37,7 +37,8 @@ var Cmd = &cobra.Command{
 
   # Verify AWS quotas in a different region
   rosa verify quota --region=us-west-2`,
-	Run: run,
+	Args: cobra.NoArgs,
+	Run:  run,
 }
 
 func init() {
@@ -47,7 +48,7 @@ func init() {
 	arguments.AddProfileFlag(flags)
 }
 
-func run(cmd *cobra.Command, _ []string) {
+func run(_ *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithOCM()
 	defer r.Cleanup()
 

--- a/cmd/verify/rosa/cmd.go
+++ b/cmd/verify/rosa/cmd.go
@@ -39,7 +39,8 @@ var Cmd = &cobra.Command{
 	Long:    "Verify that the ROSA client tools is installed and compatible.",
 	Example: `  # Verify rosa client tools
   rosa verify rosa`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 const (

--- a/cmd/version/cmd.go
+++ b/cmd/version/cmd.go
@@ -43,6 +43,7 @@ func makeCmd() *cobra.Command {
 		Short: "Prints the version of the tool",
 		Long:  "Prints the version number of the tool.",
 		Run:   run,
+		Args:  cobra.NoArgs,
 	}
 }
 

--- a/cmd/whoami/cmd.go
+++ b/cmd/whoami/cmd.go
@@ -39,7 +39,8 @@ var Cmd = &cobra.Command{
 	Long:  "Displays information about your AWS and Red Hat accounts",
 	Example: `  # Displays user information
   rosa whoami`,
-	Run: run,
+	Run:  run,
+	Args: cobra.NoArgs,
 }
 
 func init() {


### PR DESCRIPTION
This PR updates the `cobra.Command` definition of all commands within the ROSA CLI to enforce the correct handling of positional arguments. In particular:

- Commands where positional args are not supported, now define `cobra.NoArgs` as their arg handler
- Commands where a particular number of args are supported, now define `cobra.MaximumNArgs` as their arg handler.
- Commands that handle arg parsing themselves, now define `cobra.ArbitraryArgs`

When passing unknown positional args to commands now, it will fail (printing help) with the following example message:

```
Failed to execute root command: unknown command "foo" for "rosa create cluster"
```

Additionally, I have added a test for the root command that ensures that all commands are well defined in that they:

- Define their usage (long and short) and provide an example
- Correctly set a `command.Args` function
- If a leaf command, set a `command.Run` function
