### PR TITLE
prevents overwriting the client id if set for fedramp with keycloak

### DIFF
--- a/cmd/login/cmd.go
+++ b/cmd/login/cmd.go
@@ -346,9 +346,16 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command, argv []string) error {
 			if !ok {
 				tokenURL = args.tokenURL
 			}
-			clientID, ok = fedramp.ClientIDs[env]
-			if !ok {
+
+			// if client-id is provided, we don't want to just override it
+			// with Keycloak flow
+			if args.clientID != "" {
 				clientID = args.clientID
+			} else {
+				clientID, ok = fedramp.ClientIDs[env]
+				if !ok {
+					clientID = args.clientID
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Issue:
Currently for FedRAMP, any attempts to provide a client-id and secret fail due to the client-id being overwritten with values defined in [FedRAMP config](https://github.com/openshift/rosa/blob/master/pkg/fedramp/config.go#L95). This prevents us from using clients configured in our IDP to grant service account access to automated processes.

What this PR fixes:
* adds a quick check to make sure client-id wasn't provided, and if it was, sets it to that value instead of overwriting it.

Notes:
The reason for the override is because our default client does not match commercials. Furthermore, the clients used with Cognito are unique, where as the ones with Keycloak are not, so potentially we can improve this by defining a default for FedRAMP when not using admin CLI. 

For now, this is blocking osde2e efforts in FedRAMP