### PR TITLE
OCM-6883 | fix: rosa describe admin can list the admin with custom name

### DIFF
--- a/cmd/create/admin/cmd.go
+++ b/cmd/create/admin/cmd.go
@@ -39,9 +39,9 @@ const MaxPasswordLength = 23
 
 var Cmd = &cobra.Command{
 	Use:   "admin",
-	Short: "Creates an admin user to login to the cluster",
-	Long:  "Creates a cluster-admin user with an auto-generated password to login to the cluster",
-	Example: `  # Create an admin user to login to the cluster
+	Short: "Creates the 'cluster-admin' user to login to the cluster",
+	Long:  "Creates the 'cluster-admin' user with an auto-generated password to login to the cluster",
+	Example: `  # Create the 'cluster-admin' user to login to the cluster
   rosa create admin -c mycluster -p MasterKey123`,
 	Run:  run,
 	Args: cobra.NoArgs,

--- a/cmd/describe/admin/cmd.go
+++ b/cmd/describe/admin/cmd.go
@@ -22,6 +22,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/rosa/cmd/create/admin"
 	cadmin "github.com/openshift/rosa/cmd/create/admin"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
@@ -53,19 +54,20 @@ func run(_ *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
-	// Try to find an existing htpasswd identity provider and
-	// check if cluster-admin user already exists
-	existingClusterAdminIdp, _, err := cadmin.FindIDPWithAdmin(cluster, r)
+	admins, err := r.OCMClient.GetUsers(cluster.ID(), admin.ClusterAdminGroupname)
 	if err != nil {
 		r.Reporter.Errorf(err.Error())
 		os.Exit(1)
 	}
-	if existingClusterAdminIdp != nil {
-		r.Reporter.Infof("There is '%s' user on cluster '%s'. To login, run the following command:\n"+
-			"   oc login %s --username %s",
-			cadmin.ClusterAdminUsername, clusterKey, cluster.API().URL(), cadmin.ClusterAdminUsername)
+
+	if len(admins) != 0 {
+		for _, admin := range admins {
+			r.Reporter.Infof("There is '%s' user on cluster '%s'. To login, run the following command:\n"+
+				"   oc login %s --username %s",
+				admin.ID(), clusterKey, cluster.API().URL(), admin.ID())
+		}
 	} else {
-		r.Reporter.Warnf("There is no '%s' user on cluster '%s'. To create it run the following command:\n"+
+		r.Reporter.Warnf("There is no %s user on cluster '%s'. To create it run the following command:\n"+
 			"   rosa create admin -c %s", cadmin.ClusterAdminUsername, clusterKey, clusterKey)
 		os.Exit(0)
 	}

--- a/cmd/dlt/admin/cmd.go
+++ b/cmd/dlt/admin/cmd.go
@@ -86,9 +86,9 @@ func (d *DeleteUserAdminFromIDP) deleteAdmin(r *rosa.Runtime, identityProvider *
 
 var Cmd = &cobra.Command{
 	Use:   "admin",
-	Short: "Deletes the admin user",
-	Long:  "Deletes the cluster-admin user used to login to the cluster",
-	Example: `  # Delete the admin user
+	Short: "Deletes the 'cluster-admin' user",
+	Long:  "Deletes the 'cluster-admin' user used to login to the cluster",
+	Example: `  # Delete the 'cluster-admin' user
   rosa delete admin --cluster=mycluster`,
 	Run:  run,
 	Args: cobra.NoArgs,


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-6883

Signed-off-by: marcolan018 <llan@redhat.com>

In this PR, `rosa describe admin` will list out all users in `cluster-admins` group.
For the commands `rosa create admin` and `rosa delete admin`, they continue to only handle the `cluster-admin` user in `cluster-admins` group. Update help messages for those commands to make this more clear