### PR TITLE
OCM-7801 | ci: Remove redundant cleaner to fix resource clean issue

### DIFF
--- a/tests/e2e/test_rosacli_cluster.go
+++ b/tests/e2e/test_rosacli_cluster.go
@@ -172,10 +172,15 @@ var _ = Describe("Edit cluster",
 				clusterDetail, err := clusterService.ReflectClusterDescription(output)
 				Expect(err).ToNot(HaveOccurred())
 				expectedUWMValue := "Enabled"
+				recoverUWMStatus := false
 				if clusterConfig.DisableWorkloadMonitoring {
 					expectedUWMValue = "Disabled"
+					recoverUWMStatus = true
 				}
 				Expect(clusterDetail.UserWorkloadMonitoring).To(Equal(expectedUWMValue))
+				defer clusterService.EditCluster(clusterID,
+					fmt.Sprintf("--disable-workload-monitoring=%v", recoverUWMStatus),
+					"-y")
 
 				By("Disable the UWM")
 				expectedUWMValue = "Disabled"

--- a/tests/e2e/test_rosacli_idp.go
+++ b/tests/e2e/test_rosacli_idp.go
@@ -43,7 +43,6 @@ var _ = Describe("Edit IDP",
 			By("Clean remaining resources")
 			var errorList []error
 			errorList = append(errorList, rosaClient.CleanResources(clusterID))
-			errorList = append(errorList, rosaClient.CleanResources(clusterID))
 			Expect(errors.Join(errorList...)).ToNot(HaveOccurred())
 
 		})


### PR DESCRIPTION
```
lixue@Xue-Lis-MacBook-Pro rosa % ginkgo -focus "(35878|35896|49137)" tests/e2e
Running Suite: e2e tests suite - /Users/lixue/Workspace/rosa/tests/e2e
======================================================================
Random Seed: 1715268241

Will run 3 of 59 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSS•••SSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 3 of 59 Specs in 351.317 seconds
SUCCESS! -- 3 Passed | 0 Failed | 0 Pending | 56 Skipped
PASS

Ginkgo ran 1 suite in 6m1.418792847s
Test Suite Passed
```