### PR TITLE
OCM-6199 | ci: fix can not find go.mod

### DIFF
--- a/images/Dockerfile.e2e
+++ b/images/Dockerfile.e2e
@@ -1,6 +1,7 @@
 # The image is for Prow CI steps to manage the ROSA cluster lifecycle and testing
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 as builder
 WORKDIR /go/src/github.com/openshift/rosa
+COPY . .
 RUN go install ./cmd/rosa
 RUN go test -c -o /go/bin/rosatest ./tests/e2e
 RUN rosa verify openshift-client


### PR DESCRIPTION
As we [migrated Dockerfile from the repository release to rosa](https://github.com/openshift/rosa/pull/1934), on Prow CI, we will use docker_path instead of docker_literal(https://github.com/openshift/release/pull/50960). The docker_path method requires uploading the repository source code from the build context into an image layer.