### PR TITLE
OCM-7573 | fix: ensure version option args are initialised

### DIFF
--- a/cmd/rosa/main.go
+++ b/cmd/rosa/main.go
@@ -127,21 +127,21 @@ func versionCheck(cmd *cobra.Command, _ []string) {
 	rprtr := reporter.CreateReporter()
 	rosaVersion, err := versionUtils.NewRosaVersion()
 	if err != nil {
-		rprtr.Warnf("Could not verify the current version of ROSA.")
-		rprtr.Warnf("You might be running on an outdated version. Make sure you are using the current version of ROSA.")
+		rprtr.Debugf("Could not verify the current version of ROSA: %v", err)
+		rprtr.Debugf("You might be running on an outdated version. Make sure you are using the current version of ROSA.")
 		return
 	}
 	latestVersionFromMirror, isLatest, err := rosaVersion.IsLatest(info.Version)
 	if err != nil {
-		rprtr.Warnf("There was a problem retrieving the latest version of ROSA.")
-		rprtr.Warnf("You might be running on an outdated version. Make sure you are using the current version of ROSA.")
+		rprtr.Debugf("There was a problem retrieving the latest version of ROSA: %v", err)
+		rprtr.Debugf("You might be running on an outdated version. Make sure you are using the current version of ROSA.")
+		return
 	}
 	if !isLatest {
 		rprtr.Warnf("The current version (%s) is not up to date with latest released version (%s).",
 			info.Version,
 			latestVersionFromMirror.Original(),
 		)
-
 		rprtr.Warnf("It is recommended that you update to the latest version.")
 	}
 }

--- a/cmd/version/cmd_test.go
+++ b/cmd/version/cmd_test.go
@@ -24,7 +24,18 @@ var _ = Describe("RosaVersionOptions", func() {
 		mockVerify *rosa.MockVerifyRosa
 	)
 
-	When("When client only is set to false", func() {
+	When("calling NewRosaVersionOptions", func() {
+		It("should initialize ROSA Version Options correctly", func() {
+			options, err := NewRosaVersionOptions()
+			Expect(err).To(BeNil())
+			Expect(options).ToNot(BeNil())
+			Expect(options.reporter).ToNot(BeNil())
+			Expect(options.verifyRosa).ToNot(BeNil())
+			Expect(options.args).ToNot(BeNil())
+		})
+	})
+
+	When("client only is set to false", func() {
 		BeforeEach(func() {
 			ctrl = gomock.NewController(GinkgoT())
 			mockVerify = rosa.NewMockVerifyRosa(ctrl)

--- a/cmd/version/options.go
+++ b/cmd/version/options.go
@@ -34,6 +34,7 @@ func NewRosaVersionOptions() (*RosaVersionOptions, error) {
 	return &RosaVersionOptions{
 		verifyRosa: verifyRosa,
 		reporter:   reporter.CreateReporter(),
+		args:       NewRosaVersionUserOptions(),
 	}, nil
 }
 


### PR DESCRIPTION
*WHAT*
When calling BindAndValidate the option args were not initialized, this changes ensures the args are initialized on `NewRosaVersionOptions`

This change also sets the checkVersion to debug in the case of any failures while trying to check the CLI version. Only when we successfully validate the version will we warn the user if its out of date.

JIRA - https://issues.redhat.com/browse/OCM-7573