### PR TITLE
OCM-6391 | feat: Deprecate the region flag in commands which do not utilize it

### DIFF
--- a/cmd/create/cmd.go
+++ b/cmd/create/cmd.go
@@ -75,7 +75,10 @@ func init() {
 	globallyAvailableCommands := []*cobra.Command{
 		accountroles.Cmd, operatorroles.Cmd,
 		userrole.Cmd, ocmrole.Cmd,
-		oidcprovider.Cmd,
+		oidcprovider.Cmd, breakglasscredential.Cmd,
+		admin.Cmd, autoscaler.Cmd, dnsdomains.Cmd,
+		externalauthprovider.Cmd, idp.Cmd, kubeletconfig.Cmd,
+		ocmrole.Cmd, oidcprovider.Cmd, tuningconfigs.Cmd,
 	}
-	arguments.MarkRegionHidden(Cmd, globallyAvailableCommands)
+	arguments.MarkRegionDeprecated(Cmd, globallyAvailableCommands)
 }

--- a/cmd/describe/cmd.go
+++ b/cmd/describe/cmd.go
@@ -58,4 +58,13 @@ func init() {
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)
 	arguments.AddRegionFlag(flags)
+
+	globallyAvailableCommands := []*cobra.Command{
+		tuningconfigs.Cmd, cluster.Cmd, service.Cmd,
+		machinepool.Cmd, addon.Cmd, upgrade.Cmd,
+		admin.Cmd, breakglasscredential.Cmd,
+		externalauthprovider.Cmd, installation.Cmd,
+		kubeletconfig.Cmd, machinepool.Cmd, upgrade.Cmd,
+	}
+	arguments.MarkRegionDeprecated(Cmd, globallyAvailableCommands)
 }

--- a/cmd/dlt/cmd.go
+++ b/cmd/dlt/cmd.go
@@ -77,7 +77,10 @@ func init() {
 	globallyAvailableCommands := []*cobra.Command{
 		accountroles.Cmd, operatorrole.Cmd,
 		userrole.Cmd, ocmrole.Cmd,
-		oidcprovider.Cmd,
+		oidcprovider.Cmd, upgrade.Cmd, admin.Cmd,
+		service.Cmd, autoscaler.Cmd, idp.Cmd,
+		cluster.Cmd, dnsdomains.Cmd, externalauthprovider.Cmd,
+		kubeletconfig.Cmd, machinepool.Cmd, tuningconfigs.Cmd,
 	}
-	arguments.MarkRegionHidden(Cmd, globallyAvailableCommands)
+	arguments.MarkRegionDeprecated(Cmd, globallyAvailableCommands)
 }

--- a/cmd/edit/cmd.go
+++ b/cmd/edit/cmd.go
@@ -55,4 +55,12 @@ func init() {
 	arguments.AddRegionFlag(flags)
 	interactive.AddFlag(flags)
 	confirm.AddFlag(flags)
+
+	globallyAvailableCommands := []*cobra.Command{
+		autoscaler.Cmd, addon.Cmd,
+		service.Cmd, cluster.Cmd,
+		ingress.Cmd, kubeletconfig.Cmd,
+		machinepool.Cmd, tuningconfigs.Cmd,
+	}
+	arguments.MarkRegionDeprecated(Cmd, globallyAvailableCommands)
 }

--- a/cmd/grant/cmd.go
+++ b/cmd/grant/cmd.go
@@ -36,4 +36,6 @@ func init() {
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)
 	arguments.AddRegionFlag(flags)
+	globallyAvailableCommands := []*cobra.Command{user.Cmd}
+	arguments.MarkRegionDeprecated(Cmd, globallyAvailableCommands)
 }

--- a/cmd/install/cmd.go
+++ b/cmd/install/cmd.go
@@ -40,4 +40,7 @@ func init() {
 	arguments.AddRegionFlag(flags)
 	confirm.AddFlag(flags)
 	interactive.AddFlag(flags)
+
+	globallyAvailableCommands := []*cobra.Command{addon.Cmd}
+	arguments.MarkRegionDeprecated(Cmd, globallyAvailableCommands)
 }

--- a/cmd/link/cmd.go
+++ b/cmd/link/cmd.go
@@ -42,4 +42,6 @@ func init() {
 	arguments.AddProfileFlag(flags)
 	arguments.AddRegionFlag(flags)
 	confirm.AddFlag(flags)
+	globallyAvailableCommands := []*cobra.Command{userrole.Cmd, ocmrole.Cmd}
+	arguments.MarkRegionDeprecated(Cmd, globallyAvailableCommands)
 }

--- a/cmd/list/cmd.go
+++ b/cmd/list/cmd.go
@@ -83,7 +83,13 @@ func init() {
 	globallyAvailableCommands := []*cobra.Command{
 		accountroles.Cmd, userroles.Cmd,
 		ocmroles.Cmd, oidcconfig.Cmd,
-		oidcprovider.Cmd,
+		oidcprovider.Cmd, cluster.Cmd,
+		breakglasscredential.Cmd, addon.Cmd,
+		externalauthprovider.Cmd, dnsdomains.Cmd,
+		gates.Cmd, idp.Cmd, ingress.Cmd, machinepool.Cmd,
+		operatorroles.Cmd, region.Cmd, rhRegion.Cmd,
+		service.Cmd, tuningconfigs.Cmd, upgrade.Cmd,
+		user.Cmd, version.Cmd,
 	}
-	arguments.MarkRegionHidden(Cmd, globallyAvailableCommands)
+	arguments.MarkRegionDeprecated(Cmd, globallyAvailableCommands)
 }

--- a/cmd/logs/cmd.go
+++ b/cmd/logs/cmd.go
@@ -44,4 +44,6 @@ func init() {
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)
 	arguments.AddRegionFlag(flags)
+	globallyAvailableCommands := []*cobra.Command{install.Cmd, uninstall.Cmd}
+	arguments.MarkRegionDeprecated(Cmd, globallyAvailableCommands)
 }

--- a/cmd/register/cmd.go
+++ b/cmd/register/cmd.go
@@ -40,8 +40,6 @@ func init() {
 	arguments.AddRegionFlag(flags)
 	confirm.AddFlag(flags)
 
-	globallyAvailableCommands := []*cobra.Command{
-		oidcconfig.Cmd,
-	}
-	arguments.MarkRegionHidden(Cmd, globallyAvailableCommands)
+	globallyAvailableCommands := []*cobra.Command{oidcconfig.Cmd}
+	arguments.MarkRegionDeprecated(Cmd, globallyAvailableCommands)
 }

--- a/cmd/revoke/cmd.go
+++ b/cmd/revoke/cmd.go
@@ -40,4 +40,6 @@ func init() {
 	arguments.AddProfileFlag(flags)
 	arguments.AddRegionFlag(flags)
 	confirm.AddFlag(flags)
+	globallyAvailableCommands := []*cobra.Command{breakglasscredential.Cmd, user.Cmd}
+	arguments.MarkRegionDeprecated(Cmd, globallyAvailableCommands)
 }

--- a/cmd/uninstall/cmd.go
+++ b/cmd/uninstall/cmd.go
@@ -38,4 +38,6 @@ func init() {
 	arguments.AddProfileFlag(flags)
 	arguments.AddRegionFlag(flags)
 	confirm.AddFlag(flags)
+	globallyAvailableCommands := []*cobra.Command{addon.Cmd}
+	arguments.MarkRegionDeprecated(Cmd, globallyAvailableCommands)
 }

--- a/cmd/unlink/cmd.go
+++ b/cmd/unlink/cmd.go
@@ -38,4 +38,7 @@ func init() {
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)
 	confirm.AddFlag(flags)
+
+	globallyAvailableCommands := []*cobra.Command{ocmrole.Cmd, userrole.Cmd}
+	arguments.MarkRegionDeprecated(Cmd, globallyAvailableCommands)
 }

--- a/cmd/upgrade/cmd.go
+++ b/cmd/upgrade/cmd.go
@@ -49,7 +49,7 @@ func init() {
 
 	globallyAvailableCommands := []*cobra.Command{
 		accountroles.Cmd, operatorroles.Cmd,
-		roles.Cmd,
+		roles.Cmd, machinepool.Cmd, cluster.Cmd,
 	}
-	arguments.MarkRegionHidden(Cmd, globallyAvailableCommands)
+	arguments.MarkRegionDeprecated(Cmd, globallyAvailableCommands)
 }

--- a/pkg/arguments/arguments.go
+++ b/pkg/arguments/arguments.go
@@ -28,10 +28,12 @@ import (
 	"github.com/openshift/rosa/pkg/aws/profile"
 	"github.com/openshift/rosa/pkg/aws/region"
 	"github.com/openshift/rosa/pkg/debug"
-	"github.com/openshift/rosa/pkg/helper"
 )
 
 const boolType string = "bool"
+
+const regionFlagName = "region"
+const regionDeprecationMessage = "Region flag will be removed from this command in future versions"
 
 var hasUnknownFlags bool
 
@@ -314,19 +316,18 @@ func IsValidMode(modes []string, mode string) bool {
 	return false
 }
 
-func markGlobalFlagsHidden(command *cobra.Command, hidden ...string) {
+func deprecateRegion(command *cobra.Command) {
 	command.PersistentFlags().VisitAll(func(flag *pflag.Flag) {
-		name := flag.Name
-		if helper.Contains(hidden, name) {
-			flag.Hidden = true
+		if flag.Name == regionFlagName {
+			flag.Deprecated = regionDeprecationMessage
 		}
 	})
 }
 
-func MarkRegionHidden(parentCmd *cobra.Command, childrenCmds []*cobra.Command) {
+func MarkRegionDeprecated(parentCmd *cobra.Command, childrenCmds []*cobra.Command) {
+	deprecateRegion(parentCmd)
 	for _, cmd := range childrenCmds {
 		cmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-			markGlobalFlagsHidden(parentCmd, "region")
 			command.Parent().HelpFunc()(command, strings)
 		})
 	}

--- a/pkg/arguments/arguments_test.go
+++ b/pkg/arguments/arguments_test.go
@@ -10,8 +10,37 @@ import (
 
 var _ = Describe("Client", func() {
 	var (
-		cmd *cobra.Command
+		cmd      *cobra.Command
+		childCmd *cobra.Command
 	)
+
+	Context("Region deprecation test", func() {
+		BeforeEach(func() {
+			cmd = &cobra.Command{
+				Use:   "test",
+				Short: "Test command used for testing deprecation",
+				Long: "This command is used for testing the deprecation of the 'region' flag in " +
+					"arguments.go - it is used for nothing else.",
+			}
+			childCmd = &cobra.Command{
+				Use:   "child",
+				Short: "Child command used for testing deprecation",
+				Long: "This child command is used for testing the deprecation of the 'region' flag in " +
+					"arguments.go - it is used for nothing else.",
+			}
+			cmd.AddCommand(childCmd)
+
+			AddRegionFlag(cmd.PersistentFlags())
+			AddDebugFlag(cmd.PersistentFlags())
+		})
+		It("Test deprecation of region flag", func() {
+			MarkRegionDeprecated(cmd, []*cobra.Command{childCmd})
+			regionFlag := cmd.PersistentFlags().Lookup("region")
+			debugFlag := cmd.PersistentFlags().Lookup("debug")
+			Expect(regionFlag.Deprecated).To(Equal(regionDeprecationMessage))
+			Expect(debugFlag.Deprecated).To(Equal(""))
+		})
+	})
 
 	Context("Test PreprocessUnknownFlagsWithId func", func() {
 		BeforeEach(func() {

--- a/pkg/aws/region/flag.go
+++ b/pkg/aws/region/flag.go
@@ -26,7 +26,7 @@ import (
 	"github.com/openshift/rosa/pkg/helper"
 )
 
-// AddFlag adds the debug flag to the given set of command line flags.
+// AddFlag adds the region flag to the given set of command line flags.
 func AddFlag(flags *pflag.FlagSet) {
 	flags.StringVar(
 		&region,


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-6391

We put the region flag in almost every overarching command (`create`, `delete`, `list`, etc) -- yet many of the subcommands do _not_ use region. This can lead to confusion for users. As a solution, I have made a function in the same package following the same naming scheme as the function which adds the region flag. This way, we can disable using the region flag in any command we want with a single line.