### PR TITLE
OCM-7537 | ci: fix 45161,49137,66362,36128,43046

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -115,7 +115,7 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 // indirect
 	github.com/zalando/go-keyring v0.2.3 // indirect
-	golang.org/x/crypto v0.22.0 // indirect
+	golang.org/x/crypto v0.22.0
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/oauth2 v0.16.0 // indirect
 	golang.org/x/sys v0.19.0 // indirect

--- a/tests/e2e/test_rosacli_network_verifier.go
+++ b/tests/e2e/test_rosacli_network_verifier.go
@@ -141,7 +141,6 @@ var _ = Describe("Network verifier",
 					"--hosted-cp",
 				)
 				Expect(err).ToNot(HaveOccurred())
-
 			})
 
 	})

--- a/tests/e2e/test_rosacli_oidc_provider.go
+++ b/tests/e2e/test_rosacli_oidc_provider.go
@@ -47,7 +47,6 @@ var _ = Describe("OIDC provider",
 				Expect(err).To(BeNil())
 
 				By("Check if cluster is using reusable oidc config")
-				UsingReusableOIDCConfig, err := clusterService.IsUsingReusableOIDCConfig(clusterID)
 				Expect(err).To(BeNil())
 
 				notExistedClusterID := "notexistedclusterid111"
@@ -61,11 +60,7 @@ var _ = Describe("OIDC provider",
 						"-y")
 					Expect(err).To(BeNil())
 					textData := rosaClient.Parser.TextData.Input(output).Parse().Tip()
-					if UsingReusableOIDCConfig {
-						Expect(textData).To(ContainSubstring("OIDC provider already exists"))
-					} else {
-						Expect(textData).To(ContainSubstring("is ready and does not need additional configuration"))
-					}
+					Expect(textData).To(ContainSubstring("OIDC provider already exists"))
 				case false:
 					By("Create oidc-provider on classic non-sts cluster")
 					output, err := ocmResourceService.CreateOIDCProvider(

--- a/tests/utils/common/idp.go
+++ b/tests/utils/common/idp.go
@@ -2,22 +2,22 @@ package common
 
 import (
 	"fmt"
-	"os/exec"
 	"strings"
+
+	"golang.org/x/crypto/bcrypt"
 
 	. "github.com/openshift/rosa/tests/utils/log"
 )
 
 // Generate htpasspwd key value pair, return with a string
 func GenerateHtpasswdPair(user string, pass string) (string, string, string, error) {
-	generateCMD := fmt.Sprintf("htpasswd -Bbn %s %s", user, pass)
-	output, err := exec.Command("bash", "-c", generateCMD).Output()
-	htpasswdPair := strings.TrimSpace(string(output))
-	parts := strings.SplitN(htpasswdPair, ":", 2)
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(pass), bcrypt.DefaultCost)
 	if err != nil {
 		Logger.Errorf("Fail to generate htpasswd file: %v", err)
 		return "", "", "", err
 	}
+	htpasswdPair := fmt.Sprintf("%s:%s", user, string(hashedPassword))
+	parts := strings.SplitN(htpasswdPair, ":", 2)
 	return htpasswdPair, parts[0], parts[1], nil
 }
 

--- a/tests/utils/config/cluster_command.go
+++ b/tests/utils/config/cluster_command.go
@@ -80,6 +80,7 @@ func (c *command) GetFlagValue(flag string, flagWithVaue bool) string {
 // Add flags to the command
 func (c *command) AddFlags(flags ...string) {
 	for _, flag := range flags {
+		c.cmd = strings.TrimSpace(c.cmd)
 		// combine the command with space
 		c.cmd += " " + flag
 	}


### PR DESCRIPTION
[OCM-7537](https://issues.redhat.com//browse/OCM-7537) | ci: fix id:45161,id:49137,id:66362,id:36128,id:43046

fix 45161 trim the command with the space then add the flag at func (c *command) AddFlags(flags ...string)
fix 49137 dont use htpasswd banary  at GenerateMultipleHtpasswdPairs and GenerateHtpasswdPair
fix 66362 it supports on Hosted-cp cluster, remove the original checkpoint
fix 36128 Add condition for the empty user list step
fix 43046 update the message condition as the design change

The log is here,https://privatebin.corp.redhat.com/?2bd4121c47d1d65d#CT3jmB9AmcSJqwweCAuDReiupY8ts6PV5Sb9jEjxp9yA