### PR TITLE
OCM-7961 | chore: update the fips flag description

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -423,7 +423,8 @@ func initFlags(cmd *cobra.Command) {
 		&args.fips,
 		"fips",
 		false,
-		"Create cluster that uses FIPS Validated / Modules in Process cryptographic libraries.",
+		"Create cluster that uses FIPS Validated / Modules in Process cryptographic libraries. "+
+			"This is currently only available without the use of the --hosted-cp flag.",
 	)
 
 	flags.StringVar(


### PR DESCRIPTION
This was added as a way to let users know before attempting a deployment, that FIPS is not available for hosted control plane at this time.  This can be removed at a time when hosted control plane is FIPS validated.  See https://docs.aws.amazon.com/rosa/latest/userguide/rosa-deployment-options.html#rosa-deployment-model-differences for more details.