### PR TITLE
OCM-7269 | feat: Added list of kubeletconfigs to describe HCP machinepool output

### DIFF
--- a/cmd/describe/machinepool/cmd_test.go
+++ b/cmd/describe/machinepool/cmd_test.go
@@ -35,6 +35,7 @@ Subnet:
 Version:                               4.12.24
 Autorepair:                            No
 Tuning configs:                        
+Kubelet configs:                       
 Additional security group IDs:         
 Node drain grace period:               1 minute
 Message:                               
@@ -54,6 +55,7 @@ Subnet:
 Version:                               4.12.24
 Autorepair:                            No
 Tuning configs:                        
+Kubelet configs:                       
 Additional security group IDs:         
 Node drain grace period:               1 minute
 Message:                               
@@ -74,6 +76,7 @@ Subnet:
 Version:                               4.12.24
 Autorepair:                            No
 Tuning configs:                        
+Kubelet configs:                       
 Additional security group IDs:         
 Node drain grace period:               1 minute
 Message:                               

--- a/pkg/machinepool/output.go
+++ b/pkg/machinepool/output.go
@@ -24,6 +24,7 @@ var nodePoolOutputString string = "\n" +
 	"Version:                               %s\n" +
 	"Autorepair:                            %s\n" +
 	"Tuning configs:                        %s\n" +
+	"Kubelet configs:                       %s\n" +
 	"Additional security group IDs:         %s\n" +
 	"Node drain grace period:               %s\n" +
 	"Message:                               %s\n"
@@ -76,7 +77,8 @@ func nodePoolOutput(clusterId string, nodePool *cmv1.NodePool) string {
 		nodePool.Subnet(),
 		ocmOutput.PrintNodePoolVersion(nodePool.Version()),
 		ocmOutput.PrintNodePoolAutorepair(nodePool.AutoRepair()),
-		ocmOutput.PrintNodePoolTuningConfigs(nodePool.TuningConfigs()),
+		ocmOutput.PrintNodePoolConfigs(nodePool.TuningConfigs()),
+		ocmOutput.PrintNodePoolConfigs(nodePool.KubeletConfigs()),
 		ocmOutput.PrintNodePoolAdditionalSecurityGroups(nodePool.AWSNodePool()),
 		ocmOutput.PrintNodeDrainGracePeriod(nodePool.NodeDrainGracePeriod()),
 		ocmOutput.PrintNodePoolMessage(nodePool.Status()),

--- a/pkg/machinepool/output_test.go
+++ b/pkg/machinepool/output_test.go
@@ -104,8 +104,8 @@ var _ = Describe("Output", Ordered, func() {
 			npAutoscaling := cmv1.NewNodePoolAutoscaling().ID("test-as").MinReplica(2).MaxReplica(8)
 			nodePoolBuilder := *cmv1.NewNodePool().ID("test-mp").Autoscaling(npAutoscaling).Replicas(4).
 				AvailabilityZone("test-az").Subnet("test-subnets").Version(cmv1.NewVersion().
-				ID("1")).AutoRepair(false).TuningConfigs("test-tc").Labels(labels).
-				Taints(taintsBuilder)
+				ID("1")).AutoRepair(false).TuningConfigs("test-tc").
+				KubeletConfigs("test-kc").Labels(labels).Taints(taintsBuilder)
 			nodePool, err := nodePoolBuilder.Build()
 			Expect(err).ToNot(HaveOccurred())
 			labelsOutput := ocmOutput.PrintLabels(labels)
@@ -114,7 +114,7 @@ var _ = Describe("Output", Ordered, func() {
 
 			out := fmt.Sprintf(nodePoolOutputString,
 				"test-mp", "test-cluster", "Yes", replicasOutput, "", "", labelsOutput, "", taintsOutput, "test-az",
-				"test-subnets", "1", "No", "test-tc", "", "", "")
+				"test-subnets", "1", "No", "test-tc", "test-kc", "", "", "")
 
 			result := nodePoolOutput("test-cluster", nodePool)
 			Expect(out).To(Equal(result))
@@ -123,7 +123,7 @@ var _ = Describe("Output", Ordered, func() {
 			nodePoolBuilder := *cmv1.NewNodePool().ID("test-mp").Replicas(4).
 				AvailabilityZone("test-az").Subnet("test-subnets").Version(cmv1.NewVersion().
 				ID("1")).AutoRepair(false).TuningConfigs("test-tc").
-				Labels(labels).Taints(taintsBuilder)
+				KubeletConfigs("test-kc").Labels(labels).Taints(taintsBuilder)
 			nodePool, err := nodePoolBuilder.Build()
 			Expect(err).ToNot(HaveOccurred())
 			labelsOutput := ocmOutput.PrintLabels(labels)
@@ -131,7 +131,7 @@ var _ = Describe("Output", Ordered, func() {
 
 			out := fmt.Sprintf(nodePoolOutputString,
 				"test-mp", "test-cluster", "No", "4", "", "", labelsOutput, "", taintsOutput, "test-az",
-				"test-subnets", "1", "No", "test-tc", "", "", "")
+				"test-subnets", "1", "No", "test-tc", "test-kc", "", "", "")
 
 			result := nodePoolOutput("test-cluster", nodePool)
 			Expect(out).To(Equal(result))

--- a/pkg/ocm/output/nodepools.go
+++ b/pkg/ocm/output/nodepools.go
@@ -88,11 +88,11 @@ func PrintNodePoolAutorepair(autorepair bool) string {
 	return output.No
 }
 
-func PrintNodePoolTuningConfigs(tuningConfigs []string) string {
-	if len(tuningConfigs) == 0 {
+func PrintNodePoolConfigs(configs []string) string {
+	if len(configs) == 0 {
 		return ""
 	}
-	return strings.Join(tuningConfigs, ",")
+	return strings.Join(configs, ",")
 }
 
 func PrintNodeDrainGracePeriod(period *cmv1.Value) string {


### PR DESCRIPTION
This updates the output for `rosa describe machinepool` to include the list of `kubelet_configs` associated with the HCP MachinePool.