### PR TITLE
Revert "OCM-6119 | fix: block users from passing region flag when creating an oidc provider"

### DIFF
--- a/cmd/create/oidcprovider/cmd.go
+++ b/cmd/create/oidcprovider/cmd.go
@@ -78,12 +78,6 @@ func run(cmd *cobra.Command, argv []string) {
 	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
 
-	if cmd.Flags().Changed("region") {
-		r.Reporter.Errorf("The '--region' flag is not available when creating the OIDC provider. " +
-			"OIDC provider is a global AWS IAM entity.")
-		os.Exit(1)
-	}
-
 	// Allow the command to be called programmatically
 	isProgmaticallyCalled := false
 	shouldUseClusterKey := true


### PR DESCRIPTION
Reverts openshift/rosa#1786