### PR TITLE
create poc for adding plugins to rosa

### DIFF
--- a/cmd/plugin/cmd.go
+++ b/cmd/plugin/cmd.go
@@ -1,0 +1,27 @@
+package plugin
+
+import (
+	"github.com/spf13/cobra"
+
+	plugin "github.com/openshift/rosa/cmd/plugin/list"
+)
+
+var aliases = []string{"plugins"}
+
+const (
+	use   = "plugin"
+	short = "Get information about plugins"
+	long  = "Get information about installed ROSA plugins"
+)
+
+func NewPluginCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     use,
+		Aliases: aliases,
+		Short:   short,
+		Long:    long,
+		Args:    cobra.MinimumNArgs(1),
+	}
+	cmd.AddCommand(plugin.NewListRosaPlugins())
+	return cmd
+}

--- a/cmd/plugin/list/cmd.go
+++ b/cmd/plugin/list/cmd.go
@@ -1,0 +1,51 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/plugin"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+const (
+	use     = "list"
+	short   = "List ROSA plugins"
+	long    = "List all the plugins available in the users executable path"
+	example = "rosa plugins list"
+)
+
+func NewListRosaPlugins() *cobra.Command {
+	return &cobra.Command{
+		Use:     use,
+		Short:   short,
+		Long:    long,
+		Example: example,
+		Args:    cobra.NoArgs,
+		Run:     rosa.DefaultRunner(rosa.DefaultRuntime(), ListPluginRunner()),
+	}
+}
+
+func ListPluginRunner() rosa.CommandRunner {
+	return func(_ context.Context, runtime *rosa.Runtime, command *cobra.Command, args []string) error {
+		pluginHandler := plugin.NewDefaultPluginHandler()
+		plugins, err := pluginHandler.FindPlugins()
+		if err != nil {
+			return err
+		}
+
+		if len(plugins) > 0 {
+			for _, cr := range plugins {
+				fmt.Printf(""+
+					"- Name:  %s\n"+
+					"  Path:  %s\n",
+					cr.Name,
+					cr.Path,
+				)
+			}
+		}
+		return nil
+	}
+}

--- a/pkg/plugin/helper.go
+++ b/pkg/plugin/helper.go
@@ -1,0 +1,52 @@
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+)
+
+func uniquePath(path []string) []string {
+	keys := make(map[string]int)
+	uniPath := make([]string, 0)
+
+	for _, p := range path {
+		if p == "" {
+			p = "."
+		}
+		keys[p] = 1
+	}
+
+	for element := range keys {
+		uniPath = append(uniPath, element)
+	}
+
+	sort.Strings(uniPath)
+
+	return uniPath
+}
+
+func isExecutable(file string) (bool, error) {
+	info, err := os.Stat(file)
+	if err != nil {
+		return false, err
+	}
+
+	if runtime.GOOS == "windows" {
+		fileExt := strings.ToLower(filepath.Ext(file))
+
+		switch fileExt {
+		case ".bat", ".cmd", ".com", ".exe", ".ps1":
+			return true, nil
+		}
+		return false, nil
+	}
+
+	if m := info.Mode(); !m.IsDir() && m&0111 != 0 {
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -1,0 +1,161 @@
+package plugin
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+var SupportedBinaries = []string{"aws", "ocm"}
+var SupportedPrefixes = []string{"rosa"}
+
+type Plugin struct {
+	Name string
+	Path string
+}
+
+type Handler interface {
+	HandlePluginCommand(cmdArgs []string) (found bool, err error)
+	FindPlugins() (result []Plugin, err error)
+}
+
+type DefaultPluginSpec struct {
+	ValidPrefixes []string
+	ValidBinaries []string
+}
+
+func NewDefaultPluginHandler() Handler {
+	return &DefaultHandler{
+		validPrefixes: SupportedPrefixes,
+		validBinaries: SupportedBinaries,
+	}
+}
+
+var _ Handler = DefaultHandler{}
+
+type DefaultHandler struct {
+	validPrefixes []string
+	validBinaries []string
+}
+
+func (d DefaultHandler) HandlePluginCommand(cmdArgs []string) (found bool, err error) {
+	if len(cmdArgs) == 0 {
+		return false, nil
+	}
+
+	foundBinaryPath, found := d.lookup(cmdArgs[0])
+	if !found || len(foundBinaryPath) == 0 {
+		return false, nil
+	}
+
+	if err := d.execute(foundBinaryPath, cmdArgs[1:], os.Environ()); err != nil {
+		return true, err
+	}
+
+	return true, nil
+}
+
+func (d DefaultHandler) lookup(filename string) (string, bool) {
+	// check for valid binary matches first
+	for _, binary := range d.validBinaries {
+		if filename == binary {
+			path, err := exec.LookPath(filename)
+			if err != nil || len(path) == 0 {
+				continue
+			}
+			return path, true
+		}
+	}
+	// if not valid binary matches check for valid prefixes
+	for _, prefix := range d.validPrefixes {
+		path, err := exec.LookPath(fmt.Sprintf("%s-%s", prefix, filename))
+		if err != nil || len(path) == 0 {
+			continue
+		}
+		return path, true
+	}
+	return "", false
+}
+
+func (d DefaultHandler) execute(executablePath string, cmdArgs []string, env []string) error {
+	cmd := exec.Command(executablePath, cmdArgs...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	cmd.Env = env
+	return cmd.Run()
+}
+
+func (d DefaultHandler) FindPlugins() (result []Plugin, err error) {
+	defaultPath := filepath.SplitList(os.Getenv("PATH"))
+	newPath := uniquePath(defaultPath)
+
+	for _, dir := range newPath {
+		_, err = os.Stat(dir)
+		if os.IsNotExist(err) {
+			err = nil
+			continue
+		}
+		if err != nil {
+			return
+		}
+		var list []Plugin
+		list, err = d.listPlugins(dir)
+		if err != nil {
+			return
+		}
+		result = append(result, list...)
+	}
+	return
+}
+
+func (d DefaultHandler) listPlugins(dir string) (result []Plugin, err error) {
+	items, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, item := range items {
+		if item.IsDir() {
+			continue
+		}
+		name := item.Name()
+		if !d.matchBinaryName(name) {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		var executable bool
+		executable, err = isExecutable(path)
+		if err != nil {
+			return
+		}
+		if !executable {
+			fmt.Printf("Warning: %s identified as an ROSA plugin, but it is not executable.\n", path)
+		}
+		if runtime.GOOS == "windows" {
+			name = strings.TrimSuffix(name, ".exe")
+		}
+		plugin := Plugin{
+			Name: name,
+			Path: dir,
+		}
+		result = append(result, plugin)
+	}
+	return
+}
+
+func (d DefaultHandler) matchBinaryName(name string) bool {
+	for _, binary := range d.validBinaries {
+		if binary == name {
+			return true
+		}
+	}
+	for _, prefix := range d.validPrefixes {
+		if strings.HasPrefix(name, fmt.Sprintf("%s-", prefix)) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
With lots of time recently spent discussing proxy aws commands. This POC looks to add support for plugins in ROSA, allowing us to easily add the aws binary as a plugin to ROSA. 

So far this POC supports both the `aws` and `ocm` binaries along with any other plugins that are prefixed with `rosa-` 

### Usage
Using aws plugin
```
╭─croche@fedora ~/Work/ocm/rosa ‹poc-plugin› 
╰─$ rosa aws iam get-policy --policy-arn arn:aws:iam::765374464689:policy/croche-4.13-Installer-Role-Policy | jq 
{
  "Policy": {
    "PolicyName": "croche-4.13-Installer-Role-Policy",
    "PolicyId": "ANPA3EM67QKYZSNXPRRXR",
    "Arn": "arn:aws:iam::765374464689:policy/croche-4.13-Installer-Role-Policy",
    "Path": "/",
    "DefaultVersionId": "v1",
    "AttachmentCount": 1,
    "PermissionsBoundaryUsageCount": 0,
    "IsAttachable": true,
    "CreateDate": "2024-04-03T11:12:24+00:00",
    "UpdateDate": "2024-04-03T11:12:24+00:00",
    "Tags": [
      {
        "Key": "rosa_role_prefix",
        "Value": "croche-4.13"
      },
      {
        "Key": "red-hat-managed",
        "Value": "true"
      },
      {
        "Key": "rosa_openshift_version",
        "Value": "4.15"
      },
      {
        "Key": "rosa_role_type",
        "Value": "installer"
      }
    ]
  }
}
```
Using the ocm plugin
```
╭─croche@fedora ~/Work/ocm/rosa ‹poc-plugin› 
╰─$ rosa ocm list clusters
ID                                NAME                          API URL                                                     OPENSHIFT_VERSION   PRODUCT ID      CLOUD_PROVIDER  REGION ID       STATE        
17ccnfgpfasu8e731vlps34qtg9a5hv2  c9f7b02f-c28d-45f3-9892-5867  NONE                                                        NONE                ocp             NONE            NONE            ready        
188uv2hjmql5i5eirkf8thiau1pvr1t5  519a1cee-0023-1118-bce7-e153  NONE                                                        NONE                ocp             NONE            NONE            ready        
19dc5cd43lpc4i9ekje0cr8f0slicchl  63ae9d4d-6bfc-448e-9334-25e8  NONE                                                        NONE                ocp             NONE            NONE            ready  
```
Listing all plugins
```
╭─croche@fedora ~/Work/ocm/rosa ‹poc-plugin› 
╰─$ rosa plugin list                                                                                            130 ↵
- Name:  ocm
  Path:  /home/croche/go/bin
- Name:  rosa-mgmt
  Path:  /home/croche/go/bin
- Name:  rosa-ocm
  Path:  /home/croche/go/bin
- Name:  aws
  Path:  /usr/local/bin
- Name:  rosa-aws
  Path:  /usr/local/bin

```

This is just a POC and is missing tests etc, but just looking for some feedback on this.