### PR TITLE
OCM-6376 | feat: Remove shorthand for --oidc-config-id

### DIFF
--- a/cmd/list/oidcprovider/cmd.go
+++ b/cmd/list/oidcprovider/cmd.go
@@ -55,7 +55,7 @@ func init() {
 	flags.StringVarP(
 		&args.oidcConfigId,
 		"oidc-config-id",
-		"i",
+		"",
 		"",
 		"Filter by OIDC Config ID, returns one provider linked to the config ID.",
 	)


### PR DESCRIPTION
Originally was using `-i` which made sense for `id`, but it is shared with `--interactive`. I cannot think of a better shorthand to use here, and there is no real reason to have one, so removing it to fix [OCM-6376](https://issues.redhat.com//browse/OCM-6376)

https://issues.redhat.com/browse/OCM-6376