### PR TITLE
OCM-5718 | feat: Display login error if `--govcloud` supplied with commercial region

### DIFF
--- a/cmd/login/cmd_test.go
+++ b/cmd/login/cmd_test.go
@@ -1,0 +1,72 @@
+package login_test
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/rosa/cmd/login"
+	"github.com/openshift/rosa/pkg/config"
+	"github.com/openshift/rosa/pkg/fedramp"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+var _ = Describe("Validate login command", func() {
+
+	AfterEach(func() {
+		fedramp.Disable()
+		os.Setenv("AWS_REGION", "")
+	})
+
+	Context("login command", func() {
+		When("logging into FedRAMP", func() {
+			It("only 'region' is FedRAMP", func() {
+				os.Setenv("AWS_REGION", "us-gov-west-1")
+				// Load the configuration file:
+				cfg, err := config.Load()
+				Expect(err).ToNot(HaveOccurred())
+				if cfg == nil {
+					cfg = new(config.Config)
+				}
+				err = login.CheckAndLogIntoFedramp(false, false, cfg, "", "staging", rosa.NewRuntime())
+				Expect(err).ToNot(HaveOccurred())
+			})
+			It("only 'govcloud' flag is true", func() {
+				os.Setenv("AWS_REGION", "us-east-1")
+				// Load the configuration file:
+				cfg, err := config.Load()
+				Expect(err).ToNot(HaveOccurred())
+				if cfg == nil {
+					cfg = new(config.Config)
+				}
+				err = login.CheckAndLogIntoFedramp(true, false, cfg, "", "staging", rosa.NewRuntime())
+				Expect(err).To(HaveOccurred())
+			})
+			It("only 'cfg' has FedRAMP", func() {
+				os.Setenv("AWS_REGION", "us-east-1")
+				// Load the configuration file:
+				cfg, err := config.Load()
+				Expect(err).ToNot(HaveOccurred())
+				if cfg == nil {
+					cfg = new(config.Config)
+				}
+				cfg.FedRAMP = true
+				err = login.CheckAndLogIntoFedramp(false, false, cfg, "", "staging", rosa.NewRuntime())
+				Expect(err).To(HaveOccurred())
+			})
+			It("'cfg' has FedRAMP and region is govcloud", func() {
+				os.Setenv("AWS_REGION", "us-gov-east-1")
+				// Load the configuration file:
+				cfg, err := config.Load()
+				Expect(err).ToNot(HaveOccurred())
+				if cfg == nil {
+					cfg = new(config.Config)
+				}
+				cfg.FedRAMP = true
+				err = login.CheckAndLogIntoFedramp(false, false, cfg, "", "staging", rosa.NewRuntime())
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+	})
+})

--- a/cmd/login/login_suite_test.go
+++ b/cmd/login/login_suite_test.go
@@ -1,0 +1,13 @@
+package login_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCluster(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Login Suite")
+}


### PR DESCRIPTION
[OCM-5718](https://issues.redhat.com//browse/OCM-5718) describes a bug where if a user attempts to log in supplying all commercial values, except passing in `--govcloud` flag, ROSA will be in 'fedramp mode' and will attempt to run commands on the wrong API endpoint. This MR makes sure users are meaning to log into govcloud by requiring a govcloud region upon logging in.

All other logic is kept the same, so if you _only_ supply a govcloud region, or an encrypted token, etc, you will still log into fedramp. But, the `--govcloud` flag bug is solved by requiring the region upon passing the flag. If you pass `--govcloud` without meaning to (I.E. not providing a govcloud region), you will face an error. Other safeguard in this case already exists, where you must pass in a fedramp token to log in to govcloud anyway.