### PR TITLE
OCM-6106 | node drain grace period for hosted control planes

### DIFF
--- a/cmd/create/machinepool/cmd.go
+++ b/cmd/create/machinepool/cmd.go
@@ -56,6 +56,7 @@ var args struct {
 	tuningConfigs         string
 	rootDiskSize          string
 	securityGroupIds      []string
+	nodeDrainGracePeriod  string
 }
 
 var Cmd = &cobra.Command{
@@ -78,7 +79,10 @@ var Cmd = &cobra.Command{
 
   # Add a machine pool with spot instances to a cluster
   rosa create machinepool -c mycluster --name=mp-1 --replicas=2 --instance-type=r5.2xlarge --use-spot-instances \
-    --spot-max-price=0.5`,
+    --spot-max-price=0.5
+
+  # Add a machine pool to a cluster and set the node drain grace period
+  rosa create machinepool -c mycluster --name=mp-1 --node-drain-grace-period="90 minutes"`,
 	Run:  run,
 	Args: cobra.NoArgs,
 }
@@ -213,6 +217,17 @@ func init() {
 		nil,
 		"The additional Security Group IDs to be added to the machine pool. "+
 			"Format should be a comma-separated list.",
+	)
+
+	flags.StringVar(&args.nodeDrainGracePeriod,
+		"node-drain-grace-period",
+		"",
+		"You may set a grace period for how long Pod Disruption Budget-protected workloads will be "+
+			"respected when the NodePool is being replaced or upgraded.\nAfter this grace period, all remaining workloads "+
+			"will be forcibly evicted.\n"+
+			"Valid value is from 0 to 1 week (10080 minutes), and the supported units are 'minute|minutes' or "+
+			"'hour|hours'. 0 or empty value means that the NodePool can be drained without any time limitations.\n"+
+			"This flag is only supported for Hosted Control Planes.",
 	)
 
 	interactive.AddFlag(flags)

--- a/cmd/describe/machinepool/cmd_test.go
+++ b/cmd/describe/machinepool/cmd_test.go
@@ -31,8 +31,9 @@ Subnet:
 Version:                               4.12.24
 Autorepair:                            No
 Tuning configs:                        
-Message:                               
 Additional security group IDs:         
+Node drain grace period:               1 minute
+Message:                               
 `
 	describeStringWithUpgradeOutput = `
 ID:                                    nodepool85
@@ -48,8 +49,9 @@ Subnet:
 Version:                               4.12.24
 Autorepair:                            No
 Tuning configs:                        
-Message:                               
 Additional security group IDs:         
+Node drain grace period:               1 minute
+Message:                               
 Scheduled upgrade:          scheduled 4.12.25 on 2023-08-07 15:22 UTC
 `
 
@@ -59,6 +61,9 @@ aws_node_pool:
   kind: AWSNodePool
 id: nodepool85
 kind: NodePool
+node_drain_grace_period:
+  unit: minute
+  value: 1
 scheduledUpgrade:
   nextRun: 2023-08-07 15:22 UTC
   state: scheduled
@@ -275,8 +280,9 @@ var _ = Describe("Upgrade machine pool", func() {
 func formatNodePool() string {
 	version := cmv1.NewVersion().ID("4.12.24").RawID("openshift-4.12.24")
 	awsNodePool := cmv1.NewAWSNodePool().InstanceType("m5.xlarge")
+	nodeDrain := cmv1.NewValue().Value(1).Unit("minute")
 	np, err := cmv1.NewNodePool().ID(nodePoolName).Version(version).
-		AWSNodePool(awsNodePool).AvailabilityZone("us-east-1a").Build()
+		AWSNodePool(awsNodePool).AvailabilityZone("us-east-1a").NodeDrainGracePeriod(nodeDrain).Build()
 	Expect(err).To(BeNil())
 	return test.FormatResource(np)
 }

--- a/cmd/describe/machinepool/nodepool.go
+++ b/cmd/describe/machinepool/nodepool.go
@@ -51,8 +51,9 @@ func describeNodePool(r *rosa.Runtime, cluster *cmv1.Cluster, clusterKey string,
 		"Version:                               %s\n"+
 		"Autorepair:                            %s\n"+
 		"Tuning configs:                        %s\n"+
-		"Message:                               %s\n"+
-		"Additional security group IDs:         %s\n",
+		"Additional security group IDs:         %s\n"+
+		"Node drain grace period:               %s\n"+
+		"Message:                               %s\n",
 		nodePool.ID(),
 		cluster.ID(),
 		ocmOutput.PrintNodePoolAutoscaling(nodePool.Autoscaling()),
@@ -66,8 +67,9 @@ func describeNodePool(r *rosa.Runtime, cluster *cmv1.Cluster, clusterKey string,
 		ocmOutput.PrintNodePoolVersion(nodePool.Version()),
 		ocmOutput.PrintNodePoolAutorepair(nodePool.AutoRepair()),
 		ocmOutput.PrintNodePoolTuningConfigs(nodePool.TuningConfigs()),
-		ocmOutput.PrintNodePoolMessage(nodePool.Status()),
 		ocmOutput.PrintNodePoolAdditionalSecurityGroups(nodePool.AWSNodePool()),
+		ocmOutput.PrintNodeDrainGracePeriod(nodePool.NodeDrainGracePeriod()),
+		ocmOutput.PrintNodePoolMessage(nodePool.Status()),
 	)
 
 	// Print scheduled upgrades if existing

--- a/cmd/edit/machinepool/cmd.go
+++ b/cmd/edit/machinepool/cmd.go
@@ -28,15 +28,16 @@ import (
 )
 
 var args struct {
-	replicas           int
-	autoscalingEnabled bool
-	minReplicas        int
-	maxReplicas        int
-	labels             string
-	taints             string
-	version            string
-	autorepair         bool
-	tuningConfigs      string
+	replicas             int
+	autoscalingEnabled   bool
+	minReplicas          int
+	maxReplicas          int
+	labels               string
+	taints               string
+	version              string
+	autorepair           bool
+	tuningConfigs        string
+	nodeDrainGracePeriod string
 }
 
 var Cmd = &cobra.Command{
@@ -47,7 +48,9 @@ var Cmd = &cobra.Command{
 	Example: `  # Set 4 replicas on machine pool 'mp1' on cluster 'mycluster'
   rosa edit machinepool --replicas=4 --cluster=mycluster mp1
   # Enable autoscaling and Set 3-5 replicas on machine pool 'mp1' on cluster 'mycluster'
-  rosa edit machinepool --enable-autoscaling --min-replicas=3 --max-replicas=5 --cluster=mycluster mp1`,
+  rosa edit machinepool --enable-autoscaling --min-replicas=3 --max-replicas=5 --cluster=mycluster mp1
+  # Set the node drain grace period to 1 hour on machine pool 'mp1' on cluster 'mycluster'
+  rosa edit machinepool --node-drain-grace-period="1 hour" --cluster=mycluster mp1`,
 	Run: run,
 	Args: func(_ *cobra.Command, argv []string) error {
 		if len(argv) != 1 {
@@ -130,6 +133,17 @@ func init() {
 		"Name of the tuning configs to be applied to the machine pool. Format should be a comma-separated list. "+
 			"Tuning config must already exist. "+
 			"This list will overwrite any modifications made to node tuning configs on an ongoing basis.",
+	)
+
+	flags.StringVar(&args.nodeDrainGracePeriod,
+		"node-drain-grace-period",
+		"",
+		"You may set a grace period for how long Pod Disruption Budget-protected workloads will be "+
+			"respected when the NodePool is being replaced or upgraded.\nAfter this grace period, all remaining workloads "+
+			"will be forcibly evicted.\n"+
+			"Valid value is from 0 to 1 week (10080 minutes), and the supported units are 'minute|minutes' or "+
+			"'hour|hours'. 0 or empty value means that the NodePool can be drained without any time limitations.\n"+
+			"This flag is only supported for Hosted Control Planes.",
 	)
 
 	flags.MarkHidden("version")

--- a/pkg/helper/machinepools/helpers_test.go
+++ b/pkg/helper/machinepools/helpers_test.go
@@ -164,3 +164,48 @@ var _ = Describe("Label validations", func() {
 		),
 	)
 })
+
+var _ = Describe("Create node drain grace period builder validations", func() {
+	DescribeTable("Create node drain grace period builder validations",
+		func(period string, hasError bool) {
+			_, err := CreateNodeDrainGracePeriodBuilder(period)
+			if hasError {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).ToNot(HaveOccurred())
+			}
+		},
+		Entry("Should not error with empty value",
+			"",
+			false,
+		),
+		Entry("Should not error with 0 value",
+			"0",
+			false,
+		),
+		Entry("Should not error with lower limit value",
+			"1 minute",
+			false,
+		),
+		Entry("Should not error with upper limit value",
+			"10080 minutes",
+			false,
+		),
+		Entry("Should not error with hour unit",
+			"1 hour",
+			false,
+		),
+		Entry("Should not error with hours unit",
+			"168 hours",
+			false,
+		),
+		Entry("Should error with invalid number of tokens",
+			"1 minute later",
+			true,
+		),
+		Entry("Should error with invalid unit",
+			"1 day",
+			true,
+		),
+	)
+})

--- a/pkg/ocm/output/nodepools.go
+++ b/pkg/ocm/output/nodepools.go
@@ -91,3 +91,15 @@ func PrintNodePoolTuningConfigs(tuningConfigs []string) string {
 	}
 	return strings.Join(tuningConfigs, ",")
 }
+
+func PrintNodeDrainGracePeriod(period *cmv1.Value) string {
+	if period != nil && period.Value() != 0 {
+		unit := "minute"
+		if period.Value() > 1 {
+			unit += "s"
+		}
+		return fmt.Sprintf("%d %s", int(period.Value()), unit)
+	}
+
+	return ""
+}

--- a/pkg/ocm/output/nodepools_test.go
+++ b/pkg/ocm/output/nodepools_test.go
@@ -1,0 +1,32 @@
+package output
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+)
+
+var _ = Describe("Create node drain grace period builder validations", func() {
+	zeroValue, _ := cmv1.NewValue().Value(0).Build()
+	oneValue, _ := cmv1.NewValue().Value(1).Build()
+	twoValue, _ := cmv1.NewValue().Value(2).Build()
+
+	DescribeTable("Create node drain grace period builder validations",
+		func(period *cmv1.Value, expectedOutput string) {
+			output := PrintNodeDrainGracePeriod(period)
+			Expect(output).To(Equal(expectedOutput))
+		},
+		Entry(nil,
+			"",
+		),
+		Entry(zeroValue,
+			"",
+		),
+		Entry(oneValue,
+			"1 minute",
+		),
+		Entry(twoValue,
+			"2 minutes",
+		),
+	)
+})


### PR DESCRIPTION
Support node drain grace period for NodePools of HyperShift-enabled clusters. The node drain grace period is supported for these operations:
- Create machinepool (nodepool)
- Update machinepool
- Describe machinepool

https://issues.redhat.com/browse/OCM-6106