### PR TITLE
OCM-6595 | chore: bump rosa cli version to const value HEAD

### DIFF
--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,7 +18,7 @@ limitations under the License.
 
 package info
 
-const Version = "1.2.37"
+const Version = "0.0.1-src"
 
 // Build contains the short Git SHA of the CLI at the point it was build. Set via `-ldflags` at build time
 var Build = "local"


### PR DESCRIPTION
Removing convention to update Version on "Master" Branch.
Version values will be updated in release branches and final build.