### PR TITLE
OCM-6648 | fix: create node pool with security group - check version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,12 @@ https://github.com/openshift/release/blob/master/ci-operator/config/openshift/ro
 
 This repository also uses GitHub actions which are configured at `./github/workflows`
 
+## Version-gating a feature
+
+In some cases new features have minimal OCP versions.
+To add validation for a minimal version, please add the minimal version
+const to `features.go` and use the `IsFeatureSupported` function.
+
 # Questions?
 
 If you have any questions about the code or how to contribute, don't hesitate to

--- a/cmd/create/machinepool/helper_test.go
+++ b/cmd/create/machinepool/helper_test.go
@@ -7,6 +7,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/rosa/pkg/helper/features"
 	"github.com/openshift/rosa/pkg/rosa"
 )
 
@@ -67,6 +68,27 @@ var _ = Describe("Machine pool helper", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(awsNodePool.AdditionalSecurityGroupIds())).To(Equal(0))
 			Expect(awsNodePool.InstanceType()).To(Equal(instanceType))
+		})
+	})
+
+	Context("It validate version is compatible for security groups", func() {
+		It("Skips validation if the version isn't provided", func() {
+			version := ""
+			isCompatible, err := features.IsFeatureSupported(features.AdditionalDay2SecurityGroupsHcpFeature, version)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(isCompatible).To(BeTrue())
+		})
+		It("Returns false for 4.14.0", func() {
+			version := "4.14.0"
+			isCompatible, err := features.IsFeatureSupported(features.AdditionalDay2SecurityGroupsHcpFeature, version)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(isCompatible).To(BeFalse())
+		})
+		It("Returns true for 4.15.0", func() {
+			version := "4.15.0"
+			isCompatible, err := features.IsFeatureSupported(features.AdditionalDay2SecurityGroupsHcpFeature, version)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(isCompatible).To(BeTrue())
 		})
 	})
 })

--- a/cmd/create/machinepool/nodepool.go
+++ b/cmd/create/machinepool/nodepool.go
@@ -10,6 +10,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/rosa/pkg/helper/features"
 	"github.com/openshift/rosa/pkg/helper/machinepools"
 	"github.com/openshift/rosa/pkg/helper/versions"
 	"github.com/openshift/rosa/pkg/interactive"
@@ -229,7 +230,13 @@ func addNodePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster, r
 
 	isSecurityGroupIdsSet := cmd.Flags().Changed(securitygroups.MachinePoolSecurityGroupFlag)
 	securityGroupIds := args.securityGroupIds
-	if interactive.Enabled() && !isSecurityGroupIdsSet {
+	isVersionCompatibleSecurityGroupIds, err := features.IsFeatureSupported(
+		features.AdditionalDay2SecurityGroupsHcpFeature, version)
+	if err != nil {
+		r.Reporter.Errorf("%s", err)
+		os.Exit(1)
+	}
+	if interactive.Enabled() && !isSecurityGroupIdsSet && isVersionCompatibleSecurityGroupIds {
 		securityGroupIds, err = getSecurityGroupsOption(r, cmd, cluster)
 		if err != nil {
 			r.Reporter.Errorf("%s", err)

--- a/pkg/helper/features/features.go
+++ b/pkg/helper/features/features.go
@@ -1,0 +1,41 @@
+package features
+
+import (
+	"fmt"
+
+	"github.com/openshift/rosa/pkg/helper/versions"
+)
+
+type OCMFeature string
+
+const (
+	AdditionalDay2SecurityGroupsHcpFeature = "AdditionalDay2SecurityGroupsHcpFeature"
+)
+
+var ocmFeatureVersions = map[OCMFeature]string{
+	AdditionalDay2SecurityGroupsHcpFeature: "4.15.0-0.a",
+}
+
+// IsFeatureSupported checks if a feature is supported for an OCP version.
+// If the version string is empty, or the feature isn't defined, the function
+// returns true.
+func IsFeatureSupported(feature OCMFeature, version string) (bool, error) {
+	// The version is not specified.
+	if version == "" {
+		return true, nil
+	}
+
+	supportedVersion := ocmFeatureVersions[feature]
+	// OCM feature isn't defined.
+	if supportedVersion == "" {
+		return true, nil
+	}
+
+	isSupported, err := versions.IsGreaterThanOrEqual(version, supportedVersion)
+	if err != nil {
+		return false, fmt.Errorf("failed to check if feature '%s' is supported for version '%s': %v",
+			feature, version, err)
+	}
+
+	return isSupported, nil
+}

--- a/pkg/ocm/versions.go
+++ b/pkg/ocm/versions.go
@@ -43,6 +43,7 @@ const (
 
 	MinVersionForAdditionalComputeSecurityGroupIdsDay1 = "4.14.0-0.a"
 	MinVersionForAdditionalComputeSecurityGroupIdsDay2 = "4.11.0-0.a"
+	// TODO: Add new minimal versions to the `features.go` package.
 )
 
 func (c *Client) ManagedServiceVersionInquiry(serviceType string) (string, error) {


### PR DESCRIPTION
For interactive mode, check the node pool version and prompt for additional security groups accordingly.