### PR TITLE
OCM-7614 | fix: Get the merged commit but not the pull request commit

### DIFF
--- a/images/Dockerfile.e2e
+++ b/images/Dockerfile.e2e
@@ -5,7 +5,7 @@ COPY . .
 RUN go install ./cmd/rosa
 RUN go test -c -o /go/bin/rosatest ./tests/e2e
 RUN rosa verify openshift-client
-RUN rosatest --ginkgo.label-filter "e2e-commit"
+RUN rosatest --ginkgo.no-color --ginkgo.label-filter "e2e-commit"
 
 FROM registry.ci.openshift.org/ci/cli-ocm:latest as ocmcli
 

--- a/tests/e2e/e2e_pre_check_test.go
+++ b/tests/e2e/e2e_pre_check_test.go
@@ -12,11 +12,13 @@ import (
 
 var _ = Describe("PreCheck", func() {
 	It("commits-focus", labels.E2ECommit, func() {
-		author, err := rosacli.GetCommitAuthor()
+		_, err := rosacli.GetCommitAuthor()
 		Expect(err).ToNot(HaveOccurred())
 
 		focus, err := rosacli.GetCommitFoucs()
 		Expect(err).ToNot(HaveOccurred())
-		fmt.Printf("[%s] Focus: %v\n", author, focus)
+		if focus != "" {
+			fmt.Printf("The latest commit updates the test: %s\n", focus)
+		}
 	})
 })

--- a/tests/utils/exec/rosacli/pr_check.go
+++ b/tests/utils/exec/rosacli/pr_check.go
@@ -9,7 +9,7 @@ import (
 )
 
 func GetCommitAuthor() (string, error) {
-	command := "git log -n 1 --pretty=format:%an"
+	command := "git log -n 1 --no-merges --pretty=format:%an"
 	runner := NewRunner()
 
 	output, err := runner.RunCMD(strings.Split(command, " "))
@@ -21,7 +21,7 @@ func GetCommitAuthor() (string, error) {
 }
 
 func GetCommitFoucs() (string, error) {
-	command := "git log -n 1 --pretty=format:%s"
+	command := "git log -n 1 --no-merges --pretty=format:%s"
 	runner := NewRunner()
 
 	output, err := runner.RunCMD(strings.Split(command, " "))


### PR DESCRIPTION
The [output](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_rosa/1965/pull-ci-openshift-rosa-master-images-images/1783425580914446336/artifacts/build-logs/rosa-aws-cli-amd64.log) is like:
`The lastest commit updates the test: 11111|11112|21111|21112`