### PR TITLE
OCM-7990 | fix: allow min_replicas 0 with edit machinepools

### DIFF
--- a/cmd/edit/machinepool/machinepool_test.go
+++ b/cmd/edit/machinepool/machinepool_test.go
@@ -36,16 +36,6 @@ var _ = Describe("Machinepool", func() {
 			asBuilder := cmv1.NewMachinePoolAutoscaling().MaxReplicas(2).MinReplicas(0)
 			Expect(builder).To(Equal(asBuilder))
 		})
-
-		It("editMachinePoolAutoscaling should allow 0 min and 0 max replicas", func() {
-			machinePool, err := cmv1.NewMachinePool().
-				Autoscaling(cmv1.NewMachinePoolAutoscaling().MaxReplicas(2).MinReplicas(1)).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
-			builder := editMachinePoolAutoscaling(machinePool, 0, 0)
-			asBuilder := cmv1.NewMachinePoolAutoscaling().MaxReplicas(0).MinReplicas(0)
-			Expect(builder).To(Equal(asBuilder))
-		})
 	})
 
 	Context("isMultiAZMachinePool", func() {


### PR DESCRIPTION
FIXED:

A. min and max replicas set at 3
![image](https://github.com/openshift/rosa/assets/118839428/43f2b0cc-29d1-4047-b4e5-5db500b5308b)

B. edit min replicas only to 0
![image](https://github.com/openshift/rosa/assets/118839428/79594f00-17ba-435e-b060-916e7284e026)

C. result
![image](https://github.com/openshift/rosa/assets/118839428/466813d3-2834-4909-93e0-e40bccf08fb2)
