### PR TITLE
OCM-6879 | fix: allow user specify `cluster-admin` as admin username in day-1

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1064,7 +1064,7 @@ func run(cmd *cobra.Command, _ []string) {
 				os.Exit(1)
 			}
 			if isClusterAdmin {
-				clusterAdminUser = idp.GetIdpUserNameFromPrompt(cmd, r, "cluster-admin-user", clusterAdminUser)
+				clusterAdminUser = idp.GetIdpUserNameFromPrompt(cmd, r, "cluster-admin-user", clusterAdminUser, true)
 				isCustomAdminPassword, err := interactive.GetBool(interactive.Input{
 					Question: "Create custom password for cluster admin",
 					Default:  false,

--- a/cmd/create/idp/htpasswd_test.go
+++ b/cmd/create/idp/htpasswd_test.go
@@ -85,6 +85,22 @@ var _ = Describe("IDP Tests", func() {
 		)
 	})
 
+	Describe("Username Validators Tests", func() {
+		It("username with `:` cannot pass clusterAdminValidator", func() {
+			username := "my:admin"
+			err := UsernameValidator(username)
+			Expect(err).To(HaveOccurred())
+			err = clusterAdminValidator(username)
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("username `cluster-admin` cannot pass clusterAdminValidator", func() {
+			username := "cluster-admin"
+			err := UsernameValidator(username)
+			Expect(err).NotTo(HaveOccurred())
+			err = clusterAdminValidator(username)
+			Expect(err).To(HaveOccurred())
+		})
+	})
 })
 
 func CreateTmpFile(content string) (*os.File, error) {


### PR DESCRIPTION
Signed-off-by: marcolan018 <llan@redhat.com>