### PR TITLE
OCM-6515 | fix: Removed output flag from rosa token command

### DIFF
--- a/cmd/token/cmd.go
+++ b/cmd/token/cmd.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/pkg/config"
-	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/rosa"
 )
 
@@ -67,7 +66,6 @@ func NewTokenCommand() *cobra.Command {
 		false,
 		"Generate a new token.",
 	)
-	output.AddFlag(Cmd)
 	return Cmd
 }
 


### PR DESCRIPTION
**Changed**
- Removed output flag from rosa token command since we only have string output in this case

https://issues.redhat.com/browse/OCM-6515