### PR TITLE
OCM-6697 | fix: upgrade role error should print extra info when invoke from upgrade cluster

### DIFF
--- a/cmd/upgrade/roles/cmd_test.go
+++ b/cmd/upgrade/roles/cmd_test.go
@@ -1,0 +1,20 @@
+package roles
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("generateClusterUpgradeInfo", func() {
+	It("OK: Returns the cluster upgrade info string successfully", func() {
+		info := generateClusterUpgradeInfo("cluster-key-01", "4.15.0", "auto")
+
+		expected := "Account/Operator Role policies are not valid with upgrade version 4.15.0. " +
+			"Run the following command(s) to upgrade the roles:\n" +
+			"\trosa upgrade roles -c cluster-key-01 --cluster-version=4.15.0 --mode=auto\n\n" +
+			", then run the upgrade command again:\n" +
+			"\trosa upgrade cluster -c cluster-key-01\n"
+
+		Expect(info).To(Equal(expected))
+	})
+})


### PR DESCRIPTION
In [PR](https://github.com/openshift/rosa/pull/1806/files#diff-0422b55e643b32d83ec9a053112d37486dfe3471aa851274e75e49931c88b013L500-L503), some of the error handlings were removed. I've gone through each one of them and brought back the one that should be present: upgrade role error handling when invoke from upgrade cluster.

[Jira ref](https://issues.redhat.com/browse/OCM-6697)