### PR TITLE
OCM-5935 | fix: remove toolchain from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/openshift/rosa
 
 go 1.21
 
-toolchain go1.21.3
-
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.15
 	github.com/PuerkitoBio/goquery v1.8.1


### PR DESCRIPTION
Remove toolchain from go.mod as it causes build issues in CPaaS