### PR TITLE
OCM-6729 | test: automate id:OCP-73492 create/describe nodepool with tags

### DIFF
--- a/tests/utils/common/string.go
+++ b/tests/utils/common/string.go
@@ -30,6 +30,22 @@ func ParseCommaSeparatedStrings(input string) (output []string) {
 	}
 	return
 }
+
+func ParseTagsFronJsonOutput(tags string) map[string]interface{} {
+	output := make(map[string]interface{})
+	rawMap := tags[strings.Index(tags, "map[")+4 : strings.LastIndex(tags, "]")]
+	pairs := strings.Split(rawMap, " ")
+	for _, pair := range pairs {
+		kvp := strings.SplitN(pair, ":", 2)
+		if len(kvp) != 2 {
+			fmt.Printf("Bad key-value pair, ignoring...")
+			continue
+		}
+		output[kvp[0]] = kvp[1]
+	}
+	return output
+}
+
 func GenerateRandomStringWithSymbols(length int) string {
 	b := make([]byte, length)
 	_, err := r.Read(b)

--- a/tests/utils/exec/rosacli/machinepool_service.go
+++ b/tests/utils/exec/rosacli/machinepool_service.go
@@ -110,6 +110,7 @@ type NodePoolDescription struct {
 	CurrentReplicas            string `yaml:"Current replicas,omitempty"`
 	InstanceType               string `yaml:"Instance type,omitempty"`
 	Labels                     string `yaml:"Labels,omitempty"`
+	Tags                       string `yaml:"Tags,omitempty"`
 	Taints                     string `yaml:"Taints,omitempty"`
 	AvalaiblityZones           string `yaml:"Availability zone,omitempty"`
 	Subnet                     string `yaml:"Subnet,omitempty"`

--- a/tests/utils/exec/rosacli/ocm_resource_service.go
+++ b/tests/utils/exec/rosacli/ocm_resource_service.go
@@ -38,6 +38,7 @@ type OCMResourceService interface {
 
 	Whoami() (bytes.Buffer, error)
 	ReflectAccountsInfo(result bytes.Buffer) *AccountsInfo
+	UserInfo() (res *AccountsInfo, err error)
 
 	CreateAccountRole(flags ...string) (bytes.Buffer, error)
 	ReflectAccountRoleList(result bytes.Buffer) (arl AccountRoleList, err error)
@@ -192,6 +193,14 @@ func (ors *ocmResourceService) ReflectAccountsInfo(result bytes.Buffer) *Account
 	data, _ := json.Marshal(&theMap)
 	json.Unmarshal(data, res)
 	return res
+}
+
+func (ors *ocmResourceService) UserInfo() (res *AccountsInfo, err error) {
+	output, err := ors.Whoami()
+	if err != nil {
+		return
+	}
+	return ors.ReflectAccountsInfo(output), err
 }
 
 // Pasrse the result of 'rosa list user-roles' to NodePoolList struct


### PR DESCRIPTION
[OCM-7857](https://issues.redhat.com//browse/OCM-7857)
$ ginkgo --focus 73492 tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.14.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: e2e tests suite - /home/aaraj/ocm-forked-code/rosa/tests/e2e
===========================================================================
Random Seed: 1715586959

Will run 1 of 61 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 61 Specs in 81.510 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 60 Skipped
PASS

Ginkgo ran 1 suite in 1m28.026703813s
Test Suite Passed
