### PR TITLE
OCM-7669 | fix: valide rolename and policyarn in rosa attach/detach cmd

### DIFF
--- a/cmd/attach/policy/cmd.go
+++ b/cmd/attach/policy/cmd.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"strings"
 
+	"slices"
+
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/pkg/interactive"
@@ -33,7 +35,7 @@ const (
 	short   = "Attach AWS IAM Policies to an AWS IAM Role"
 	long    = "Attach existing AWS IAM Policies to an AWS IAM Role in the authenticated AWS Account"
 	example = `  # Attach policy <policy_arn_1> and <policy_arn_2> to role <role_name>
-  rosa attach policy --role-arn=<role_name> --policy-arns=<policy_arn_1>,<policy_arn_2>`
+  rosa attach policy --role-name=<role_name> --policy-arns=<policy_arn_1>,<policy_arn_2>`
 )
 
 type RosaAttachPolicyOptions struct {
@@ -84,6 +86,8 @@ func AttachPolicyRunner(userOptions *RosaAttachPolicyOptions) rosa.CommandRunner
 		options.BindAndValidate(*userOptions)
 		policySvc := policy.NewPolicyService(r.OCMClient, r.AWSClient)
 		policyArns := strings.Split(options.policyArns, ",")
+		slices.Sort(policyArns)
+		policyArns = slices.Compact(policyArns)
 		err := policySvc.ValidateAttachOptions(options.roleName, policyArns)
 		if err != nil {
 			return err

--- a/cmd/attach/policy/cmd_test.go
+++ b/cmd/attach/policy/cmd_test.go
@@ -70,9 +70,9 @@ var _ = Describe("rosa attach policy", func() {
 
 		const (
 			roleName   = "sample-role"
-			policyArn1 = "sample-policy-arn-1"
-			policyArn2 = "sample-policy-arn-2"
-			policyArn3 = "sample-policy-arn-3"
+			policyArn1 = "arn:aws:iam::111111111111:policy/Sample-Policy-1"
+			policyArn2 = "arn:aws:iam::111111111111:policy/Sample-Policy-2"
+			policyArn3 = "arn:aws:iam::111111111111:policy/Sample-Policy-3"
 
 			roleNotFoundMsg   = "roleNotFoundMsg"
 			policyNotFoundMsg = "policyNotFoundMsg"

--- a/cmd/detach/policy/cmd.go
+++ b/cmd/detach/policy/cmd.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"strings"
 
+	"slices"
+
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/pkg/interactive"
@@ -33,7 +35,7 @@ const (
 	short   = "Detach AWS IAM Policies from an AWS IAM Role"
 	long    = "Detach AWS IAM Policies from an AWS IAM Role in the authenticated AWS Account"
 	example = `  # Detach policy <policy_arn_1> and <policy_arn_2> from role <role_name>
-  rosa detach policy --role-arn=<role_name> --policy-arns=<policy_arn_1>,<policy_arn_2>`
+  rosa detach policy --role-name=<role_name> --policy-arns=<policy_arn_1>,<policy_arn_2>`
 )
 
 type RosaDetachPolicyOptions struct {
@@ -84,6 +86,8 @@ func DetachPolicyRunner(userOptions *RosaDetachPolicyOptions) rosa.CommandRunner
 		options.BindAndValidate(*userOptions)
 		policySvc := policy.NewPolicyService(r.OCMClient, r.AWSClient)
 		policyArns := strings.Split(options.policyArns, ",")
+		slices.Sort(policyArns)
+		policyArns = slices.Compact(policyArns)
 		err := policySvc.ValidateDetachOptions(options.roleName, policyArns)
 		if err != nil {
 			return err

--- a/cmd/detach/policy/cmd_test.go
+++ b/cmd/detach/policy/cmd_test.go
@@ -67,8 +67,8 @@ var _ = Describe("rosa detach policy", func() {
 
 		const (
 			roleName   = "sample-role"
-			policyArn1 = "sample-policy-arn-1"
-			policyArn2 = "sample-policy-arn-2"
+			policyArn1 = "arn:aws:iam::111111111111:policy/Sample-Policy-1"
+			policyArn2 = "arn:aws:iam::111111111111:policy/Sample-Policy-2"
 
 			roleNotFoundMsg   = "roleNotFoundMsg"
 			policyNotFoundMsg = "policyNotFoundMsg"

--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -40,6 +40,9 @@ var RoleNameRE = regexp.MustCompile(`^[\w+=,.@-]+$`)
 var RoleArnRE = regexp.MustCompile(
 	`^arn:aws[\w-]*:iam::\d{12}:role(?:\/+[\w+=,.@-]+)+$`,
 )
+var PolicyArnRE = regexp.MustCompile(
+	`^arn:aws[\w-]*:iam::(\d{12}|aws):policy(?:\/+[\w+=,.@-]+)+$`,
+)
 
 // UserTagKeyRE , UserTagValueRE - https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html#tag-conventions
 var UserTagKeyRE = regexp.MustCompile(`^[\pL\pZ\pN_.:/=+\-@]{1,128}$`)

--- a/pkg/policy/policy_service.go
+++ b/pkg/policy/policy_service.go
@@ -179,6 +179,10 @@ func validatePolicyQuota(c aws.Client, roleName string, policyArns []string) err
 }
 
 func validateRoleAndPolicies(c aws.Client, roleName string, policyArns []string) error {
+	if !aws.RoleNameRE.MatchString(roleName) {
+		return fmt.Errorf("Invalid role name '%s', expected a valid role name matching %s",
+			roleName, aws.RoleNameRE.String())
+	}
 	role, err := c.GetRoleByName(roleName)
 	if err != nil {
 		return fmt.Errorf(
@@ -199,6 +203,10 @@ func validateRoleAndPolicies(c aws.Client, roleName string, policyArns []string)
 	}
 
 	for _, policyArn := range policyArns {
+		if !aws.PolicyArnRE.MatchString(policyArn) {
+			return fmt.Errorf("Invalid policy arn '%s', expected a valid policy arn matching %s",
+				policyArn, aws.PolicyArnRE.String())
+		}
 		_, err = c.IsPolicyExists(policyArn)
 		if err != nil {
 			return fmt.Errorf(

--- a/pkg/policy/policy_service_test.go
+++ b/pkg/policy/policy_service_test.go
@@ -57,8 +57,8 @@ var _ = Describe("Policy Service", func() {
 	Context("Attach Policy", Ordered, func() {
 		BeforeAll(func() {
 			roleName = "sample-role"
-			policyArn1 = "sample-policy-arn-1"
-			policyArn2 = "sample-policy-arn-2"
+			policyArn1 = "arn:aws:iam::111111111111:policy/Sample-Policy-1"
+			policyArn2 = "arn:aws:iam::111111111111:policy/Sample-Policy-2"
 			policyArns = []string{policyArn1, policyArn2}
 			role = &iamtypes.Role{
 				Tags: []iamtypes.Tag{
@@ -92,6 +92,19 @@ var _ = Describe("Policy Service", func() {
 			ocmClient = ocm.NewClientWithConnection(connection)
 
 			policySvc = NewPolicyService(ocmClient, awsClient)
+		})
+		It("Test validateRoleAndPolicies -- valid rolename and policyarn", func() {
+			awsClient.EXPECT().GetRoleByName(roleName).Return(*role, nil)
+			err := validateRoleAndPolicies(awsClient, "", policyArns)
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).To(Equal(fmt.Sprintf(
+				"Invalid role name '%s', expected a valid role name matching %s",
+				"", mock.RoleNameRE.String())))
+			err = validateRoleAndPolicies(awsClient, roleName, []string{"invalid-policy-arn"})
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).To(Equal(fmt.Sprintf(
+				"Invalid policy arn '%s', expected a valid policy arn matching %s",
+				"invalid-policy-arn", mock.PolicyArnRE.String())))
 		})
 		It("Test ValidateAttachOptions", func() {
 			awsClient.EXPECT().GetRoleByName(roleName).Return(*role, nil)


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-7669
https://issues.redhat.com/browse/OCM-7668
Signed-off-by: marcolan018 <llan@redhat.com>