### PR TITLE
OCM-7937 | fix: allow 0 min replicas for classic cluster autoscaling mp

### DIFF
--- a/cmd/edit/machinepool/machinepool.go
+++ b/cmd/edit/machinepool/machinepool.go
@@ -222,16 +222,20 @@ func editMachinePoolAutoscaling(machinePool *cmv1.MachinePool,
 	asBuilder := cmv1.NewMachinePoolAutoscaling()
 	changed := false
 
-	if machinePool.Autoscaling().MinReplicas() != minReplicas && minReplicas >= 1 {
-		asBuilder = asBuilder.MinReplicas(minReplicas)
+	newMin := machinePool.Autoscaling().MinReplicas()
+	newMax := machinePool.Autoscaling().MaxReplicas()
+
+	if machinePool.Autoscaling().MinReplicas() != minReplicas && minReplicas >= 0 {
+		newMin = minReplicas
 		changed = true
 	}
-	if machinePool.Autoscaling().MaxReplicas() != maxReplicas && maxReplicas >= 1 {
-		asBuilder = asBuilder.MaxReplicas(maxReplicas)
+	if machinePool.Autoscaling().MaxReplicas() != maxReplicas && maxReplicas >= 0 {
+		newMax = maxReplicas
 		changed = true
 	}
 
 	if changed {
+		asBuilder = asBuilder.MinReplicas(newMin).MaxReplicas(newMax)
 		return asBuilder
 	}
 	return nil

--- a/cmd/edit/machinepool/machinepool_test.go
+++ b/cmd/edit/machinepool/machinepool_test.go
@@ -26,6 +26,26 @@ var _ = Describe("Machinepool", func() {
 			asBuilder := cmv1.NewMachinePoolAutoscaling().MaxReplicas(3).MinReplicas(2)
 			Expect(builder).To(Equal(asBuilder))
 		})
+
+		It("editMachinePoolAutoscaling should allow 0 min replicas", func() {
+			machinePool, err := cmv1.NewMachinePool().
+				Autoscaling(cmv1.NewMachinePoolAutoscaling().MaxReplicas(2).MinReplicas(1)).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			builder := editMachinePoolAutoscaling(machinePool, 0, 2)
+			asBuilder := cmv1.NewMachinePoolAutoscaling().MaxReplicas(2).MinReplicas(0)
+			Expect(builder).To(Equal(asBuilder))
+		})
+
+		It("editMachinePoolAutoscaling should allow 0 min and 0 max replicas", func() {
+			machinePool, err := cmv1.NewMachinePool().
+				Autoscaling(cmv1.NewMachinePoolAutoscaling().MaxReplicas(2).MinReplicas(1)).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			builder := editMachinePoolAutoscaling(machinePool, 0, 0)
+			asBuilder := cmv1.NewMachinePoolAutoscaling().MaxReplicas(0).MinReplicas(0)
+			Expect(builder).To(Equal(asBuilder))
+		})
 	})
 
 	Context("isMultiAZMachinePool", func() {


### PR DESCRIPTION
Able to set autoscaling min replicas to 0 for machine pools (classic) after fix:
![image](https://github.com/openshift/rosa/assets/118839428/ab67197f-94d2-4a3e-ab66-e5163e9439da)

