### PR TITLE
OCM-7346 | chore: increment master version (to 1.2.39)

### DIFF
--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,7 +18,7 @@ limitations under the License.
 
 package info
 
-const Version = "1.2.37"
+const Version = "1.2.39"
 
 // Build contains the short Git SHA of the CLI at the point it was build. Set via `-ldflags` at build time
 var Build = "local"


### PR DESCRIPTION
Release branch version: 1.2.38.RC1 (as of April 9, 2024)
To be Master branch version: 1.2.39