### PR TITLE
OCM-7924 | fix: list machinepool should show inline

### DIFF
--- a/cmd/list/machinepool/cmd_test.go
+++ b/cmd/list/machinepool/cmd_test.go
@@ -32,11 +32,11 @@ const (
 		"              us-east-1a, us-east-1b, us-east-1c               Yes (max $5)    default    " +
 		"\nnodepool853  Yes          1-100     m5.xlarge      test=label    test=taint:    " +
 		"us-east-1a, us-east-1b, us-east-1c               Yes (max $5)    default    \n"
-	multipleNodePoolsOutput = "ID           AUTOSCALING  REPLICAS  INSTANCE TYPE  LABELS    TAINTS" +
-		"    AVAILABILITY ZONE  SUBNET  VERSION  AUTOREPAIR  \nnodepool85   No" +
-		"           /0        m5.xlarge                          us-east-1a     " +
-		"            4.12.24  No          \nnodepool852  Yes          " +
-		"/\n - Min replicas: 100\n - Max replicas: 1000  m5.xlarge  test=label        us-east-1a    4.12.24  No  \n"
+	multipleNodePoolsOutput = "ID           AUTOSCALING  REPLICAS   INSTANCE TYPE  LABELS        TAINTS    " +
+		"AVAILABILITY ZONE  SUBNET  VERSION  AUTOREPAIR  \nnodepool85   No           /0         " +
+		"m5.xlarge                              us-east-1a                 4.12.24  No          " +
+		"\nnodepool852  Yes          /100-1000  m5.xlarge      test=label              us-east-1a                 " +
+		"4.12.24  No          \n"
 )
 
 var _ = Describe("List machine pool", func() {

--- a/pkg/machinepool/machinepool.go
+++ b/pkg/machinepool/machinepool.go
@@ -197,7 +197,7 @@ func getNodePoolsString(nodePools []*cmv1.NodePool) string {
 			ocmOutput.PrintNodePoolAutoscaling(nodePool.Autoscaling()),
 			ocmOutput.PrintNodePoolReplicasShort(
 				ocmOutput.PrintNodePoolCurrentReplicas(nodePool.Status()),
-				ocmOutput.PrintNodePoolReplicas(nodePool.Autoscaling(), nodePool.Replicas()),
+				ocmOutput.PrintNodePoolReplicasInline(nodePool.Autoscaling(), nodePool.Replicas()),
 			),
 			ocmOutput.PrintNodePoolInstanceType(nodePool.AWSNodePool()),
 			ocmOutput.PrintLabels(nodePool.Labels()),

--- a/pkg/ocm/output/nodepools.go
+++ b/pkg/ocm/output/nodepools.go
@@ -33,6 +33,15 @@ func PrintNodePoolAutoscaling(autoscaling *cmv1.NodePoolAutoscaling) string {
 	return output.No
 }
 
+func PrintNodePoolReplicasInline(autoscaling *cmv1.NodePoolAutoscaling, replicas int) string {
+	if autoscaling != nil {
+		return fmt.Sprintf("%d-%d",
+			autoscaling.MinReplica(),
+			autoscaling.MaxReplica())
+	}
+	return fmt.Sprintf("%d", replicas)
+}
+
 func PrintNodePoolReplicas(autoscaling *cmv1.NodePoolAutoscaling, replicas int) string {
 	if autoscaling != nil {
 		return fmt.Sprintf(`

--- a/pkg/ocm/output/nodepools_test.go
+++ b/pkg/ocm/output/nodepools_test.go
@@ -16,17 +16,31 @@ var _ = Describe("Create node drain grace period builder validations", func() {
 			output := PrintNodeDrainGracePeriod(period)
 			Expect(output).To(Equal(expectedOutput))
 		},
-		Entry(nil,
+		Entry("Should return empty string", nil,
 			"",
 		),
-		Entry(zeroValue,
+		Entry("Should return empty string", zeroValue,
 			"",
 		),
-		Entry(oneValue,
+		Entry("Should return 1 minute", oneValue,
 			"1 minute",
 		),
-		Entry(twoValue,
+		Entry("Should return 2 minutes", twoValue,
 			"2 minutes",
 		),
 	)
+})
+
+var _ = Describe("PrintNodePoolReplicasInline", func() {
+	It("Should print the correct output if autoscaling exists", func() {
+		autoscaling := cmv1.NewNodePoolAutoscaling().MinReplica(2).MaxReplica(6)
+		output := PrintNodePoolReplicasInline((*cmv1.NodePoolAutoscaling)(autoscaling), 2)
+		Expect(output).To(Equal("2-6"))
+	})
+
+	It("Should print the correct output if autoscaling is nill", func() {
+		output := PrintNodePoolReplicasInline(nil, 2)
+		Expect(output).To(Equal("2"))
+	})
+
 })

--- a/pkg/ocm/output/output_test.go
+++ b/pkg/ocm/output/output_test.go
@@ -1,0 +1,13 @@
+package output
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestOutput(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Output Suite")
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-7924

```
➜  rosa git:(OCM-7924) ✗ ./rosa list machinepools -c magchen-hcp
ID       AUTOSCALING  REPLICAS  INSTANCE TYPE  LABELS    TAINTS    AVAILABILITY ZONE  SUBNET                    VERSION  AUTOREPAIR  
workers  Yes          2/2-5     m5.xlarge                          us-west-2a         subnet-0e1835a4c861e6a98  4.15.8   Yes         
```