### PR TITLE
OCM-6592 | fix: filter out local-zone and wave-length zone associated subnets during 'rosa create machinepool (HCP)'

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -3972,7 +3972,6 @@ func getInitialValidSubnets(awsClient aws.Client, ids []string, r *reporter.Obje
 	localZoneSubnets := []string{}
 
 	validSubnets, err := awsClient.ListSubnets(ids...)
-
 	if err != nil {
 		return initialValidSubnets, err
 	}
@@ -4000,6 +3999,7 @@ func getInitialValidSubnets(awsClient aws.Client, ids []string, r *reporter.Obje
 		r.Warnf("The following subnets were excluded because they are on local zone or wavelength zone: %s",
 			helper.SliceToSortedString(localZoneSubnets))
 	}
+
 	return initialValidSubnets, nil
 }
 

--- a/cmd/create/machinepool/helper.go
+++ b/cmd/create/machinepool/helper.go
@@ -70,7 +70,8 @@ func getSubnetFromUser(cmd *cobra.Command, r *rosa.Runtime, isSubnetSet bool, cl
 // getSubnetOptions gets one of the cluster subnets and returns a slice of formatted VPC's private subnets.
 func getSubnetOptions(r *rosa.Runtime, cluster *cmv1.Cluster) ([]string, error) {
 	// Fetch VPC's subnets
-	privateSubnets, err := r.AWSClient.GetVPCPrivateSubnets(cluster.AWS().SubnetIDs()[0])
+	privateSubnets, err := r.AWSClient.GetVPCPrivateSubnets(
+		cluster.Hypershift().Enabled(), cluster.AWS().SubnetIDs()[0])
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/create/machinepool/nodepool.go
+++ b/cmd/create/machinepool/nodepool.go
@@ -433,7 +433,7 @@ func addNodePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster, r
 func getSubnetFromAvailabilityZone(cmd *cobra.Command, r *rosa.Runtime, isAvailabilityZoneSet bool,
 	cluster *cmv1.Cluster) (string, error) {
 
-	privateSubnets, err := r.AWSClient.GetVPCPrivateSubnets(cluster.AWS().SubnetIDs()[0])
+	privateSubnets, err := r.AWSClient.GetVPCPrivateSubnets(true, cluster.AWS().SubnetIDs()[0])
 	if err != nil {
 		return "", err
 	}

--- a/pkg/aws/client_mock.go
+++ b/pkg/aws/client_mock.go
@@ -385,19 +385,34 @@ func (mr *MockClientMockRecorder) FetchPublicSubnetMap(subnets interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchPublicSubnetMap", reflect.TypeOf((*MockClient)(nil).FetchPublicSubnetMap), subnets)
 }
 
-// FilterVPCsPrivateSubnets mocks base method.
-func (m *MockClient) FilterVPCsPrivateSubnets(subnets []*ec2.Subnet) ([]*ec2.Subnet, error) {
+// FilterSubnetsWithStandardAvailabilityZones mocks base method.
+func (m *MockClient) FilterSubnetsWithStandardAvailabilityZones(subnets []*ec2.Subnet) ([]*ec2.Subnet, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FilterVPCsPrivateSubnets", subnets)
+	ret := m.ctrl.Call(m, "FilterSubnetsWithStandardAvailabilityZones", subnets)
+	ret0, _ := ret[0].([]*ec2.Subnet)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FilterSubnetsWithStandardAvailabilityZones indicates an expected call of FilterSubnetsWithStandardAvailabilityZones.
+func (mr *MockClientMockRecorder) FilterSubnetsWithStandardAvailabilityZones(subnets interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FilterSubnetsWithStandardAvailabilityZones", reflect.TypeOf((*MockClient)(nil).FilterSubnetsWithStandardAvailabilityZones), subnets)
+}
+
+// FilterVPCsPrivateSubnets mocks base method.
+func (m *MockClient) FilterVPCsPrivateSubnets(isHostedCp bool, subnets []*ec2.Subnet) ([]*ec2.Subnet, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FilterVPCsPrivateSubnets", isHostedCp, subnets)
 	ret0, _ := ret[0].([]*ec2.Subnet)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FilterVPCsPrivateSubnets indicates an expected call of FilterVPCsPrivateSubnets.
-func (mr *MockClientMockRecorder) FilterVPCsPrivateSubnets(subnets interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) FilterVPCsPrivateSubnets(isHostedCp, subnets interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FilterVPCsPrivateSubnets", reflect.TypeOf((*MockClient)(nil).FilterVPCsPrivateSubnets), subnets)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FilterVPCsPrivateSubnets", reflect.TypeOf((*MockClient)(nil).FilterVPCsPrivateSubnets), isHostedCp, subnets)
 }
 
 // FindPolicyARN mocks base method.
@@ -865,18 +880,18 @@ func (mr *MockClientMockRecorder) GetSubnetAvailabilityZone(subnetID interface{}
 }
 
 // GetVPCPrivateSubnets mocks base method.
-func (m *MockClient) GetVPCPrivateSubnets(subnetID string) ([]*ec2.Subnet, error) {
+func (m *MockClient) GetVPCPrivateSubnets(isHostedCp bool, subnetID string) ([]*ec2.Subnet, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetVPCPrivateSubnets", subnetID)
+	ret := m.ctrl.Call(m, "GetVPCPrivateSubnets", isHostedCp, subnetID)
 	ret0, _ := ret[0].([]*ec2.Subnet)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetVPCPrivateSubnets indicates an expected call of GetVPCPrivateSubnets.
-func (mr *MockClientMockRecorder) GetVPCPrivateSubnets(subnetID interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) GetVPCPrivateSubnets(isHostedCp, subnetID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPCPrivateSubnets", reflect.TypeOf((*MockClient)(nil).GetVPCPrivateSubnets), subnetID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPCPrivateSubnets", reflect.TypeOf((*MockClient)(nil).GetVPCPrivateSubnets), isHostedCp, subnetID)
 }
 
 // GetVPCSubnets mocks base method.

--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -727,7 +727,7 @@ func ValidateHostedClusterSubnets(awsClient aws.Client, isPrivate bool, subnetID
 		}
 	}
 
-	privateSubnets, privateSubnetsErr := awsClient.FilterVPCsPrivateSubnets(subnets)
+	privateSubnets, privateSubnetsErr := awsClient.FilterVPCsPrivateSubnets(true, subnets)
 	if privateSubnetsErr != nil {
 		return 0, privateSubnetsErr
 	}


### PR DESCRIPTION
BEFORE: (shows local-zone subnets)
![image](https://github.com/openshift/rosa/assets/118839428/cc1e372d-a956-4a2d-b01d-e4bb8c2bfbba)


AFTER: (local-zone subnets filtered away)
![image](https://github.com/openshift/rosa/assets/118839428/042a5971-3293-45ac-b290-fd8ca9575995)

