### PR TITLE
OCM-6687 | fix: 4.14 nightly version not compatible with ROSA HCP

### DIFF
--- a/pkg/ocm/versions.go
+++ b/pkg/ocm/versions.go
@@ -36,7 +36,7 @@ const (
 	LowestHttpTokensRequiredSupport = "4.11.0"
 	LowestSTSMinor                  = "4.7"
 
-	LowestHostedCpSupport            = "4.14.0"
+	LowestHostedCpSupport            = "4.14.0-0.a"
 	MinVersionForManagedIngressV2    = "4.14.0-0.a"
 	MinVersionForMachinePoolRootDisk = "4.10.0-0.a"
 	VersionPrefix                    = "openshift-v"

--- a/pkg/ocm/versions_test.go
+++ b/pkg/ocm/versions_test.go
@@ -155,7 +155,7 @@ var _ = Describe("Versions", Ordered, func() {
 				func() string { return "4.11.0-0.nightly-2022-10-17-040259-nightly" },
 				func() string { return NightlyChannelGroup }, false, false, nil),
 			Entry("OK: Nightly channel group and good version",
-				func() string { return "4.14.1-0.nightly-2022-11-25-185455-nightly" },
+				func() string { return "4.14.0-0.nightly-2024-03-13-015516" },
 				func() string { return NightlyChannelGroup }, true, true, nil),
 			Entry("OK: When a greater version than the minimum is provided",
 				func() string { return "4.15.0" },


### PR DESCRIPTION
Issue with nightly versions being evaluated as prelease versions.
This caused cluster create issues with openshift nightly versions greater than 4.14.0.
The minimum versions for HCP required is 4.14.0

With command:
`./rosa create cluster --hosted-cp --channel-group=nightly`

Interactive List before fix (rosa create cluster) [only shows 4.15.0+ nightly versions]
![image](https://github.com/openshift/rosa/assets/118839428/6791be38-4d16-4baf-bbca-da09194e2ad3)

Interactive List after fix (rosa create cluster)
![image](https://github.com/openshift/rosa/assets/118839428/960dda29-71bc-4b06-ae19-52fa918af06f)

Confirming fix includes all nightly versions meeting 4.14.0 version requirement.
