### PR TITLE
OCM-7168 | fix: Add info after successfully created breakglasscredentials

### DIFF
--- a/cmd/create/breakglasscredential/cmd.go
+++ b/cmd/create/breakglasscredential/cmd.go
@@ -78,6 +78,13 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command, argv []string) error {
 	if err != nil {
 		return fmt.Errorf("An error occurred while polling for kubeconfig: %v", err)
 	}
+
+	r.Reporter.Infof("Successfully created a break glass credential for cluster '%s'.",
+		clusterKey)
+	r.Reporter.Infof(
+		"To retrieve only the kubeconfig for this credential "+
+			"use: 'rosa describe break-glass-credential %s -c %s --kubeconfig'",
+		credentialResponse.ID(), clusterKey)
 	fmt.Print(kubeconfig)
 
 	return nil

--- a/cmd/describe/breakglasscredential/cmd.go
+++ b/cmd/describe/breakglasscredential/cmd.go
@@ -101,7 +101,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command, argv []string) error {
 		r.Reporter.Infof(
 			"To retrieve only the kubeconfig for this credential "+
 				"use: 'rosa describe break-glass-credential %s -c %s --kubeconfig'",
-			breakGlassCredentialId, cluster.Name())
+			breakGlassCredentialId, clusterKey)
 	}
 
 	breakGlassCredentialConfig, err := r.OCMClient.GetBreakGlassCredential(cluster.ID(), breakGlassCredentialId)

--- a/cmd/list/externalauthprovider/cmd.go
+++ b/cmd/list/externalauthprovider/cmd.go
@@ -70,7 +70,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 	r.Reporter.Debugf("Loading external authentication providers for cluster '%s'", clusterKey)
 	externalAuthProviders, err := r.OCMClient.GetExternalAuths(cluster.ID())
 	if err != nil {
-		return fmt.Errorf("failed to get external authentication providers for cluster '%s': %v", cluster.ID(), err)
+		return fmt.Errorf("failed to get external authentication providers for cluster '%s': %v", clusterKey, err)
 	}
 
 	if output.HasFlag() {

--- a/cmd/list/externalauthprovider/cmd_test.go
+++ b/cmd/list/externalauthprovider/cmd_test.go
@@ -76,6 +76,17 @@ var _ = Describe("list external-auth-provider", func() {
 			Expect(stdout).To(Equal(""))
 		})
 
+		It("Returns error if not found", func() {
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusInternalServerError, ""))
+			stdout, _, err := test.RunWithOutputCapture(runWithRuntime, testRuntime.RosaRuntime, Cmd)
+			Expect(err).NotTo(BeNil())
+			Expect(err.Error()).To(Equal(
+				"failed to get external authentication providers for cluster 'cluster1': " +
+					"expected response content type 'application/json' but received '' and content ''"))
+			Expect(stdout).To(Equal(""))
+		})
+
 		It("Succeeds", func() {
 			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
 			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatExternalAuthList(externalAuths)))

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -280,6 +280,10 @@ func FormatResource(resource interface{}) string {
 		if res, ok := resource.(*v1.ExternalAuth); ok {
 			err = v1.MarshalExternalAuth(res, &outputJson)
 		}
+	case "*v1.BreakGlassCredential":
+		if res, ok := resource.(*v1.BreakGlassCredential); ok {
+			err = v1.MarshalBreakGlassCredential(res, &outputJson)
+		}
 	default:
 		{
 			return "NOTIMPLEMENTED"


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-7168