### PR TITLE
COM-7477 | feat: show state description for HCP upgrade policies

### DIFF
--- a/cmd/describe/upgrade/cmd.go
+++ b/cmd/describe/upgrade/cmd.go
@@ -133,12 +133,14 @@ func formatHypershiftUpgrade(upgrade ocm.HypershiftUpgrader) string {
 %-35s%s
 %-35s%s
 %-35s%s
+%-35s%s
 `,
 		"ID:", upgrade.ID(),
 		"Cluster ID:", upgrade.ClusterID(),
 		"Schedule Type:", upgrade.ScheduleType(),
 		"Next Run:", upgrade.NextRun().Format("2006-01-02 15:04 MST"),
-		"Upgrade State:", upgrade.State().Value()))
+		"Upgrade State:", upgrade.State().Value(),
+		"State Message:", upgrade.State().Description()))
 	if upgrade.Schedule() != "" {
 		builder = append(builder, fmt.Sprintf(`
 %-35s%s

--- a/cmd/describe/upgrade/cmd_test.go
+++ b/cmd/describe/upgrade/cmd_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Describe upgrade", func() {
 	Context("Format Hypershift upgrade", func() {
 		It("Node pool upgrade is scheduled", func() {
 			nowUTC := time.Now().UTC()
-			upgradeState := cmv1.NewUpgradePolicyState().Value("scheduled")
+			upgradeState := cmv1.NewUpgradePolicyState().Value("scheduled").Description("Upgrade scheduled.")
 			npUpgradePolicy, err := cmv1.NewNodePoolUpgradePolicy().ID("id1").Version("4.12.19").
 				State(upgradeState).NextRun(nowUTC).Build()
 			Expect(err).To(BeNil())
@@ -31,6 +31,7 @@ Cluster ID:
 Schedule Type:                     
 Next Run:                          %s
 Upgrade State:                     scheduled
+State Message:                     Upgrade scheduled.
 
 Version:                           4.12.19
 `, nowUTC.Format("2006-01-02 15:04 MST"))))
@@ -38,7 +39,7 @@ Version:                           4.12.19
 		It("Node pool upgrade is scheduled with a date", func() {
 			format.TruncatedDiff = false
 			nowUTC := time.Now().UTC()
-			upgradeState := cmv1.NewUpgradePolicyState().Value("scheduled")
+			upgradeState := cmv1.NewUpgradePolicyState().Value("scheduled").Description("Upgrade scheduled.")
 			npUpgradePolicy, err := cmv1.NewNodePoolUpgradePolicy().ID("id1").Version("4.12.19").
 				State(upgradeState).NextRun(nowUTC).Schedule(nowUTC.Format("2006-01-02 15:04 MST")).
 				EnableMinorVersionUpgrades(true).Build()
@@ -52,6 +53,7 @@ Cluster ID:
 Schedule Type:                     
 Next Run:                          %s
 Upgrade State:                     scheduled
+State Message:                     Upgrade scheduled.
 
 Schedule At:                       %s
 


### PR DESCRIPTION
Added status info in state description as part of https://issues.redhat.com/browse/OCM-6654. Need to expose the state description for HCP upgrade policies.