### PR TITLE
OCM-6822 | fix: use cluster name in error message

### DIFF
--- a/cmd/create/externalauthprovider/cmd.go
+++ b/cmd/create/externalauthprovider/cmd.go
@@ -82,7 +82,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command, argv []string) error {
 		cmd.Flags(), "", false, externalAuthProvidersArgs)
 	if err != nil {
 		return fmt.Errorf("failed to create an external authentication provider for cluster '%s': %s",
-			cluster.ID(), err)
+			clusterKey, err)
 	}
 
 	err = externalAuthService.CreateExternalAuthProvider(cluster, clusterKey, externalAuthProvidersArgs, r)

--- a/pkg/externalauthprovider/flags.go
+++ b/pkg/externalauthprovider/flags.go
@@ -79,14 +79,14 @@ func (e *ExternalAuthServiceImpl) CreateExternalAuthProvider(cluster *cmv1.Clust
 	externalAuthConfig, err := CreateExternalAuthConfig(args)
 	if err != nil {
 		return fmt.Errorf("failed to create an external authentication provider for cluster '%s': %s",
-			cluster.ID(), err)
+			clusterKey, err)
 	}
 
 	_, err = r.OCMClient.CreateExternalAuth(cluster.ID(), externalAuthConfig)
 
 	if err != nil {
 		return fmt.Errorf("failed to create an external authentication provider for cluster '%s': %s",
-			cluster.ID(), err)
+			clusterKey, err)
 	}
 	return nil
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-6822

Error now shows the cluster name instead of cluster id:
```
E: failed to create an external authentication provider for cluster 'magchen-hcp': external_auth.issuer.audiences must contain at least one audience
```