### PR TITLE
OCM-7136 | fix: support create breakglasscredential without optional flags

### DIFF
--- a/cmd/create/breakglasscredential/cmd.go
+++ b/cmd/create/breakglasscredential/cmd.go
@@ -57,8 +57,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command, argv []string) error {
 		return err
 	}
 
-	if !breakglasscredential.IsBreakGlassCredentialSetViaCLI(cmd.Flags()) && !interactive.Enabled() {
-		interactive.Enable()
+	if interactive.Enabled() {
 		r.Reporter.Infof("Enabling interactive mode")
 	}
 	r.Reporter.Debugf("Creating a break glass credential for cluster '%s'", clusterKey)

--- a/pkg/breakglasscredential/flags.go
+++ b/pkg/breakglasscredential/flags.go
@@ -113,13 +113,15 @@ func CreateBreakGlass(cluster *cmv1.Cluster,
 func CreateBreakGlassConfig(args *BreakGlassCredentialArgs) (*cmv1.BreakGlassCredential, error) {
 	breakGlassBuilder := cmv1.NewBreakGlassCredential()
 
-	if args.username != "" {
-		breakGlassBuilder.Username(args.username)
-	}
+	if args != nil {
+		if args.username != "" {
+			breakGlassBuilder.Username(args.username)
+		}
 
-	if args.expirationDuration != 0 {
-		expirationTimeStamp := time.Now().Add(args.expirationDuration).Round(time.Second)
-		breakGlassBuilder.ExpirationTimestamp(expirationTimeStamp)
+		if args.expirationDuration != 0 {
+			expirationTimeStamp := time.Now().Add(args.expirationDuration).Round(time.Second)
+			breakGlassBuilder.ExpirationTimestamp(expirationTimeStamp)
+		}
 	}
 
 	return breakGlassBuilder.Build()

--- a/pkg/breakglasscredential/flags_test.go
+++ b/pkg/breakglasscredential/flags_test.go
@@ -11,7 +11,33 @@ import (
 
 var _ = Describe("Break glass credential", func() {
 	Context("CreateBreakGlassConfig", func() {
-		It("Returns the expected value", func() {
+		It("Returns the value with nil arg", func() {
+			args := BreakGlassCredentialArgs{}
+			credential, err := CreateBreakGlassConfig(&args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(credential).NotTo(BeNil())
+		})
+
+		It("Returns the expected value with just username set", func() {
+			args := BreakGlassCredentialArgs{
+				username: "abc",
+			}
+			credential, err := CreateBreakGlassConfig(&args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(credential.Username()).To(Equal("abc"))
+		})
+
+		It("Returns the expected value with just expirationDuration set", func() {
+			args := BreakGlassCredentialArgs{
+				expirationDuration: time.Hour,
+			}
+			credential, err := CreateBreakGlassConfig(&args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(credential.Username()).To(Equal(""))
+			Expect(credential.ExpirationTimestamp()).To(Equal(time.Now().Add(time.Hour).Round(time.Second)))
+		})
+
+		It("Returns the expected value with both username and expirationDuration set", func() {
 			args := BreakGlassCredentialArgs{
 				username:           "abc",
 				expirationDuration: time.Hour,


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-7136