### PR TITLE
OCM-6768 | fix: Create machine pool with security group - filter options

### DIFF
--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -1279,19 +1278,10 @@ func (c *awsClient) GetSecurityGroupIds(vpcId string) ([]ec2types.SecurityGroup,
 		return []ec2types.SecurityGroup{}, err
 	}
 
-	for _, secGroup := range resp.SecurityGroups {
-		if c.Ec2ResourceHasTag(secGroup.Tags, tags.RedHatManaged, strconv.FormatBool(true)) {
-			continue
-		}
-		if aws.ToString(secGroup.GroupName) == "default" {
-			continue
-		}
-	}
-
 	return resp.SecurityGroups, nil
 }
 
-func (c *awsClient) Ec2ResourceHasTag(tags []ec2types.Tag, tagName, tagValue string) bool {
+func Ec2ResourceHasTag(tags []ec2types.Tag, tagName, tagValue string) bool {
 	for _, tag := range tags {
 		if aws.ToString(tag.Key) == tagName && aws.ToString(tag.Value) == tagValue {
 			return true

--- a/pkg/interactive/securitygroups/security_groups_test.go
+++ b/pkg/interactive/securitygroups/security_groups_test.go
@@ -1,0 +1,52 @@
+package securitygroups
+
+import (
+	"testing"
+
+	awsSdk "github.com/aws/aws-sdk-go-v2/aws"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+func TestSecurityGroups(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Security groups Suite")
+}
+
+var _ = Describe("Security groups", func() {
+	Context("Validate security group tags", func() {
+		It("Return invalid for security group with red-hat-managed tag", func() {
+			sg := ec2types.SecurityGroup{
+				Tags: []ec2types.Tag{
+					{
+						Key:   awsSdk.String("red-hat-managed"),
+						Value: awsSdk.String("true"),
+					},
+				},
+			}
+			isValid := isValidSecurityGroup(sg)
+			Expect(isValid).To(Equal(false))
+		})
+		It("Return invalid for security group with 'default' name'", func() {
+			sg := ec2types.SecurityGroup{
+				GroupName: awsSdk.String("default"),
+			}
+			isValid := isValidSecurityGroup(sg)
+			Expect(isValid).To(Equal(false))
+		})
+		It("Return valid for security group", func() {
+			sg := ec2types.SecurityGroup{
+				GroupName: awsSdk.String("sg-1"),
+				Tags: []ec2types.Tag{
+					{
+						Key:   awsSdk.String("red-hat-managed"),
+						Value: awsSdk.String("false"),
+					},
+				},
+			}
+			isValid := isValidSecurityGroup(sg)
+			Expect(isValid).To(Equal(true))
+		})
+	})
+})


### PR DESCRIPTION
For interactive mode, filter out security groups with `red-hat-managed` tag and with name `default`.

Improve the UX, to prevent an error returned from the backend.