### PR TITLE
Change 'RunE' calls to just 'Run'

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -217,10 +217,7 @@ func run(cmd *cobra.Command, argv []string) {
 
 	// Validate AWS quota
 	// Call `verify quota` as part of init
-	err = quota.Cmd.RunE(cmd, argv)
-	if err != nil {
-		r.Reporter.Warnf("Insufficient AWS quotas. Cluster installation might fail.")
-	}
+	quota.Cmd.Run(cmd, argv)
 	// Verify version of `oc`
 	oc.Cmd.Run(cmd, argv)
 

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -3174,11 +3174,7 @@ func run(cmd *cobra.Command, _ []string) {
 			if !output.HasFlag() || r.Reporter.IsTerminal() {
 				r.Reporter.Infof("Preparing to create operator roles.")
 			}
-			err := operatorroles.Cmd.RunE(operatorroles.Cmd, []string{clusterName, mode, permissionsBoundary})
-			if err != nil {
-				r.Reporter.Errorf("There was a problem creating operator roles: %v", err)
-				os.Exit(1)
-			}
+			operatorroles.Cmd.Run(operatorroles.Cmd, []string{clusterName, mode, permissionsBoundary})
 			if !output.HasFlag() || r.Reporter.IsTerminal() {
 				r.Reporter.Infof("Preparing to create OIDC Provider.")
 			}

--- a/cmd/create/ocmrole/cmd.go
+++ b/cmd/create/ocmrole/cmd.go
@@ -284,11 +284,7 @@ func run(cmd *cobra.Command, argv []string) {
 		r.OCMClient.LogEvent("ROSACreateOCMRoleModeAuto", map[string]string{
 			ocm.Response: ocm.Success,
 		})
-		err = linkocmrole.Cmd.RunE(linkocmrole.Cmd, []string{roleARN})
-		if err != nil {
-			r.Reporter.Errorf("Unable to link role arn '%s' with the organization account id : '%s' : %v",
-				roleARN, orgID, err)
-		}
+		linkocmrole.Cmd.Run(linkocmrole.Cmd, []string{roleARN})
 	case aws.ModeManual:
 		r.OCMClient.LogEvent("ROSACreateOCMRoleModeManual", map[string]string{})
 		_, _, err = checkRoleExists(r, roleNameRequested, isAdmin, aws.ModeManual)

--- a/cmd/create/userrole/cmd.go
+++ b/cmd/create/userrole/cmd.go
@@ -221,11 +221,7 @@ func run(cmd *cobra.Command, argv []string) {
 			ocm.Response: ocm.Success,
 		})
 
-		err = linkuser.Cmd.RunE(linkuser.Cmd, []string{roleARN})
-		if err != nil {
-			r.Reporter.Errorf("Unable to link role arn '%s' with the account id : '%s' : %v",
-				roleARN, currentAccount.ID(), err)
-		}
+		linkuser.Cmd.Run(linkuser.Cmd, []string{roleARN})
 	case aws.ModeManual:
 		r.OCMClient.LogEvent("ROSACreateUserRoleModeManual", map[string]string{})
 		err = generateUserRolePolicyFiles(r.Reporter, env, currentAccount.ID(), policies)

--- a/cmd/dlt/ocmrole/cmd.go
+++ b/cmd/dlt/ocmrole/cmd.go
@@ -182,12 +182,7 @@ func run(cmd *cobra.Command, argv []string) {
 		r.OCMClient.LogEvent("ROSADeleteOCMRoleModeAuto", nil)
 		if isLinked {
 			r.Reporter.Warnf("Role ARN '%s' is linked to organization '%s'", roleARN, orgID)
-			err = unlinkocmrole.Cmd.RunE(unlinkocmrole.Cmd, []string{roleARN})
-			if err != nil {
-				r.Reporter.Errorf("Unable to unlink role ARN '%s' from organization : '%s' : %v",
-					roleARN, orgID, err)
-				os.Exit(1)
-			}
+			unlinkocmrole.Cmd.Run(unlinkocmrole.Cmd, []string{roleARN})
 		}
 		if roleExistOnAWS {
 			err := r.AWSClient.DeleteOCMRole(roleName, managedPolicies)

--- a/cmd/dlt/userrole/cmd.go
+++ b/cmd/dlt/userrole/cmd.go
@@ -181,12 +181,7 @@ func run(cmd *cobra.Command, argv []string) {
 		if isLinked {
 			r.Reporter.Warnf("Role ARN '%s' is linked to account '%s'",
 				roleARN, currentAccount.ID())
-			err = unlinkuserrole.Cmd.RunE(unlinkuserrole.Cmd, []string{roleARN})
-			if err != nil {
-				r.Reporter.Errorf("Unable to unlink role ARN '%s' from account : '%s' : '%v'",
-					roleARN, currentAccount.ID(), err)
-				os.Exit(1)
-			}
+			unlinkuserrole.Cmd.Run(unlinkuserrole.Cmd, []string{roleARN})
 		}
 		err := r.AWSClient.DeleteUserRole(roleName)
 		if err != nil {

--- a/cmd/initialize/cmd.go
+++ b/cmd/initialize/cmd.go
@@ -191,11 +191,7 @@ func run(cmd *cobra.Command, argv []string) {
 
 	// Validate AWS quota
 	// Call `verify quota` as part of init
-	err = quota.Cmd.RunE(cmd, argv)
-	if err != nil {
-		r.Reporter.Errorf("%v", err)
-		os.Exit(1)
-	}
+	quota.Cmd.Run(cmd, argv)
 
 	// Ensure that there is an AWS user to create all the resources needed by the cluster:
 	r.Reporter.Infof("Ensuring cluster administrator user '%s'...", aws.AdminUserName)

--- a/cmd/upgrade/cluster/cmd.go
+++ b/cmd/upgrade/cluster/cmd.go
@@ -491,19 +491,7 @@ func checkSTSRolesCompatibility(r *rosa.Runtime, cluster *cmv1.Cluster, mode str
 	version string, clusterKey string) {
 	r.Reporter.Infof("Ensuring account and operator role policies for cluster '%s'"+
 		" are compatible with upgrade.", cluster.ID())
-	err := roles.Cmd.RunE(roles.Cmd, []string{mode, cluster.ID(), version, cluster.Version().ChannelGroup()})
-	if err != nil {
-		rolesStr := fmt.Sprintf("rosa upgrade roles -c %s --cluster-version=%s --mode=%s", clusterKey, version, mode)
-		upgradeClusterStr := fmt.Sprintf("rosa upgrade cluster -c %s", clusterKey)
-
-		if r.Reporter.IsTerminal() {
-			r.Reporter.Infof("Account/Operator Role policies are not valid with upgrade version %s. "+
-				"Run the following command(s) to upgrade the roles and run the upgrade command again:\n\n"+
-				"\t%s\n"+
-				"\t%s\n", version, rolesStr, upgradeClusterStr)
-		}
-		os.Exit(0)
-	}
+	roles.Cmd.Run(roles.Cmd, []string{mode, cluster.ID(), version, cluster.Version().ChannelGroup()})
 	if r.Reporter.IsTerminal() {
 		r.Reporter.Infof("Account and operator roles for cluster '%s' are compatible with upgrade", clusterKey)
 	}


### PR DESCRIPTION
https://github.com/openshift/rosa/pull/1779 changed any `RunE` calls to just use `Run`, which means that any other commands calling those `RunE` functions would now panic due to calling a nil function. This PR changes those calls to use the new `Run`.