### PR TITLE
OCM-5942 | feat: allow users set delete protection on cluster

### DIFF
--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -166,9 +166,9 @@ func run(cmd *cobra.Command, argv []string) {
 
 	clusterName := cluster.Name()
 
-	isPrivate := "No"
+	isPrivate := output.No
 	if cluster.API().Listening() == cmv1.ListeningMethodInternal {
-		isPrivate = "Yes"
+		isPrivate = output.Yes
 	}
 
 	detailsPage := getDetailsLink(r.OCMClient.GetConnectionURL())
@@ -321,21 +321,28 @@ func run(cmd *cobra.Command, argv []string) {
 					operatorIAMRole.RoleARN())
 			}
 		}
-		var awsManaged string
+
+		awsManaged := output.No
 		if cluster.AWS().STS().ManagedPolicies() {
-			awsManaged = "Yes"
-		} else {
-			awsManaged = "No"
+			awsManaged = output.Yes
 		}
 		str = fmt.Sprintf("%sManaged Policies:           %s\n", str, awsManaged)
+	}
+
+	deleteProtection := DisabledOutput
+	if !cluster.DeleteProtection().Enabled() {
+		deleteProtection = EnabledOutput
 	}
 
 	str = fmt.Sprintf("%s"+
 		"State:                      %s %s\n"+
 		"Private:                    %s\n"+
-		"Created:                    %s\n", str,
+		"Delete Protection:          %s\n"+
+		"Created:                    %s\n",
+		str,
 		cluster.State(), phase,
 		isPrivate,
+		deleteProtection,
 		cluster.CreationTimestamp().Format("Jan _2 2006 15:04:05 MST"))
 
 	str = fmt.Sprintf("%s"+

--- a/pkg/input/consts.go
+++ b/pkg/input/consts.go
@@ -1,0 +1,3 @@
+package input
+
+const DoubleQuotesToRemove = `""`

--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -672,6 +672,19 @@ func (c *Client) DeleteCluster(clusterKey string, bestEffort bool,
 	return cluster, nil
 }
 
+func (c *Client) UpdateClusterDeletionProtection(clusterId string, deleteProtection *cmv1.DeleteProtection) error {
+	response, err := c.ocm.ClustersMgmt().V1().Clusters().
+		Cluster(clusterId).
+		DeleteProtection().
+		Update().
+		Body(deleteProtection).
+		Send()
+	if err != nil {
+		return handleErr(response.Error(), err)
+	}
+	return nil
+}
+
 // EnsureNoPendingClusters ensures that no clusters are pending in the account. For non-STS clusters,
 // the osdCcsAdmin user credentials are used to create the cluster, and it is required that these credentials
 // are rotated between cluster creation. If a user is creating a non-STS cluster, we need to therefore make sure


### PR DESCRIPTION
This change allows a user to edit delete protection on clusters, and adds the delete protection to the describe output. 

This change lacks tests due to the size of the refactors needed to make this easy to test. Happy to follow up with refactors after

JIRA - https://issues.redhat.com/browse/OCM-5942

Validation
```
╭─croche@fedora ~/Work/ocm/rosa ‹OCM-5942› 
╰─$ rosa describe cluster -c croche                             

Name:                       croche
Domain Prefix:              croche
Display Name:               croche
ID:                         2a874cc5sm2o72h5h9fdq8ciafr0h8tq
External ID:                790b1651-7566-4e32-8c2f-f290592b6665
Control Plane:              Customer Hosted
OpenShift Version:          4.14.12
Channel Group:              stable
DNS:                        croche.hgnf.s1.devshift.org
AWS Account:                765374464689
API URL:                    https://api.croche.hgnf.s1.devshift.org:6443
Console URL:                https://console-openshift-console.apps.croche.hgnf.s1.devshift.org
Region:                     eu-west-1
Multi-AZ:                   false

Nodes:
 - Control plane:           3
 - Infra:                   2
 - Compute:                 2
Network:
 - Type:                    OVNKubernetes
 - Service CIDR:            172.30.0.0/16
 - Machine CIDR:            10.0.0.0/16
 - Pod CIDR:                10.128.0.0/14
 - Host Prefix:             /23
Infra ID:                   croche-hrj2f
EC2 Metadata Http Tokens:   optional
Role (STS) ARN:             arn:aws:iam::765374464689:role/cro-Installer-Role
Support Role ARN:           arn:aws:iam::765374464689:role/cro-Support-Role
Instance IAM Roles:
 - Control plane:           arn:aws:iam::765374464689:role/cro-ControlPlane-Role
 - Worker:                  arn:aws:iam::765374464689:role/cro-Worker-Role
Operator IAM Roles:
 - arn:aws:iam::765374464689:role/croche-l5l6-openshift-machine-api-aws-cloud-credentials
 - arn:aws:iam::765374464689:role/croche-l5l6-openshift-cloud-credential-operator-cloud-credential
 - arn:aws:iam::765374464689:role/croche-l5l6-openshift-image-registry-installer-cloud-credentials
 - arn:aws:iam::765374464689:role/croche-l5l6-openshift-ingress-operator-cloud-credentials
 - arn:aws:iam::765374464689:role/croche-l5l6-openshift-cluster-csi-drivers-ebs-cloud-credentials
 - arn:aws:iam::765374464689:role/croche-l5l6-openshift-cloud-network-config-controller-cloud-cred
Managed Policies:           No
State:                      ready 
Private:                    No
Delete Protection:          Disabled
Created:                    Mar 26 2024 12:31:49 UTC
User Workload Monitoring:   Enabled
Details Page:               https://qaprodauth.console.redhat.com/openshift/details/s/2eE4Gnq0uM1pfqPqAh24lI9gjdk
OIDC Endpoint URL:          https://oidc.os1.devshift.org/2a874cc5sm2o72h5h9fdq8ciafr0h8tq (Classic)

╭─croche@fedora ~/Work/ocm/rosa ‹OCM-5942› 
╰─$ rosa edit cluster -c croche --enable-delete-protection=true 
I: Interactive mode enabled.
Any optional fields can be ignored and will not be updated.
? Private cluster, check this command's help for possible impacts: No
? Disable Workload monitoring: No
? Enable cluster deletion protection: Yes
I: Updated cluster 'croche'
╭─croche@fedora ~/Work/ocm/rosa ‹OCM-5942› 
╰─$ rosa describe cluster -c croche

Name:                       croche
Domain Prefix:              croche
Display Name:               croche
ID:                         2a874cc5sm2o72h5h9fdq8ciafr0h8tq
External ID:                790b1651-7566-4e32-8c2f-f290592b6665
Control Plane:              Customer Hosted
OpenShift Version:          4.14.12
Channel Group:              stable
DNS:                        croche.hgnf.s1.devshift.org
AWS Account:                765374464689
API URL:                    https://api.croche.hgnf.s1.devshift.org:6443
Console URL:                https://console-openshift-console.apps.croche.hgnf.s1.devshift.org
Region:                     eu-west-1
Multi-AZ:                   false

Nodes:
 - Control plane:           3
 - Infra:                   2
 - Compute:                 2
Network:
 - Type:                    OVNKubernetes
 - Service CIDR:            172.30.0.0/16
 - Machine CIDR:            10.0.0.0/16
 - Pod CIDR:                10.128.0.0/14
 - Host Prefix:             /23
Infra ID:                   croche-hrj2f
EC2 Metadata Http Tokens:   optional
Role (STS) ARN:             arn:aws:iam::765374464689:role/cro-Installer-Role
Support Role ARN:           arn:aws:iam::765374464689:role/cro-Support-Role
Instance IAM Roles:
 - Control plane:           arn:aws:iam::765374464689:role/cro-ControlPlane-Role
 - Worker:                  arn:aws:iam::765374464689:role/cro-Worker-Role
Operator IAM Roles:
 - arn:aws:iam::765374464689:role/croche-l5l6-openshift-machine-api-aws-cloud-credentials
 - arn:aws:iam::765374464689:role/croche-l5l6-openshift-cloud-credential-operator-cloud-credential
 - arn:aws:iam::765374464689:role/croche-l5l6-openshift-image-registry-installer-cloud-credentials
 - arn:aws:iam::765374464689:role/croche-l5l6-openshift-ingress-operator-cloud-credentials
 - arn:aws:iam::765374464689:role/croche-l5l6-openshift-cluster-csi-drivers-ebs-cloud-credentials
 - arn:aws:iam::765374464689:role/croche-l5l6-openshift-cloud-network-config-controller-cloud-cred
Managed Policies:           No
State:                      ready 
Private:                    No
Delete Protection:          Enabled
Created:                    Mar 26 2024 12:31:49 UTC
User Workload Monitoring:   Enabled
Details Page:               https://qaprodauth.console.redhat.com/openshift/details/s/2eE4Gnq0uM1pfqPqAh24lI9gjdk
OIDC Endpoint URL:          https://oidc.os1.devshift.org/2a874cc5sm2o72h5h9fdq8ciafr0h8tq (Classic)

╭─croche@fedora ~/Work/ocm/rosa ‹OCM-5942› 
╰─$ rosa edit cluster -c croche                                 
I: Interactive mode enabled.
Any optional fields can be ignored and will not be updated.
? Private cluster, check this command's help for possible impacts: No
? Disable Workload monitoring: No
? Enable cluster deletion protection: No
I: Updated cluster 'croche'
╭─croche@fedora ~/Work/ocm/rosa ‹OCM-5942› 
╰─$ rosa describe cluster -c croche

Name:                       croche
Domain Prefix:              croche
Display Name:               croche
ID:                         2a874cc5sm2o72h5h9fdq8ciafr0h8tq
External ID:                790b1651-7566-4e32-8c2f-f290592b6665
Control Plane:              Customer Hosted
OpenShift Version:          4.14.12
Channel Group:              stable
DNS:                        croche.hgnf.s1.devshift.org
AWS Account:                765374464689
API URL:                    https://api.croche.hgnf.s1.devshift.org:6443
Console URL:                https://console-openshift-console.apps.croche.hgnf.s1.devshift.org
Region:                     eu-west-1
Multi-AZ:                   false

Nodes:
 - Control plane:           3
 - Infra:                   2
 - Compute:                 2
Network:
 - Type:                    OVNKubernetes
 - Service CIDR:            172.30.0.0/16
 - Machine CIDR:            10.0.0.0/16
 - Pod CIDR:                10.128.0.0/14
 - Host Prefix:             /23
Infra ID:                   croche-hrj2f
EC2 Metadata Http Tokens:   optional
Role (STS) ARN:             arn:aws:iam::765374464689:role/cro-Installer-Role
Support Role ARN:           arn:aws:iam::765374464689:role/cro-Support-Role
Instance IAM Roles:
 - Control plane:           arn:aws:iam::765374464689:role/cro-ControlPlane-Role
 - Worker:                  arn:aws:iam::765374464689:role/cro-Worker-Role
Operator IAM Roles:
 - arn:aws:iam::765374464689:role/croche-l5l6-openshift-machine-api-aws-cloud-credentials
 - arn:aws:iam::765374464689:role/croche-l5l6-openshift-cloud-credential-operator-cloud-credential
 - arn:aws:iam::765374464689:role/croche-l5l6-openshift-image-registry-installer-cloud-credentials
 - arn:aws:iam::765374464689:role/croche-l5l6-openshift-ingress-operator-cloud-credentials
 - arn:aws:iam::765374464689:role/croche-l5l6-openshift-cluster-csi-drivers-ebs-cloud-credentials
 - arn:aws:iam::765374464689:role/croche-l5l6-openshift-cloud-network-config-controller-cloud-cred
Managed Policies:           No
State:                      ready 
Private:                    No
Delete Protection:          Disabled
Created:                    Mar 26 2024 12:31:49 UTC
User Workload Monitoring:   Enabled
Details Page:               https://qaprodauth.console.redhat.com/openshift/details/s/2eE4Gnq0uM1pfqPqAh24lI9gjdk
OIDC Endpoint URL:          https://oidc.os1.devshift.org/2a874cc5sm2o72h5h9fdq8ciafr0h8tq (Classic)

```