### PR TITLE
OCM-6302 | ci: Prow job update to check PR author in commit check

### DIFF
--- a/hack/commit-msg-verify.sh
+++ b/hack/commit-msg-verify.sh
@@ -1,11 +1,28 @@
 #!/usr/bin/env bash
 
+# This regex matches the pull number with an author from the job spec. Prow does not have a PULL_AUTHOR job var
+PULL_AUTHOR=$(echo $JOB_SPEC | grep -Po "$PULL_NUMBER,\"author\":\"\K[^\"]*")
+
 # PULL_BASE_SHA and PULL_PULL_SHA are set in prow job
 PULL_BASE_SHA="${PULL_BASE_SHA:-$(git merge-base master HEAD)}"
 PULL_PULL_SHA="${PULL_PULL_SHA:-HEAD}"
 
-pattern="^[A-Z]+-[0-9]+ \| (feat|fix|docs|style|refactor|test|chore|build|ci|perf): .*$"
-
+# Lists of GitHub users for whom the commit validation should be skipped:
+# # This contains the bots used in the ROSA project
+# * openshift-merge-bot[bot] - bot responsible for merigng MRs
+# * openshift-ci[bot] - bot responsible for running tests / approvals
+declare -a skip_pr_authors=(
+  "openshift-ci[bot]"
+  "openshift-merge-bot[bot]"
+)
+echo "The PR Author is \"${PULL_AUTHOR}\""
+for skip_pr_author in "${skip_pr_authors[@]}"
+do
+  if [ "${PULL_AUTHOR}" = "${skip_pr_author}" ]; then
+    echo "The commits created by this PR author (probably bot) should be skipped!!!"
+    exit 0
+  fi
+done
 commits=$(git rev-list --no-merges $PULL_BASE_SHA..$PULL_PULL_SHA)
 
 for sha in $commits; do
@@ -18,4 +35,4 @@ for sha in $commits; do
   fi
 done
 
-echo "All commit message are valid"
+echo "All commit messages are valid"


### PR DESCRIPTION
[https://issues.redhat.com/browse/OCM-6302](https://issues.redhat.com/browse/OCM-6302)

Updates the hack script, ran by prow, which checks PR commit msgs to also check PR author