### PR TITLE
OCM-6496 | chore: Remove error from reporter.Builder.Build method signature

### DIFF
--- a/cmd/download/oc/cmd.go
+++ b/cmd/download/oc/cmd.go
@@ -40,7 +40,7 @@ var Cmd = &cobra.Command{
 }
 
 func run(cmd *cobra.Command, argv []string) {
-	reporter := rprtr.CreateReporterOrExit()
+	reporter := rprtr.CreateReporter()
 
 	// Verify whether `oc` is installed
 	oc.Cmd.Run(cmd, argv)

--- a/cmd/download/rosa/cmd.go
+++ b/cmd/download/rosa/cmd.go
@@ -40,7 +40,7 @@ var Cmd = &cobra.Command{
 }
 
 func run(_ *cobra.Command, _ []string) {
-	reporter := rprtr.CreateReporterOrExit()
+	reporter := rprtr.CreateReporter()
 
 	platform := getPlatform()
 	extension := helper.GetExtension()

--- a/cmd/logout/cmd.go
+++ b/cmd/logout/cmd.go
@@ -34,7 +34,7 @@ var Cmd = &cobra.Command{
 }
 
 func run(_ *cobra.Command, _ []string) {
-	reporter := rprtr.CreateReporterOrExit()
+	reporter := rprtr.CreateReporter()
 	// Remove the configuration file:
 	err := config.Remove()
 	if err != nil {

--- a/cmd/verify/oc/cmd.go
+++ b/cmd/verify/oc/cmd.go
@@ -38,7 +38,7 @@ var Cmd = &cobra.Command{
 }
 
 func run(_ *cobra.Command, _ []string) {
-	reporter := rprtr.CreateReporterOrExit()
+	reporter := rprtr.CreateReporter()
 
 	// Verify whether `oc` is installed
 	if reporter.IsTerminal() {

--- a/cmd/verify/rosa/cmd.go
+++ b/cmd/verify/rosa/cmd.go
@@ -50,7 +50,7 @@ const (
 )
 
 func run(_ *cobra.Command, _ []string) {
-	rprtr := reporter.CreateReporterOrExit()
+	rprtr := reporter.CreateReporter()
 
 	currVersion, err := version.NewVersion(info.Version)
 	if err != nil {

--- a/pkg/color/flag.go
+++ b/pkg/color/flag.go
@@ -67,3 +67,7 @@ func UseColor() bool {
 		return (stdout.Mode()&os.ModeDevice != 0) && (stdout.Mode()&os.ModeNamedPipe == 0)
 	}
 }
+
+func SetColor(colorOption string) {
+	color = colorOption
+}

--- a/pkg/debug/flag.go
+++ b/pkg/debug/flag.go
@@ -37,5 +37,9 @@ func Enabled() bool {
 	return enabled
 }
 
+func SetEnabled(debugEnabled bool) {
+	enabled = debugEnabled
+}
+
 // enabled is a boolean flag that indicates that the debug mode is enabled.
 var enabled bool

--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -677,12 +677,7 @@ func (c *Client) DeleteCluster(clusterKey string, bestEffort bool,
 // are rotated between cluster creation. If a user is creating a non-STS cluster, we need to therefore make sure
 // no other clusters are pending in the account in order to ensure no race condition occurs.
 func (c *Client) EnsureNoPendingClusters(awsCreator *aws.Creator) error {
-	reporter, err := rprtr.New().
-		Build()
-	if err != nil {
-		return fmt.Errorf("Error creating cluster reporter: %w", err)
-	}
-
+	reporter := rprtr.CreateReporter()
 	/**
 	1) Poll the cluster with same arn from ocm
 	2) Check the status and if pending enter to a loop until it becomes installing
@@ -712,12 +707,7 @@ func (c *Client) EnsureNoPendingClusters(awsCreator *aws.Creator) error {
 }
 
 func (c *Client) createClusterSpec(config Spec) (*cmv1.Cluster, error) {
-	reporter, err := rprtr.New().
-		Build()
-	if err != nil {
-		return nil, fmt.Errorf("Error creating cluster reporter: %v", err)
-	}
-
+	reporter := rprtr.CreateReporter()
 	clusterProperties := map[string]string{}
 
 	if config.CustomProperties != nil {

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -25,28 +25,9 @@ import (
 	"github.com/openshift/rosa/pkg/debug"
 )
 
-// Builder contains the information and logic needed to create a new reporter.
-type Builder struct {
-	// Empty on purpose.
-}
-
 // Object is the reported object used by the tool. It prints the messages to the standard output or
 // error streams.
 type Object struct {
-	errors int
-}
-
-// New creates a builder that can then be used to configure and build a reporter.
-func New() *Builder {
-	return &Builder{}
-}
-
-// Build uses the information contained in the builder to create a new reporter.
-func (b *Builder) Build() (result *Object, err error) {
-	// Create and populate the object:
-	result = &Object{}
-
-	return
 }
 
 // Debugf prints a debug message with the given format and arguments.
@@ -61,9 +42,9 @@ func (r *Object) Debugf(format string, args ...interface{}) {
 func (r *Object) Infof(format string, args ...interface{}) {
 	message := fmt.Sprintf(format, args...)
 	if color.UseColor() {
-		_, _ = fmt.Fprintf(os.Stdout, "%s%s\n", infoPrefix, message)
+		_, _ = fmt.Fprintf(os.Stdout, "%s%s\n", infoColorPrefix, message)
 	} else {
-		_, _ = fmt.Fprintf(os.Stdout, "%s%s\n", "INFO: ", message)
+		_, _ = fmt.Fprintf(os.Stdout, "%s%s\n", infoPrefix, message)
 	}
 }
 
@@ -71,9 +52,9 @@ func (r *Object) Infof(format string, args ...interface{}) {
 func (r *Object) Warnf(format string, args ...interface{}) {
 	message := fmt.Sprintf(format, args...)
 	if color.UseColor() {
-		_, _ = fmt.Fprintf(os.Stderr, "%s%s\n", warnPrefix, message)
+		_, _ = fmt.Fprintf(os.Stderr, "%s%s\n", warnColorPrefix, message)
 	} else {
-		_, _ = fmt.Fprintf(os.Stderr, "%s%s\n", "WARN: ", message)
+		_, _ = fmt.Fprintf(os.Stderr, "%s%s\n", warnPrefix, message)
 	}
 }
 
@@ -83,24 +64,21 @@ func (r *Object) Warnf(format string, args ...interface{}) {
 func (r *Object) Errorf(format string, args ...interface{}) error {
 	message := fmt.Sprintf(format, args...)
 	if color.UseColor() {
-		_, _ = fmt.Fprintf(os.Stderr, "%s%s\n", errorPrefix, message)
+		_, _ = fmt.Fprintf(os.Stderr, "%s%s\n", errorColorPrefix, message)
 	} else {
-		_, _ = fmt.Fprintf(os.Stderr, "%s%s\n", "ERR: ", message)
+		_, _ = fmt.Fprintf(os.Stderr, "%s%s\n", errorPrefix, message)
 	}
-	r.errors++
 	return errors.New(message)
-}
-
-// Errors returns the number of errors that have been reported via this reporter.
-func (r *Object) Errors() int {
-	return r.errors
 }
 
 // Message prefix using ANSI scape sequences to set colors:
 const (
-	infoPrefix  = "\033[0;36mI:\033[m "
-	warnPrefix  = "\033[0;33mW:\033[m "
-	errorPrefix = "\033[0;31mE:\033[m "
+	infoColorPrefix  = "\033[0;36mI:\033[m "
+	infoPrefix       = "INFO: "
+	warnColorPrefix  = "\033[0;33mW:\033[m "
+	warnPrefix       = "WARN: "
+	errorColorPrefix = "\033[0;31mE:\033[m "
+	errorPrefix      = "ERR: "
 )
 
 // Determine whether the reporter output is meant for the terminal
@@ -113,15 +91,7 @@ func (r *Object) IsTerminal() bool {
 	return (stdout.Mode()&os.ModeDevice != 0) && (stdout.Mode()&os.ModeNamedPipe == 0)
 }
 
-// CreateReporterOrExit creates the reportor instance or exits to the console
-// noting the error on failure.
-func CreateReporterOrExit() *Object {
-	// Create the reporter:
-	reporter, err := New().
-		Build()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create reporter: %v\n", err)
-		os.Exit(1)
-	}
-	return reporter
+// CreateReporter returns a new reporter
+func CreateReporter() *Object {
+	return &Object{}
 }

--- a/pkg/reporter/reporter_test.go
+++ b/pkg/reporter/reporter_test.go
@@ -1,0 +1,178 @@
+package reporter
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/rosa/pkg/color"
+	"github.com/openshift/rosa/pkg/debug"
+)
+
+func TestReporter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "reporter testing")
+}
+
+var _ = Describe("Reporter Tests", func() {
+
+	var reporter *Object
+
+	BeforeEach(func() {
+		reporter = CreateReporter()
+	})
+
+	AfterEach(func() {
+		color.SetColor("auto")
+		debug.SetEnabled(false)
+	})
+
+	It("Returns a reporter", func() {
+		reporter := CreateReporter()
+		Expect(reporter).NotTo(BeNil())
+	})
+
+	Context("Info", func() {
+		It("Prints an info message without color", func() {
+			color.SetColor("never")
+			Expect(color.UseColor()).To(BeFalse())
+
+			stdOut, stdErr := captureStdOutAndStdError(func() {
+				reporter.Infof("Hello World")
+			})
+
+			Expect(stdOut).To(Equal(infoPrefix + "Hello World\n"))
+			Expect(stdErr).To(BeEmpty())
+		})
+
+		It("Prints an info message with color", func() {
+			color.SetColor("always")
+			Expect(color.UseColor()).To(BeTrue())
+
+			stdOut, stdErr := captureStdOutAndStdError(func() {
+				reporter.Infof("Hello World")
+			})
+
+			Expect(stdOut).To(Equal(infoColorPrefix + "Hello World\n"))
+			Expect(stdErr).To(BeEmpty())
+		})
+	})
+
+	Context("Warn", func() {
+		It("Prints a warn message without color", func() {
+			color.SetColor("never")
+			Expect(color.UseColor()).To(BeFalse())
+
+			stdOut, stdErr := captureStdOutAndStdError(func() {
+				reporter.Warnf("Hello World")
+			})
+			Expect(stdErr).To(Equal(warnPrefix + "Hello World\n"))
+			Expect(stdOut).To(BeEmpty())
+		})
+
+		It("Prints a warn message with color", func() {
+			color.SetColor("always")
+			Expect(color.UseColor()).To(BeTrue())
+
+			stdOut, stdErr := captureStdOutAndStdError(func() {
+				reporter.Warnf("Hello World")
+			})
+			Expect(stdErr).To(Equal(warnColorPrefix + "Hello World\n"))
+			Expect(stdOut).To(BeEmpty())
+		})
+	})
+
+	Context("Error", func() {
+		It("Prints an error message without color", func() {
+			color.SetColor("never")
+			Expect(color.UseColor()).To(BeFalse())
+
+			stdOut, stdErr := captureStdOutAndStdError(func() {
+				reporter.Errorf("Hello World")
+			})
+			Expect(stdErr).To(Equal(errorPrefix + "Hello World\n"))
+			Expect(stdOut).To(BeEmpty())
+		})
+
+		It("Prints an error message with color", func() {
+			color.SetColor("always")
+			Expect(color.UseColor()).To(BeTrue())
+
+			stdOut, stdErr := captureStdOutAndStdError(func() {
+				reporter.Errorf("Hello World")
+			})
+			Expect(stdErr).To(Equal(errorColorPrefix + "Hello World\n"))
+			Expect(stdOut).To(BeEmpty())
+		})
+	})
+
+	Context("Debug", func() {
+		It("Does not print if debug is not enabled", func() {
+			debug.SetEnabled(false)
+			Expect(debug.Enabled()).To(BeFalse())
+
+			stdOut, stdErr := captureStdOutAndStdError(func() {
+				reporter.Debugf("Hello World")
+			})
+			reporter.Debugf("Hello world")
+			Expect(stdOut).To(BeEmpty())
+			Expect(stdErr).To(BeEmpty())
+		})
+
+		It("Prints a debug message without color", func() {
+			debug.SetEnabled(true)
+			Expect(debug.Enabled()).To(BeTrue())
+			color.SetColor("never")
+			Expect(color.UseColor()).To(BeFalse())
+
+			stdOut, stdErr := captureStdOutAndStdError(func() {
+				reporter.Debugf("Hello World")
+			})
+
+			Expect(stdOut).To(Equal(infoPrefix + "Hello World\n"))
+			Expect(stdErr).To(BeEmpty())
+		})
+
+		It("Prints a debug message with color", func() {
+			debug.SetEnabled(true)
+			Expect(debug.Enabled()).To(BeTrue())
+			color.SetColor("always")
+			Expect(color.UseColor()).To(BeTrue())
+
+			stdOut, stdErr := captureStdOutAndStdError(func() {
+				reporter.Debugf("Hello World")
+			})
+			Expect(stdOut).To(Equal(infoColorPrefix + "Hello World\n"))
+			Expect(stdErr).To(BeEmpty())
+		})
+	})
+})
+
+func captureStdOutAndStdError(function func()) (string, string) {
+	var stdout []byte
+	var stderr []byte
+
+	rout, wout, _ := os.Pipe()
+	oldOut := os.Stdout
+	rerr, werr, _ := os.Pipe()
+	oldErr := os.Stderr
+	defer func() {
+		os.Stdout = oldOut
+		os.Stderr = oldErr
+	}()
+	os.Stdout = wout
+	os.Stderr = werr
+
+	go func() {
+		function()
+		wout.Close()
+		werr.Close()
+	}()
+	stdout, _ = io.ReadAll(rout)
+	stderr, _ = io.ReadAll(rerr)
+
+	return string(stdout), string(stderr)
+}

--- a/pkg/rosa/runtime.go
+++ b/pkg/rosa/runtime.go
@@ -26,7 +26,7 @@ type Runtime struct {
 }
 
 func NewRuntime() *Runtime {
-	reporter := reporter.CreateReporterOrExit()
+	reporter := reporter.CreateReporter()
 	logger := logging.NewLogger()
 	spinner := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
 	return &Runtime{Reporter: reporter, Logger: logger, Spinner: spinner}


### PR DESCRIPTION
This PR removes the `error` from the `reporter.Builder.Build()` method signature as it was not used and lead to unnecessary error handling and propagation. Instead, replaced with a single `reporter.CreateReporter` function and removed the `Builder` functionality completely.