### PR TITLE
OCM-6391 | fix: Ability to disable region flag deprecation manually

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -3214,7 +3214,12 @@ func run(cmd *cobra.Command, _ []string) {
 				"for more information.")
 	}
 
+	var disableRegionDeprecation bool
+	clusterdescribe.Cmd.LocalFlags().BoolVar(&disableRegionDeprecation, arguments.DisableRegionDeprecationFlagName,
+		true, "Temporarily used for disabling a warning message ran from other commands (no reason to"+
+			" print for cluster describe called inside cluster create, but there is a use for a lone describe.")
 	clusterdescribe.Cmd.Run(clusterdescribe.Cmd, []string{cluster.ID()})
+	disableRegionDeprecation = false // No longer disable
 
 	if isSTS {
 		if mode != "" {

--- a/pkg/arguments/arguments.go
+++ b/pkg/arguments/arguments.go
@@ -37,6 +37,7 @@ const regionFlagName = "region"
 const regionDeprecationMessage = "Region flag will be removed from this command in future versions"
 
 var hasUnknownFlags bool
+var DisableRegionDeprecationFlagName = "disable-region-deprecation"
 
 // ParseUnknownFlags parses all flags from the CLI, including
 // unknown ones, and adds them to the current command tree
@@ -335,9 +336,12 @@ func MarkRegionDeprecated(parentCmd *cobra.Command, childrenCmds []*cobra.Comman
 		cmd.Run = func(c *cobra.Command, args []string) {
 			outputFlag := cmd.Flag("output")
 			regionFlag := cmd.Flag("region")
+			disableDeprecationFlag := cmd.Flag(DisableRegionDeprecationFlagName)
 			hasChangedOutputFlag := outputFlag != nil && outputFlag.Value.String() != outputFlag.DefValue
 			hasChangedRegionFlag := regionFlag != nil && regionFlag.Value.String() != regionFlag.DefValue
-			if hasChangedRegionFlag && !hasChangedOutputFlag {
+			isRegionDeprecationDisabled := disableDeprecationFlag != nil &&
+				disableDeprecationFlag.Value.String() != disableDeprecationFlag.DefValue
+			if hasChangedRegionFlag && !hasChangedOutputFlag && !isRegionDeprecationDisabled {
 				_, _ = fmt.Fprintf(os.Stdout, "%s%s\n", "\u001B[0;33mW:\u001B[m ", regionDeprecationMessage)
 			}
 			currentRun(c, args)

--- a/pkg/arguments/arguments_test.go
+++ b/pkg/arguments/arguments_test.go
@@ -12,9 +12,10 @@ import (
 
 var _ = Describe("Client", func() {
 	var (
-		cmd      *cobra.Command
-		childCmd *cobra.Command
-		o        string
+		cmd                      *cobra.Command
+		childCmd                 *cobra.Command
+		o                        string
+		disableRegionDeprecation bool
 	)
 
 	Context("Region deprecation test", func() {
@@ -45,6 +46,13 @@ var _ = Describe("Client", func() {
 				"output",
 				"o",
 				"",
+				"",
+			)
+			flagSet.BoolVarP(
+				&disableRegionDeprecation,
+				DisableRegionDeprecationFlagName,
+				"",
+				true,
 				"",
 			)
 		})
@@ -86,6 +94,20 @@ var _ = Describe("Client", func() {
 			out, _ := io.ReadAll(r)
 			os.Stdout = original
 			Expect(string(out)).To(BeEmpty())
+		})
+		It("Nested function (disableRegionDeprecation flag)", func() {
+			MarkRegionDeprecated(cmd, []*cobra.Command{childCmd})
+			original := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+			childCmd.Flag(DisableRegionDeprecationFlagName).Value.Set("true")
+			childCmd.Run(childCmd, []string{})
+			err := w.Close()
+			Expect(err).ToNot(HaveOccurred())
+			out, _ := io.ReadAll(r)
+			os.Stdout = original
+			Expect(string(out)).To(BeEmpty())
+			childCmd.Flag(DisableRegionDeprecationFlagName).Value.Set("false")
 		})
 	})
 


### PR DESCRIPTION
[OCM-6391](https://issues.redhat.com//browse/OCM-6391)

When a nested cmd which deprecates region flag is ran (create cluster with describe cluster running from the create's `Run` func), it showed the deprecation msg of the nested cmd. This MR allows a bypass for the deprecation warning