### PR TITLE
OCM-6883 | fix: revise the help message for rosa admin commands

### DIFF
--- a/cmd/create/admin/cmd.go
+++ b/cmd/create/admin/cmd.go
@@ -39,9 +39,9 @@ const MaxPasswordLength = 23
 
 var Cmd = &cobra.Command{
 	Use:   "admin",
-	Short: "Creates an admin user to login to the cluster",
-	Long:  "Creates a cluster-admin user with an auto-generated password to login to the cluster",
-	Example: `  # Create an admin user to login to the cluster
+	Short: "Creates the 'cluster-admin' user to login to the cluster",
+	Long:  "Creates the 'cluster-admin' user with an auto-generated password to login to the cluster",
+	Example: `  # Create the 'cluster-admin‘ user to login to the cluster
   rosa create admin -c mycluster -p MasterKey123`,
 	Run:  run,
 	Args: cobra.NoArgs,

--- a/cmd/describe/admin/cmd.go
+++ b/cmd/describe/admin/cmd.go
@@ -29,9 +29,9 @@ import (
 
 var Cmd = &cobra.Command{
 	Use:   "admin",
-	Short: "Show details of the cluster-admin user",
-	Long:  "Show details of the cluster-admin user and a command to login to the cluster",
-	Example: `  # Describe cluster-admin user of a cluster named mycluster
+	Short: "Show details of the 'cluster-admin' user",
+	Long:  "Show details of the 'cluster-admin' user and a command to login to the cluster",
+	Example: `  # Describe 'cluster-admin' user of a cluster named mycluster
   rosa describe admin -c mycluster`,
 	Run:  run,
 	Args: cobra.NoArgs,

--- a/cmd/dlt/admin/cmd.go
+++ b/cmd/dlt/admin/cmd.go
@@ -87,8 +87,8 @@ func (d *DeleteUserAdminFromIDP) deleteAdmin(r *rosa.Runtime, identityProvider *
 var Cmd = &cobra.Command{
 	Use:   "admin",
 	Short: "Deletes the admin user",
-	Long:  "Deletes the cluster-admin user used to login to the cluster",
-	Example: `  # Delete the admin user
+	Long:  "Deletes the ’cluster-admin‘ user used to login to the cluster",
+	Example: `  # Delete the ’cluster-admin' user
   rosa delete admin --cluster=mycluster`,
 	Run:  run,
 	Args: cobra.NoArgs,


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-6883
to update the help message for rosa admin commands, to specify that those commands only handle the 'cluster-admin' user, not a common admin user in cluster-admins group
Signed-off-by: marcolan018 <llan@redhat.com>