### PR TITLE
OCM-7870 | fix: Display external-auth-providers-enabled flag

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -374,7 +374,6 @@ func initFlags(cmd *cobra.Command) {
 		false,
 		"Enable external authentication configuration for a Hosted Control Plane cluster.",
 	)
-	flags.MarkHidden(ExternalAuthProvidersEnabledFlag)
 
 	flags.StringSliceVar(
 		&args.tags,

--- a/cmd/create/cluster/cmd_test.go
+++ b/cmd/create/cluster/cmd_test.go
@@ -405,6 +405,20 @@ var _ = Describe("Filtering", func() {
 	)
 })
 
+var _ = Describe("hostPrefixValidator()", func() {
+	It("KO: invalid format", func() {
+		err := hostPrefixValidator("abc")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("strconv.Atoi: parsing \"abc\": invalid syntax"))
+	})
+
+	It("KO: short format", func() {
+		err := hostPrefixValidator("123456")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("Invalid Network Host Prefix /123456: Subnet length should be between 23 and 26"))
+	})
+})
+
 var _ = Describe("validateBillingAccount()", func() {
 
 	It("OK: valid billing account", func() {


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-7870