### PR TITLE
OCM-6484 | fix: generates a valid operator role prefix from the cluster name

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1689,7 +1689,7 @@ func run(cmd *cobra.Command, _ []string) {
 	computedOperatorIamRoleList := []ocm.OperatorIAMRole{}
 	if isSTS {
 		if operatorRolesPrefix == "" {
-			operatorRolesPrefix = getRolePrefix(clusterName)
+			operatorRolesPrefix = roles.GeOperatorRolePrefixFromClusterName(clusterName)
 		}
 		if interactive.Enabled() {
 			operatorRolesPrefix, err = interactive.GetString(interactive.Input{
@@ -3917,10 +3917,6 @@ func buildTagsCommand(tags map[string]string) []string {
 		formattedTags = append(formattedTags, fmt.Sprintf("%s%s%s", k, delim, v))
 	}
 	return formattedTags
-}
-
-func getRolePrefix(clusterName string) string {
-	return fmt.Sprintf("%s-%s", clusterName, helper.RandomLabel(4))
 }
 
 func calculateReplicas(

--- a/cmd/create/service/cmd.go
+++ b/cmd/create/service/cmd.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
-	"github.com/openshift/rosa/pkg/helper"
+	"github.com/openshift/rosa/pkg/helper/roles"
 	"github.com/openshift/rosa/pkg/info"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/output"
@@ -401,7 +401,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// operator role logic.
-	operatorRolesPrefix := getRolePrefix(args.ClusterName)
+	operatorRolesPrefix := roles.GeOperatorRolePrefixFromClusterName(args.ClusterName)
 	operatorIAMRoleList := []ocm.OperatorIAMRole{}
 
 	// Managed Services does not support Hypershift at this time.
@@ -474,8 +474,4 @@ func getAccountRolePrefix(roleARN string, role aws.AccountRole) (string, error) 
 	}
 	rolePrefix := aws.TrimRoleSuffix(roleName, fmt.Sprintf("-%s-Role", role.Name))
 	return rolePrefix, nil
-}
-
-func getRolePrefix(clusterName string) string {
-	return fmt.Sprintf("%s-%s", clusterName, helper.RandomLabel(4))
 }

--- a/pkg/helper/helpers_test.go
+++ b/pkg/helper/helpers_test.go
@@ -3,11 +3,13 @@ package helper_test
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	. "github.com/openshift/rosa/pkg/helper"
+	"github.com/openshift/rosa/pkg/helper/roles"
 )
 
 var _ = Describe("Helper", func() {
@@ -143,5 +145,17 @@ var _ = Describe("Helper", func() {
 			})
 		})
 
+		var _ = Context("GeOperatorRolePrefixFromClusterName()", func() {
+			DescribeTable("GeOperatorRolePrefixFromClusterName test casess",
+				func(clusterName, expectedClusterNamePrefix string) {
+					operatorRolePrefix := roles.GeOperatorRolePrefixFromClusterName(clusterName)
+					Expect(operatorRolePrefix).To(ContainSubstring(fmt.Sprintf("%s-", expectedClusterNamePrefix)))
+					Expect(len(operatorRolePrefix) <= 32).To(BeTrue())
+				},
+				Entry("Uses the cluster name as the in the operator role prefix when the name is <= 27 chars",
+					"cluster-name", "cluster-name"),
+				Entry("Uses the first 27 characters of the cluster name when the cluster name is > 27 chars",
+					strings.Repeat("a", 54), strings.Repeat("a", 27)))
+		})
 	})
 })

--- a/pkg/helper/roles/helpers.go
+++ b/pkg/helper/roles/helpers.go
@@ -20,8 +20,21 @@ import (
 )
 
 const (
-	RosaUpgradeAccRolesModeAuto = "ROSAUpgradeAccountRolesModeAuto"
+	RosaUpgradeAccRolesModeAuto            = "ROSAUpgradeAccountRolesModeAuto"
+	maxClusterNameLengthToUseForRolePrefix = 27
 )
+
+// GeOperatorRolePrefixFromClusterName returns a valid operator role prefix from the cluster name
+// An operator role prefix is considered valid if it's length is less than or equal to 32 chars.
+// A random 4 characters label is attached to the cluster name to reduce chances of collision.
+// The cluster name and the random label are separate by '-'.
+// If the cluster name is longer than 27 characters, only the first 27 characters will be used.
+func GeOperatorRolePrefixFromClusterName(clusterName string) string {
+	if len(clusterName) > maxClusterNameLengthToUseForRolePrefix {
+		return fmt.Sprintf("%s-%s", clusterName[0:maxClusterNameLengthToUseForRolePrefix], helper.RandomLabel(4))
+	}
+	return fmt.Sprintf("%s-%s", clusterName, helper.RandomLabel(4))
+}
 
 func GetOperatorRoleName(cluster *cmv1.Cluster, missingOperator *cmv1.STSOperator) string {
 	rolePrefix := cluster.AWS().STS().OperatorRolePrefix()


### PR DESCRIPTION
A valid operator role prefix has at most 32 characters, but the cluster name can have up to 54 characters this was causing errors as the one reported in https://issues.redhat.com/browse/OCM-6484. To fix this issue, we use only the first 27 characters of the name if the name is longer than 27 characters.