### PR TITLE
OCM-7498 | test: automate id:OCP-72715 create/edit nodepool with node…

### DIFF
--- a/tests/utils/exec/rosacli/machinepool_service.go
+++ b/tests/utils/exec/rosacli/machinepool_service.go
@@ -29,6 +29,7 @@ type MachinePoolService interface {
 	DescribeAndReflectMachinePool(clusterID string, name string) (*MachinePoolDescription, error)
 
 	RetrieveHelpForCreate() (bytes.Buffer, error)
+	RetrieveHelpForEdit() (bytes.Buffer, error)
 }
 
 type machinepoolService struct {
@@ -273,6 +274,11 @@ func (m *machinepoolService) ReflectNodePoolList(result bytes.Buffer) (npl *Node
 // Create MachinePool
 func (m *machinepoolService) RetrieveHelpForCreate() (output bytes.Buffer, err error) {
 	return m.client.Runner.Cmd("create", "machinepool").CmdFlags("-h").Run()
+}
+
+// Edit Machinepool
+func (m *machinepoolService) RetrieveHelpForEdit() (output bytes.Buffer, err error) {
+	return m.client.Runner.Cmd("edit", "machinepool").CmdFlags("-h").Run()
 }
 
 // Pasrse the result of 'rosa describe cluster' to the RosaClusterDescription struct


### PR DESCRIPTION
[OCM-7498](https://issues.redhat.com//browse/OCM-7498) | test: automate id:OCP-72715 create/edit nodepool with node_drain_grace_period to HCP cluster via ROSA cli can work well

output log :- https://privatebin.corp.redhat.com/?1ad49d4e676ed805#8v53avRQLUaTRr6uunhpBqV9fUjhSbgD5qQtEeNxzmCC 