### PR TITLE
OCM-6161 | ci: Automate HCP machinepool creation with security groups

### DIFF
--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -17,5 +18,6 @@ func TestROSACLIProvider(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	clusterID = os.Getenv("CLUSTER_ID")
 	ctx = context.Background()
 })

--- a/tests/e2e/hcp_machine_pool_test.go
+++ b/tests/e2e/hcp_machine_pool_test.go
@@ -1,0 +1,65 @@
+package e2e
+
+import (
+	"os"
+	"path"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/rosa/tests/utils/common"
+	"github.com/openshift/rosa/tests/utils/exec/rosacli"
+	"github.com/openshift/rosa/tests/utils/log"
+)
+
+var _ = Describe("Create Machine Pool", func() {
+
+	var client *rosacli.Client
+	BeforeEach(func() {
+		Expect(clusterID).ToNot(BeEmpty(), "Cluster ID is empty, please export the env variable CLUSTER_ID")
+		client = rosacli.NewClient()
+	})
+	It("to hosted cluster with additional security group IDs will work [id:72195]", func() {
+		By("Prepare security groups")
+		// This part is finding security groups according to old structure of day1.
+		// Need to be updated after ocm-common migration
+		preparedSGFile := path.Join(os.Getenv("SHARED_DIR"), "security_groups_ids")
+		if _, err := os.Stat(preparedSGFile); err != nil {
+			log.Logger.Warnf("Didn't find file %s", preparedSGFile)
+			Skip("the security groups are not prepared, skip this testing")
+		}
+		sgContent, err := common.ReadFileContent(preparedSGFile)
+		Expect(err).ToNot(HaveOccurred())
+		sgIDs := strings.Split(sgContent, " ")
+
+		By("Create machinepool with security groups set")
+		mpName := "mp-72195"
+		_, err = client.MachinePool.CreateMachinePool(clusterID, mpName,
+			"--additional-security-group-ids", strings.Join(sgIDs, ","),
+			"--replicas", "1",
+			"-y",
+		)
+		Expect(err).ToNot(HaveOccurred())
+		defer client.MachinePool.DeleteMachinePool(clusterID, mpName)
+
+		By("Check the machinepool detail by describe")
+		mpDescription, err := client.MachinePool.DescribeAndReflectNodePool(clusterID, mpName)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(mpDescription.AdditionalSecurityGroupIDs).To(Equal(strings.Join(sgIDs, ", ")))
+
+		By("Create another machinepool without security groups and describe it")
+		mpName = "mp-72195-nsg"
+		_, err = client.MachinePool.CreateMachinePool(clusterID, mpName,
+			"--replicas", "1",
+			"-y",
+		)
+		Expect(err).ToNot(HaveOccurred())
+		defer client.MachinePool.DeleteMachinePool(clusterID, mpName)
+		By("Check the machinepool detail by describe")
+		mpDescription, err = client.MachinePool.DescribeAndReflectNodePool(clusterID, mpName)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mpDescription.AdditionalSecurityGroupIDs).To(BeEmpty())
+	})
+})

--- a/tests/utils/common/file.go
+++ b/tests/utils/common/file.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"os"
+	"strings"
 
 	. "github.com/openshift/rosa/tests/utils/log"
 )
@@ -26,4 +27,15 @@ func CreateFileWithContent(fileAbsPath string, content string) (string, error) {
 		return "", err
 	}
 	return fileAbsPath, err
+}
+
+// Read file content to a string
+func ReadFileContent(fileAbsPath string) (string, error) {
+	output, err := os.ReadFile(fileAbsPath)
+	if err != nil {
+		Logger.Errorf("Failed to read file: %s", err)
+		return "", err
+	}
+	content := strings.TrimSuffix(string(output), "\n")
+	return content, err
 }

--- a/tests/utils/exec/rosacli/machinepool_service.go
+++ b/tests/utils/exec/rosacli/machinepool_service.go
@@ -98,21 +98,23 @@ type NodePoolList struct {
 }
 
 type NodePoolDescription struct {
-	ID               string `yaml:"ID,omitempty"`
-	ClusterID        string `yaml:"Cluster ID,omitempty"`
-	AutoScaling      string `yaml:"Autoscaling,omitempty"`
-	DesiredReplicas  string `yaml:"Desired replicas,omitempty"`
-	CurrentReplicas  string `yaml:"Current replicas,omitempty"`
-	InstanceType     string `yaml:"Instance type,omitempty"`
-	Labels           string `yaml:"Labels,omitempty"`
-	Taints           string `yaml:"Taints,omitempty"`
-	AvalaiblityZones string `yaml:"Availability zone,omitempty"`
-	Subnet           string `yaml:"Subnet,omitempty"`
-	Version          string `yaml:"Version,omitempty"`
-	AutoRepair       string `yaml:"Autorepair,omitempty"`
-	TuningConfigs    string `yaml:"Tuning configs,omitempty"`
-	Message          string `yaml:"Message,omitempty"`
-	ScheduledUpgrade string `yaml:"Scheduled upgrade,omitempty"`
+	ID                         string `yaml:"ID,omitempty"`
+	ClusterID                  string `yaml:"Cluster ID,omitempty"`
+	AutoScaling                string `yaml:"Autoscaling,omitempty"`
+	DesiredReplicas            string `yaml:"Desired replicas,omitempty"`
+	CurrentReplicas            string `yaml:"Current replicas,omitempty"`
+	InstanceType               string `yaml:"Instance type,omitempty"`
+	Labels                     string `yaml:"Labels,omitempty"`
+	Taints                     string `yaml:"Taints,omitempty"`
+	AvalaiblityZones           string `yaml:"Availability zone,omitempty"`
+	Subnet                     string `yaml:"Subnet,omitempty"`
+	Version                    string `yaml:"Version,omitempty"`
+	AutoRepair                 string `yaml:"Autorepair,omitempty"`
+	TuningConfigs              string `yaml:"Tuning configs,omitempty"`
+	Message                    string `yaml:"Message,omitempty"`
+	ScheduledUpgrade           string `yaml:"Scheduled upgrade,omitempty"`
+	AdditionalSecurityGroupIDs string `yaml:"Additional security group IDs,omitempty"`
+	NodeDrainGracePeriod       string `yaml:"Node drain grace period,omitempty"`
 }
 
 // Create MachinePool


### PR DESCRIPTION
```
lixue@Xue-Lis-MacBook-Pro rosa % ginkgo -focus "with additional security group IDs" tests/e2e
Running Suite: e2e tests suite - /Users/lixue/Workspace/rosa/tests/e2e
======================================================================
Random Seed: 1712152071

Will run 1 of 2 specs
time="2024-04-03T21:47:53+08:00" level=info msg="Running command: rosa create machinepool --additional-security-group-ids sg-0497af1a40908d82b,sg-0fff00cf3ca25b0c8,sg-058b2374174cfd370,sg-0f953b1e74639a371 --replicas 1 -y -c 2add20bo15cedljf52rppgq0f52jo3aj --name mp-72195"
time="2024-04-03T21:48:08+08:00" level=info msg="Get Combining Stdout and Stder is :\nINFO: Machine pool 'mp-72195' created successfully on hosted cluster '2add20bo15cedljf52rppgq0f52jo3aj'\nINFO: To view the machine pool details, run 'rosa describe machinepool --cluster 2add20bo15cedljf52rppgq0f52jo3aj --machinepool mp-72195'\nINFO: To view all machine pools, run 'rosa list machinepools --cluster 2add20bo15cedljf52rppgq0f52jo3aj'\n"
time="2024-04-03T21:48:08+08:00" level=info msg="Running command: rosa describe machinepool mp-72195 -c 2add20bo15cedljf52rppgq0f52jo3aj"
time="2024-04-03T21:48:13+08:00" level=info msg="Get Combining Stdout and Stder is :\n\nID:                                    mp-72195\nCluster ID:                            2add20bo15cedljf52rppgq0f52jo3aj\nAutoscaling:                           No\nDesired replicas:                      1\nCurrent replicas:                      0\nInstance type:                         m5.xlarge\nLabels:                                \nTaints:                                \nAvailability zone:                     us-west-2a\nSubnet:                                subnet-06bf16b5b55d68b12\nVersion:                               4.15.6\nAutorepair:                            Yes\nTuning configs:                        \nAdditional security group IDs:         sg-0497af1a40908d82b, sg-0fff00cf3ca25b0c8, sg-058b2374174cfd370, sg-0f953b1e74639a371\nNode drain grace period:               \nMessage:                               WaitingForAvailableMachines\n"
time="2024-04-03T21:48:13+08:00" level=info msg="Running command: rosa create machinepool --replicas 1 -y -c 2add20bo15cedljf52rppgq0f52jo3aj --name mp-72195-nsg"
time="2024-04-03T21:48:26+08:00" level=info msg="Get Combining Stdout and Stder is :\nINFO: Machine pool 'mp-72195-nsg' created successfully on hosted cluster '2add20bo15cedljf52rppgq0f52jo3aj'\nINFO: To view the machine pool details, run 'rosa describe machinepool --cluster 2add20bo15cedljf52rppgq0f52jo3aj --machinepool mp-72195-nsg'\nINFO: To view all machine pools, run 'rosa list machinepools --cluster 2add20bo15cedljf52rppgq0f52jo3aj'\n"
time="2024-04-03T21:48:26+08:00" level=info msg="Running command: rosa describe machinepool mp-72195-nsg -c 2add20bo15cedljf52rppgq0f52jo3aj"
time="2024-04-03T21:48:33+08:00" level=info msg="Get Combining Stdout and Stder is :\n\nID:                                    mp-72195-nsg\nCluster ID:                            2add20bo15cedljf52rppgq0f52jo3aj\nAutoscaling:                           No\nDesired replicas:                      1\nCurrent replicas:                      0\nInstance type:                         m5.xlarge\nLabels:                                \nTaints:                                \nAvailability zone:                     us-west-2a\nSubnet:                                subnet-06bf16b5b55d68b12\nVersion:                               4.15.6\nAutorepair:                            Yes\nTuning configs:                        \nAdditional security group IDs:         \nNode drain grace period:               \nMessage:                               WaitingForAvailableMachines\n"
time="2024-04-03T21:48:33+08:00" level=info msg="Running command: rosa delete machinepool -c 2add20bo15cedljf52rppgq0f52jo3aj mp-72195-nsg -y"
time="2024-04-03T21:48:37+08:00" level=info msg="Get Combining Stdout and Stder is :\nINFO: Successfully deleted machine pool 'mp-72195-nsg' from hosted cluster '2add20bo15cedljf52rppgq0f52jo3aj'\n"
time="2024-04-03T21:48:37+08:00" level=info msg="Running command: rosa delete machinepool -c 2add20bo15cedljf52rppgq0f52jo3aj mp-72195 -y"
time="2024-04-03T21:48:42+08:00" level=info msg="Get Combining Stdout and Stder is :\nINFO: Successfully deleted machine pool 'mp-72195' from hosted cluster '2add20bo15cedljf52rppgq0f52jo3aj'\n"
•S

Ran 1 of 2 Specs in 49.737 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 1 Skipped
You're using deprecated Ginkgo functionality:
=============================================
  --ginkgo.slow-spec-threshold is deprecated --slow-spec-threshold has been deprecated and will be removed in a future version of Ginkgo.  This feature has proved to be more noisy than useful.  You can use --poll-progress-after, instead, to get more actionable feedback about potentially slow specs and understand where they might be getting stuck.

To silence deprecations that can be silenced set the following environment variable:
  ACK_GINKGO_DEPRECATIONS=2.13.0

PASS

Ginkgo ran 1 suite in 51.524559605s
Test Suite Passed
```