### PR TITLE
OCM-7266 | feat: Added support for delete of KubeletConfig for HCP clusters

### DIFF
--- a/cmd/create/kubeletconfig/cmd.go
+++ b/cmd/create/kubeletconfig/cmd.go
@@ -24,7 +24,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/pkg/interactive"
-	"github.com/openshift/rosa/pkg/interactive/confirm"
 	. "github.com/openshift/rosa/pkg/kubeletconfig"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
@@ -52,7 +51,7 @@ func NewCreateKubeletConfigCommand() *cobra.Command {
 		Args:    cobra.NoArgs,
 	}
 
-	options.AddFlagsToCommand(cmd)
+	options.AddAllFlags(cmd)
 	ocm.AddClusterFlag(cmd)
 	interactive.AddFlag(cmd.Flags())
 	return cmd
@@ -97,11 +96,7 @@ func CreateKubeletConfigRunner(options *KubeletConfigOptions) rosa.CommandRunner
 		if !cluster.Hypershift().Enabled() {
 			// Creating a KubeletConfig for a classic cluster must prompt the user, as the changes apply
 			// immediately and cause reboots of the worker nodes in their cluster
-			prompt := fmt.Sprintf("Creating a KubeletConfig for cluster '%s' will cause all non-Control Plane "+
-				"nodes to reboot. This may cause outages to your applications. Do you wish to continue?", clusterKey)
-
-			if !confirm.ConfirmRaw(prompt) {
-				r.Reporter.Infof("Creation of KubeletConfig for cluster '%s' aborted.", clusterKey)
+			if !PromptUserToAcceptWorkerNodeReboot(OperationCreate, r) {
 				return nil
 			}
 		}

--- a/cmd/dlt/cmd.go
+++ b/cmd/dlt/cmd.go
@@ -66,7 +66,8 @@ func init() {
 	Cmd.AddCommand(tuningconfigs.Cmd)
 	Cmd.AddCommand(dnsdomains.Cmd)
 	Cmd.AddCommand(autoscaler.Cmd)
-	Cmd.AddCommand(kubeletconfig.Cmd)
+	kubeletconfig := kubeletconfig.NewDeleteKubeletConfigCommand()
+	Cmd.AddCommand(kubeletconfig)
 	Cmd.AddCommand(externalauthprovider.Cmd)
 
 	flags := Cmd.PersistentFlags()
@@ -80,7 +81,7 @@ func init() {
 		oidcprovider.Cmd, upgrade.Cmd, admin.Cmd,
 		service.Cmd, autoscaler.Cmd, idp.Cmd,
 		cluster.Cmd, dnsdomains.Cmd, externalauthprovider.Cmd,
-		kubeletconfig.Cmd, machinepool.Cmd, tuningconfigs.Cmd,
+		kubeletconfig, machinepool.Cmd, tuningconfigs.Cmd,
 	}
 	arguments.MarkRegionDeprecated(Cmd, globallyAvailableCommands)
 }

--- a/cmd/dlt/kubeletconfig/cmd_test.go
+++ b/cmd/dlt/kubeletconfig/cmd_test.go
@@ -1,0 +1,120 @@
+package kubeletconfig
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+
+	. "github.com/openshift/rosa/pkg/kubeletconfig"
+	"github.com/openshift/rosa/pkg/output"
+	. "github.com/openshift/rosa/pkg/test"
+)
+
+var _ = Describe("delete kubeletconfig", func() {
+
+	It("Correctly builds the command", func() {
+		cmd := NewDeleteKubeletConfigCommand()
+		Expect(cmd).NotTo(BeNil())
+
+		Expect(cmd.Use).To(Equal(use))
+		Expect(cmd.Short).To(Equal(short))
+		Expect(cmd.Long).To(Equal(long))
+		Expect(cmd.Args).NotTo(BeNil())
+		Expect(cmd.Run).NotTo(BeNil())
+
+		Expect(cmd.Flags().Lookup("cluster")).NotTo(BeNil())
+		Expect(cmd.Flags().Lookup(PodPidsLimitOption)).To(BeNil())
+		Expect(cmd.Flags().Lookup(NameOption)).NotTo(BeNil())
+	})
+
+	Context("Delete KubeletConfig Runner", func() {
+
+		var t *TestingRuntime
+
+		BeforeEach(func() {
+			t = NewTestRuntime()
+			output.SetOutput("")
+		})
+
+		AfterEach(func() {
+			output.SetOutput("")
+		})
+
+		It("Returns an error if the cluster does not exist", func() {
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, FormatClusterList(make([]*cmv1.Cluster, 0))))
+			t.SetCluster("cluster", nil)
+
+			runner := DeleteKubeletConfigRunner(NewKubeletConfigOptions())
+			err := runner(context.Background(), t.RosaRuntime, nil, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(
+				Equal("There is no cluster with identifier or name 'cluster'"))
+		})
+
+		It("Deletes KubeletConfig by name for HCP Clusters", func() {
+
+			cluster := MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateReady)
+				b := cmv1.HypershiftBuilder{}
+				b.Enabled(true)
+				c.Hypershift(&b)
+			})
+
+			kubeletConfig := MockKubeletConfig(func(k *cmv1.KubeletConfigBuilder) {
+				k.ID("testing").PodPidsLimit(5000).Name("testing")
+			})
+
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(
+					http.StatusOK, FormatClusterList([]*cmv1.Cluster{cluster})))
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusOK, FormatKubeletConfigList([]*cmv1.KubeletConfig{kubeletConfig})))
+			t.ApiServer.RouteToHandler(http.MethodDelete,
+				fmt.Sprintf("/api/clusters_mgmt/v1/clusters/%s/kubelet_configs/%s", cluster.ID(), kubeletConfig.ID()),
+				RespondWithJSON(http.StatusOK, FormatResource(kubeletConfig)))
+			t.SetCluster("cluster", cluster)
+
+			options := NewKubeletConfigOptions()
+			options.Name = "testing"
+
+			runner := DeleteKubeletConfigRunner(options)
+			t.StdOutReader.Record()
+
+			err := runner(context.Background(), t.RosaRuntime, nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			stdOut, _ := t.StdOutReader.Read()
+			Expect(stdOut).To(Equal("INFO: Successfully deleted KubeletConfig for cluster 'cluster'\n"))
+		})
+
+		It("Fails to delete KubeletConfig by name for HCP Clusters if the KubeletConfig does not exist", func() {
+			cluster := MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateReady)
+				b := cmv1.HypershiftBuilder{}
+				b.Enabled(true)
+				c.Hypershift(&b)
+			})
+
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(
+					http.StatusOK, FormatClusterList([]*cmv1.Cluster{cluster})))
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusOK, FormatKubeletConfigList([]*cmv1.KubeletConfig{})))
+			t.SetCluster("cluster", cluster)
+
+			options := NewKubeletConfigOptions()
+			options.Name = "testing"
+
+			runner := DeleteKubeletConfigRunner(options)
+
+			err := runner(context.Background(), t.RosaRuntime, nil, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Failed to delete KubeletConfig for cluster 'cluster'"))
+		})
+	})
+})

--- a/cmd/dlt/kubeletconfig/kubeletconfig_suite_test.go
+++ b/cmd/dlt/kubeletconfig/kubeletconfig_suite_test.go
@@ -1,0 +1,13 @@
+package kubeletconfig
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDeleteKubeletConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Delete KubeletConfig Suite")
+}

--- a/cmd/edit/kubeletconfig/cmd.go
+++ b/cmd/edit/kubeletconfig/cmd.go
@@ -24,7 +24,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/pkg/interactive"
-	"github.com/openshift/rosa/pkg/interactive/confirm"
 	. "github.com/openshift/rosa/pkg/kubeletconfig"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
@@ -63,7 +62,7 @@ func NewEditKubeletConfigCommand() *cobra.Command {
 
 	ocm.AddClusterFlag(cmd)
 	interactive.AddFlag(flags)
-	options.AddFlagsToCommand(cmd)
+	options.AddAllFlags(cmd)
 	return cmd
 }
 
@@ -109,11 +108,7 @@ func EditKubeletConfigRunner(options *KubeletConfigOptions) rosa.CommandRunner {
 
 		if !cluster.Hypershift().Enabled() {
 			// Classic clusters must prompt the user as edit will cause all worker nodes to reboot
-			prompt := fmt.Sprintf("Updating the custom KubeletConfig for cluster '%s' will cause all non-Control Plane "+
-				"nodes to reboot. This may cause outages to your applications. Do you wish to continue?", r.GetClusterKey())
-
-			if !confirm.ConfirmRaw(prompt) {
-				r.Reporter.Infof("Update of custom KubeletConfig for cluster '%s' aborted.", r.GetClusterKey())
+			if !PromptUserToAcceptWorkerNodeReboot(OperationEdit, r) {
 				return nil
 			}
 		}

--- a/pkg/kubeletconfig/input.go
+++ b/pkg/kubeletconfig/input.go
@@ -1,0 +1,49 @@
+package kubeletconfig
+
+import (
+	"fmt"
+
+	"github.com/openshift/rosa/pkg/interactive/confirm"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+const (
+	promptMessage = "%s the KubeletConfig for cluster '%s' will cause all non-Control Plane " +
+		"nodes to reboot. This may cause outages to your applications. Do you wish to continue?"
+	abortMessage                     = "%s of KubeletConfig for cluster '%s' aborted."
+	OperationDelete KubeletOperation = "delete"
+	OperationEdit   KubeletOperation = "edit"
+	OperationCreate KubeletOperation = "create"
+)
+
+type KubeletOperation string
+
+var (
+	singularTense = map[KubeletOperation]string{
+		OperationEdit:   "Edit",
+		OperationDelete: "Delete",
+		OperationCreate: "Create",
+	}
+
+	futureTense = map[KubeletOperation]string{
+		OperationEdit:   "Editing",
+		OperationDelete: "Deleting",
+		OperationCreate: "Creating",
+	}
+)
+
+func PromptUserToAcceptWorkerNodeReboot(operation KubeletOperation, r *rosa.Runtime) bool {
+	if !confirm.ConfirmRaw(buildPromptMessage(operation, r.GetClusterKey())) {
+		r.Reporter.Infof(buildAbortMessage(operation, r.GetClusterKey()))
+		return false
+	}
+	return true
+}
+
+func buildAbortMessage(operation KubeletOperation, clusterKey string) string {
+	return fmt.Sprintf(abortMessage, singularTense[operation], clusterKey)
+}
+
+func buildPromptMessage(operation KubeletOperation, clusterKey string) string {
+	return fmt.Sprintf(promptMessage, futureTense[operation], clusterKey)
+}

--- a/pkg/kubeletconfig/input_test.go
+++ b/pkg/kubeletconfig/input_test.go
@@ -1,0 +1,19 @@
+package kubeletconfig
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("KubeletConfig Input", func() {
+	It("Generates the abort message", func() {
+		msg := buildAbortMessage(OperationCreate, "foo")
+		Expect(msg).To(Equal("Create of KubeletConfig for cluster 'foo' aborted."))
+	})
+
+	It("Generates the prompt message", func() {
+		msg := buildPromptMessage(OperationCreate, "foo")
+		Expect(msg).To(Equal("Creating the KubeletConfig for cluster 'foo' will cause all non-Control Plane " +
+			"nodes to reboot. This may cause outages to your applications. Do you wish to continue?"))
+	})
+})

--- a/pkg/kubeletconfig/options.go
+++ b/pkg/kubeletconfig/options.go
@@ -15,7 +15,17 @@ func NewKubeletConfigOptions() *KubeletConfigOptions {
 	return &KubeletConfigOptions{}
 }
 
-func (k *KubeletConfigOptions) AddFlagsToCommand(cmd *cobra.Command) {
+func (k *KubeletConfigOptions) AddNameFlag(cmd *cobra.Command) {
+	flags := cmd.Flags()
+	flags.SortFlags = false
+	flags.StringVar(
+		&k.Name,
+		NameOption,
+		NameOptionDefaultValue,
+		NameOptionUsage)
+}
+
+func (k *KubeletConfigOptions) AddAllFlags(cmd *cobra.Command) {
 	flags := cmd.Flags()
 	flags.SortFlags = false
 	flags.IntVar(
@@ -23,11 +33,7 @@ func (k *KubeletConfigOptions) AddFlagsToCommand(cmd *cobra.Command) {
 		PodPidsLimitOption,
 		PodPidsLimitOptionDefaultValue,
 		PodPidsLimitOptionUsage)
-	flags.StringVar(
-		&k.Name,
-		NameOption,
-		NameOptionDefaultValue,
-		NameOptionUsage)
+	k.AddNameFlag(cmd)
 }
 
 func (k *KubeletConfigOptions) ValidateForHypershift() error {

--- a/pkg/kubeletconfig/options_test.go
+++ b/pkg/kubeletconfig/options_test.go
@@ -9,7 +9,7 @@ import (
 
 var _ = Describe("KubeletConfigOptions", func() {
 
-	It("Adds flags to command", func() {
+	It("Add all flags to command", func() {
 		cmd := &cobra.Command{}
 		flags := cmd.Flags()
 		Expect(flags).NotTo(BeNil())
@@ -17,10 +17,26 @@ var _ = Describe("KubeletConfigOptions", func() {
 		Expect(flags.Lookup(NameOption)).To(BeNil())
 
 		options := NewKubeletConfigOptions()
-		options.AddFlagsToCommand(cmd)
+		options.AddAllFlags(cmd)
 
 		flag := flags.Lookup(PodPidsLimitOption)
 		assertFlag(flag, PodPidsLimitOption, PodPidsLimitOptionUsage)
+
+		flag = flags.Lookup(NameOption)
+		assertFlag(flag, NameOption, NameOptionUsage)
+	})
+
+	It("Adds name flag to command", func() {
+		cmd := &cobra.Command{}
+		flags := cmd.Flags()
+		Expect(flags).NotTo(BeNil())
+		Expect(flags.Lookup(NameOption)).To(BeNil())
+
+		options := NewKubeletConfigOptions()
+		options.AddNameFlag(cmd)
+
+		flag := flags.Lookup(PodPidsLimitOption)
+		Expect(flag).To(BeNil())
 
 		flag = flags.Lookup(NameOption)
 		assertFlag(flag, NameOption, NameOptionUsage)

--- a/pkg/ocm/kubeletconfig.go
+++ b/pkg/ocm/kubeletconfig.go
@@ -27,8 +27,38 @@ func (c *Client) GetClusterKubeletConfig(clusterID string) (*cmv1.KubeletConfig,
 	return response.Body(), true, nil
 }
 
-func (c *Client) DeleteKubeletConfig(clusterID string) error {
-	response, err := c.ocm.ClustersMgmt().V1().Clusters().Cluster(clusterID).KubeletConfig().Delete().Send()
+func (c *Client) DeleteKubeletConfigByName(ctx context.Context, clusterId string, name string) error {
+	kubeletConfig, exists, err := c.FindKubeletConfigByName(ctx, clusterId, name)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		return fmt.Errorf("The KubeletConfig with name '%s' does not exist on cluster '%s'", name, clusterId)
+	}
+
+	response, err := c.ocm.ClustersMgmt().
+		V1().
+		Clusters().
+		Cluster(clusterId).
+		KubeletConfigs().
+		KubeletConfig(kubeletConfig.ID()).
+		Delete().
+		SendContext(ctx)
+
+	if err != nil {
+		return handleErr(response.Error(), err)
+	}
+	return nil
+}
+
+func (c *Client) DeleteKubeletConfig(ctx context.Context, clusterID string) error {
+	response, err := c.ocm.ClustersMgmt().
+		V1().
+		Clusters().
+		Cluster(clusterID).
+		KubeletConfig().
+		Delete().SendContext(ctx)
 	if err != nil {
 		return handleErr(response.Error(), err)
 	}


### PR DESCRIPTION
This PR updates `rosa delete kubeletconfig` with support for HCP clusters.