### PR TITLE
OCM-7925 | ci: Fix ingress list result cannot be reflect issue

### DIFF
--- a/tests/e2e/dummy_test.go
+++ b/tests/e2e/dummy_test.go
@@ -9,6 +9,7 @@ import (
 
 	TC "github.com/openshift/rosa/tests/ci/config"
 	"github.com/openshift/rosa/tests/utils/common"
+	"github.com/openshift/rosa/tests/utils/config"
 	"github.com/openshift/rosa/tests/utils/exec/rosacli"
 	"github.com/openshift/rosa/tests/utils/log"
 	"github.com/openshift/rosa/tests/utils/profilehandler"
@@ -57,6 +58,23 @@ var _ = Describe("ROSA CLI Test", func() {
 			Expect(len(subnets)).To(Equal(2))
 		})
 
+	})
+	Describe("ROSAClientServiceTestingCode testing", func() {
+		var rosaClient *rosacli.Client
+		var clusterID string
+		BeforeEach(func() {
+			rosaClient = rosacli.NewClient()
+			clusterID = config.GetClusterID()
+			Expect(clusterID).ToNot(BeEmpty())
+		})
+		It("IngressServiceTesting", func() {
+			output, err := rosaClient.Ingress.ListIngress(clusterID)
+			Expect(err).ToNot(HaveOccurred())
+			ingressList, err := rosaClient.Ingress.ReflectIngressList(output)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ingressList.Ingresses).ToNot(BeEmpty())
+			Expect(ingressList.Ingresses[0].LBType).ToNot(BeEmpty())
+		})
 	})
 	Describe("logstreamtest", func() {
 		It("", func() {

--- a/tests/utils/exec/rosacli/ingress_service.go
+++ b/tests/utils/exec/rosacli/ingress_service.go
@@ -50,12 +50,16 @@ type IngressList struct {
 	Ingresses []Ingress `json:"Ingresses,omitempty"`
 }
 type Ingress struct {
-	ID                string `yaml:"ID,omitempty"`
-	ApplicationRouter string `yaml:"APPLICATION ROUTER,omitempty"`
-	Private           string `yaml:"PRIVATE,omitempty"`
-	Default           string `yaml:"DEFAULT,omitempty"`
-	RouteSelectors    string `yaml:"ROUTE SELECTORS,omitempty"`
-	LBType            string `yaml:"LB-TYPE,omitempty"`
+	ClusterID                string `yaml:"Cluster ID,omitempty"`
+	ID                       string `yaml:"ID,omitempty" json:"ID,omitempty"`
+	ApplicationRouter        string `yaml:"APPLICATION ROUTER,omitempty" json:"APPLICATION ROUTER,omitempty"`
+	Private                  string `yaml:"Private,omitempty" json:"PRIVATE,omitempty"`
+	Default                  string `yaml:"Default,omitempty" json:"DEFAULT,omitempty"`
+	RouteSelectors           string `yaml:"ROUTE SELECTORS,omitempty" json:"ROUTE SELECTORS,omitempty"`
+	LBType                   string `yaml:"LB-Type,omitempty" json:"LB-TYPE,omitempty"`
+	ExcludeNamespace         string `yaml:"Exclude Namespce,omitempty" json:"EXCLUDED NAMESPACE,omitempty"`
+	WildcardPolicy           string `yaml:"Wildcard Policy,omitempty" json:"WILDCARD POLICY,omitempty"`
+	NamespaceOwnershipPolicy string `yaml:"Namespace Ownership Policy,omitempty" json:"NAMESPACE OWNERSHIP,omitempty"`
 }
 
 // Get specified ingress by ingress id


### PR DESCRIPTION
```
lixue@Xue-Lis-MacBook-Pro rosa % ginkgo -focus IngressServiceTesting tests/e2e     
Running Suite: e2e tests suite - /Users/lixue/Workspace/rosa/tests/e2e
======================================================================
Random Seed: 1715234948

Will run 1 of 59 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSS

Ran 1 of 59 Specs in 3.484 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 58 Skipped
PASS

Ginkgo ran 1 suite in 9.257267263s
Test Suite Passed
```