### PR TITLE
OCM-6468 | fix: change describe node pool output

### DIFF
--- a/cmd/describe/machinepool/cmd_test.go
+++ b/cmd/describe/machinepool/cmd_test.go
@@ -18,38 +18,38 @@ import (
 const (
 	nodePoolName         = "nodepool85"
 	describeStringOutput = `
-ID:                         nodepool85
-Cluster ID:                 24vf9iitg3p6tlml88iml6j6mu095mh8
-Autoscaling:                No
-Desired replicas:           0
-Current replicas:           
-Instance type:              m5.xlarge
-Labels:                     
-Taints:                     
-Availability zone:          us-east-1a
-Subnet:                     
-Version:                    4.12.24
-Autorepair:                 No
-Tuning configs:             
-Message:                    
-Security Group IDs:         
+ID:                                    nodepool85
+Cluster ID:                            24vf9iitg3p6tlml88iml6j6mu095mh8
+Autoscaling:                           No
+Desired replicas:                      0
+Current replicas:                      
+Instance type:                         m5.xlarge
+Labels:                                
+Taints:                                
+Availability zone:                     us-east-1a
+Subnet:                                
+Version:                               4.12.24
+Autorepair:                            No
+Tuning configs:                        
+Message:                               
+Additional security group IDs:         
 `
 	describeStringWithUpgradeOutput = `
-ID:                         nodepool85
-Cluster ID:                 24vf9iitg3p6tlml88iml6j6mu095mh8
-Autoscaling:                No
-Desired replicas:           0
-Current replicas:           
-Instance type:              m5.xlarge
-Labels:                     
-Taints:                     
-Availability zone:          us-east-1a
-Subnet:                     
-Version:                    4.12.24
-Autorepair:                 No
-Tuning configs:             
-Message:                    
-Security Group IDs:         
+ID:                                    nodepool85
+Cluster ID:                            24vf9iitg3p6tlml88iml6j6mu095mh8
+Autoscaling:                           No
+Desired replicas:                      0
+Current replicas:                      
+Instance type:                         m5.xlarge
+Labels:                                
+Taints:                                
+Availability zone:                     us-east-1a
+Subnet:                                
+Version:                               4.12.24
+Autorepair:                            No
+Tuning configs:                        
+Message:                               
+Additional security group IDs:         
 Scheduled upgrade:          scheduled 4.12.25 on 2023-08-07 15:22 UTC
 `
 

--- a/cmd/describe/machinepool/nodepool.go
+++ b/cmd/describe/machinepool/nodepool.go
@@ -38,21 +38,21 @@ func describeNodePool(r *rosa.Runtime, cluster *cmv1.Cluster, clusterKey string,
 
 	// Prepare string
 	nodePoolOutput := fmt.Sprintf("\n"+
-		"ID:                         %s\n"+
-		"Cluster ID:                 %s\n"+
-		"Autoscaling:                %s\n"+
-		"Desired replicas:           %s\n"+
-		"Current replicas:           %s\n"+
-		"Instance type:              %s\n"+
-		"Labels:                     %s\n"+
-		"Taints:                     %s\n"+
-		"Availability zone:          %s\n"+
-		"Subnet:                     %s\n"+
-		"Version:                    %s\n"+
-		"Autorepair:                 %s\n"+
-		"Tuning configs:             %s\n"+
-		"Message:                    %s\n"+
-		"Security Group IDs:         %s\n",
+		"ID:                                    %s\n"+
+		"Cluster ID:                            %s\n"+
+		"Autoscaling:                           %s\n"+
+		"Desired replicas:                      %s\n"+
+		"Current replicas:                      %s\n"+
+		"Instance type:                         %s\n"+
+		"Labels:                                %s\n"+
+		"Taints:                                %s\n"+
+		"Availability zone:                     %s\n"+
+		"Subnet:                                %s\n"+
+		"Version:                               %s\n"+
+		"Autorepair:                            %s\n"+
+		"Tuning configs:                        %s\n"+
+		"Message:                               %s\n"+
+		"Additional security group IDs:         %s\n",
 		nodePool.ID(),
 		cluster.ID(),
 		ocmOutput.PrintNodePoolAutoscaling(nodePool.Autoscaling()),


### PR DESCRIPTION
Add `Additional` to the security group IDs field.