### PR TITLE
OCM-7253 | feat: Refactor describe machine pool cmd to use new default runner

### DIFF
--- a/cmd/describe/cmd.go
+++ b/cmd/describe/cmd.go
@@ -49,7 +49,8 @@ func init() {
 	Cmd.AddCommand(installation.Cmd)
 	Cmd.AddCommand(upgrade.Cmd)
 	Cmd.AddCommand(tuningconfigs.Cmd)
-	Cmd.AddCommand(machinepool.Cmd)
+	machinePoolCommand := machinepool.NewDescribeMachinePoolCommand()
+	Cmd.AddCommand(machinePoolCommand)
 	Cmd.AddCommand(kubeletconfig.Cmd)
 	Cmd.AddCommand(autoscaler.NewDescribeAutoscalerCommand())
 	Cmd.AddCommand(externalauthprovider.Cmd)
@@ -61,10 +62,10 @@ func init() {
 
 	globallyAvailableCommands := []*cobra.Command{
 		tuningconfigs.Cmd, cluster.Cmd, service.Cmd,
-		machinepool.Cmd, addon.Cmd, upgrade.Cmd,
+		machinePoolCommand, addon.Cmd, upgrade.Cmd,
 		admin.Cmd, breakglasscredential.Cmd,
 		externalauthprovider.Cmd, installation.Cmd,
-		kubeletconfig.Cmd, machinepool.Cmd, upgrade.Cmd,
+		kubeletconfig.Cmd, upgrade.Cmd,
 	}
 	arguments.MarkRegionDeprecated(Cmd, globallyAvailableCommands)
 }

--- a/cmd/describe/machinepool/options.go
+++ b/cmd/describe/machinepool/options.go
@@ -1,0 +1,40 @@
+package machinepool
+
+import (
+	"fmt"
+
+	"github.com/openshift/rosa/pkg/reporter"
+)
+
+type DescribeMachinepoolUserOptions struct {
+	machinepool string
+}
+
+type DescribeMachinepoolOptions struct {
+	reporter *reporter.Object
+
+	args DescribeMachinepoolUserOptions
+}
+
+func NewDescribeMachinepoolUserOptions() DescribeMachinepoolUserOptions {
+	return DescribeMachinepoolUserOptions{machinepool: ""}
+}
+
+func NewDescribeMachinepoolOptions() *DescribeMachinepoolOptions {
+	return &DescribeMachinepoolOptions{
+		reporter: reporter.CreateReporter(),
+		args:     DescribeMachinepoolUserOptions{},
+	}
+}
+
+func (m *DescribeMachinepoolOptions) Machinepool() string {
+	return m.args.machinepool
+}
+
+func (m *DescribeMachinepoolOptions) Bind(args DescribeMachinepoolUserOptions) error {
+	if args.machinepool == "" {
+		return fmt.Errorf("you need to specify a machine pool name")
+	}
+	m.args.machinepool = args.machinepool
+	return nil
+}

--- a/cmd/describe/machinepool/options_test.go
+++ b/cmd/describe/machinepool/options_test.go
@@ -1,0 +1,33 @@
+package machinepool
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Test describe machinepool options", func() {
+	var args DescribeMachinepoolUserOptions
+	Context("Describe Machinepool User Options", func() {
+		It("Creates default options", func() {
+			args = NewDescribeMachinepoolUserOptions()
+			Expect(args.machinepool).To(Equal(""))
+		})
+	})
+	Context("Describe Machinepool Options", func() {
+		var options DescribeMachinepoolOptions
+		It("Create args from options using Bind (also tests MachinePool func)", func() {
+			// Set value then bind
+			testMachinepool := "test"
+			args.machinepool = testMachinepool
+			err := options.Bind(args)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(options.Machinepool()).To(Equal(testMachinepool))
+		})
+		It("Fail to bind args due to empty machinepool name", func() {
+			args.machinepool = ""
+			err := options.Bind(args)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("you need to specify a machine pool name"))
+		})
+	})
+})

--- a/pkg/machinepool/machinepool_test.go
+++ b/pkg/machinepool/machinepool_test.go
@@ -13,9 +13,6 @@ var policyBuilder cmv1.NodePoolUpgradePolicyBuilder
 var date time.Time
 
 var _ = Describe("Machinepool and nodepool", func() {
-	Context("Machinepools", func() {
-
-	})
 	Context("Nodepools", Ordered, func() {
 		BeforeAll(func() {
 			location, err := time.LoadLocation("America/New_York")

--- a/pkg/test/helpers_suite_test.go
+++ b/pkg/test/helpers_suite_test.go
@@ -1,0 +1,13 @@
+package test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDescribeUpgrade(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test helpers suite")
+}

--- a/pkg/test/helpers_test.go
+++ b/pkg/test/helpers_test.go
@@ -1,0 +1,39 @@
+package test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Test helpers", func() {
+	Context("StdOutReader", func() {
+		var stringToPrint = "Testing\nTesting\n\t123"
+		var stringToPrint2 = "testing out recording and reading stdout, which should allow us to easily test actual " +
+			"output printed to the terminal it's nice to have, and eases testing by not only focusing on function " +
+			"returns, but also functions which do not return anything\t\t\t123"
+		It("Record and read stdout", func() {
+			t := NewTestRuntime()
+			err := t.StdOutReader.Record()
+			Expect(err).ToNot(HaveOccurred())
+			fmt.Println(stringToPrint)
+			out, err := t.StdOutReader.Read()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(Equal(stringToPrint + "\n"))
+
+			err = t.StdOutReader.Record()
+			Expect(err).ToNot(HaveOccurred())
+			fmt.Println(stringToPrint2)
+			out, err = t.StdOutReader.Read()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(Equal(stringToPrint2 + "\n"))
+
+			// Make sure it does not continue to capture
+			fmt.Println("!!!!!")
+			_, err = t.StdOutReader.Read()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("close |1: file already closed"))
+		})
+	})
+})


### PR DESCRIPTION
[OCM-7253](https://issues.redhat.com//browse/OCM-7253)

Pt 2 to the RCI Milestone 2 for `describe machine-pool`

Refactors the command to use new default runner, and refactors tests

DoD:

    Command uses new default runner
    Command has at least 70% unit test coverage
