### PR TITLE
OCM-7619 | ci: Automated 73469 for tags supporting on classic

### DIFF
--- a/tests/utils/exec/rosacli/machinepool_service.go
+++ b/tests/utils/exec/rosacli/machinepool_service.go
@@ -67,18 +67,19 @@ type MachinePoolList struct {
 
 // Struct for the 'rosa list machinepool' output for non-hosted-cp clusters
 type MachinePoolDescription struct {
-	ID               string `yaml:"ID,omitempty"`
-	ClusterID        string `yaml:"Cluster ID,omitempty"`
+	AvailablityZones string `yaml:"Availability zones,omitempty"`
 	AutoScaling      string `yaml:"Autoscaling,omitempty"`
-	Replicas         string `yaml:"Replicas,omitempty"`
+	ClusterID        string `yaml:"Cluster ID,omitempty"`
+	DiskSize         string `yaml:"Disk size,omitempty"`
+	ID               string `yaml:"ID,omitempty"`
 	InstanceType     string `yaml:"Instance type,omitempty"`
 	Labels           string `yaml:"Labels,omitempty"`
-	Taints           string `yaml:"Taints,omitempty"`
-	AvailablityZones string `yaml:"Availability zones,omitempty"`
+	Replicas         string `yaml:"Replicas,omitempty"`
+	SecurityGroupIDs string `yaml:"Security Group IDs,omitempty"`
 	Subnets          string `yaml:"Subnets,omitempty"`
 	SpotInstances    string `yaml:"Spot instances,omitempty"`
-	DiskSize         string `yaml:"Disk size,omitempty"`
-	SecurityGroupIDs string `yaml:"Security Group IDs,omitempty"`
+	Taints           string `yaml:"Taints,omitempty"`
+	Tags             string `yaml:"Tags,omitempty"`
 }
 
 // Struct for the 'rosa list machinepool' output for hosted-cp clusters


### PR DESCRIPTION
Here is the running log
```
lixue@Xue-Lis-MacBook-Pro rosa % ginkgo -focus 73469 tests/e2e
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.13.2
  Mismatched package versions found:
    2.13.0 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: e2e tests suite - /Users/lixue/Workspace/rosa/tests/e2e
======================================================================
Random Seed: 1714296234

Will run 1 of 52 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSStime="2024-04-28T17:24:00+08:00" level=info msg="Running command: rosa create machinepool -h -c 2atmfocid44m1621kdbsle5lpqimv1bh --name mp-73469"
time="2024-04-28T17:24:00+08:00" level=info msg="Get Combining Stdout and Stder is :\nAdd a machine pool to the cluster.\n\nUsage:\n  rosa create machinepool [flags]\n\nAliases:\n  machinepool, machinepools, machine-pool, machine-pools\n\nExamples:\n  # Interactively add a machine pool to a cluster named \"mycluster\"\n  rosa create machinepool --cluster=mycluster --interactive\n\n  # Add a machine pool mp-1 with 3 replicas of m5.xlarge to a cluster\n  rosa create machinepool --cluster=mycluster --name=mp-1 --replicas=3 --instance-type=m5.xlarge\n\n  # Add a machine pool mp-1 with autoscaling enabled and 3 to 6 replicas of m5.xlarge to a cluster\n  rosa create machinepool --cluster=mycluster --name=mp-1 --enable-autoscaling \\\n\t--min-replicas=3 --max-replicas=6 --instance-type=m5.xlarge\n\n  # Add a machine pool with labels to a cluster\n  rosa create machinepool -c mycluster --name=mp-1 --replicas=2 --instance-type=r5.2xlarge --labels=foo=bar,bar=baz,\n\n  # Add a machine pool with spot instances to a cluster\n  rosa create machinepool -c mycluster --name=mp-1 --replicas=2 --instance-type=r5.2xlarge --use-spot-instances \\\n    --spot-max-price=0.5\n\n  # Add a machine pool to a cluster and set the node drain grace period\n  rosa create machinepool -c mycluster --name=mp-1 --node-drain-grace-period=\"90 minutes\"\n\nFlags:\n      --additional-security-group-ids strings   The additional Security Group IDs to be added to the machine pool. Format should be a comma-separated list.\n      --autorepair                              Select auto-repair behaviour for a machinepool in a hosted cluster. (default true)\n      --availability-zone string                Select availability zone to create a single AZ machine pool for a multi-AZ cluster\n  -c, --cluster string                          Name or ID of the cluster.\n      --disk-size string                        Root disk size with a suffix like GiB or TiB\n      --enable-autoscaling                      Enable autoscaling for the machine pool.\n  -h, --help                                    help for machinepool\n      --instance-type string                    Instance type that should be used. (default \"m5.xlarge\")\n  -i, --interactive                             Enable interactive mode.\n      --labels string                           Labels for machine pool. Format should be a comma-separated list of 'key=value'. This list will overwrite any modifications made to Node labels on an ongoing basis.\n      --max-replicas int                        Maximum number of machines for the machine pool.\n      --min-replicas int                        Minimum number of machines for the machine pool.\n      --multi-availability-zone                 Create a multi-AZ machine pool for a multi-AZ cluster (default true)\n      --name string                             Name for the machine pool (required).\n      --node-drain-grace-period string          You may set a grace period for how long Pod Disruption Budget-protected workloads will be respected when the NodePool is being replaced or upgraded.\n                                                After this grace period, all remaining workloads will be forcibly evicted.\n                                                Valid value is from 0 to 1 week (10080 minutes), and the supported units are 'minute|minutes' or 'hour|hours'. 0 or empty value means that the NodePool can be drained without any time limitations.\n                                                This flag is only supported for Hosted Control Planes.\n  -o, --output string                           Output format. Allowed formats are [json yaml]\n      --replicas int                            Count of machines for the machine pool (required when autoscaling is disabled).\n      --spot-max-price string                   Max price for spot instance. If empty use the on-demand price. (default \"on-demand\")\n      --subnet string                           Select subnet to create a single AZ machine pool for BYOVPC cluster\n      --tags strings                            Apply user defined tags to all resources created by ROSA in AWS. Tags are comma separated, for example: 'key value, foo bar'\n      --taints string                           Taints for machine pool. Format should be a comma-separated list of 'key=value:ScheduleType'. This list will overwrite any modifications made to Node taints on an ongoing basis.\n      --tuning-configs string                   Name of the tuning configs to be applied to the machine pool. Format should be a comma-separated list. Tuning config must already exist. This list will overwrite any modifications made to node tuning configs on an ongoing basis.\n      --use-spot-instances                      Use spot instances for the machine pool.\n      --version string                          Version of OpenShift that will be used to install a machine pool for a hosted cluster, for example \"4.12.4\"\n\nGlobal Flags:\n      --color string     Surround certain characters with escape sequences to display them in color on the terminal. Allowed options are [auto never always] (default \"auto\")\n      --debug            Enable debug mode.\n      --profile string   Use a specific AWS profile from your credential file.\n      --region string    Use a specific AWS region, overriding the AWS_REGION environment variable.\n  -y, --yes              Automatically answer yes to confirm operation.\n"
time="2024-04-28T17:24:00+08:00" level=info msg="Running command: rosa create machinepool --replicas 3 --tags test:testvalue,test2:testValue/openshift -c 2atmfocid44m1621kdbsle5lpqimv1bh --name mp-73469"
time="2024-04-28T17:24:11+08:00" level=info msg="Get Combining Stdout and Stder is :\nINFO: Machine pool 'mp-73469' created successfully on cluster '2atmfocid44m1621kdbsle5lpqimv1bh'\nINFO: To view the machine pool details, run 'rosa describe machinepool --cluster 2atmfocid44m1621kdbsle5lpqimv1bh --machinepool mp-73469'\nINFO: To view all machine pools, run 'rosa list machinepools --cluster 2atmfocid44m1621kdbsle5lpqimv1bh'\n"
time="2024-04-28T17:24:11+08:00" level=info msg="Running command: rosa describe machinepool mp-73469 -c 2atmfocid44m1621kdbsle5lpqimv1bh"
time="2024-04-28T17:24:15+08:00" level=info msg="Get Combining Stdout and Stder is :\n\nID:                                    mp-73469\nCluster ID:                            2atmfocid44m1621kdbsle5lpqimv1bh\nAutoscaling:                           No\nReplicas:                              3\nInstance type:                         m5.xlarge\nLabels:                                \nTaints:                                \nAvailability zones:                    us-east-1a, us-east-1b, us-east-1c\nSubnets:                               subnet-03afc22b5ffc72ab4, subnet-02b7b9fb0c4b6ec20, subnet-011bd23ac6b95c0ed\nSpot instances:                        No\nDisk size:                             300 GiB\nAdditional Security Group IDs:         \nTags:                                  red-hat-clustertype=rosa, red-hat-managed=true, test=testvalue, test2=testValue/openshift\n"
time="2024-04-28T17:24:15+08:00" level=info msg="Running command: rosa create machinepool --replicas 3 --tags invalid -c 2atmfocid44m1621kdbsle5lpqimv1bh --name invalid-73469"
time="2024-04-28T17:24:24+08:00" level=info msg="Get Combining Stdout and Stder is :\nERR: invalid tag format for tag '[invalid]'. Expected tag format: 'key:value'\n"
time="2024-04-28T17:24:24+08:00" level=info msg="Running command: rosa create machinepool --replicas 3 --tags notagvalue: -c 2atmfocid44m1621kdbsle5lpqimv1bh --name invalid-73469"
time="2024-04-28T17:24:32+08:00" level=info msg="Get Combining Stdout and Stder is :\nERR: invalid tag format, tag key or tag value can not be empty\n"
time="2024-04-28T17:24:32+08:00" level=info msg="Running command: rosa create machinepool --replicas 3 --tags :notagkey -c 2atmfocid44m1621kdbsle5lpqimv1bh --name invalid-73469"
time="2024-04-28T17:24:40+08:00" level=info msg="Get Combining Stdout and Stder is :\nERR: invalid tag format, tag key or tag value can not be empty\n"
time="2024-04-28T17:24:40+08:00" level=info msg="Running command: rosa create machinepool --replicas 3 --tags non-ascii:值 -c 2atmfocid44m1621kdbsle5lpqimv1bh --name invalid-73469"
time="2024-04-28T17:24:49+08:00" level=info msg="Get Combining Stdout and Stder is :\nERR: Failed to add machine pool to cluster '2atmfocid44m1621kdbsle5lpqimv1bh': Invalid Machine Pool AWS tags\n"
time="2024-04-28T17:24:49+08:00" level=info msg="Remove remaining machinepool 'mp-73469'"
time="2024-04-28T17:24:49+08:00" level=info msg="Running command: rosa delete machinepool -c 2atmfocid44m1621kdbsle5lpqimv1bh mp-73469 -y"
time="2024-04-28T17:24:57+08:00" level=info msg="Get Combining Stdout and Stder is :\nINFO: Successfully deleted machine pool 'mp-73469' from cluster '2atmfocid44m1621kdbsle5lpqimv1bh'\n"
time="2024-04-28T17:24:57+08:00" level=info msg="Remove remaining machinepool 'mp-73469'"
time="2024-04-28T17:24:57+08:00" level=info msg="Running command: rosa delete machinepool -c 2atmfocid44m1621kdbsle5lpqimv1bh mp-73469 -y"
time="2024-04-28T17:25:00+08:00" level=info msg="Get Combining Stdout and Stder is :\nERR: Failed to get machine pool 'mp-73469' for cluster '2atmfocid44m1621kdbsle5lpqimv1bh'\n"
•SSSSSSSSSSSSSSSSSSSSS

Ran 1 of 52 Specs in 60.476 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 51 Skipped
PASS

Ginkgo ran 1 suite in 1m6.50028656s
Test Suite Passed
```