### PR TITLE
OCM-7902 | ci: Bump ocm-common to support intellegient proxy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/nathan-fiscaletti/consolesize-go v0.0.0-20210105204122-a87d9f614b9d
 	github.com/onsi/ginkgo/v2 v2.17.1
 	github.com/onsi/gomega v1.30.0
-	github.com/openshift-online/ocm-common v0.0.0-20240426075354-0921f33327e3
+	github.com/openshift-online/ocm-common v0.0.0-20240508111534-37822c515806
 	github.com/openshift-online/ocm-sdk-go v0.1.418
 	github.com/pkg/errors v0.9.1
 	github.com/robfig/cron/v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -271,8 +271,8 @@ github.com/onsi/ginkgo/v2 v2.17.1 h1:V++EzdbhI4ZV4ev0UTIj0PzhzOcReJFyJaLjtSF55M8
 github.com/onsi/ginkgo/v2 v2.17.1/go.mod h1:llBI3WDLL9Z6taip6f33H76YcWtJv+7R3HigUjbIBOs=
 github.com/onsi/gomega v1.30.0 h1:hvMK7xYz4D3HapigLTeGdId/NcfQx1VHMJc60ew99+8=
 github.com/onsi/gomega v1.30.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
-github.com/openshift-online/ocm-common v0.0.0-20240426075354-0921f33327e3 h1:y5uWnDsW1kggef4rXfXiHO1avR3q7O/UOyG1LZAq7Vg=
-github.com/openshift-online/ocm-common v0.0.0-20240426075354-0921f33327e3/go.mod h1:TajXvAf+ieJvlrCvzbVAq1gqf0CMmtT39sHbL549KKw=
+github.com/openshift-online/ocm-common v0.0.0-20240508111534-37822c515806 h1:YEDgruMDet/LJyav5G6VuvMhCf3tm7mQxR9ZS/yjn2E=
+github.com/openshift-online/ocm-common v0.0.0-20240508111534-37822c515806/go.mod h1:aAE9ThwbT6pHKyVP15TW724yV0uvdNL3ZnIxena2j5s=
 github.com/openshift-online/ocm-sdk-go v0.1.418 h1:UgMcx16YOS0cs6c0b0ZXbffnjciiuvAp2fE63tnLwLI=
 github.com/openshift-online/ocm-sdk-go v0.1.418/go.mod h1:CiAu2jwl3ITKOxkeV0Qnhzv4gs35AmpIzVABQLtcI2Y=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/tests/ci/config/config.go
+++ b/tests/ci/config/config.go
@@ -75,7 +75,7 @@ func init() {
 	Test.ClusterInstallLogArtifactFile = path.Join(Test.ArtifactDir, ".install.log")
 	Test.ClusterAdminFile = path.Join(Test.ArtifactDir, ".admin")
 	Test.TestFocusFile = path.Join(Test.RootDir, "tests", "ci", "data", "commit-focus")
-	Test.ProxySSHPemFile = path.Join(Test.OutputDir, "openshift-qe.pem")
+	Test.ProxySSHPemFile = "ocm-test-proxy"
 	Test.ProxyCABundleFile = path.Join(Test.OutputDir, "proxy-bundle.ca")
 
 	waitingTime, err := strconv.Atoi(common.ReadENVWithDefaultValue("CLUSTER_TIMEOUT", "60"))

--- a/tests/ci/data/profiles/rosa-classic.yaml
+++ b/tests/ci/data/profiles/rosa-classic.yaml
@@ -2,7 +2,7 @@ profiles:
 - as: rosa-advanced
   version: "latest"
   channel_group: "candidate"
-  region: "us-east-1"
+  region: "us-west-2"
   cluster:
     multi_az: true
     instance_type: "r5.xlarge"

--- a/tests/e2e/dummy_test.go
+++ b/tests/e2e/dummy_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/openshift/rosa/tests/utils/config"
 	"github.com/openshift/rosa/tests/utils/exec/rosacli"
 	"github.com/openshift/rosa/tests/utils/log"
-	"github.com/openshift/rosa/tests/utils/profilehandler"
 	PH "github.com/openshift/rosa/tests/utils/profilehandler"
 )
 
@@ -50,12 +49,19 @@ var _ = Describe("ROSA CLI Test", func() {
 	})
 	Describe("ocm-common test", func() {
 		It("VPCClientTesting", func() {
-			vpcClient, err := profilehandler.PrepareVPC("us-east-1", "xueli-test", "10.0.0.0/16")
+			vpcClient, err := PH.PrepareVPC("us-east-1", "xueli-test", "10.0.0.0/16")
 			Expect(err).ToNot(HaveOccurred())
 			defer vpcClient.DeleteVPCChain(true)
-			subnets, err := profilehandler.PrepareSubnets(vpcClient, "us-east-1", []string{}, true)
+			subnets, err := PH.PrepareSubnets(vpcClient, "us-east-1", []string{}, true)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(subnets)).To(Equal(2))
+			_, ip, ca, err := vpcClient.LaunchProxyInstance("us-east-1a", "xueli-test", TC.Test.OutputDir)
+
+			Expect(err).ToNot(HaveOccurred())
+			fmt.Println(ip)
+			fmt.Println(ca)
+			log.Logger.Infof("Got configured proxy ip: %v", ip)
+			log.Logger.Infof("Got configured proxy ca: %v", ca)
 		})
 
 	})

--- a/tests/utils/profilehandler/data_preparation.go
+++ b/tests/utils/profilehandler/data_preparation.go
@@ -117,8 +117,8 @@ func PrepareSubnets(vpcClient *vpc_client.VPC, region string, zones []string, mu
 	return resultMap, nil
 }
 
-func PrepareProxy(vpcClient *vpc_client.VPC, zone string, sshPemFile string, caFile string) (*ProxyDetail, error) {
-	_, privateIP, caContent, err := vpcClient.LaunchProxyInstance("", zone, sshPemFile)
+func PrepareProxy(vpcClient *vpc_client.VPC, zone string, sshPemFileName string, sshPemFileRecordDir string, caFile string) (*ProxyDetail, error) {
+	_, privateIP, caContent, err := vpcClient.LaunchProxyInstance(zone, sshPemFileName, sshPemFileRecordDir)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/utils/profilehandler/profile_handler.go
+++ b/tests/utils/profilehandler/profile_handler.go
@@ -412,7 +412,11 @@ func GenerateClusterCreateFlags(profile *Profile, client *rosacli.Client) ([]str
 			}
 		}
 		if profile.ClusterConfig.ProxyEnabled {
-			proxy, err := PrepareProxy(vpc, profile.Region, config.Test.ProxySSHPemFile, config.Test.ProxyCABundleFile)
+			proxyName := vpc.VPCName
+			if proxyName == "" {
+				proxyName = clusterName
+			}
+			proxy, err := PrepareProxy(vpc, profile.Region, proxyName, config.Test.OutputDir, config.Test.ProxyCABundleFile)
 			if err != nil {
 				return flags, err
 			}

--- a/vendor/github.com/openshift-online/ocm-common/pkg/aws/consts/consts.go
+++ b/vendor/github.com/openshift-online/ocm-common/pkg/aws/consts/consts.go
@@ -49,16 +49,14 @@ const (
 	QEFlagKey = "ocm_ci_flag"
 
 	// Proxy related
-	ProxyName       = "ocm-proxy"
-	InstanceKeyName = "openshift-qe"
-	AWSInstanceUser = "ec2-user"
-	BastionName     = "ocm-bastion"
+	ProxyName             = "ocm-proxy"
+	InstanceKeyNamePrefix = "ocm-ci"
+	AWSInstanceUser       = "ec2-user"
+	BastionName           = "ocm-bastion"
 )
 
-var ProxyImageMap = map[string]string{
-	"us-west-2":      "ami-03b82d95dbe67072d",
-	"ap-northeast-1": "ami-0517f6ca1da98f337",
-}
+var PublicImageName = "al2023-ami-2023.4.20240416.0-kernel-6.1-x86_64"
+
 var BastionImageMap = map[string]string{
 	"us-east-1":      "ami-01c647eace872fc02",
 	"us-east-2":      "ami-00a9282ce3b5ddfb1",

--- a/vendor/github.com/openshift-online/ocm-common/pkg/file/file.go
+++ b/vendor/github.com/openshift-online/ocm-common/pkg/file/file.go
@@ -1,0 +1,39 @@
+package file
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/openshift-online/ocm-common/pkg/log"
+)
+
+func WriteToFile(content string, fileName string, path ...string) (string, error) {
+	KeyPath, _ := os.UserHomeDir()
+
+	if len(path) != 0 {
+		KeyPath = path[0]
+	}
+
+	filePath := fmt.Sprintf("%s/%s", KeyPath, fileName)
+	if IfFileExists(filePath) {
+		err := os.Remove(filePath)
+		if err != nil {
+			log.LogInfo("Delete file err:%v", err)
+			return "", err
+		}
+	}
+	err := os.WriteFile(filePath, []byte(content), 0600)
+	if err != nil {
+		log.LogInfo("Write to file err:%v", err)
+		return "", err
+	}
+	return filePath, nil
+}
+
+func IfFileExists(path string) bool {
+	_, err := os.Stat(path)
+	if err != nil {
+		return os.IsExist(err)
+	}
+	return true
+}

--- a/vendor/github.com/openshift-online/ocm-common/pkg/test/vpc_client/bastion.go
+++ b/vendor/github.com/openshift-online/ocm-common/pkg/test/vpc_client/bastion.go
@@ -33,7 +33,13 @@ func (vpc *VPC) LaunchBastion(imageID string, zone string) (*types.Instance, err
 		return inst, err
 	}
 
-	instOut, err := vpc.AWSClient.LaunchInstance(pubSubnet.ID, imageID, 1, "t3.medium", CON.InstanceKeyName, []string{SGID}, true)
+	key, err := vpc.CreateKeyPair(fmt.Sprintf("%s-bastion", CON.InstanceKeyNamePrefix))
+	if err != nil {
+		log.LogError("Create key pair failed %s", err)
+		return inst, err
+	}
+	instOut, err := vpc.AWSClient.LaunchInstance(pubSubnet.ID, imageID, 1, "t3.medium", *key.KeyName, []string{SGID}, true)
+
 	if err != nil {
 		log.LogError("Launch bastion instance failed %s", err)
 		return inst, err

--- a/vendor/github.com/openshift-online/ocm-common/pkg/test/vpc_client/instance.go
+++ b/vendor/github.com/openshift-online/ocm-common/pkg/test/vpc_client/instance.go
@@ -30,14 +30,20 @@ func (vpc *VPC) TerminateVPCInstances(nonClusterOnly bool) error {
 		return err
 	}
 	needTermination := []string{}
+	keyPairNames := []string{}
 	for _, inst := range insts {
 		needTermination = append(needTermination, *inst.InstanceId)
+		keyPairNames = append(keyPairNames, *inst.KeyName)
 	}
 	err = vpc.AWSClient.TerminateInstances(needTermination, true, 20)
 	if err != nil {
 		log.LogError("Terminating instances %s meet error: %s", strings.Join(needTermination, ","), err)
 	} else {
 		log.LogInfo("Terminating instances %s successfully", strings.Join(needTermination, ","))
+	}
+	err = vpc.DeleteKeyPair(keyPairNames)
+	if err != nil {
+		log.LogError("Delete key pair %s meet error: %s", strings.Join(keyPairNames, ","), err)
 	}
 	return err
 

--- a/vendor/github.com/openshift-online/ocm-common/pkg/test/vpc_client/key_pair.go
+++ b/vendor/github.com/openshift-online/ocm-common/pkg/test/vpc_client/key_pair.go
@@ -1,24 +1,26 @@
 package vpc_client
 
 import (
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/openshift-online/ocm-common/pkg/log"
 )
 
-func (vpc *VPC) CreateKeyPair(keyName string) (*string, error) {
+func (vpc *VPC) CreateKeyPair(keyName string) (*ec2.CreateKeyPairOutput, error) {
 	output, err := vpc.AWSClient.CreateKeyPair(keyName)
 	if err != nil {
 		return nil, err
 	}
 	log.LogInfo("create key pair: %v successfully\n", *output.KeyPairId)
-	content := output.KeyMaterial
 
-	return content, nil
+	return output, nil
 }
 
-func (vpc *VPC) DeleteKeyPair(keyName string) error {
-	_, err := vpc.AWSClient.DeleteKeyPair(keyName)
-	if err != nil {
-		return err
+func (vpc *VPC) DeleteKeyPair(keyNames []string) error {
+	for _, key := range keyNames {
+		_, err := vpc.AWSClient.DeleteKeyPair(key)
+		if err != nil {
+			return err
+		}
 	}
 	log.LogInfo("delete key pair successfully\n")
 	return nil

--- a/vendor/github.com/openshift-online/ocm-common/pkg/test/vpc_client/proxy.go
+++ b/vendor/github.com/openshift-online/ocm-common/pkg/test/vpc_client/proxy.go
@@ -7,33 +7,37 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
 	CON "github.com/openshift-online/ocm-common/pkg/aws/consts"
+	"github.com/openshift-online/ocm-common/pkg/file"
 	"github.com/openshift-online/ocm-common/pkg/log"
 )
 
 // LaunchProxyInstance will launch a proxy instance on the indicated zone.
 // If set imageID to empty, it will find the proxy image in the ProxyImageMap map
 // LaunchProxyInstance will return proxyInstance detail, privateIPAddress,CAcontent and error
-func (vpc *VPC) LaunchProxyInstance(imageID string, zone string, sshKey string) (types.Instance, string, string, error) {
-	var inst types.Instance
-	if imageID == "" {
-		var ok bool
-		imageID, ok = CON.ProxyImageMap[vpc.Region]
-		if !ok {
-			log.LogInfo("Cannot find proxy image of region %s in map ProxyImageMap, will copy from existing region", vpc.Region)
-			var err error
-			imageID, err = vpc.CopyImageToProxy(CON.ProxyName)
-			if err != nil {
-				log.LogError("Error to copy image ID %s: %s", imageID, err)
-				return inst, "", "", err
-			}
-			//Wait 30 minutes for image to active
-			result, err := vpc.WaitImageToActive(imageID, 30)
-			if err != nil || !result {
-				log.LogError("Error wait image %s to active %s", imageID, err)
-				return inst, "", "", err
-			}
-		}
+func (vpc *VPC) LaunchProxyInstance(zone string, keypairName string, privateKeyPath string) (inst types.Instance, privateIP string, proxyServerCA string, err error) {
+	filters := []map[string][]string{
+		{
+			"name": {
+				CON.PublicImageName,
+			},
+		},
 	}
+
+	output, err := vpc.AWSClient.DescribeImage([]string{}, filters...)
+	if err != nil {
+		log.LogError("Describe image met error: %s", err)
+		return inst, "", "", err
+	}
+	if output == nil {
+		log.LogError("Got the empty image via the filter: %s", filters)
+		return inst, "", "", nil
+	}
+	if len(output.Images) < 1 {
+		log.LogError("Can't get the vaild image")
+		return inst, "", "", nil
+	}
+	imageID := *output.Images[0].ImageId
+	log.LogInfo("Got the image ID : %s", imageID)
 
 	pubSubnet, err := vpc.PreparePublicSubnet(zone)
 	if err != nil {
@@ -46,20 +50,40 @@ func (vpc *VPC) LaunchProxyInstance(imageID string, zone string, sshKey string) 
 		return inst, "", "", err
 	}
 
-	instOut, err := vpc.AWSClient.LaunchInstance(pubSubnet.ID, imageID, 1, "t3.medium", CON.InstanceKeyName, []string{SGID}, true)
+	keyName := fmt.Sprintf("%s-%s", CON.InstanceKeyNamePrefix, keypairName)
+	key, err := vpc.CreateKeyPair(keyName)
+	if err != nil {
+		log.LogError("Create key pair %s failed %s", keyName, err)
+		return inst, "", "", err
+	}
+	tags := map[string]string{
+		"Name": CON.ProxyName,
+	}
+	_, err = vpc.AWSClient.TagResource(*key.KeyPairId, tags)
+	if err != nil {
+		log.LogError("Add tag for key pair %s failed %s", *key.KeyPairId, err)
+		return inst, "", "", err
+	}
+	privateKeyName := fmt.Sprintf("%s-%s", keypairName, "keyPair.pem")
+	sshKey, err := file.WriteToFile(*key.KeyMaterial, privateKeyName, privateKeyPath)
+	if err != nil {
+		log.LogError("Write private key to file failed %s", err)
+		return inst, "", "", err
+	}
+
+	instOut, err := vpc.AWSClient.LaunchInstance(pubSubnet.ID, imageID, 1, "t3.medium", keyName, []string{SGID}, true)
 	if err != nil {
 		log.LogError("Launch proxy instance failed %s", err)
 		return inst, "", "", err
 	} else {
 		log.LogInfo("Launch proxy instance %s succeed", *instOut.Instances[0].InstanceId)
 	}
-	tags := map[string]string{
-		"Name": CON.ProxyName,
-	}
+
 	instID := *instOut.Instances[0].InstanceId
 	_, err = vpc.AWSClient.TagResource(instID, tags)
 	if err != nil {
-		return inst, "", "", fmt.Errorf("tag instance %s failed:%s", instID, err)
+		log.LogError("Add tag for instance  %s failed %s", instID, err)
+		return inst, "", "", err
 	}
 
 	publicIP, err := vpc.AWSClient.AllocateEIPAndAssociateInstance(instID)
@@ -70,56 +94,38 @@ func (vpc *VPC) LaunchProxyInstance(imageID string, zone string, sshKey string) 
 	log.LogInfo("Prepare EIP successfully for the proxy preparation. Launch with IP: %s", publicIP)
 
 	time.Sleep(2 * time.Minute)
-	cmd1 := "http_proxy=127.0.0.1:8080 curl http://mitm.it/cert/pem -s > mitm-ca.pem"
-	cmd2 := "cat mitm-ca.pem"
 	hostname := fmt.Sprintf("%s:22", publicIP)
-	_, err = Exec_CMD(CON.AWSInstanceUser, sshKey, hostname, cmd1)
+	err = setupMITMProxyServer(sshKey, hostname)
 	if err != nil {
-		log.LogError("login instance to run cmd %s failed %s", cmd1, err)
-		return inst, "", "", err
-	}
-	caContent, err := Exec_CMD(CON.AWSInstanceUser, sshKey, hostname, cmd2)
-	if err != nil {
-		log.LogError("login instance to run cmd %s failed %s", cmd2, err)
+		log.LogError("Setup MITM proxy server failed  %s", err)
 		return inst, "", "", err
 	}
 
+	cmd := "cat mitm-ca.pem"
+	caContent, err := Exec_CMD(CON.AWSInstanceUser, sshKey, hostname, cmd)
+	if err != nil {
+		log.LogError("login instance to run cmd %s:%s", cmd, err)
+		return inst, "", "", err
+	}
 	return instOut.Instances[0], *instOut.Instances[0].PrivateIpAddress, caContent, err
 }
 
-func (vpc *VPC) CopyImageToProxy(name string) (destinationImageID string, err error) {
-	sourceRegion := "us-west-2"
-	sourceImageID, ok := CON.ProxyImageMap[sourceRegion]
-	if !ok {
-		log.LogError("Can't find image from region %s :%s", sourceRegion, err)
-		return "", err
+func setupMITMProxyServer(sshKey string, hostname string) (err error) {
+	setupProxyCMDs := []string{
+		"sudo yum install -y wget",
+		"wget https://snapshots.mitmproxy.org/7.0.2/mitmproxy-7.0.2-linux.tar.gz",
+		"mkdir mitm",
+		"tar zxvf mitmproxy-7.0.2-linux.tar.gz -C mitm",
+		"nohup ./mitm/mitmdump --showhost --ssl-insecure > mitm.log 2>&1 &",
+		"sleep 5",
+		"http_proxy=127.0.0.1:8080 curl http://mitm.it/cert/pem -s > ~/mitm-ca.pem",
 	}
-	destinationImageID, err = vpc.AWSClient.CopyImage(sourceImageID, sourceRegion, name)
-	if err != nil {
-		log.LogError("Copy image %s meet error %s", sourceImageID, err)
-		return "", err
-	}
-	return destinationImageID, nil
-}
-
-func (vpc *VPC) WaitImageToActive(imageID string, timeout time.Duration) (imageAvailable bool, err error) {
-	log.LogInfo("Waiting for image %s status to active. Timeout after %v mins", imageID, timeout)
-	startTime := time.Now()
-	imageAvailable = false
-	for time.Now().Before(startTime.Add(timeout * time.Minute)) {
-		output, err := vpc.AWSClient.DescribeImage(imageID)
+	for _, cmd := range setupProxyCMDs {
+		_, err = Exec_CMD(CON.AWSInstanceUser, sshKey, hostname, cmd)
 		if err != nil {
-			log.LogError("Error happened when describe image status: %s", imageID)
-			return imageAvailable, err
+			return err
 		}
-		if string(output.Images[0].State) == "available" {
-			imageAvailable = true
-			return imageAvailable, nil
-		}
-
-		time.Sleep(time.Minute)
+		log.LogDebug("Run the cmd successfully: %s", cmd)
 	}
-	err = fmt.Errorf("timeout for waiting image active")
-	return imageAvailable, err
-
+	return
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -405,7 +405,7 @@ github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
-# github.com/openshift-online/ocm-common v0.0.0-20240426075354-0921f33327e3
+# github.com/openshift-online/ocm-common v0.0.0-20240508111534-37822c515806
 ## explicit; go 1.21
 github.com/openshift-online/ocm-common/pkg/aws/aws_client
 github.com/openshift-online/ocm-common/pkg/aws/consts
@@ -413,6 +413,7 @@ github.com/openshift-online/ocm-common/pkg/aws/errors
 github.com/openshift-online/ocm-common/pkg/aws/utils
 github.com/openshift-online/ocm-common/pkg/aws/validations
 github.com/openshift-online/ocm-common/pkg/cluster/validations
+github.com/openshift-online/ocm-common/pkg/file
 github.com/openshift-online/ocm-common/pkg/idp/utils
 github.com/openshift-online/ocm-common/pkg/idp/validations
 github.com/openshift-online/ocm-common/pkg/log


### PR DESCRIPTION
```
lixue@Xue-Lis-MacBook-Pro rosa % export REGION=ap-northeast-1
lixue@Xue-Lis-MacBook-Pro rosa % ginkgo run --label-filter day1-prepare tests/e2e
Running Suite: e2e tests suite - /Users/lixue/Workspace/rosa/tests/e2e
======================================================================
Random Seed: 1715321526

Will run 1 of 59 specs
SSSSSSSSSSSSStime="2024-05-10 14:14:46" level=info msg="Going to prepare a vpc with name xueli-ezzmx0aqk2zzcv, on region ap-northeast-1, with cidr 10.0.0.0/16 "
time="2024-05-10 14:14:46" level=info msg="Going to create vpc and the follow resources on zones: "
time="2024-05-10 14:14:47" level=info msg="Create vpc success vpc-0e17b9398f9eb6a5c"
time="2024-05-10 14:14:48" level=info msg="Tag resource vpc-0e17b9398f9eb6a5c successfully"
time="2024-05-10 14:14:48" level=info msg="Created vpc with ID vpc-0e17b9398f9eb6a5c"
time="2024-05-10 14:14:48" level=info msg="VPC created on AWS with id: vpc-0e17b9398f9eb6a5c"
time="2024-05-10 14:14:48" level=info msg="Modify vpc dns attribute DnsHostnames successfully for vpc-0e17b9398f9eb6a5c"
time="2024-05-10 14:14:48" level=info msg="VPC DNS Updated on AWS with id: vpc-0e17b9398f9eb6a5c"
time="2024-05-10 14:14:48" level=info msg="Create igw success: igw-02d6d18dcbe0f6473"
time="2024-05-10 14:14:49" level=info msg="Attach igw success: igw-02d6d18dcbe0f6473"
time="2024-05-10 14:14:49" level=info msg="Prepare vpc internetgateway for vpc vpc-0e17b9398f9eb6a5c"
time="2024-05-10 14:14:49" level=info msg="Create subnets successfully"
time="2024-05-10 14:14:49" level=info msg="Create vpc chain successfully. Enjoy it."
time="2024-05-10 14:14:49" level=info msg="Going to prepare proper pair of subnets"
time="2024-05-10 14:14:49" level=info msg="Got no public subnet for current zone ap-northeast-1a, going to create one"
time="2024-05-10 14:14:49" level=info msg="Created subnet subnet-02e0d7c2d8cc24e8d for vpc vpc-0e17b9398f9eb6a5c"
time="2024-05-10 14:14:50" level=info msg="Created subnet with ID subnet-02e0d7c2d8cc24e8d"
time="2024-05-10 14:14:50" level=info msg="Associate route table success rtbassoc-0afebf304e1520255"
time="2024-05-10 14:14:51" level=info msg="Create route success for route table: rtb-0ac6667672e2d820f"
time="2024-05-10 14:14:51" level=info msg="Tag resource subnet-02e0d7c2d8cc24e8d successfully"
time="2024-05-10 14:14:51" level=info msg="Got no proper private subnet for current zone ap-northeast-1a, going to create one"
time="2024-05-10 14:14:52" level=info msg="Created subnet subnet-0bf38ac033311c44e for vpc vpc-0e17b9398f9eb6a5c"
time="2024-05-10 14:14:53" level=info msg="Created subnet with ID subnet-0bf38ac033311c44e"
time="2024-05-10 14:14:53" level=info msg="Associate route table success rtbassoc-08252df3ee7be083b"
time="2024-05-10 14:14:53" level=info msg="Allocated EIP eipalloc-07a441bd5de313081 with ip 52.199.237.198"
time="2024-05-10 14:14:54" level=info msg="Create nat success: nat-04a16b1ab4cc4d6fe"
time="2024-05-10 14:16:43" level=info msg="Create route success for route table: rtb-0f1815d5bc841a005"
time="2024-05-10 14:16:43" level=info msg="Tag resource subnet-0bf38ac033311c44e successfully"
time="2024-05-10 14:16:43" level=info msg="Going to prepare proper pair of subnets"
time="2024-05-10 14:16:43" level=info msg="Subnet subnet-02e0d7c2d8cc24e8d in zone: ap-northeast-1a, region ap-northeast-1"
time="2024-05-10 14:16:43" level=info msg="Subnet subnet-0bf38ac033311c44e in zone: ap-northeast-1a, region ap-northeast-1"
time="2024-05-10 14:16:43" level=info msg="Got no public subnet for current zone ap-northeast-1c, going to create one"
time="2024-05-10 14:16:44" level=info msg="Created subnet subnet-053bd406b62d150b5 for vpc vpc-0e17b9398f9eb6a5c"
time="2024-05-10 14:16:44" level=info msg="Created subnet with ID subnet-053bd406b62d150b5"
time="2024-05-10 14:16:45" level=info msg="Associate route table success rtbassoc-051a53734d31201df"
time="2024-05-10 14:16:45" level=info msg="Create route success for route table: rtb-0ec263ae5855dd0af"
time="2024-05-10 14:16:46" level=info msg="Tag resource subnet-053bd406b62d150b5 successfully"
time="2024-05-10 14:16:46" level=info msg="Got no proper private subnet for current zone ap-northeast-1c, going to create one"
time="2024-05-10 14:16:47" level=info msg="Created subnet subnet-0e6754a14c61d57a9 for vpc vpc-0e17b9398f9eb6a5c"
time="2024-05-10 14:16:47" level=info msg="Created subnet with ID subnet-0e6754a14c61d57a9"
time="2024-05-10 14:16:48" level=info msg="Associate route table success rtbassoc-02f15283cc6686931"
time="2024-05-10 14:16:48" level=info msg="Found existing nat gateway: nat-04a16b1ab4cc4d6fe"
time="2024-05-10 14:16:48" level=info msg="Create route success for route table: rtb-071fd431597f318dc"
time="2024-05-10 14:16:49" level=info msg="Tag resource subnet-0e6754a14c61d57a9 successfully"
time="2024-05-10 14:16:49" level=info msg="Going to prepare proper pair of subnets"
time="2024-05-10 14:16:49" level=info msg="Subnet subnet-02e0d7c2d8cc24e8d in zone: ap-northeast-1a, region ap-northeast-1"
time="2024-05-10 14:16:49" level=info msg="Subnet subnet-0bf38ac033311c44e in zone: ap-northeast-1a, region ap-northeast-1"
time="2024-05-10 14:16:49" level=info msg="Subnet subnet-053bd406b62d150b5 in zone: ap-northeast-1c, region ap-northeast-1"
time="2024-05-10 14:16:49" level=info msg="Subnet subnet-0e6754a14c61d57a9 in zone: ap-northeast-1c, region ap-northeast-1"
time="2024-05-10 14:16:49" level=info msg="Got no public subnet for current zone ap-northeast-1d, going to create one"
time="2024-05-10 14:16:49" level=info msg="Created subnet subnet-0fbf32be38f9ea6eb for vpc vpc-0e17b9398f9eb6a5c"
time="2024-05-10 14:16:50" level=info msg="Created subnet with ID subnet-0fbf32be38f9ea6eb"
time="2024-05-10 14:16:51" level=info msg="Associate route table success rtbassoc-0ee24aaa328a5736c"
time="2024-05-10 14:16:51" level=info msg="Create route success for route table: rtb-094f2605987c8081a"
time="2024-05-10 14:16:52" level=info msg="Tag resource subnet-0fbf32be38f9ea6eb successfully"
time="2024-05-10 14:16:52" level=info msg="Got no proper private subnet for current zone ap-northeast-1d, going to create one"
time="2024-05-10 14:16:52" level=info msg="Created subnet subnet-02ad71b4b7666b7c6 for vpc vpc-0e17b9398f9eb6a5c"
time="2024-05-10 14:16:53" level=info msg="Created subnet with ID subnet-02ad71b4b7666b7c6"
time="2024-05-10 14:16:53" level=info msg="Associate route table success rtbassoc-05c7dcf5feb3c0784"
time="2024-05-10 14:16:53" level=info msg="Found existing nat gateway: nat-04a16b1ab4cc4d6fe"
time="2024-05-10 14:16:54" level=info msg="Create route success for route table: rtb-0f422d0200ca8e527"
time="2024-05-10 14:16:54" level=info msg="Tag resource subnet-02ad71b4b7666b7c6 successfully"
time="2024-05-10 14:16:55" level=info msg="Create security group sg-0dda04d874c1944a7 success for vpc-0e17b9398f9eb6a5c"
time="2024-05-10 14:16:55" level=info msg="Tag resource sg-0dda04d874c1944a7 successfully"
time="2024-05-10 14:16:55" level=info msg="Created tagged security group with ID sg-0dda04d874c1944a7"
time="2024-05-10 14:16:55" level=info msg="Authorize security group success sg-0dda04d874c1944a7"
time="2024-05-10 14:16:56" level=info msg="Authorize security group success sg-0dda04d874c1944a7"
time="2024-05-10 14:16:56" level=info msg="Create security group sg-0ff7347fce56e88c3 success for vpc-0e17b9398f9eb6a5c"
time="2024-05-10 14:16:57" level=info msg="Tag resource sg-0ff7347fce56e88c3 successfully"
time="2024-05-10 14:16:57" level=info msg="Created tagged security group with ID sg-0ff7347fce56e88c3"
time="2024-05-10 14:16:57" level=info msg="Authorize security group success sg-0ff7347fce56e88c3"
time="2024-05-10 14:16:57" level=info msg="Authorize security group success sg-0ff7347fce56e88c3"
time="2024-05-10 14:16:58" level=info msg="Create security group sg-029550d6670391c1b success for vpc-0e17b9398f9eb6a5c"
time="2024-05-10 14:16:58" level=info msg="Tag resource sg-029550d6670391c1b successfully"
time="2024-05-10 14:16:58" level=info msg="Created tagged security group with ID sg-029550d6670391c1b"
time="2024-05-10 14:16:59" level=info msg="Authorize security group success sg-029550d6670391c1b"
time="2024-05-10 14:16:59" level=info msg="Authorize security group success sg-029550d6670391c1b"
time="2024-05-10 14:16:59" level=info msg="Got the image ID : ami-0c1de55b79f5aff9b"
time="2024-05-10 14:17:00" level=info msg="Create security group sg-068efe8c99f2c4394 success for vpc-0e17b9398f9eb6a5c"
time="2024-05-10 14:17:00" level=info msg="Tag resource sg-068efe8c99f2c4394 successfully"
time="2024-05-10 14:17:00" level=info msg="Created tagged security group with ID sg-068efe8c99f2c4394"
time="2024-05-10 14:17:01" level=info msg="Authorize security group success sg-068efe8c99f2c4394"
time="2024-05-10 14:17:01" level=info msg="Authorize security group success sg-068efe8c99f2c4394"
time="2024-05-10 14:17:01" level=info msg="Authorize SG sg-068efe8c99f2c4394 prepared successfully for proxy."
time="2024-05-10 14:17:01" level=info msg="Create key pair success: key-0aa894a5318f0b096"
time="2024-05-10 14:17:01" level=info msg="create key pair: key-0aa894a5318f0b096 successfully\n"
time="2024-05-10 14:17:02" level=info msg="Tag resource key-0aa894a5318f0b096 successfully"
time="2024-05-10 14:17:03" level=info msg="Waiting for below instances ready: i-03f148758cac2c0c6"
time="2024-05-10 14:17:03" level=info msg="Check instances status of i-03f148758cac2c0c6"
time="2024-05-10 14:17:03" level=info msg="Instance ID i-03f148758cac2c0c6 is in status of not-applicable"
time="2024-05-10 14:17:03" level=info msg="Instance ID i-03f148758cac2c0c6 is in state of pending"
time="2024-05-10 14:18:03" level=info msg="Check instances status of i-03f148758cac2c0c6"
time="2024-05-10 14:18:03" level=info msg="Instance ID i-03f148758cac2c0c6 is in status of initializing"
time="2024-05-10 14:18:03" level=info msg="Instance ID i-03f148758cac2c0c6 is in state of running"
time="2024-05-10 14:18:03" level=info msg="All instances running"
time="2024-05-10 14:18:03" level=info msg="Launch proxy instance i-03f148758cac2c0c6 succeed"
time="2024-05-10 14:18:04" level=info msg="Tag resource i-03f148758cac2c0c6 successfully"
time="2024-05-10 14:18:04" level=info msg="Allocated EIP eipalloc-093877163ccace209 with ip 54.65.34.107"
time="2024-05-10 14:18:04" level=info msg="Successfully allocated EIP: 54.65.34.107"
time="2024-05-10 14:18:05" level=info msg="Successfully allocated 54.65.34.107 with instance i-03f148758cac2c0c6.\n\tallocation id: eipalloc-093877163ccace209, association id: eipassoc-0c0d5d27b25cfce86\n"
time="2024-05-10 14:18:05" level=info msg="Prepare EIP successfully for the proxy preparation. Launch with IP: 54.65.34.107"
time="2024-05-10 14:20:32" level=info msg="Preparing OCM testing kms key"
time="2024-05-10 14:21:37" level=info msg="Configuring sts roles to key polilies of arn:aws:kms:ap-northeast-1:::**********::key/b25cf7c1-5939-44cc-8fa2-5b65eaaec008"
•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 59 Specs in 3323.244 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 58 Skipped
PASS

Ginkgo ran 1 suite in 55m34.565769531s
Test Suite Passed
lixue@Xue-Lis-MacBook-Pro rosa % cat tests/output/rosa-advanced/cluster-id 
2b5mtmopefmucn2gonpoba3j3vdtnvkp%                                                                                                               
lixue@Xue-Lis-MacBook-Pro rosa % rosa describe cluster -c 2b5mtmopefmucn2gonpoba3j3vdtnvkp 

Name:                       xueli-ezzmx0aqk2zzcv3kylgx3dmcwyaa5mwf8bbx9ydeidqdpoec
Domain Prefix:              xueli-ezzmx0aqk
Display Name:               xueli-ezzmx0aqk2zzcv3kylgx3dmcwyaa5mwf8bbx9ydeidqdpoec
ID:                         2b5mtmopefmucn2gonpoba3j3vdtnvkp
External ID:                43884962-7415-4424-8991-118fc173638f
Control Plane:              Customer Hosted
OpenShift Version:          
Channel Group:              stable
DNS:                        xueli-ezzmx0aqk.4kej.s1.devshift.org
AWS Account:                301721915996
API URL:                    https://api.xueli-ezzmx0aqk.4kej.s1.devshift.org:6443
Console URL:                https://console-openshift-console.apps.xueli-ezzmx0aqk.4kej.s1.devshift.org
Region:                     ap-northeast-1
Multi-AZ:                   true

Nodes:
 - Control plane:           3
 - Infra:                   3
 - Compute (Autoscaled):    3-6
 - Additional Security Group IDs:
   - Control Plane:     sg-0dda04d874c1944a7, sg-0ff7347fce56e88c3, sg-029550d6670391c1b
   - Infra:             sg-0dda04d874c1944a7, sg-0ff7347fce56e88c3, sg-029550d6670391c1b
Network:
 - Type:                    OVNKubernetes
 - Service CIDR:            172.31.0.0/24
 - Machine CIDR:            10.0.0.0/16
 - Pod CIDR:                192.168.0.0/18
 - Host Prefix:             /25
 - Subnets:                 subnet-0bf38ac033311c44e, subnet-0e6754a14c61d57a9, subnet-02ad71b4b7666b7c6, subnet-02e0d7c2d8cc24e8d, subnet-053bd406b62d150b5, subnet-0fbf32be38f9ea6eb
Infra ID:                   xueli-ezzmx0aqk-xx4m5
Proxy:
 - HTTPProxy:               http://10.0.0.101:8080
 - HTTPSProxy:              https://10.0.0.101:8080
 - NoProxy:                 quay.io
Additional trust bundle:    REDACTED
EC2 Metadata Http Tokens:   required
Role (STS) ARN:             arn:aws:iam::**********:role/test/xueli-ezzmx0aqk2zzcv3kylgx3dmcwy-Installer-Role
Support Role ARN:           arn:aws:iam::::**********::role/test/xueli-ezzmx0aqk2zzcv3kylgx3dmcwy-Support-Role
Instance IAM Roles:
 - Control plane:           arn:aws:iam::::**********::role/test/xueli-ezzmx0aqk2zzcv3kylgx3dmcwy-ControlPlane-Role
 - Worker:                  arn:aws:iam::::**********::role/test/xueli-ezzmx0aqk2zzcv3kylgx3dmcwy-Worker-Role
Operator IAM Roles:
 - arn:aws:iam::::**********::role/test/xueli-ezzmx0aqk2zzcv3kylgx3dmcwy-openshift-machine-api-aws-cloud
 - arn:aws:iam::::**********::role/test/xueli-ezzmx0aqk2zzcv3kylgx3dmcwy-openshift-cloud-credential-oper
 - arn:aws:iam::::**********::role/test/xueli-ezzmx0aqk2zzcv3kylgx3dmcwy-openshift-image-registry-instal
 - arn:aws:iam::::**********::role/test/xueli-ezzmx0aqk2zzcv3kylgx3dmcwy-openshift-ingress-operator-clou
 - arn:aws:iam::::**********::role/test/xueli-ezzmx0aqk2zzcv3kylgx3dmcwy-openshift-cluster-csi-drivers-e
 - arn:aws:iam::::**********::role/test/xueli-ezzmx0aqk2zzcv3kylgx3dmcwy-openshift-cloud-network-config-
Managed Policies:           No
State:                      ready 
Private:                    No
Delete Protection:          Disabled
Created:                    May 10 2024 06:21:20 UTC
User Workload Monitoring:   Disabled
FIPS mode:                  Enabled
Details Page:               https://qaprodauth.console.redhat.com/openshift/details/s/2gGRlkwfs0mUQBZu2a25SAPj9qD
OIDC Endpoint URL:          https://xueli-ezzmx0aqk-oidc-i3r3.s3.ap-northeast-1.amazonaws.com (Unmanaged)

lixue@Xue-Lis-MacBook-Pro rosa % ls tests/output/rosa-advanced 
api.url                                 cluster-name                            infra_id
cluster-config                          cluster-type                            proxy-bundle.ca
cluster-detail.json                     console.url                             resources.json
cluster-id                              create_cluster.sh                       xueli-ezzmx0aqk2zzcv-keyPair.pem
lixue@Xue-Lis-MacBook-Pro rosa % echo $TEST_PROFILE
rosa-advanced
```