### PR TITLE
OCM-6668 | chore: Make all codecov reporting informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,6 +5,7 @@ coverage:
         paths:
           - "cmd"
           - "pkg"
+        informational: true
     patch:
       default:
         paths:


### PR DESCRIPTION
This PR makes our Codecov reporting informative. This places greater emphasis on PR reviewers to request unit testing and make suggestions around code layout to ensure new additions are testable.