### PR TITLE
OCM-7927 | fix: Get the orgin junit file from ArtifactDir

### DIFF
--- a/tests/utils/exec/rosacli/report_portal.go
+++ b/tests/utils/exec/rosacli/report_portal.go
@@ -133,7 +133,7 @@ func GenerateReportXMLFile() (int, int, map[string][]Testcase, map[string][]Test
 	passedNum := 0
 	issuedNum := 0
 
-	xmlFileList := ListFiles(config.Test.OutputDir, ".xml")
+	xmlFileList := ListFiles(config.Test.ArtifactDir, ".xml")
 	for _, xmlFile := range xmlFileList {
 		xmlFilename := path.Base(xmlFile)
 		xmlFilePrefix := strings.TrimSuffix(xmlFilename, ".xml")
@@ -183,18 +183,18 @@ func GenerateReportXMLFile() (int, int, map[string][]Testcase, map[string][]Test
 	return passedNum, issuedNum, issuedTCList, successedTCList
 }
 
-func ListFiles(outputDir string, subfix string) []string {
+func ListFiles(dir string, subfix string) []string {
 	var Files []string
-	fs, err := os.ReadDir(outputDir)
+	fs, err := os.ReadDir(dir)
 	if err != nil {
-		panic(fmt.Sprintf("Failed to open the directory %s: %v\n", outputDir, err))
+		panic(fmt.Sprintf("Failed to open the directory %s: %v\n", dir, err))
 	}
 	for _, f := range fs {
 		if path.Ext(f.Name()) != subfix {
 			continue
 		}
 
-		filename := path.Join(outputDir, f.Name())
+		filename := path.Join(dir, f.Name())
 		Files = append(Files, filename)
 	}
 


### PR DESCRIPTION
The step [rosa-test-e2e](https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/pr-logs/pull/openshift_release/51873/rehearse-51873-periodic-ci-openshift-openshift-tests-private-master-rosacli-aws-rosa-hcp-e2e-f3/1789151228039532544) always fails
```
error: failed to create/update secret: failed to update secret: Secret "aws-rosa-hcp-e2e-f3" is invalid: data: Too long: must have at most 1048576 bytes
```

The reason is that we should not put *.xml under the SHARED_DIR.