### PR TITLE
OCM-6391 | fix: Add region deprecation disablement to sub-commands

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -3214,30 +3214,19 @@ func run(cmd *cobra.Command, _ []string) {
 				"for more information.")
 	}
 
-	disableUsage := "Temporarily used for disabling a warning message ran from other commands (no reason to" +
-		" print for cluster describe called inside cluster create, but there is a use for a lone describe."
-	var disableRegionDeprecation bool
-	clusterdescribe.Cmd.LocalFlags().BoolVar(&disableRegionDeprecation, arguments.DisableRegionDeprecationFlagName,
-		true, disableUsage)
+	arguments.DisableRegionDeprecationWarning = true // disable region deprecation warning
 	clusterdescribe.Cmd.Run(clusterdescribe.Cmd, []string{cluster.ID()})
-	disableRegionDeprecation = false // No longer disable
 
 	if isSTS {
 		if mode != "" {
 			if !output.HasFlag() || r.Reporter.IsTerminal() {
 				r.Reporter.Infof("Preparing to create operator roles.")
 			}
-			disableRegionDeprecation = true // disable again
-			operatorroles.Cmd.LocalFlags().BoolVar(&disableRegionDeprecation, arguments.DisableRegionDeprecationFlagName,
-				true, disableUsage)
 			operatorroles.Cmd.Run(operatorroles.Cmd, []string{clusterName, mode, permissionsBoundary})
 			if !output.HasFlag() || r.Reporter.IsTerminal() {
 				r.Reporter.Infof("Preparing to create OIDC Provider.")
 			}
-			oidcprovider.Cmd.LocalFlags().BoolVar(&disableRegionDeprecation, arguments.DisableRegionDeprecationFlagName,
-				true, disableUsage)
 			oidcprovider.Cmd.Run(oidcprovider.Cmd, []string{clusterName, mode, ""})
-			disableRegionDeprecation = false // No longer disable
 		} else {
 			output := ""
 			if len(operatorRoles) == 0 {
@@ -3272,11 +3261,8 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	if args.watch {
-		disableRegionDeprecation = true // Disable region deprecation
-		clusterdescribe.Cmd.LocalFlags().BoolVar(&disableRegionDeprecation, arguments.DisableRegionDeprecationFlagName,
-			true, disableUsage)
 		installLogs.Cmd.Run(installLogs.Cmd, []string{clusterName})
-		disableRegionDeprecation = false // No longer disable
+		arguments.DisableRegionDeprecationWarning = false // no longer disable deprecation warning
 	} else if !output.HasFlag() || r.Reporter.IsTerminal() {
 		r.Reporter.Infof(
 			"To determine when your cluster is Ready, run 'rosa describe cluster -c %s'.",

--- a/cmd/create/ocmrole/cmd.go
+++ b/cmd/create/ocmrole/cmd.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 
 	linkocmrole "github.com/openshift/rosa/cmd/link/ocmrole"
+	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
 	awscb "github.com/openshift/rosa/pkg/aws/commandbuilder"
 	"github.com/openshift/rosa/pkg/aws/tags"
@@ -279,7 +280,9 @@ func run(cmd *cobra.Command, _ []string) {
 		r.OCMClient.LogEvent("ROSACreateOCMRoleModeAuto", map[string]string{
 			ocm.Response: ocm.Success,
 		})
+		arguments.DisableRegionDeprecationWarning = true // disable region deprecation warning
 		linkocmrole.Cmd.Run(linkocmrole.Cmd, []string{roleARN})
+		arguments.DisableRegionDeprecationWarning = false // enable region deprecation again
 	case interactive.ModeManual:
 		r.OCMClient.LogEvent("ROSACreateOCMRoleModeManual", map[string]string{})
 		_, _, err = checkRoleExists(r, roleNameRequested, isAdmin, interactive.ModeManual)

--- a/cmd/create/oidcconfig/cmd.go
+++ b/cmd/create/oidcconfig/cmd.go
@@ -296,7 +296,9 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 	oidcConfigStrategy.execute(r)
 	if !args.rawFiles {
+		arguments.DisableRegionDeprecationWarning = true // disable region deprecation warning
 		oidcprovider.Cmd.Run(oidcprovider.Cmd, []string{"", mode, oidcConfigInput.IssuerUrl})
+		arguments.DisableRegionDeprecationWarning = false // enable region deprecation again
 	}
 }
 

--- a/cmd/create/userrole/cmd.go
+++ b/cmd/create/userrole/cmd.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 
 	linkuser "github.com/openshift/rosa/cmd/link/userrole"
+	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
 	awscb "github.com/openshift/rosa/pkg/aws/commandbuilder"
 	"github.com/openshift/rosa/pkg/aws/tags"
@@ -215,8 +216,9 @@ func run(cmd *cobra.Command, _ []string) {
 		r.OCMClient.LogEvent("ROSACreateUserRoleModeAuto", map[string]string{
 			ocm.Response: ocm.Success,
 		})
-
+		arguments.DisableRegionDeprecationWarning = true // disable region deprecation warning
 		linkuser.Cmd.Run(linkuser.Cmd, []string{roleARN})
+		arguments.DisableRegionDeprecationWarning = false // enable region deprecation again
 	case interactive.ModeManual:
 		r.OCMClient.LogEvent("ROSACreateUserRoleModeManual", map[string]string{})
 		err = generateUserRolePolicyFiles(r.Reporter, env, r.Creator.Partition, currentAccount.ID(), policies)

--- a/cmd/dlt/cluster/cmd.go
+++ b/cmd/dlt/cluster/cmd.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openshift/rosa/cmd/dlt/oidcprovider"
 	"github.com/openshift/rosa/cmd/dlt/operatorrole"
 	uninstallLogs "github.com/openshift/rosa/cmd/logs/uninstall"
+	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/ocm"
@@ -120,7 +121,9 @@ func run(_ *cobra.Command, _ []string) {
 		fmt.Print(commands, "\n")
 	}
 	if args.watch {
+		arguments.DisableRegionDeprecationWarning = true // disable region deprecation warning
 		uninstallLogs.Cmd.Run(uninstallLogs.Cmd, []string{clusterKey})
+		arguments.DisableRegionDeprecationWarning = false // enable region deprecation again
 	} else {
 		r.Reporter.Infof("To watch your cluster uninstallation logs, run 'rosa logs uninstall -c %s --watch'",
 			clusterKey,

--- a/cmd/dlt/ocmrole/cmd.go
+++ b/cmd/dlt/ocmrole/cmd.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 
 	unlinkocmrole "github.com/openshift/rosa/cmd/unlink/ocmrole"
+	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
 	awscb "github.com/openshift/rosa/pkg/aws/commandbuilder"
 	"github.com/openshift/rosa/pkg/helper"
@@ -177,7 +178,9 @@ func run(cmd *cobra.Command, argv []string) {
 		r.OCMClient.LogEvent("ROSADeleteOCMRoleModeAuto", nil)
 		if isLinked {
 			r.Reporter.Warnf("Role ARN '%s' is linked to organization '%s'", roleARN, orgID)
+			arguments.DisableRegionDeprecationWarning = true // disable region deprecation warning
 			unlinkocmrole.Cmd.Run(unlinkocmrole.Cmd, []string{roleARN})
+			arguments.DisableRegionDeprecationWarning = false // enable region deprecation again
 		}
 		if roleExistOnAWS {
 			err := r.AWSClient.DeleteOCMRole(roleName, managedPolicies)

--- a/cmd/dlt/oidcconfig/cmd.go
+++ b/cmd/dlt/oidcconfig/cmd.go
@@ -117,7 +117,9 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 	oidcConfigStrategy.execute(r)
+	arguments.DisableRegionDeprecationWarning = true // disable region deprecation warning
 	oidcprovider.Cmd.Run(oidcprovider.Cmd, []string{"", mode, oidcConfigInput.IssuerUrl})
+	arguments.DisableRegionDeprecationWarning = false // enable region deprecation again
 	r.OCMClient.DeleteOidcConfig(args.oidcConfigId)
 	if r.Reporter.IsTerminal() {
 		r.Reporter.Infof("Registered OIDC Config ID '%s'"+

--- a/cmd/dlt/userrole/cmd.go
+++ b/cmd/dlt/userrole/cmd.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 
 	unlinkuserrole "github.com/openshift/rosa/cmd/unlink/userrole"
+	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
 	awscb "github.com/openshift/rosa/pkg/aws/commandbuilder"
 	"github.com/openshift/rosa/pkg/helper"
@@ -176,7 +177,9 @@ func run(cmd *cobra.Command, argv []string) {
 		if isLinked {
 			r.Reporter.Warnf("Role ARN '%s' is linked to account '%s'",
 				roleARN, currentAccount.ID())
+			arguments.DisableRegionDeprecationWarning = true // disable region deprecation warning
 			unlinkuserrole.Cmd.Run(unlinkuserrole.Cmd, []string{roleARN})
+			arguments.DisableRegionDeprecationWarning = false // enable region deprecation again
 		}
 		err := r.AWSClient.DeleteUserRole(roleName)
 		if err != nil {

--- a/cmd/register/oidcconfig/cmd.go
+++ b/cmd/register/oidcconfig/cmd.go
@@ -218,5 +218,7 @@ func run(cmd *cobra.Command, _ []string) {
 		output := fmt.Sprintf(InformOperatorRolesOutput, oidcConfig.ID())
 		r.Reporter.Infof(output)
 	}
+	arguments.DisableRegionDeprecationWarning = true // disable region deprecation warning
 	oidcprovider.Cmd.Run(oidcprovider.Cmd, []string{"", mode, args.issuerUrl})
+	arguments.DisableRegionDeprecationWarning = false // enable region deprecation again
 }

--- a/cmd/upgrade/cluster/cmd.go
+++ b/cmd/upgrade/cluster/cmd.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/cmd/upgrade/roles"
+	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/ocm"
@@ -479,7 +480,9 @@ func checkSTSRolesCompatibility(r *rosa.Runtime, cluster *cmv1.Cluster, mode str
 	version string, clusterKey string) {
 	r.Reporter.Infof("Ensuring account and operator role policies for cluster '%s'"+
 		" are compatible with upgrade.", cluster.ID())
+	arguments.DisableRegionDeprecationWarning = true // disable region deprecation warning
 	roles.Cmd.Run(roles.Cmd, []string{mode, cluster.ID(), version, cluster.Version().ChannelGroup()})
+	arguments.DisableRegionDeprecationWarning = false // enable region deprecation again
 	if r.Reporter.IsTerminal() {
 		r.Reporter.Infof("Account and operator roles for cluster '%s' are compatible with upgrade", clusterKey)
 	}


### PR DESCRIPTION
[OCM-6391](https://issues.redhat.com//browse/OCM-6391)

is a ticket where we temporarily deprecate the region flag before removing it from commands which do not use it. This is a bug fix for the create cluster command, which housed 4 commands that have this deprecation.