### PR TITLE
OCM-7488 | fix: remove dependency on OCM for checking ROSA version

### DIFF
--- a/cmd/version/cmd.go
+++ b/cmd/version/cmd.go
@@ -38,7 +38,7 @@ func NewRosaVersionCommand() *cobra.Command {
 		Short: short,
 		Long:  long,
 		Args:  cobra.NoArgs,
-		Run:   rosa.DefaultRunner(rosa.RuntimeWithOCM(), RosaVersionRunner(o)),
+		Run:   rosa.DefaultRunner(rosa.DefaultRuntime(), RosaVersionRunner(o)),
 	}
 
 	cmd.Flags().SortFlags = false
@@ -59,7 +59,7 @@ func NewRosaVersionCommand() *cobra.Command {
 }
 
 func RosaVersionRunner(userOptions RosaVersionUserOptions) rosa.CommandRunner {
-	return func(ctx context.Context, runtime *rosa.Runtime, command *cobra.Command, args []string) error {
+	return func(_ context.Context, _ *rosa.Runtime, _ *cobra.Command, _ []string) error {
 		options, err := NewRosaVersionOptions()
 		options.BindAndValidate(userOptions)
 		if err != nil {


### PR DESCRIPTION
## WHAT

Refactor of the version command introduced a dependency on OCM runtime. This removes the dependency from the Version CMD

## Verification
1. Logout of ROSA
```
rosa logout
```
2. Run version
```
rosa version
```

## JIRA 
jira - https://issues.redhat.com/browse/OCM-7488 