### PR TITLE
OCM-7079 | feat: select security groups interactive - filtering

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -4062,7 +4062,7 @@ func getSecurityGroups(r *rosa.Runtime, cmd *cobra.Command, isVersionCompatibleC
 			os.Exit(1)
 		}
 		*additionalSgIds = interactiveSgs.
-			GetSecurityGroupIds(r, cmd, vpcId, kind)
+			GetSecurityGroupIds(r, cmd, vpcId, kind, "")
 	}
 	for i, sg := range *additionalSgIds {
 		(*additionalSgIds)[i] = strings.TrimSpace(sg)

--- a/cmd/create/machinepool/helper.go
+++ b/cmd/create/machinepool/helper.go
@@ -99,7 +99,14 @@ func getSecurityGroupsOption(r *rosa.Runtime, cmd *cobra.Command, cluster *cmv1.
 		return []string{}, err
 	}
 
-	return interactiveSgs.GetSecurityGroupIds(r, cmd, vpcId, interactiveSgs.MachinePoolKind), nil
+	var id string
+	if cluster.Hypershift().Enabled() {
+		id = cluster.ID()
+	} else {
+		id = cluster.InfraID()
+	}
+
+	return interactiveSgs.GetSecurityGroupIds(r, cmd, vpcId, interactiveSgs.MachinePoolKind, id), nil
 }
 
 func getVpcIdFromSubnet(subnet ec2types.Subnet) (string, error) {

--- a/pkg/interactive/securitygroups/security_groups_test.go
+++ b/pkg/interactive/securitygroups/security_groups_test.go
@@ -1,6 +1,7 @@
 package securitygroups
 
 import (
+	"fmt"
 	"testing"
 
 	awsSdk "github.com/aws/aws-sdk-go-v2/aws"
@@ -25,14 +26,14 @@ var _ = Describe("Security groups", func() {
 					},
 				},
 			}
-			isValid := isValidSecurityGroup(sg)
+			isValid := isValidSecurityGroup(sg, "")
 			Expect(isValid).To(Equal(false))
 		})
 		It("Return invalid for security group with 'default' name'", func() {
 			sg := ec2types.SecurityGroup{
 				GroupName: awsSdk.String("default"),
 			}
-			isValid := isValidSecurityGroup(sg)
+			isValid := isValidSecurityGroup(sg, "")
 			Expect(isValid).To(Equal(false))
 		})
 		It("Return valid for security group", func() {
@@ -45,7 +46,35 @@ var _ = Describe("Security groups", func() {
 					},
 				},
 			}
-			isValid := isValidSecurityGroup(sg)
+			isValid := isValidSecurityGroup(sg, "")
+			Expect(isValid).To(Equal(true))
+		})
+		It("Return invalid for security group that has a cluster tag equals owned", func() {
+			infraId := "123"
+			sg := ec2types.SecurityGroup{
+				GroupName: awsSdk.String("sg-1"),
+				Tags: []ec2types.Tag{
+					{
+						Key:   awsSdk.String(fmt.Sprintf("kubernetes.io/cluster/%s", infraId)),
+						Value: awsSdk.String("owned"),
+					},
+				},
+			}
+			isValid := isValidSecurityGroup(sg, infraId)
+			Expect(isValid).To(Equal(false))
+		})
+		It("Return valid for security group that has a cluster tag equals shared", func() {
+			id := "123"
+			sg := ec2types.SecurityGroup{
+				GroupName: awsSdk.String("sg-1"),
+				Tags: []ec2types.Tag{
+					{
+						Key:   awsSdk.String(fmt.Sprintf("kubernetes.io/cluster/%s", id)),
+						Value: awsSdk.String("shared"),
+					},
+				},
+			}
+			isValid := isValidSecurityGroup(sg, id)
 			Expect(isValid).To(Equal(true))
 		})
 	})


### PR DESCRIPTION
Checking if the security group has a cluster tag, and filter accordingly.
Improve UX by preventing an error returned from the backend, for the same validation.