### PR TITLE
OCM-7307 | fix: remove older attributes for component routes

### DIFF
--- a/cmd/edit/ingress/flags.go
+++ b/cmd/edit/ingress/flags.go
@@ -80,20 +80,6 @@ func addIngressV2Flags(flags *pflag.FlagSet) {
 	)
 
 	flags.StringVar(
-		&args.clusterRoutesHostname,
-		clusterRoutesHostnameFlag,
-		"",
-		"Components route hostname for oauth, console, downloads.",
-	)
-
-	flags.StringVar(
-		&args.clusterRoutesTlsSecretRef,
-		clusterRoutesTlsSecretRefFlag,
-		"",
-		"Components route TLS secret reference for oauth, console, downloads.",
-	)
-
-	flags.StringVar(
 		&args.componentRoutes,
 		componentRoutesFlag,
 		"",


### PR DESCRIPTION
[OCM-7307](https://issues.redhat.com//browse/OCM-7307)

Remove older attributes as they are not to be used. Favor `--component-routes` attribute