### PR TITLE
OCM-6391 | fix: Remove duplicate oidcprovider cmd call

### DIFF
--- a/cmd/create/cmd.go
+++ b/cmd/create/cmd.go
@@ -77,8 +77,7 @@ func init() {
 		userrole.Cmd, ocmrole.Cmd,
 		oidcprovider.Cmd, breakglasscredential.Cmd,
 		admin.Cmd, autoscaler.Cmd, dnsdomains.Cmd,
-		externalauthprovider.Cmd, idp.Cmd, kubeletconfig.Cmd,
-		oidcprovider.Cmd, tuningconfigs.Cmd,
+		externalauthprovider.Cmd, idp.Cmd, kubeletconfig.Cmd, tuningconfigs.Cmd,
 	}
 	arguments.MarkRegionDeprecated(Cmd, globallyAvailableCommands)
 }


### PR DESCRIPTION
There was an extra addition of the oidcprovider command in a region deprecation call. Removed here.