### PR TITLE
OCM-7358 | fix: invert describe out for cluster delete protection

### DIFF
--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -330,7 +330,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	deleteProtection := DisabledOutput
-	if !cluster.DeleteProtection().Enabled() {
+	if cluster.DeleteProtection().Enabled() {
 		deleteProtection = EnabledOutput
 	}
 


### PR DESCRIPTION
### WHAT
Inverts the check for the delete protection output. This was a regression introduced when changing output from yes/no to enabled/disabled

### Verification
```
$ rosa describe cluster -c croche

Name:                       croche
Domain Prefix:              croche
Display Name:               croche
ID:                         2ai5ok6qebvc8jk442pnsoci2ob00fmn
External ID:                cd7d5abb-c099-417e-8e5b-b84069c1e6bd
Control Plane:              Customer Hosted
OpenShift Version:          4.15.6
Channel Group:              stable
DNS:                        croche.cgbh.s1.devshift.org
AWS Account:                765374464689
API URL:                    https://api.croche.cgbh.s1.devshift.org:6443
Console URL:                https://console-openshift-console.apps.croche.cgbh.s1.devshift.org
Region:                     eu-west-1
Multi-AZ:                   false

Nodes:
 - Control plane:           3
 - Infra:                   2
 - Compute:                 2
Network:
 - Type:                    OVNKubernetes
 - Service CIDR:            172.30.0.0/16
 - Machine CIDR:            10.0.0.0/16
 - Pod CIDR:                10.128.0.0/14
 - Host Prefix:             /23
Infra ID:                   croche-mdddk
EC2 Metadata Http Tokens:   optional
Role (STS) ARN:             arn:aws:iam::765374464689:role/croche10-Installer-Role
Support Role ARN:           arn:aws:iam::765374464689:role/croche10-Support-Role
Instance IAM Roles:
 - Control plane:           arn:aws:iam::765374464689:role/croche10-ControlPlane-Role
 - Worker:                  arn:aws:iam::765374464689:role/croche10-Worker-Role
Operator IAM Roles:
 - arn:aws:iam::765374464689:role/croche-d4x9-openshift-cloud-credential-operator-cloud-credential
 - arn:aws:iam::765374464689:role/croche-d4x9-openshift-image-registry-installer-cloud-credentials
 - arn:aws:iam::765374464689:role/croche-d4x9-openshift-ingress-operator-cloud-credentials
 - arn:aws:iam::765374464689:role/croche-d4x9-openshift-cluster-csi-drivers-ebs-cloud-credentials
 - arn:aws:iam::765374464689:role/croche-d4x9-openshift-cloud-network-config-controller-cloud-cred
 - arn:aws:iam::765374464689:role/croche-d4x9-openshift-machine-api-aws-cloud-credentials
Managed Policies:           No
State:                      ready 
Private:                    No
Delete Protection:          Disabled
Created:                    Apr 10 2024 15:03:47 UTC
User Workload Monitoring:   Enabled
Details Page:               https://qaprodauth.console.redhat.com/openshift/details/s/2eujbNzzmYWKZitj3LIY53bdaTp
OIDC Endpoint URL:          https://oidc.os1.devshift.org/2ai5ok6qebvc8jk442pnsoci2ob00fmn (Classic)

╭─croche@fedora ~/Work/scripts ‹master●› 
╰─$ rosa edit cluster -c croche --enable-delete-protection=true 
I: Interactive mode enabled.
Any optional fields can be ignored and will not be updated.
? Private cluster, check this command's help for possible impacts: No
? Disable Workload monitoring: No
? Enable cluster deletion protection: Yes
I: Updated cluster 'croche'
╭─croche@fedora ~/Work/scripts ‹master●› 
╰─$ rosa describe cluster -c croche                             

Name:                       croche
Domain Prefix:              croche
Display Name:               croche
ID:                         2ai5ok6qebvc8jk442pnsoci2ob00fmn
External ID:                cd7d5abb-c099-417e-8e5b-b84069c1e6bd
Control Plane:              Customer Hosted
OpenShift Version:          4.15.6
Channel Group:              stable
DNS:                        croche.cgbh.s1.devshift.org
AWS Account:                765374464689
API URL:                    https://api.croche.cgbh.s1.devshift.org:6443
Console URL:                https://console-openshift-console.apps.croche.cgbh.s1.devshift.org
Region:                     eu-west-1
Multi-AZ:                   false

Nodes:
 - Control plane:           3
 - Infra:                   2
 - Compute:                 2
Network:
 - Type:                    OVNKubernetes
 - Service CIDR:            172.30.0.0/16
 - Machine CIDR:            10.0.0.0/16
 - Pod CIDR:                10.128.0.0/14
 - Host Prefix:             /23
Infra ID:                   croche-mdddk
EC2 Metadata Http Tokens:   optional
Role (STS) ARN:             arn:aws:iam::765374464689:role/croche10-Installer-Role
Support Role ARN:           arn:aws:iam::765374464689:role/croche10-Support-Role
Instance IAM Roles:
 - Control plane:           arn:aws:iam::765374464689:role/croche10-ControlPlane-Role
 - Worker:                  arn:aws:iam::765374464689:role/croche10-Worker-Role
Operator IAM Roles:
 - arn:aws:iam::765374464689:role/croche-d4x9-openshift-cloud-credential-operator-cloud-credential
 - arn:aws:iam::765374464689:role/croche-d4x9-openshift-image-registry-installer-cloud-credentials
 - arn:aws:iam::765374464689:role/croche-d4x9-openshift-ingress-operator-cloud-credentials
 - arn:aws:iam::765374464689:role/croche-d4x9-openshift-cluster-csi-drivers-ebs-cloud-credentials
 - arn:aws:iam::765374464689:role/croche-d4x9-openshift-cloud-network-config-controller-cloud-cred
 - arn:aws:iam::765374464689:role/croche-d4x9-openshift-machine-api-aws-cloud-credentials
Managed Policies:           No
State:                      ready 
Private:                    No
Delete Protection:          Enabled
Created:                    Apr 10 2024 15:03:47 UTC
User Workload Monitoring:   Enabled
Details Page:               https://qaprodauth.console.redhat.com/openshift/details/s/2eujbNzzmYWKZitj3LIY53bdaTp
OIDC Endpoint URL:          https://oidc.os1.devshift.org/2ai5ok6qebvc8jk442pnsoci2ob00fmn (Classic)
```

JIRA - https://issues.redhat.com/browse/OCM-7358