### PR TITLE
OCM-6926 | fix: Support local envs in GetEnv()

### DIFF
--- a/pkg/ocm/config.go
+++ b/pkg/ocm/config.go
@@ -105,6 +105,12 @@ func GetEnv() (string, error) {
 				}
 			}
 		}
+	} else { // Go back to exact URL check (in case of other URLs like local envs, etc.)
+		for env, api := range urlAliases {
+			if api == strings.TrimSuffix(cfg.URL, "/") {
+				return env, nil
+			}
+		}
 	}
 
 	// Special use case for Admin users in the GovCloud environment

--- a/pkg/ocm/config.go
+++ b/pkg/ocm/config.go
@@ -91,13 +91,6 @@ func GetEnv() (string, error) {
 	urlAliases := URLAliases
 	if cfg.FedRAMP {
 		urlAliases = fedramp.URLAliases
-		// Special use case for Admin users in the GovCloud environment
-		for env, api := range urlAliases {
-			fmt.Println(strings.TrimSuffix(cfg.URL, "/"))
-			if api == strings.TrimSuffix(cfg.URL, "/") {
-				return env, nil
-			}
-		}
 	}
 
 	// Check for OCM environments (including regionalized URLs)
@@ -114,7 +107,7 @@ func GetEnv() (string, error) {
 		}
 	}
 
-	// URL check as a fallback mechanism (in case of other URLs like local envs, etc.)
+	// URL check as a fallback mechanism (in case of other URLs like local envs, fedRAMP envs, etc.)
 	for env, api := range urlAliases {
 		if api == strings.TrimSuffix(cfg.URL, "/") {
 			return env, nil

--- a/pkg/ocm/config.go
+++ b/pkg/ocm/config.go
@@ -91,6 +91,13 @@ func GetEnv() (string, error) {
 	urlAliases := URLAliases
 	if cfg.FedRAMP {
 		urlAliases = fedramp.URLAliases
+		// Special use case for Admin users in the GovCloud environment
+		for env, api := range urlAliases {
+			fmt.Println(strings.TrimSuffix(cfg.URL, "/"))
+			if api == strings.TrimSuffix(cfg.URL, "/") {
+				return env, nil
+			}
+		}
 	}
 
 	// Check for OCM environments (including regionalized URLs)
@@ -105,16 +112,10 @@ func GetEnv() (string, error) {
 				}
 			}
 		}
-	} else { // Go back to exact URL check (in case of other URLs like local envs, etc.)
-		for env, api := range urlAliases {
-			if api == strings.TrimSuffix(cfg.URL, "/") {
-				return env, nil
-			}
-		}
 	}
 
-	// Special use case for Admin users in the GovCloud environment
-	for env, api := range fedramp.AdminURLAliases {
+	// URL check as a fallback mechanism (in case of other URLs like local envs, etc.)
+	for env, api := range urlAliases {
 		if api == strings.TrimSuffix(cfg.URL, "/") {
 			return env, nil
 		}

--- a/pkg/ocm/config_test.go
+++ b/pkg/ocm/config_test.go
@@ -146,7 +146,7 @@ var _ = Describe("Gateway URL Resolution", func() {
 		})
 
 		It("Returns a valid fedRAMP env", func() {
-			url := "https://api-admin.int.openshiftusgov.com"
+			url := "https://api.int.openshiftusgov.com"
 			cfg := &config.Config{}
 			cfg.URL = url
 			cfg.FedRAMP = true

--- a/pkg/ocm/config_test.go
+++ b/pkg/ocm/config_test.go
@@ -130,6 +130,37 @@ var _ = Describe("Gateway URL Resolution", func() {
 			Expect(env).To(Equal("staging"))
 		})
 
+		It("Returns a valid local env", func() {
+			url := "http://localhost:8000"
+			cfg := &config.Config{}
+			cfg.URL = url
+			err := config.Save(cfg)
+			Expect(err).To(BeNil())
+			currentConfig, err := config.Load()
+			Expect(err).To(BeNil())
+			Expect(currentConfig.URL).To(Equal(url))
+
+			env, err := GetEnv()
+			Expect(err).To(BeNil())
+			Expect(env).To(Equal("local"))
+		})
+
+		It("Returns a valid fedRAMP env", func() {
+			url := "https://api-admin.int.openshiftusgov.com"
+			cfg := &config.Config{}
+			cfg.URL = url
+			cfg.FedRAMP = true
+			err := config.Save(cfg)
+			Expect(err).To(BeNil())
+			currentConfig, err := config.Load()
+			Expect(err).To(BeNil())
+			Expect(currentConfig.URL).To(Equal(url))
+
+			env, err := GetEnv()
+			Expect(err).To(BeNil())
+			Expect(env).To(Equal("integration"))
+		})
+
 		It("Returns a valid regionalized env", func() {
 			url := "https://api.aws.ap-southeast-1.integration.openshift.com"
 			cfg := &config.Config{}


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-6926

**Changed**
- Added complete URL check as a fallback mechanism for GetEnv() in case of specific local or other URLs
- Added test case to confirm the behavior

**Tested**
- Local env should be supported in GetEnv() : tested