### PR TITLE
OCM-7860 | fix: add detach commands for arbitrary policies

### DIFF
--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -148,7 +148,7 @@ type Client interface {
 		credRequests map[string]*cmv1.STSOperator,
 	) ([]string, error)
 	GetOperatorRolesFromAccountByPrefix(prefix string, credRequest map[string]*cmv1.STSOperator) ([]string, error)
-	GetOperatorRolePolicies(roles []string) (map[string][]string, error)
+	GetOperatorRolePolicies(roles []string) (map[string][]string, map[string][]string, error)
 	GetAccountRolesForCurrentEnv(env string, accountID string) ([]Role, error)
 	GetAccountRoleForCurrentEnv(env string, roleName string) (Role, error)
 	GetAccountRoleForCurrentEnvWithPrefix(env string, rolePrefix string,
@@ -156,7 +156,7 @@ type Client interface {
 	DeleteAccountRole(roleName string, prefix string, managedPolicies bool) error
 	DeleteOCMRole(roleARN string, managedPolicies bool) error
 	DeleteUserRole(roleName string) error
-	GetAccountRolePolicies(roles []string, prefix string) (map[string][]PolicyDetail, error)
+	GetAccountRolePolicies(roles []string, prefix string) (map[string][]PolicyDetail, map[string][]PolicyDetail, error)
 	GetAttachedPolicy(role *string) ([]PolicyDetail, error)
 	HasPermissionsBoundary(roleName string) (bool, error)
 	GetOpenIDConnectProviderByClusterIdTag(clusterID string) (string, error)

--- a/pkg/aws/mock_client.go
+++ b/pkg/aws/mock_client.go
@@ -587,12 +587,13 @@ func (mr *MockClientMockRecorder) GetAccountRoleForCurrentEnvWithPrefix(env, rol
 }
 
 // GetAccountRolePolicies mocks base method.
-func (m *MockClient) GetAccountRolePolicies(roles []string, prefix string) (map[string][]PolicyDetail, error) {
+func (m *MockClient) GetAccountRolePolicies(roles []string, prefix string) (map[string][]PolicyDetail, map[string][]PolicyDetail, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAccountRolePolicies", roles, prefix)
 	ret0, _ := ret[0].(map[string][]PolicyDetail)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(map[string][]PolicyDetail)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // GetAccountRolePolicies indicates an expected call of GetAccountRolePolicies.
@@ -812,12 +813,13 @@ func (mr *MockClientMockRecorder) GetOperatorRoleDefaultPolicy(roleName any) *go
 }
 
 // GetOperatorRolePolicies mocks base method.
-func (m *MockClient) GetOperatorRolePolicies(roles []string) (map[string][]string, error) {
+func (m *MockClient) GetOperatorRolePolicies(roles []string) (map[string][]string, map[string][]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOperatorRolePolicies", roles)
 	ret0, _ := ret[0].(map[string][]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(map[string][]string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // GetOperatorRolePolicies indicates an expected call of GetOperatorRolePolicies.

--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -1006,7 +1006,7 @@ func (c *awsClient) DeleteOperatorRole(roleName string, managedPolicies bool) er
 	if err != nil {
 		return err
 	}
-	policies, err := getAttachedPolicies(c.iamClient, roleName, tagFilter)
+	policies, _, err := getAttachedPolicies(c.iamClient, roleName, tagFilter)
 	if err != nil {
 		return err
 	}
@@ -1073,7 +1073,7 @@ func (c *awsClient) DeleteAccountRole(roleName string, prefix string, managedPol
 	if err != nil {
 		return err
 	}
-	policyMap, err := getAttachedPolicies(c.iamClient, roleName, getAcctRolePolicyTags(prefix))
+	policyMap, _, err := getAttachedPolicies(c.iamClient, roleName, getAcctRolePolicyTags(prefix))
 	if err != nil {
 		return err
 	}
@@ -1256,35 +1256,39 @@ func (c *awsClient) deletePolicyVersions(policyArn string) error {
 	return nil
 }
 
-func (c *awsClient) GetAttachedPolicyWithTags(role *string, tagFilter map[string]string) ([]PolicyDetail, error) {
+func (c *awsClient) GetAttachedPolicyWithTags(role *string,
+	tagFilter map[string]string) ([]PolicyDetail, []PolicyDetail, error) {
 	policies := []PolicyDetail{}
+	excludedPolicies := []PolicyDetail{}
 	attachedPoliciesOutput, err := c.iamClient.ListAttachedRolePolicies(
 		context.Background(),
 		&iam.ListAttachedRolePoliciesInput{RoleName: role},
 	)
 	if err != nil && !awserr.IsNoSuchEntityException(err) {
-		return policies, err
+		return policies, excludedPolicies, err
 	}
 
 	for _, policy := range attachedPoliciesOutput.AttachedPolicies {
 		hasTags, err := isPolicyHasTags(c.iamClient, policy.PolicyArn, tagFilter)
 		if err != nil {
-			return policies, err
+			return policies, excludedPolicies, err
+		}
+		policyDetail := PolicyDetail{
+			PolicyName: aws.ToString(policy.PolicyName),
+			PolicyArn:  aws.ToString(policy.PolicyArn),
+			PolicyType: Attached,
 		}
 		if hasTags {
-			policyDetail := PolicyDetail{
-				PolicyName: aws.ToString(policy.PolicyName),
-				PolicyArn:  aws.ToString(policy.PolicyArn),
-				PolicyType: Attached,
-			}
 			policies = append(policies, policyDetail)
+		} else {
+			excludedPolicies = append(excludedPolicies, policyDetail)
 		}
 	}
 
 	rolePolicyOutput, err := c.iamClient.ListRolePolicies(context.Background(),
 		&iam.ListRolePoliciesInput{RoleName: role})
 	if err != nil && !awserr.IsNoSuchEntityException(err) {
-		return policies, err
+		return policies, excludedPolicies, err
 	}
 	for _, policy := range rolePolicyOutput.PolicyNames {
 		policyDetail := PolicyDetail{
@@ -1294,11 +1298,12 @@ func (c *awsClient) GetAttachedPolicyWithTags(role *string, tagFilter map[string
 		policies = append(policies, policyDetail)
 	}
 
-	return policies, nil
+	return policies, excludedPolicies, nil
 }
 
 func (c *awsClient) GetAttachedPolicy(role *string) ([]PolicyDetail, error) {
-	return c.GetAttachedPolicyWithTags(role, map[string]string{})
+	policies, _, err := c.GetAttachedPolicyWithTags(role, map[string]string{})
+	return policies, err
 }
 
 func (c *awsClient) detachOperatorRolePolicies(role *string) error {
@@ -1530,32 +1535,37 @@ func (c *awsClient) buildRoles(roleName string, accountID string) ([]Role, error
 	return roles, nil
 }
 
-func (c *awsClient) GetAccountRolePolicies(roles []string, prefix string) (map[string][]PolicyDetail, error) {
-	roleMap := make(map[string][]PolicyDetail)
+func (c *awsClient) GetAccountRolePolicies(roles []string, prefix string) (map[string][]PolicyDetail,
+	map[string][]PolicyDetail, error) {
+	rolePolicies := make(map[string][]PolicyDetail)
+	roleExcludedPolicies := make(map[string][]PolicyDetail)
 	for _, role := range roles {
-		policies, err := c.GetAttachedPolicyWithTags(aws.String(role), getAcctRolePolicyTags(prefix))
+		policies, excludedPolicies, err := c.GetAttachedPolicyWithTags(aws.String(role), getAcctRolePolicyTags(prefix))
 		if err != nil && !awserr.IsNoSuchEntityException(err) {
-			return roleMap, err
+			return rolePolicies, roleExcludedPolicies, err
 		}
-		roleMap[role] = policies
+		rolePolicies[role] = policies
+		roleExcludedPolicies[role] = excludedPolicies
 	}
-	return roleMap, nil
+	return rolePolicies, roleExcludedPolicies, nil
 }
 
-func (c *awsClient) GetOperatorRolePolicies(roles []string) (map[string][]string, error) {
-	roleMap := map[string][]string{}
+func (c *awsClient) GetOperatorRolePolicies(roles []string) (map[string][]string, map[string][]string, error) {
+	rolePolicies := map[string][]string{}
+	roleExcludedPolicies := map[string][]string{}
 	for _, role := range roles {
 		tagFilter, err := getOperatorRolePolicyTags(c.iamClient, role)
 		if err != nil {
-			return roleMap, err
+			return rolePolicies, roleExcludedPolicies, err
 		}
-		policies, err := getAttachedPolicies(c.iamClient, role, tagFilter)
+		policies, excludedPolicies, err := getAttachedPolicies(c.iamClient, role, tagFilter)
 		if err != nil {
-			return roleMap, err
+			return rolePolicies, roleExcludedPolicies, err
 		}
-		roleMap[role] = policies
+		rolePolicies[role] = policies
+		roleExcludedPolicies[role] = excludedPolicies
 	}
-	return roleMap, nil
+	return rolePolicies, roleExcludedPolicies, nil
 }
 
 func (c *awsClient) GetOpenIDConnectProviderByClusterIdTag(clusterID string) (string, error) {
@@ -1956,7 +1966,7 @@ func (c *awsClient) ListAttachedRolePolicies(roleName string) ([]string, error) 
 }
 
 func (c *awsClient) GetAccountRoleDefaultPolicy(roleName string, prefix string) (string, error) {
-	policies, err := getAttachedPolicies(c.iamClient, roleName, getAcctRolePolicyTags(prefix))
+	policies, _, err := getAttachedPolicies(c.iamClient, roleName, getAcctRolePolicyTags(prefix))
 	if err != nil {
 		return "", err
 	}
@@ -1975,7 +1985,7 @@ func (c *awsClient) GetOperatorRoleDefaultPolicy(roleName string) (string, error
 	if err != nil {
 		return "", nil
 	}
-	policies, err := getAttachedPolicies(c.iamClient, roleName, tagfilter)
+	policies, _, err := getAttachedPolicies(c.iamClient, roleName, tagfilter)
 	if err != nil {
 		return "", err
 	}
@@ -2065,25 +2075,28 @@ func isPolicyHasTags(c client.IamApiClient, poilcyArn *string, tagFilter map[str
 }
 
 func getAttachedPolicies(c client.IamApiClient, role string,
-	tagFilter map[string]string) ([]string, error) {
+	tagFilter map[string]string) ([]string, []string, error) {
 	policyArr := []string{}
+	excludedPolicyArr := []string{}
 	policiesOutput, err := c.ListAttachedRolePolicies(context.Background(),
 		&iam.ListAttachedRolePoliciesInput{
 			RoleName: aws.String(role),
 		})
 	if err != nil {
-		return policyArr, err
+		return policyArr, excludedPolicyArr, err
 	}
 	for _, policy := range policiesOutput.AttachedPolicies {
 		hasTags, err := isPolicyHasTags(c, policy.PolicyArn, tagFilter)
 		if err != nil {
-			return policyArr, err
+			return policyArr, excludedPolicyArr, err
 		}
 		if hasTags {
 			policyArr = append(policyArr, aws.ToString(policy.PolicyArn))
+		} else {
+			excludedPolicyArr = append(excludedPolicyArr, aws.ToString(policy.PolicyArn))
 		}
 	}
-	return policyArr, nil
+	return policyArr, excludedPolicyArr, nil
 }
 
 func getAcctRolePolicyTags(prefix string) map[string]string {

--- a/pkg/aws/policies_test.go
+++ b/pkg/aws/policies_test.go
@@ -258,14 +258,14 @@ var _ = Describe("Cluster Roles/Policies", func() {
 			RoleName: aws.String(operatorName),
 		}).Return(operatorRoleTags, nil)
 
-		policies, err := getAttachedPolicies(mockIamAPI, accountRole, getAcctRolePolicyTags(rolePrefix))
+		policies, _, err := getAttachedPolicies(mockIamAPI, accountRole, getAcctRolePolicyTags(rolePrefix))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(policies).To(HaveLen(1))
 		Expect(policies[0]).To(Equal(accountRolePolicyArn))
 
 		tagFilter, err := getOperatorRolePolicyTags(mockIamAPI, operatorName)
 		Expect(err).NotTo(HaveOccurred())
-		policies, err = getAttachedPolicies(mockIamAPI, operatorRole, tagFilter)
+		policies, _, err = getAttachedPolicies(mockIamAPI, operatorRole, tagFilter)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(policies).To(HaveLen(1))
 		Expect(policies[0]).To(Equal(operatorRolePolicyArn))


### PR DESCRIPTION
[OCM-7860](https://issues.redhat.com//browse/OCM-7860) | fix: add detach commands for arbitrary policies in rosa delete roles commands
https://issues.redhat.com/browse/OCM-7860
Signed-off-by: marcolan018 <llan@redhat.com>