### PR TITLE
OCM-6767 | fix: describe node pool - adjust output

### DIFF
--- a/cmd/describe/machinepool/cmd_test.go
+++ b/cmd/describe/machinepool/cmd_test.go
@@ -52,7 +52,7 @@ Tuning configs:
 Additional security group IDs:         
 Node drain grace period:               1 minute
 Message:                               
-Scheduled upgrade:          scheduled 4.12.25 on 2023-08-07 15:22 UTC
+Scheduled upgrade:                     scheduled 4.12.25 on 2023-08-07 15:22 UTC
 `
 
 	describeYamlWithUpgradeOutput = `availability_zone: us-east-1a

--- a/cmd/describe/machinepool/nodepool.go
+++ b/cmd/describe/machinepool/nodepool.go
@@ -75,7 +75,7 @@ func describeNodePool(r *rosa.Runtime, cluster *cmv1.Cluster, clusterKey string,
 	// Print scheduled upgrades if existing
 	if scheduledUpgrade != nil {
 		nodePoolOutput = fmt.Sprintf("%s"+
-			"Scheduled upgrade:          %s %s on %s\n",
+			"Scheduled upgrade:                     %s %s on %s\n",
 			nodePoolOutput,
 			scheduledUpgrade.State().Value(),
 			scheduledUpgrade.Version(),


### PR DESCRIPTION
Add more spaces for schedule nodepool upgrade prompt.

e.g.
```
oadler@dhcp-1-179:rosa (OCM-6767)$ rosa describe machinepool -c oadler-mar-8 test4

ID:                                    test4
Cluster ID:                            2a279k19s61nr623etadtgnqblcnrrrl
Autoscaling:                           No
Desired replicas:                      1
Current replicas:                      1
Instance type:                         m5.xlarge
Labels:                                
Taints:                                
Availability zone:                     us-west-2a
Subnet:                                subnet-0e3a4046c1c2f1078
Version:                               4.15.0
Autorepair:                            Yes
Tuning configs:                        
Additional security group IDs:         sg-095aab06f92f0239d, sg-0d28be792f1e45343
Node drain grace period:               
Message:                               
Scheduled upgrade:                     pending 4.15.3 on 2024-03-18 08:08 UTC
```
