### PR TITLE
OCM-7264 | feat: Updated to support create kubeletconfig for HCP clusters

### DIFF
--- a/cmd/create/cmd.go
+++ b/cmd/create/cmd.go
@@ -63,7 +63,8 @@ func init() {
 	Cmd.AddCommand(tuningconfigs.Cmd)
 	Cmd.AddCommand(dnsdomains.Cmd)
 	Cmd.AddCommand(autoscaler.Cmd)
-	Cmd.AddCommand(kubeletconfig.Cmd)
+	kubeletConfig := kubeletconfig.NewCreateKubeletConfigCommand()
+	Cmd.AddCommand(kubeletConfig)
 	Cmd.AddCommand(externalauthprovider.Cmd)
 	Cmd.AddCommand(breakglasscredential.Cmd)
 
@@ -77,7 +78,7 @@ func init() {
 		userrole.Cmd, ocmrole.Cmd,
 		oidcprovider.Cmd, breakglasscredential.Cmd,
 		admin.Cmd, autoscaler.Cmd, dnsdomains.Cmd,
-		externalauthprovider.Cmd, idp.Cmd, kubeletconfig.Cmd, tuningconfigs.Cmd,
+		externalauthprovider.Cmd, idp.Cmd, kubeletConfig, tuningconfigs.Cmd,
 	}
 	arguments.MarkRegionDeprecated(Cmd, globallyAvailableCommands)
 }

--- a/cmd/create/kubeletconfig/cmd_test.go
+++ b/cmd/create/kubeletconfig/cmd_test.go
@@ -1,0 +1,187 @@
+package kubeletconfig
+
+import (
+	"context"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/testing"
+
+	. "github.com/openshift/rosa/pkg/kubeletconfig"
+	"github.com/openshift/rosa/pkg/output"
+	. "github.com/openshift/rosa/pkg/test"
+)
+
+var _ = Describe("create kubeletconfig", func() {
+
+	It("Correctly builds the command", func() {
+		cmd := NewCreateKubeletConfigCommand()
+		Expect(cmd).NotTo(BeNil())
+
+		Expect(cmd.Use).To(Equal(use))
+		Expect(cmd.Short).To(Equal(short))
+		Expect(cmd.Long).To(Equal(long))
+		Expect(cmd.Args).NotTo(BeNil())
+		Expect(cmd.Run).NotTo(BeNil())
+
+		Expect(cmd.Flags().Lookup("cluster")).NotTo(BeNil())
+		Expect(cmd.Flags().Lookup("interactive")).NotTo(BeNil())
+		Expect(cmd.Flags().Lookup(PodPidsLimitOption)).NotTo(BeNil())
+		Expect(cmd.Flags().Lookup(NameOption)).NotTo(BeNil())
+	})
+
+	Context("CreateKubeletConfig Runner", func() {
+
+		var t *TestingRuntime
+
+		BeforeEach(func() {
+			t = NewTestRuntime()
+			output.SetOutput("")
+		})
+
+		AfterEach(func() {
+			output.SetOutput("")
+		})
+
+		It("Returns an error if the cluster does not exist", func() {
+			t.ApiServer.AppendHandlers(testing.RespondWithJSON(http.StatusOK, FormatClusterList(make([]*cmv1.Cluster, 0))))
+			t.SetCluster("cluster", nil)
+
+			runner := CreateKubeletConfigRunner(NewKubeletConfigOptions())
+			err := runner(context.Background(), t.RosaRuntime, nil, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(
+				Equal("There is no cluster with identifier or name 'cluster'"))
+		})
+
+		It("Returns an error if the cluster is not ready", func() {
+
+			cluster := MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateInstalling)
+			})
+
+			t.ApiServer.AppendHandlers(
+				testing.RespondWithJSON(
+					http.StatusOK, FormatClusterList([]*cmv1.Cluster{cluster})))
+			t.SetCluster("cluster", nil)
+
+			runner := CreateKubeletConfigRunner(NewKubeletConfigOptions())
+			err := runner(context.Background(), t.RosaRuntime, nil, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(
+				Equal("Cluster 'cluster' is not yet ready. Current state is 'installing'"))
+
+		})
+
+		It("Returns an error if a kubeletconfig already exists for classic cluster", func() {
+			cluster := MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateReady)
+			})
+
+			config := MockKubeletConfig(func(k *cmv1.KubeletConfigBuilder) {
+				k.Name("test").PodPidsLimit(10000).ID("foo")
+			})
+
+			t.ApiServer.AppendHandlers(
+				testing.RespondWithJSON(
+					http.StatusOK, FormatClusterList([]*cmv1.Cluster{cluster})))
+			t.ApiServer.AppendHandlers(
+				testing.RespondWithJSON(http.StatusOK, FormatResource(config)))
+			t.SetCluster("cluster", nil)
+
+			runner := CreateKubeletConfigRunner(NewKubeletConfigOptions())
+			err := runner(context.Background(), t.RosaRuntime, nil, nil)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(
+				Equal("A KubeletConfig for cluster 'cluster' already exists." +
+					" You should edit it via 'rosa edit kubeletconfig'"))
+		})
+
+		It("Returns an error if it fails to read the kubeletconfig from OCM for classic cluster", func() {
+
+			cluster := MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateReady)
+			})
+
+			t.ApiServer.AppendHandlers(
+				testing.RespondWithJSON(
+					http.StatusOK, FormatClusterList([]*cmv1.Cluster{cluster})))
+			t.ApiServer.AppendHandlers(
+				testing.RespondWithJSON(http.StatusInternalServerError, "{}"))
+			t.SetCluster("cluster", nil)
+
+			runner := CreateKubeletConfigRunner(NewKubeletConfigOptions())
+			err := runner(context.Background(), t.RosaRuntime, nil, nil)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(
+				ContainSubstring("Failed getting KubeletConfig for cluster 'cluster'"))
+		})
+
+		It("Creates the KubeletConfig for HCP clusters", func() {
+			cluster := MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateReady)
+				b := cmv1.HypershiftBuilder{}
+				b.Enabled(true)
+				c.Hypershift(&b)
+
+			})
+
+			kubeletConfig := MockKubeletConfig(func(k *cmv1.KubeletConfigBuilder) {
+				k.ID("test-id").PodPidsLimit(10000).Name("testing")
+			})
+
+			t.ApiServer.AppendHandlers(
+				testing.RespondWithJSON(
+					http.StatusOK, FormatClusterList([]*cmv1.Cluster{cluster})))
+			t.ApiServer.AppendHandlers(
+				testing.RespondWithJSON(http.StatusCreated, FormatResource(kubeletConfig)))
+			t.SetCluster("cluster", nil)
+
+			options := NewKubeletConfigOptions()
+			options.PodPidsLimit = 10000
+
+			runner := CreateKubeletConfigRunner(options)
+			t.StdOutReader.Record()
+
+			err := runner(context.Background(), t.RosaRuntime, nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			stdOut, _ := t.StdOutReader.Read()
+			Expect(stdOut).To(Equal("INFO: Successfully created KubeletConfig for cluster 'cluster'\n"))
+		})
+
+		It("Returns an error if failing to create the KubeletConfig for HCP Clusters", func() {
+			cluster := MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateReady)
+				b := cmv1.HypershiftBuilder{}
+				b.Enabled(true)
+				c.Hypershift(&b)
+
+			})
+
+			kubeletConfig := MockKubeletConfig(func(k *cmv1.KubeletConfigBuilder) {
+				k.ID("test-id").PodPidsLimit(10000).Name("testing")
+			})
+
+			t.ApiServer.AppendHandlers(
+				testing.RespondWithJSON(
+					http.StatusOK, FormatClusterList([]*cmv1.Cluster{cluster})))
+			t.ApiServer.AppendHandlers(
+				testing.RespondWithJSON(http.StatusBadRequest, FormatResource(kubeletConfig)))
+			t.SetCluster("cluster", nil)
+
+			options := NewKubeletConfigOptions()
+			options.PodPidsLimit = 10000
+
+			runner := CreateKubeletConfigRunner(options)
+
+			err := runner(context.Background(), t.RosaRuntime, nil, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Failed creating KubeletConfig for cluster 'cluster':"))
+		})
+	})
+})

--- a/cmd/create/kubeletconfig/kubeletconfig_suite_test.go
+++ b/cmd/create/kubeletconfig/kubeletconfig_suite_test.go
@@ -1,0 +1,13 @@
+package kubeletconfig
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCreateKubeletConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Create KubeletConfig Suite")
+}

--- a/pkg/kubeletconfig/consts.go
+++ b/pkg/kubeletconfig/consts.go
@@ -4,10 +4,15 @@ const (
 	MinPodPidsLimit                = 4096
 	MaxPodPidsLimit                = 16384
 	MaxUnsafePodPidsLimit          = 3694303
+	NameOption                     = "name"
+	NameOptionDefaultValue         = ""
+	NameOptionUsage                = "Sets the name for this KubeletConfig (optional, generated if omitted)"
 	PodPidsLimitOption             = "pod-pids-limit"
-	PodPidsLimitOptionUsage        = "Sets the requested pod_pids_limit for your custom KubeletConfig."
+	PodPidsLimitOptionUsage        = "Sets the requested pod_pids_limit for this KubeletConfig."
 	PodPidsLimitOptionDefaultValue = 0
 	InteractivePodPidsLimitPrompt  = "Pod Pids Limit?"
 	InteractivePodPidsLimitHelp    = "Set the Pod Pids Limit field to a value between 4096 and %d"
+	InteractiveNameHelpPrompt      = "Name?"
+	InteractiveNameHelp            = "Set the name of this KubeletConfig (optional)"
 	ByPassPidsLimitCapability      = "capability.organization.bypass_pids_limits"
 )

--- a/pkg/kubeletconfig/options.go
+++ b/pkg/kubeletconfig/options.go
@@ -1,0 +1,27 @@
+package kubeletconfig
+
+import "github.com/spf13/cobra"
+
+type KubeletConfigOptions struct {
+	Name         string
+	PodPidsLimit int
+}
+
+func NewKubeletConfigOptions() *KubeletConfigOptions {
+	return &KubeletConfigOptions{}
+}
+
+func (k *KubeletConfigOptions) AddFlagsToCommand(cmd *cobra.Command) {
+	flags := cmd.Flags()
+	flags.SortFlags = false
+	flags.IntVar(
+		&k.PodPidsLimit,
+		PodPidsLimitOption,
+		PodPidsLimitOptionDefaultValue,
+		PodPidsLimitOptionUsage)
+	flags.StringVar(
+		&k.Name,
+		NameOption,
+		NameOptionDefaultValue,
+		NameOptionUsage)
+}

--- a/pkg/kubeletconfig/options_test.go
+++ b/pkg/kubeletconfig/options_test.go
@@ -1,0 +1,34 @@
+package kubeletconfig
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+)
+
+var _ = Describe("KubeletConfigOptions", func() {
+
+	It("Adds flags to command", func() {
+		cmd := &cobra.Command{}
+		flags := cmd.Flags()
+		Expect(flags).NotTo(BeNil())
+		Expect(flags.Lookup(PodPidsLimitOption)).To(BeNil())
+		Expect(flags.Lookup(NameOption)).To(BeNil())
+
+		options := NewKubeletConfigOptions()
+		options.AddFlagsToCommand(cmd)
+
+		flag := flags.Lookup(PodPidsLimitOption)
+		assertFlag(flag, PodPidsLimitOption, PodPidsLimitOptionUsage)
+
+		flag = flags.Lookup(NameOption)
+		assertFlag(flag, NameOption, NameOptionUsage)
+	})
+})
+
+func assertFlag(flag *flag.Flag, name string, usage string) {
+	Expect(flag).NotTo(BeNil())
+	Expect(flag.Name).To(Equal(name))
+	Expect(flag.Usage).To(Equal(usage))
+}

--- a/pkg/ocm/kubeletconfig.go
+++ b/pkg/ocm/kubeletconfig.go
@@ -9,6 +9,7 @@ import (
 
 type KubeletConfigArgs struct {
 	PodPidsLimit int
+	Name         string
 }
 
 func (c *Client) GetClusterKubeletConfig(clusterID string) (*cmv1.KubeletConfig, error) {
@@ -35,7 +36,7 @@ func (c *Client) DeleteKubeletConfig(clusterID string) error {
 
 func toOCMKubeletConfig(args KubeletConfigArgs) (*cmv1.KubeletConfig, error) {
 	builder := &cmv1.KubeletConfigBuilder{}
-	kubeletConfig, err := builder.PodPidsLimit(args.PodPidsLimit).Build()
+	kubeletConfig, err := builder.PodPidsLimit(args.PodPidsLimit).Name(args.Name).Build()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ocm/kubeletconfig_test.go
+++ b/pkg/ocm/kubeletconfig_test.go
@@ -131,8 +131,9 @@ var _ = Describe("KubeletConfig", Ordered, func() {
 			),
 		)
 
-		args := KubeletConfigArgs{podPidsLimit}
+		args := KubeletConfigArgs{podPidsLimit, kubeletName}
 		kubeletConfig, err := ocmClient.CreateKubeletConfig(clusterId, args)
+		Expect(kubeletConfig.Name()).To(Equal(kubeletName))
 
 		Expect(kubeletConfig).NotTo(BeNil())
 		Expect(err).NotTo(HaveOccurred())
@@ -147,7 +148,7 @@ var _ = Describe("KubeletConfig", Ordered, func() {
 			),
 		)
 
-		args := KubeletConfigArgs{podPidsLimit}
+		args := KubeletConfigArgs{podPidsLimit, kubeletName}
 		_, err := ocmClient.CreateKubeletConfig(clusterId, args)
 		Expect(err).To(HaveOccurred())
 	})
@@ -160,7 +161,7 @@ var _ = Describe("KubeletConfig", Ordered, func() {
 			),
 		)
 
-		args := KubeletConfigArgs{podPidsLimit}
+		args := KubeletConfigArgs{podPidsLimit, kubeletName}
 		kubeletConfig, err := ocmClient.UpdateKubeletConfig(clusterId, args)
 
 		Expect(kubeletConfig).NotTo(BeNil())
@@ -175,7 +176,7 @@ var _ = Describe("KubeletConfig", Ordered, func() {
 			),
 		)
 
-		args := KubeletConfigArgs{podPidsLimit}
+		args := KubeletConfigArgs{podPidsLimit, kubeletName}
 		_, err := ocmClient.UpdateKubeletConfig(clusterId, args)
 		Expect(err).To(HaveOccurred())
 	})

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -270,6 +270,10 @@ func FormatResource(resource interface{}) string {
 	var outputJson bytes.Buffer
 	var err error
 	switch reflect.TypeOf(resource).String() {
+	case "*v1.KubeletConfig":
+		if res, ok := resource.(*v1.KubeletConfig); ok {
+			err = v1.MarshalKubeletConfig(res, &outputJson)
+		}
 	case "*v1.Version":
 		if res, ok := resource.(*v1.Version); ok {
 			err = v1.MarshalVersion(res, &outputJson)


### PR DESCRIPTION
This PR updates the `rosa create kubeletconfig` command to support HCP clusters. The following changes are added:

- Adds an optional `--name` field to the command (if omitted, the name is generated server-side)
- Removes the code that enforces KubeletConfig creation on Classic clusters only
- Refactors the `create kubeletconfig` command to use the new `Runner` model
- Adds test coverage.