### PR TITLE
OCM-7533 | ci: add Dockerfile for rosa-aws-cli:release

### DIFF
--- a/images/Dockerfile.release
+++ b/images/Dockerfile.release
@@ -1,0 +1,17 @@
+# The image is for using the latest released rosa CLI
+FROM registry.ci.openshift.org/ci/cli-ocm:latest as ocmcli
+
+FROM registry.ci.openshift.org/origin/4.16:cli
+COPY --from=ocmcli /usr/bin/ocm /usr/bin/ocm
+RUN yum -y install --setopt=skip_missing_names_on_install=False \
+    jq \
+    unzip && yum clean all
+RUN curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip -q awscliv2.zip && \
+    ./aws/install && \
+    rm -rf awscliv2.zip aws &&\
+    aws --version
+RUN curl -sL $(curl -s https://api.github.com/repos/openshift/rosa/releases/latest | jq -r '.assets[] | select(.name == "rosa-linux-amd64") | .browser_download_url') --output /usr/bin/rosa && \
+    chmod +x /usr/bin/rosa
+RUN rosa verify openshift-client
+WORKDIR /rosa


### PR DESCRIPTION
The prow CI jobs are [51184](https://github.com/openshift/release/pull/51184)