### PR TITLE
OCM-7268 | feat: Update create machinepool command to support kubeletconfigs

### DIFF
--- a/cmd/create/machinepool/cmd.go
+++ b/cmd/create/machinepool/cmd.go
@@ -54,6 +54,7 @@ var args struct {
 	version               string
 	autorepair            bool
 	tuningConfigs         string
+	kubeletConfigs        string
 	rootDiskSize          string
 	securityGroupIds      []string
 	nodeDrainGracePeriod  string
@@ -205,6 +206,15 @@ func init() {
 		"Name of the tuning configs to be applied to the machine pool. Format should be a comma-separated list. "+
 			"Tuning config must already exist. "+
 			"This list will overwrite any modifications made to node tuning configs on an ongoing basis.",
+	)
+
+	flags.StringVar(
+		&args.kubeletConfigs,
+		"kubelet-configs",
+		"",
+		"Name of the kubelet configs to be applied to the machine pool. Format should be a comma-separated list. "+
+			"Kubelet config must already exist. "+
+			"This list will overwrite any modifications made to node kubelet configs on an ongoing basis.",
 	)
 
 	flags.StringVar(&args.rootDiskSize,

--- a/pkg/ocm/kubeletconfig.go
+++ b/pkg/ocm/kubeletconfig.go
@@ -80,6 +80,22 @@ func toOCMKubeletConfig(args KubeletConfigArgs) (*cmv1.KubeletConfig, error) {
 	return kubeletConfig, nil
 }
 
+func (c *Client) ListKubeletConfigNames(clusterId string) ([]string, error) {
+	configs, err := c.ListKubeletConfigs(context.Background(), clusterId)
+	if err != nil {
+		return make([]string, 0), err
+	}
+
+	var names []string
+
+	if len(configs) > 0 {
+		for _, c := range configs {
+			names = append(names, c.Name())
+		}
+	}
+	return names, nil
+}
+
 func (c *Client) CreateKubeletConfig(clusterID string, args KubeletConfigArgs) (*cmv1.KubeletConfig, error) {
 
 	kubeletConfig, err := toOCMKubeletConfig(args)


### PR DESCRIPTION
This PR updates the `rosa create machinepool` command with support for the `--kubelet-configs` option, that allows the user to specify a list of KubeletConfig `name` to attach to a specific HCP MachinePool.