### PR TITLE
OCM-6391 | fix: Fixed bug where deprecation shows for parent cmd

### DIFF
--- a/cmd/create/cmd.go
+++ b/cmd/create/cmd.go
@@ -78,7 +78,7 @@ func init() {
 		oidcprovider.Cmd, breakglasscredential.Cmd,
 		admin.Cmd, autoscaler.Cmd, dnsdomains.Cmd,
 		externalauthprovider.Cmd, idp.Cmd, kubeletconfig.Cmd,
-		ocmrole.Cmd, oidcprovider.Cmd, tuningconfigs.Cmd,
+		oidcprovider.Cmd, tuningconfigs.Cmd,
 	}
 	arguments.MarkRegionDeprecated(Cmd, globallyAvailableCommands)
 }

--- a/pkg/arguments/arguments.go
+++ b/pkg/arguments/arguments.go
@@ -20,6 +20,7 @@ package arguments
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -325,10 +326,15 @@ func deprecateRegion(command *cobra.Command) {
 }
 
 func MarkRegionDeprecated(parentCmd *cobra.Command, childrenCmds []*cobra.Command) {
-	deprecateRegion(parentCmd)
 	for _, cmd := range childrenCmds {
 		cmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
+			deprecateRegion(parentCmd)
 			command.Parent().HelpFunc()(command, strings)
 		})
+		currentRun := cmd.Run
+		cmd.Run = func(c *cobra.Command, args []string) {
+			_, _ = fmt.Fprintf(os.Stdout, "%s%s\n", "\u001B[0;33mW:\u001B[m ", regionDeprecationMessage)
+			currentRun(c, args)
+		}
 	}
 }


### PR DESCRIPTION
[OCM-6391](https://issues.redhat.com//browse/OCM-6391) is a previously finished ticket which had a small bug, it is now fixed. The deprecation msg was showing up in parent cmds, when it was only meant to show up in certain subcommands. This MR fixes that