### PR TITLE
OSD-22376 | refactor: updates fedramp client id configuration

### DIFF
--- a/cmd/login/cmd.go
+++ b/cmd/login/cmd.go
@@ -324,6 +324,10 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command, argv []string) error {
 	}
 	// Override configuration details for FedRAMP:
 	if fedramp.Enabled() {
+		clientID = fedramp.ClientID
+		if args.clientID != "" {
+			clientID = args.clientID
+		}
 		if fedramp.HasAdminFlag(cmd) {
 			gatewayURL, ok = fedramp.AdminURLAliases[env]
 			if !ok {
@@ -345,17 +349,6 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command, argv []string) error {
 			tokenURL, ok = fedramp.TokenURLs[env]
 			if !ok {
 				tokenURL = args.tokenURL
-			}
-
-			// if client-id is provided, we don't want to just override it
-			// with Keycloak flow
-			if args.clientID != "" {
-				clientID = args.clientID
-			} else {
-				clientID, ok = fedramp.ClientIDs[env]
-				if !ok {
-					clientID = args.clientID
-				}
 			}
 		}
 	}

--- a/pkg/fedramp/config.go
+++ b/pkg/fedramp/config.go
@@ -91,13 +91,9 @@ var AdminTokenURLs = map[string]string{
 	"integration": fmt.Sprintf("https://rh-ocm-appsre-integration.%s", cognitoURL),
 }
 
-// ClientIDs allows the value of the `--env` option to map to the Keycloak clients.
-var ClientIDs = map[string]string{
-	"production":  "console-dot",
-	"staging":     "console-dot",
-	"staging01":   "console-dot",
-	"integration": "console-dot",
-}
+// ClientID stores the client id for use with all `--env` options for Keycloak authentication flow.
+// Value is the same for all env's
+var ClientID = "console-dot"
 
 // AdminClientIDs allows the value of the `--env` option to map to the various Admin AWS Cognito user pool clients.
 var AdminClientIDs = map[string]string{


### PR DESCRIPTION
Client ID used for keycloak auth is the same for all envs, no need to define it multiple times depending on env

Updates logic to set the appropriate client id when FedRAMP is enabled  and the `--admin` flag is not passed

Changes are mostly for code cleanliness