### PR TITLE
Validation for user account-role creation 

### DIFF
--- a/tests/e2e/test_rosacli_iam_roles.go
+++ b/tests/e2e/test_rosacli_iam_roles.go
@@ -1049,4 +1049,104 @@ var _ = Describe("Edit IAM",
 					Expect(rosaClient.Parser.TextData.Input(output).Parse().Tip()).To(ContainSubstring("OIDC provider already exists"))
 				}
 			})
+
+		It("Validation for account-role creation by user - [id:43067]",
+			labels.Medium,
+			func() {
+				var (
+					validRolePrefix                          = "valid"
+					invalidRolePrefix                        = "^^^^"
+					longRolePrefix                           = "accountroleprefixlongerthan32characters"
+					validModeAuto                            = "auto"
+					validModeManual                          = "manual"
+					invalidMode                              = "invalid"
+					invalidPermissionsBoundaryArn     string = "invalid"
+					nonExistingPermissionsBoundaryArn string = "arn:aws:iam::aws:policy/non-existing"
+				)
+
+				By("Try to create account-roles with invalid prefix")
+				output, err := ocmResourceService.CreateAccountRole("--mode", validModeAuto,
+					"--prefix", invalidRolePrefix,
+					"--permissions-boundary", permissionsBoundaryArn,
+					"-y")
+				Expect(err).NotTo(BeNil())
+
+				accountRolePrefixesNeedCleanup = append(accountRolePrefixesNeedCleanup, invalidRolePrefix)
+				textData := rosaClient.Parser.TextData.Input(output).Parse().Tip()
+				Expect(textData).To(ContainSubstring("Expected a valid role prefix matching ^[\\w+=,.@-]+$"))
+
+				By("Try to create account-roles with longer than 32 chars prefix")
+				output, err = ocmResourceService.CreateAccountRole("--mode", validModeAuto,
+					"--prefix", longRolePrefix,
+					"--permissions-boundary", permissionsBoundaryArn,
+					"--hosted-cp",
+					"-y")
+				Expect(err).NotTo(BeNil())
+
+				accountRolePrefixesNeedCleanup = append(accountRolePrefixesNeedCleanup, longRolePrefix)
+				textData = rosaClient.Parser.TextData.Input(output).Parse().Tip()
+				Expect(textData).To(ContainSubstring("Expected a prefix with no more than 32 characters"))
+
+				By("Try to create account-roles with invalid mode")
+				output, _ = ocmResourceService.CreateAccountRole("--mode", invalidMode,
+					"--prefix", validRolePrefix,
+					"--permissions-boundary", permissionsBoundaryArn,
+					"-y")
+				Expect(err).NotTo(BeNil())
+
+				accountRolePrefixesNeedCleanup = append(accountRolePrefixesNeedCleanup, validRolePrefix)
+				textData = rosaClient.Parser.TextData.Input(output).Parse().Tip()
+				Expect(textData).To(ContainSubstring("Invalid mode. Allowed values are [auto manual]"))
+
+				By("Try to create account-roles with force-policy-creation and manual mode")
+				output, _ = ocmResourceService.CreateAccountRole("--mode", validModeManual,
+					"--prefix", validRolePrefix,
+					"-f",
+					"--hosted-cp",
+					"--permissions-boundary", permissionsBoundaryArn,
+				)
+				Expect(err).NotTo(BeNil())
+
+				accountRolePrefixesNeedCleanup = append(accountRolePrefixesNeedCleanup, validRolePrefix)
+				textData = rosaClient.Parser.TextData.Input(output).Parse().Tip()
+				Expect(textData).To(ContainSubstring("Forcing creation of policies only works in auto mode"))
+
+				By("Try to create account-roles with invalid permission boundary")
+				output, _ = ocmResourceService.CreateAccountRole("--mode", validModeAuto,
+					"--prefix", validRolePrefix,
+					"--permissions-boundary", invalidPermissionsBoundaryArn,
+					"-y",
+				)
+				Expect(err).NotTo(BeNil())
+
+				accountRolePrefixesNeedCleanup = append(accountRolePrefixesNeedCleanup, validRolePrefix)
+				textData = rosaClient.Parser.TextData.Input(output).Parse().Tip()
+				Expect(textData).To(ContainSubstring("Expected a valid policy ARN for permissions boundary: Invalid ARN: arn: invalid prefix"))
+
+				By("Try to create account-roles with non-existing permission boundary")
+				output, _ = ocmResourceService.CreateAccountRole("--mode", validModeAuto,
+					"--prefix", validRolePrefix,
+					"--hosted-cp",
+					"--permissions-boundary", nonExistingPermissionsBoundaryArn,
+					"-y",
+				)
+				Expect(err).NotTo(BeNil())
+
+				accountRolePrefixesNeedCleanup = append(accountRolePrefixesNeedCleanup, validRolePrefix)
+				textData = rosaClient.Parser.TextData.Input(output).Parse().Tip()
+				Expect(textData).To(ContainSubstring("There was an error creating the account roles: NoSuchEntity"))
+
+				By("Try to create account-roles with non-existing permission boundary")
+				output, _ = ocmResourceService.CreateAccountRole("--mode", validModeAuto,
+					"--prefix", validRolePrefix,
+					"--hosted-cp",
+					"--permissions-boundary", nonExistingPermissionsBoundaryArn,
+					"-y",
+				)
+				Expect(err).NotTo(BeNil())
+
+				accountRolePrefixesNeedCleanup = append(accountRolePrefixesNeedCleanup, validRolePrefix)
+				textData = rosaClient.Parser.TextData.Input(output).Parse().Tip()
+				Expect(textData).To(ContainSubstring("There was an error creating the account roles: NoSuchEntity"))
+			})
 	})


### PR DESCRIPTION
$ ginkgo --focus 43067 tests/e2e
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.11.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: e2e tests suite - /home/akanni/OCP-Repository/rosa/tests/e2e
===========================================================================
Random Seed: 1715328272

Will run 1 of 62 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSS

Ran 1 of 62 Specs in 160.816 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 61 Skipped
PASS

Ginkgo ran 1 suite in 2m43.503904479s
Test Suite Passed
