### PR TITLE
OCM-6926 | fix: Added back the condition to check for empty env flag

### DIFF
--- a/cmd/login/cmd.go
+++ b/cmd/login/cmd.go
@@ -50,6 +50,8 @@ const oauthClientId = "ocm-cli"
 
 var reAttempt bool
 
+var env string
+
 var args struct {
 	tokenURL      string
 	clientID      string
@@ -183,7 +185,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command, argv []string) error {
 	}
 
 	// Check mandatory options:
-	env := args.env
+	env = args.env
 
 	// Fail fast if config is keyring managed and invalid
 	if keyring, ok := config.IsKeyringManaged(); ok {
@@ -256,7 +258,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command, argv []string) error {
 	token := args.token
 
 	// Determine if we should be using the FedRAMP environment:
-	err = CheckAndLogIntoFedramp(fedramp.HasFlag(cmd), fedramp.HasAdminFlag(cmd), cfg, token, env, r)
+	err = CheckAndLogIntoFedramp(fedramp.HasFlag(cmd), fedramp.HasAdminFlag(cmd), cfg, token, r)
 	if err != nil {
 		r.Reporter.Errorf("%s", err.Error())
 		os.Exit(1)
@@ -543,7 +545,7 @@ func Call(cmd *cobra.Command, argv []string, reporter *rprtr.Object) error {
 	return nil
 }
 
-func CheckAndLogIntoFedramp(hasFlag, hasAdminFlag bool, cfg *config.Config, token string, env string,
+func CheckAndLogIntoFedramp(hasFlag, hasAdminFlag bool, cfg *config.Config, token string,
 	runtime *rosa.Runtime) error {
 	if hasFlag ||
 		(cfg.FedRAMP && token == "") ||
@@ -557,7 +559,7 @@ func CheckAndLogIntoFedramp(hasFlag, hasAdminFlag bool, cfg *config.Config, toke
 
 		fedramp.Enable()
 		// Always default to prod
-		if env == sdk.DefaultURL {
+		if env == sdk.DefaultURL || env == "" {
 			env = "production"
 		}
 		if hasAdminFlag {

--- a/cmd/login/cmd_test.go
+++ b/cmd/login/cmd_test.go
@@ -45,6 +45,7 @@ var _ = Describe("Validate login command", func() {
 
 	Context("login command", func() {
 		When("logging into FedRAMP", func() {
+			env = "staging"
 			It("only 'region' is FedRAMP", func() {
 				os.Setenv("AWS_REGION", "us-gov-west-1")
 				// Load the configuration file:
@@ -53,7 +54,8 @@ var _ = Describe("Validate login command", func() {
 				if cfg == nil {
 					cfg = new(config.Config)
 				}
-				err = CheckAndLogIntoFedramp(false, false, cfg, "", "staging", rosa.NewRuntime())
+				env = "staging"
+				err = CheckAndLogIntoFedramp(false, false, cfg, "", rosa.NewRuntime())
 				Expect(err).ToNot(HaveOccurred())
 			})
 			It("only 'govcloud' flag is true", func() {
@@ -64,7 +66,7 @@ var _ = Describe("Validate login command", func() {
 				if cfg == nil {
 					cfg = new(config.Config)
 				}
-				err = CheckAndLogIntoFedramp(true, false, cfg, "", "staging", rosa.NewRuntime())
+				err = CheckAndLogIntoFedramp(true, false, cfg, "", rosa.NewRuntime())
 				Expect(err).To(HaveOccurred())
 			})
 			It("only 'cfg' has FedRAMP", func() {
@@ -76,7 +78,7 @@ var _ = Describe("Validate login command", func() {
 					cfg = new(config.Config)
 				}
 				cfg.FedRAMP = true
-				err = CheckAndLogIntoFedramp(false, false, cfg, "", "staging", rosa.NewRuntime())
+				err = CheckAndLogIntoFedramp(false, false, cfg, "", rosa.NewRuntime())
 				Expect(err).To(HaveOccurred())
 			})
 			It("'cfg' has FedRAMP and region is govcloud", func() {
@@ -88,7 +90,7 @@ var _ = Describe("Validate login command", func() {
 					cfg = new(config.Config)
 				}
 				cfg.FedRAMP = true
-				err = CheckAndLogIntoFedramp(false, false, cfg, "", "staging", rosa.NewRuntime())
+				err = CheckAndLogIntoFedramp(false, false, cfg, "", rosa.NewRuntime())
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})

--- a/cmd/login/cmd_test.go
+++ b/cmd/login/cmd_test.go
@@ -93,6 +93,20 @@ var _ = Describe("Validate login command", func() {
 				err = CheckAndLogIntoFedramp(false, false, cfg, "", rosa.NewRuntime())
 				Expect(err).ToNot(HaveOccurred())
 			})
+			It("env is empty", func() {
+				os.Setenv("AWS_REGION", "us-gov-east-1")
+				// Load the configuration file:
+				cfg, err := config.Load()
+				Expect(err).ToNot(HaveOccurred())
+				if cfg == nil {
+					cfg = new(config.Config)
+				}
+				env = ""
+				cfg.FedRAMP = true
+				err = CheckAndLogIntoFedramp(false, false, cfg, "", rosa.NewRuntime())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(env).To(Equal("production"))
+			})
 		})
 	})
 })


### PR DESCRIPTION
**Changed**
- Added back the condition to check for empty env flag

**Tested**
- FedRAMP login flow should work as expected : tested