### PR TITLE
OCM-7738 | ci: Enhance the output of rosacli e2e testing

### DIFF
--- a/tests/e2e/dummy_test.go
+++ b/tests/e2e/dummy_test.go
@@ -58,4 +58,18 @@ var _ = Describe("ROSA CLI Test", func() {
 		})
 
 	})
+	Describe("logstreamtest", func() {
+		It("", func() {
+			funcA := func(causeError bool) error {
+				rosacli.NewClient().OCMResource.ListRegion()
+				log.Logger.Debugf("I am debug message with caseuError %v", causeError)
+				if causeError {
+					return fmt.Errorf("test")
+				}
+				return nil
+			}
+			// Expect(funcA(true)).ToNot(HaveOccurred())
+			Expect(funcA(false)).ToNot(HaveOccurred())
+		})
+	})
 })

--- a/tests/utils/exec/rosacli/cmd_client.go
+++ b/tests/utils/exec/rosacli/cmd_client.go
@@ -70,12 +70,6 @@ func NewClient() *Client {
 	return client
 }
 
-func NewSensitiveClient() *Client {
-	client := NewClient()
-	client.Runner.Sensitive(true)
-	return client
-}
-
 func (c *Client) CleanResources(clusterID string) error {
 	var errorList []error
 

--- a/tests/utils/log/constants.go
+++ b/tests/utils/log/constants.go
@@ -7,6 +7,13 @@ import (
 const (
 	RedactValue = "*************"
 )
+const (
+	info  = "INFO"
+	debug = "DEBUG"
+	fatal = "FATAL"
+	warn  = "WARN"
+	err   = "ERROR"
+)
 
 var RedactKeyList = []*regexp.Regexp{
 	regexp.MustCompile(`(\\?"password\\?":\\?")([^"]*)(\\?")`),


### PR DESCRIPTION
There were too much log show in the output of the CI. This PR will improve it to avoid some noise
When case is passed there will be no log output
```
lixue@Xue-Lis-MacBook-Pro rosa % ginkgo -focus 68828 tests/e2e
Running Suite: e2e tests suite - /Users/lixue/Workspace/rosa/tests/e2e
======================================================================
Random Seed: 1714992769

Will run 1 of 58 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSS

Ran 1 of 58 Specs in 23.412 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 57 Skipped
PASS

Ginkgo ran 1 suite in 29.26163914s
Test Suite Passed
```
But when case failed all details will show
```
lixue@Xue-Lis-MacBook-Pro rosa % ginkgo -focus 68828 tests/e2e
Running Suite: e2e tests suite - /Users/lixue/Workspace/rosa/tests/e2e
======================================================================
Random Seed: 1714992871

Will run 1 of 58 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
• [FAILED] [22.324 seconds]
Edit kubeletconfig [It] can create podPidLimit via rosacli will work well - [id:68828] [day2, feature-kubeletconfig, Critical]
/Users/lixue/Workspace/rosa/tests/e2e/test_rosacli_kubelet_config.go:47

  Timeline >>
  STEP: Get the cluster @ 05/06/24 18:54:37.19
  STEP: Init the client @ 05/06/24 18:54:37.19
  STEP: Check cluster is hosted @ 05/06/24 18:54:37.19
  2024-05-06T18:54:37+08:00 - INFO : Running command: rosa describe cluster -c 2b2vvgtmo9vim1n49m8id4aca1qhoc7r --output json
  Got need redacted string from log match regex (arn:aws:[a-z]+:[a-z0-9-]*:)([0-9]{12})(:)
  2024-05-06T18:54:41+08:00 - DEBUG : Get Combining Stdout and Stder is :
  {
    "addons": {
      "items": []
    },
    "api": {
      "listening": "external",
      "url": "https://api.xueli416.h5xs.s1.devshift.org:6443"
    },
    "aws": {
      "audit_log": {
        "role_arn": ""
      },
      "ec2_metadata_http_tokens": "optional",
      "private_link": false,
      "private_link_configuration": {},
      "tags": {
        "red-hat-clustertype": "rosa",
        "red-hat-managed": "true"
      }
    },
    "aws_infrastructure_access_role_grants": {
      "items": []
    },
    "billing_model": "standard",
    "byo_oidc": {
      "enabled": false
    },
    "ccs": {
      "disable_scp_checks": false,
      "enabled": true,
      "kind": "CCS"
    },
    "cloud_provider": {
      "href": "/api/clusters_mgmt/v1/cloud_providers/aws",
      "id": "aws",
      "kind": "CloudProviderLink"
    },
    "console": {
      "url": "https://console-openshift-console.apps.xueli416.h5xs.s1.devshift.org"
    },
    "creation_timestamp": "2024-05-06T03:25:59Z",
    "delete_protection": {
      "enabled": false
    },
    "disable_user_workload_monitoring": false,
    "displayName": "xueli416",
    "dns": {
      "base_domain": "h5xs.s1.devshift.org"
    },
    "domain_prefix": "xueli416",
    "etcd_encryption": true,
    "expiration_timestamp": "2024-05-07T15:25:55Z",
    "external_auth_config": {
      "enabled": false,
      "external_auths": {
        "items": []
      }
    },
    "external_configuration": {
      "labels": {
        "items": []
      },
      "manifests": {
        "items": []
      },
      "syncsets": {
        "items": []
      }
    },
    "external_id": "0cf2a87b-bc92-4ba3-8d12-e46a1395b96b",
    "fips": true,
    "flavour": {
      "href": "/api/clusters_mgmt/v1/flavours/osd-4",
      "id": "osd-4",
      "kind": "FlavourLink"
    },
    "groups": {
      "items": []
    },
    "href": "/api/clusters_mgmt/v1/clusters/2b2vvgtmo9vim1n49m8id4aca1qhoc7r",
    "hypershift": {
      "enabled": false
    },
    "id": "2b2vvgtmo9vim1n49m8id4aca1qhoc7r",
    "identity_providers": {
      "items": []
    },
    "inflight_checks": {
      "items": []
    },
    "infra_id": "xueli416-n4n4c",
    "ingresses": {
      "items": []
    },
    "kind": "Cluster",
    "machine_pools": {
      "items": []
    },
    "managed": true,
    "managed_service": {
      "enabled": false
    },
    "multi_az": false,
    "name": "xueli416",
    "network": {
      "host_prefix": 23,
      "machine_cidr": "10.0.0.0/16",
      "pod_cidr": "10.128.0.0/14",
      "service_cidr": "172.30.0.0/16",
      "type": "OVNKubernetes"
    },
    "node_drain_grace_period": {
      "unit": "minutes",
      "value": 60
    },
    "nodes": {
      "availability_zones": [
        "us-west-2a"
      ],
      "compute": 2,
      "compute_labels": {
        "aaa": "ddd"
      },
      "compute_machine_type": {
        "href": "/api/clusters_mgmt/v1/machine_types/m5.xlarge",
        "id": "m5.xlarge",
        "kind": "MachineTypeLink"
      },
      "compute_root_volume": {
        "aws": {
          "size": 300
        }
      },
      "infra": 2,
      "infra_machine_type": {
        "href": "/api/clusters_mgmt/v1/machine_types/r5.xlarge",
        "id": "r5.xlarge",
        "kind": "MachineTypeLink"
      },
      "master": 3
    },
    "openshift_version": "4.16.0-ec.6",
    "product": {
      "href": "/api/clusters_mgmt/v1/products/rosa",
      "id": "rosa",
      "kind": "ProductLink"
    },
    "properties": {
      "rosa_cli_version": "1.2.39-RC2",
      "rosa_creator_arn": "arn:aws:iam::*************:user/xueli"
    },
    "region": {
      "href": "/api/clusters_mgmt/v1/cloud_providers/aws/regions/us-west-2",
      "id": "us-west-2",
      "kind": "CloudRegionLink"
    },
    "state": "ready",
    "status": {
      "configuration_mode": "full",
      "dns_ready": true,
      "kind": "ClusterStatus",
      "limited_support_reason_count": 0,
      "oidc_ready": false,
      "provision_error_code": "",
      "provision_error_message": "",
      "state": "ready"
    },
    "subscription": {
      "href": "/api/accounts_mgmt/v1/subscriptions/2g4nwnnBHfwOQR8NWNyDPNZTBG6",
      "id": "2g4nwnnBHfwOQR8NWNyDPNZTBG6",
      "kind": "SubscriptionLink"
    },
    "version": {
      "channel_group": "candidate",
      "end_of_life_timestamp": "2025-10-31T00:00:00Z",
      "href": "/api/clusters_mgmt/v1/versions/openshift-v4.16.0-ec.6-candidate",
      "id": "openshift-v4.16.0-ec.6-candidate",
      "kind": "Version",
      "raw_id": "4.16.0-ec.6"
    }
  }

  STEP: Run the command to create a kubeletconfig to the cluster @ 05/06/24 18:54:41.018
  2024-05-06T18:54:41+08:00 - INFO : Running command: rosa create kubeletconfig -c 2b2vvgtmo9vim1n49m8id4aca1qhoc7r --pod-pids-limit 12345
  2024-05-06T18:54:44+08:00 - DEBUG : Get Combining Stdout and Stder is :
? Creating the custom KubeletConfig for cluster '2b2vvgtmo9vim1n49m8id4aca1qhoc7r' will cause all non-Control Plane nodes to reboot. This may cause outages to your applications. Do you wish to continue? (y/N) INFO: Creation of custom KubeletConfig for cluster '2b2vvgtmo9vim1n49m8id4aca1qhoc7r' aborted.

  STEP: Check if cluster is hosted control plane cluster @ 05/06/24 18:54:44.83
  2024-05-06T18:54:44+08:00 - INFO : Running command: rosa describe cluster -c 2b2vvgtmo9vim1n49m8id4aca1qhoc7r --output json
  Got need redacted string from log match regex (arn:aws:[a-z]+:[a-z0-9-]*:)([0-9]{12})(:)
  2024-05-06T18:54:48+08:00 - DEBUG : Get Combining Stdout and Stder is :
  {
    "addons": {
      "items": []
    },
    "api": {
      "listening": "external",
      "url": "https://api.xueli416.h5xs.s1.devshift.org:6443"
    },
    "aws": {
      "audit_log": {
        "role_arn": ""
      },
      "ec2_metadata_http_tokens": "optional",
      "private_link": false,
      "private_link_configuration": {},
      "tags": {
        "red-hat-clustertype": "rosa",
        "red-hat-managed": "true"
      }
    },
    "aws_infrastructure_access_role_grants": {
      "items": []
    },
    "billing_model": "standard",
    "byo_oidc": {
      "enabled": false
    },
    "ccs": {
      "disable_scp_checks": false,
      "enabled": true,
      "kind": "CCS"
    },
    "cloud_provider": {
      "href": "/api/clusters_mgmt/v1/cloud_providers/aws",
      "id": "aws",
      "kind": "CloudProviderLink"
    },
    "console": {
      "url": "https://console-openshift-console.apps.xueli416.h5xs.s1.devshift.org"
    },
    "creation_timestamp": "2024-05-06T03:25:59Z",
    "delete_protection": {
      "enabled": false
    },
    "disable_user_workload_monitoring": false,
    "displayName": "xueli416",
    "dns": {
      "base_domain": "h5xs.s1.devshift.org"
    },
    "domain_prefix": "xueli416",
    "etcd_encryption": true,
    "expiration_timestamp": "2024-05-07T15:25:55Z",
    "external_auth_config": {
      "enabled": false,
      "external_auths": {
        "items": []
      }
    },
    "external_configuration": {
      "labels": {
        "items": []
      },
      "manifests": {
        "items": []
      },
      "syncsets": {
        "items": []
      }
    },
    "external_id": "0cf2a87b-bc92-4ba3-8d12-e46a1395b96b",
    "fips": true,
    "flavour": {
      "href": "/api/clusters_mgmt/v1/flavours/osd-4",
      "id": "osd-4",
      "kind": "FlavourLink"
    },
    "groups": {
      "items": []
    },
    "href": "/api/clusters_mgmt/v1/clusters/2b2vvgtmo9vim1n49m8id4aca1qhoc7r",
    "hypershift": {
      "enabled": false
    },
    "id": "2b2vvgtmo9vim1n49m8id4aca1qhoc7r",
    "identity_providers": {
      "items": []
    },
    "inflight_checks": {
      "items": []
    },
    "infra_id": "xueli416-n4n4c",
    "ingresses": {
      "items": []
    },
    "kind": "Cluster",
    "machine_pools": {
      "items": []
    },
    "managed": true,
    "managed_service": {
      "enabled": false
    },
    "multi_az": false,
    "name": "xueli416",
    "network": {
      "host_prefix": 23,
      "machine_cidr": "10.0.0.0/16",
      "pod_cidr": "10.128.0.0/14",
      "service_cidr": "172.30.0.0/16",
      "type": "OVNKubernetes"
    },
    "node_drain_grace_period": {
      "unit": "minutes",
      "value": 60
    },
    "nodes": {
      "availability_zones": [
        "us-west-2a"
      ],
      "compute": 2,
      "compute_labels": {
        "aaa": "ddd"
      },
      "compute_machine_type": {
        "href": "/api/clusters_mgmt/v1/machine_types/m5.xlarge",
        "id": "m5.xlarge",
        "kind": "MachineTypeLink"
      },
      "compute_root_volume": {
        "aws": {
          "size": 300
        }
      },
      "infra": 2,
      "infra_machine_type": {
        "href": "/api/clusters_mgmt/v1/machine_types/r5.xlarge",
        "id": "r5.xlarge",
        "kind": "MachineTypeLink"
      },
      "master": 3
    },
    "openshift_version": "4.16.0-ec.6",
    "product": {
      "href": "/api/clusters_mgmt/v1/products/rosa",
      "id": "rosa",
      "kind": "ProductLink"
    },
    "properties": {
      "rosa_cli_version": "1.2.39-RC2",
      "rosa_creator_arn": "arn:aws:iam::*************:user/xueli"
    },
    "region": {
      "href": "/api/clusters_mgmt/v1/cloud_providers/aws/regions/us-west-2",
      "id": "us-west-2",
      "kind": "CloudRegionLink"
    },
    "state": "ready",
    "status": {
      "configuration_mode": "full",
      "dns_ready": true,
      "kind": "ClusterStatus",
      "limited_support_reason_count": 0,
      "oidc_ready": false,
      "provision_error_code": "",
      "provision_error_message": "",
      "state": "ready"
    },
    "subscription": {
      "href": "/api/accounts_mgmt/v1/subscriptions/2g4nwnnBHfwOQR8NWNyDPNZTBG6",
      "id": "2g4nwnnBHfwOQR8NWNyDPNZTBG6",
      "kind": "SubscriptionLink"
    },
    "version": {
      "channel_group": "candidate",
      "end_of_life_timestamp": "2025-10-31T00:00:00Z",
      "href": "/api/clusters_mgmt/v1/versions/openshift-v4.16.0-ec.6-candidate",
      "id": "openshift-v4.16.0-ec.6-candidate",
      "kind": "Version",
      "raw_id": "4.16.0-ec.6"
    }
  }

  STEP: Run the command to ignore the warning @ 05/06/24 18:54:48.529
  2024-05-06T18:54:48+08:00 - INFO : Running command: rosa create kubeletconfig -c 2b2vvgtmo9vim1n49m8id4aca1qhoc7r -y --pod-pids-limit 12345
  2024-05-06T18:54:52+08:00 - DEBUG : Get Combining Stdout and Stder is :
  INFO: Successfully created custom KubeletConfig for cluster '2b2vvgtmo9vim1n49m8id4aca1qhoc7r'

  STEP: Describe the kubeletconfig @ 05/06/24 18:54:52.79
  2024-05-06T18:54:52+08:00 - INFO : Running command: rosa describe kubeletconfig -c 2b2vvgtmo9vim1n49m8id4aca1qhoc7r
  2024-05-06T18:54:56+08:00 - DEBUG : Get Combining Stdout and Stder is :

  Pod Pids Limit:                       12345

  2024-05-06T18:54:56+08:00 - INFO : Running command: rosa delete kubeletconfig -c 2b2vvgtmo9vim1n49m8id4aca1qhoc7r -y
  2024-05-06T18:54:59+08:00 - DEBUG : Get Combining Stdout and Stder is :
  INFO: Successfully deleted custom KubeletConfig for cluster '2b2vvgtmo9vim1n49m8id4aca1qhoc7r'

  [FAILED] in [It] - /Users/lixue/Workspace/rosa/tests/e2e/test_rosacli_kubelet_config.go:83 @ 05/06/24 18:54:59.514
  STEP: Clean the cluster @ 05/06/24 18:54:59.515
  2024-05-06T18:54:59+08:00 - DEBUG : Nothing to clean in Version Service
  2024-05-06T18:54:59+08:00 - DEBUG : Nothing to clean in NetworkVerifierService Service
  2024-05-06T18:54:59+08:00 - DEBUG : Nothing releated to cluster was done there
  2024-05-06T18:54:59+08:00 - DEBUG : Nothing releated to cluster was done there
  << Timeline

  [FAILED] This error is made by intention to test the new logger
  Expected
      <int>: 12345
  to equal
      <int>: 123456
  In [It] at: /Users/lixue/Workspace/rosa/tests/e2e/test_rosacli_kubelet_config.go:83 @ 05/06/24 18:54:59.514
------------------------------
SSSSSSSSSSSSSSSS

Summarizing 1 Failure:
  [FAIL] Edit kubeletconfig [It] can create podPidLimit via rosacli will work well - [id:68828] [day2, feature-kubeletconfig, Critical]
  /Users/lixue/Workspace/rosa/tests/e2e/test_rosacli_kubelet_config.go:83

Ran 1 of 58 Specs in 22.328 seconds
FAIL! -- 0 Passed | 1 Failed | 0 Pending | 57 Skipped
--- FAIL: TestROSACLIProvider (22.33s)
FAIL

Ginkgo ran 1 suite in 28.127536885s

Test Suite Failed
```