### PR TITLE
OCM-6753 | fix: hcp private cluster subnet validation

### DIFF
--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -734,7 +734,7 @@ func ValidateHostedClusterSubnets(awsClient aws.Client, isPrivate bool, subnetID
 	}
 
 	privateSubnetCount := len(privateSubnets)
-	publicSubnetsCount := len(vpcSubnets) - privateSubnetCount
+	publicSubnetsCount := len(subnets) - privateSubnetCount
 
 	if isPrivate {
 		if publicSubnetsCount > 0 {


### PR DESCRIPTION
In the PR https://github.com/openshift/rosa/pull/1854 

The `ValidateHostedClusterSubnets` publicSubnetsCount calculation were changed.
This cause rosa unable to create private hcp clusters in some cases due to validation failure:

```
E: The number of public subnets for a private hosted cluster should be zero
```

This change is to revert back to the previous calculation method. 

Reference: https://issues.redhat.com/browse/OCM-6753