### PR TITLE
OCM-5736 | feat: Make auth and device code flags visible

### DIFF
--- a/cmd/login/cmd.go
+++ b/cmd/login/cmd.go
@@ -137,7 +137,6 @@ func init() {
 		"Login using OAuth Authorization Code. This should be used for most cases where a "+
 			"browser is available.",
 	)
-	flags.MarkHidden("use-auth-code")
 	flags.BoolVar(
 		&args.useDeviceCode,
 		"use-device-code",
@@ -146,7 +145,6 @@ func init() {
 			"This should only be used for remote hosts and containers where browsers are "+
 			"not available. Use auth code for all other scenarios.",
 	)
-	flags.MarkHidden("use-device-code")
 	arguments.AddRegionFlag(flags)
 	fedramp.AddFlag(flags)
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-5736


**Changed**
- Make auth and device code flags visible

**Tested**
- Flags should be visible in `rosa login --help` : tested