### PR TITLE
OCM-6501 | fix: Adjust describe machine pool output

### DIFF
--- a/cmd/describe/machinepool/cmd_test.go
+++ b/cmd/describe/machinepool/cmd_test.go
@@ -96,18 +96,18 @@ version:
   raw_id: openshift-4.12.24
 `
 	describeClassicStringOutput = `
-ID:                         nodepool85
-Cluster ID:                 24vf9iitg3p6tlml88iml6j6mu095mh8
-Autoscaling:                No
-Replicas:                   0
-Instance type:              m5.xlarge
-Labels:                     
-Taints:                     
-Availability zones:         us-east-1a, us-east-1b, us-east-1c
-Subnets:                    
-Spot instances:             Yes (max $5)
-Disk size:                  default
-Security Group IDs:         
+ID:                                    nodepool85
+Cluster ID:                            24vf9iitg3p6tlml88iml6j6mu095mh8
+Autoscaling:                           No
+Replicas:                              0
+Instance type:                         m5.xlarge
+Labels:                                
+Taints:                                
+Availability zones:                    us-east-1a, us-east-1b, us-east-1c
+Subnets:                               
+Spot instances:                        Yes (max $5)
+Disk size:                             default
+Additional Security Group IDs:         
 `
 	describeClassicYamlOutput = `availability_zones:
 - us-east-1a

--- a/pkg/machinepool/output.go
+++ b/pkg/machinepool/output.go
@@ -29,18 +29,18 @@ var nodePoolOutputString string = "\n" +
 	"Message:                               %s\n"
 
 var machinePoolOutputString = "\n" +
-	"ID:                         %s\n" +
-	"Cluster ID:                 %s\n" +
-	"Autoscaling:                %s\n" +
-	"Replicas:                   %s\n" +
-	"Instance type:              %s\n" +
-	"Labels:                     %s\n" +
-	"Taints:                     %s\n" +
-	"Availability zones:         %s\n" +
-	"Subnets:                    %s\n" +
-	"Spot instances:             %s\n" +
-	"Disk size:                  %s\n" +
-	"Security Group IDs:         %s\n"
+	"ID:                                    %s\n" +
+	"Cluster ID:                            %s\n" +
+	"Autoscaling:                           %s\n" +
+	"Replicas:                              %s\n" +
+	"Instance type:                         %s\n" +
+	"Labels:                                %s\n" +
+	"Taints:                                %s\n" +
+	"Availability zones:                    %s\n" +
+	"Subnets:                               %s\n" +
+	"Spot instances:                        %s\n" +
+	"Disk size:                             %s\n" +
+	"Additional Security Group IDs:         %s\n"
 
 func machinePoolOutput(clusterId string, machinePool *cmv1.MachinePool) string {
 	return fmt.Sprintf(machinePoolOutputString,

--- a/pkg/machinepool/output_test.go
+++ b/pkg/machinepool/output_test.go
@@ -41,6 +41,26 @@ var _ = Describe("Output", Ordered, func() {
 			result := machinePoolOutput("test-cluster", machinePool)
 			Expect(out).To(Equal(result))
 		})
+		It("machinepool output with additional security groups", func() {
+			awsMachinePoolBuilder := cmv1.NewAWSMachinePool().AdditionalSecurityGroupIds("123")
+			machinePoolBuilder := *cmv1.NewMachinePool().ID("test-mp").Autoscaling(cmv1.NewMachinePoolAutoscaling().
+				ID("test-as")).Replicas(4).InstanceType("test-it").
+				Labels(labels).Taints(taintsBuilder).AvailabilityZones("test-az").
+				Subnets("test-subnet").
+				AWS(awsMachinePoolBuilder)
+			machinePool, err := machinePoolBuilder.Build()
+			Expect(err).ToNot(HaveOccurred())
+			labelsOutput := ocmOutput.PrintLabels(labels)
+			taintsOutput := ocmOutput.PrintTaints([]*cmv1.Taint{taint})
+
+			out := fmt.Sprintf(machinePoolOutputString,
+				"test-mp", "test-cluster", "Yes", "0-0", "test-it", labelsOutput, taintsOutput,
+				"test-az", "test-subnet", ocmOutput.PrintMachinePoolSpot(machinePool),
+				ocmOutput.PrintMachinePoolDiskSize(machinePool), "123")
+
+			result := machinePoolOutput("test-cluster", machinePool)
+			Expect(out).To(Equal(result))
+		})
 		It("machinepool output without autoscaling", func() {
 			machinePoolBuilder := *cmv1.NewMachinePool().ID("test-mp2").
 				Replicas(4).InstanceType("test-it2").Labels(labels).


### PR DESCRIPTION
Change to additional security groups ids to match the flag name.

e.g.
```
oadler@fedora:rosa (OCM-6501)$ rosa describe machinepool -c croche worker

ID:                                    worker
Cluster ID:                            2ai5ok6qebvc8jk442pnsoci2ob00fmn
Autoscaling:                           No
Replicas:                              2
Instance type:                         m5.xlarge
Labels:                                
Taints:                                
Availability zones:                    eu-west-1a
Subnets:                               
Spot instances:                        No
Disk size:                             300 GiB
Additional Security Group IDs:         123
```
