### PR TITLE
Allow longer cluster names up to 54 chars and an optional domain-prefix to customize the DNS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,15 @@ The commit message should follow this template:
 [optional FOOTER(s)]
 ```
 
+For example:
+```shell
+OCM-6141 | feat: Allow longer cluster names up to 54 chars 
+
+Also allow users to supply an optional domain-prefix to customize the DNS
+
+Signed-off-by: Foo Bar <foo.bar@baz.com>
+```
+
 The commit contains the following structural types, to communicate your intent:
 
 - `fix:` a commit of the type fix patches a bug in your codebase (this correlates with PATCH in Semantic Versioning).

--- a/cmd/create/cluster/cmd_test.go
+++ b/cmd/create/cluster/cmd_test.go
@@ -41,6 +41,17 @@ var _ = Describe("Validate build command", func() {
 		defaultMachinePoolLabels = "machine-pool-label"
 	})
 	Context("build command", func() {
+		When("domain prefix is present is true", func() {
+			It("prints --domain-prefix", func() {
+				clusterConfig.DomainPrefix = "dns-label"
+				command := buildCommand(clusterConfig, operatorRolesPrefix,
+					expectedOperatorRolePath, userSelectedAvailabilityZones,
+					defaultMachinePoolLabels, argsDotProperties)
+				Expect(command).To(Equal(
+					"rosa create cluster --cluster-name cluster-name --domain-prefix dns-label" +
+						" --operator-roles-prefix prefix"))
+			})
+		})
 
 		When("--etcd-encryption is true", func() {
 			It("prints --etcd-encryption-kms-arn", func() {

--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -157,9 +157,11 @@ func run(cmd *cobra.Command, argv []string) {
 		phase = fmt.Sprintf("(%s)", cluster.Status().Description())
 	}
 
+	domainPrefix := cluster.DomainPrefix()
+
 	clusterDNS := "Not ready"
 	if cluster.Status() != nil && cluster.Status().DNSReady() {
-		clusterDNS = strings.Join([]string{cluster.Name(), cluster.DNS().BaseDomain()}, ".")
+		clusterDNS = strings.Join([]string{domainPrefix, cluster.DNS().BaseDomain()}, ".")
 	}
 
 	clusterName := cluster.Name()
@@ -201,6 +203,7 @@ func run(cmd *cobra.Command, argv []string) {
 	// Print short cluster description:
 	str = fmt.Sprintf("\n"+
 		"Name:                       %s\n"+
+		"Domain Prefix:              %s\n"+
 		"Display Name:               %s\n"+
 		"ID:                         %s\n"+
 		"External ID:                %s\n"+
@@ -224,6 +227,7 @@ func run(cmd *cobra.Command, argv []string) {
 		"%s"+
 		"%s",
 		clusterName,
+		domainPrefix,
 		displayName,
 		cluster.ID(),
 		cluster.ExternalID(),

--- a/cmd/upgrade/cluster/cmd_test.go
+++ b/cmd/upgrade/cluster/cmd_test.go
@@ -21,15 +21,6 @@ var _ = Describe("Upgrade", Ordered, func() {
 	const cronSchedule = "* * * * *"
 	const timeSchedule = "10:00"
 	const dateSchedule = "2023-06-01"
-	var clusterNotFound = `
-	{
-	  "kind": "Error",
-	  "id": "404",
-	  "href": "/api/clusters_mgmt/v1/errors/404",
-	  "code": "CLUSTERS-MGMT-404",
-	  "reason": "Cluster 'cluster1' not found",
-	  "operation_id": "8f4c6a3e-4d40-41fd-9288-60ee670ef846"
-	}`
 	var emptyClusterList = test.FormatClusterList([]*cmv1.Cluster{})
 	version4130 := cmv1.NewVersion().ID("openshift-v4.13.0").RawID("4.13.0").ReleaseImage("1").
 		HREF("/api/clusters_mgmt/v1/versions/openshift-v4.13.0").Enabled(true).ChannelGroup("stable").
@@ -281,7 +272,7 @@ var _ = Describe("Upgrade", Ordered, func() {
 			EnableMinorVersionUpgrades(false).Build()
 		Expect(err).To(BeNil())
 		testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusCreated, test.FormatResource(cpUpgradePolicy)))
-		testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusNotFound, clusterNotFound))
+		// return an empty list to indicate that no cluster is found
 		testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, emptyClusterList))
 		err = runWithRuntime(testRuntime.RosaRuntime, Cmd)
 		Expect(err).ToNot(BeNil())

--- a/pkg/ocm/helpers_test.go
+++ b/pkg/ocm/helpers_test.go
@@ -395,3 +395,61 @@ var _ = Describe("ValidateSubnetsCount", func() {
 		})
 	})
 })
+
+var _ = Describe("IsValidClusterName()", func() {
+	DescribeTable("IsValidClusterName() test cases", func(name string, expected bool) {
+		valid := IsValidClusterName(name)
+		Expect(expected).To(Equal(valid))
+	},
+		Entry("returns false when an empty name is given", "", false),
+		Entry("returns false when name is not a valid DNS label", "9hjh9", false),
+		Entry("returns false when name is not a valid DNS label", "hjh-", false),
+		Entry("returns false when name is longer than 54 chars", strings.Repeat("h", 55), false),
+		Entry("returns true when name valid", strings.Repeat("h", 25), true))
+})
+
+var _ = Describe("ClusterNameValidator()", func() {
+	DescribeTable("ClusterNameValidator() test cases", func(name interface{}, shouldErr bool) {
+		err := ClusterNameValidator(name)
+		if shouldErr {
+			Expect(err).To(HaveOccurred())
+		} else {
+			Expect(err).NotTo(HaveOccurred())
+		}
+	},
+		Entry("should error when a non string arg is given", 5, true),
+		Entry("should error when an empty name is given", "", true),
+		Entry("should error when name is not a valid DNS label", "9hjh9", true),
+		Entry("should error when name is not a valid DNS label", "hjh-", true),
+		Entry("should error when name is longer than 54 chars", strings.Repeat("h", 55), true),
+		Entry("should not error when name valid", strings.Repeat("h", 25), false))
+})
+
+var _ = Describe("IsValidClusterDomainPrefix()", func() {
+	DescribeTable("IsValidClusterDomainPrefix() test cases", func(domainPrefix string, expected bool) {
+		valid := IsValidClusterDomainPrefix(domainPrefix)
+		Expect(expected).To(Equal(valid))
+	},
+		Entry("returns false when an empty domain prefix is given", "", false),
+		Entry("returns false when domain prefix is not a valid DNS label", "9hjh9", false),
+		Entry("returns false when domain prefix is not a valid DNS label", "hjh-", false),
+		Entry("returns false when domain prefix is longer than 15 chars", strings.Repeat("h", 16), false),
+		Entry("returns true when domain prefix valid", strings.Repeat("h", 15), true))
+})
+
+var _ = Describe("ClusterDomainPrefixValidator()", func() {
+	DescribeTable("ClusterDomainPrefixValidator() test case", func(domainPrefix interface{}, shouldErr bool) {
+		err := ClusterDomainPrefixValidator(domainPrefix)
+		if shouldErr {
+			Expect(err).To(HaveOccurred())
+		} else {
+			Expect(err).NotTo(HaveOccurred())
+		}
+	},
+		Entry("should error when a non string arg is given", 5, true),
+		Entry("should not error when an empty domain prefix is given", "", false),
+		Entry("shoud error when domain prefix is not a valid DNS label", "9hjh9", true),
+		Entry("should error when domain prefix is not a valid DNS label", "hjh-", true),
+		Entry("should error when domain prefix is longer than 15 chars", strings.Repeat("h", 16), true),
+		Entry("should not error when domain prefix valid", strings.Repeat("h", 15), false))
+})


### PR DESCRIPTION
The changes does the following:
- Bump the SDK to latest version 
- Update the `describe cluster ` command to show the domain prefix and changes how the DNS is constructed by using this field
- Update the `create cluster` command to allow; name to be <= 54 chars, domain-prefix <= 15 with their associated DNS label validation
- Update `FetchCluster(key,creator)` to remove the no longer valid fact that name <= 15 and only perform the backend search that covered for all cases i.e name, id, external_id 

Example output of the describe command (notice the name and the domain prefix):
```
./rosa describe cluster -c very-long-name-for-machi-cluster                                              

Name:                       very-long-name-for-machi-cluster
Domain Prefix:              machi
Display Name:               very-long-name-for-machi-cluster
ID:                         29nmlnar1alaqt5jrorc769ka40fbcke
External ID:                5d3724a4-36f0-46da-a2ab-3345960948a8
Control Plane:              ROSA Service Hosted
OpenShift Version:          4.14.9
Channel Group:              stable
DNS:                        machi.tg36.i3.devshift.org
AWS Account:               xxx
AWS Billing Account:       yyyy
API URL:                    https://api.machi.tg36.i3.devshift.org:443
Console URL:                https://console-openshift-console.apps.rosa.machi.tg36.i3.devshift.org
Region:                     us-west-2
Availability:
 - Control Plane:           MultiAZ
 - Data Plane:              SingleAZ

Nodes:
 - Compute (desired):       2
 - Compute (current):       2
...
```

JIRA: [OCM-6141](https://issues.redhat.com//browse/OCM-6141)