### PR TITLE
OCM-7264 | fix: Ensured that name is optional when creating a KubeletConfig

### DIFF
--- a/pkg/ocm/kubeletconfig.go
+++ b/pkg/ocm/kubeletconfig.go
@@ -67,7 +67,12 @@ func (c *Client) DeleteKubeletConfig(ctx context.Context, clusterID string) erro
 
 func toOCMKubeletConfig(args KubeletConfigArgs) (*cmv1.KubeletConfig, error) {
 	builder := &cmv1.KubeletConfigBuilder{}
-	kubeletConfig, err := builder.PodPidsLimit(args.PodPidsLimit).Name(args.Name).Build()
+	builder.PodPidsLimit(args.PodPidsLimit)
+	if args.Name != "" {
+		builder.Name(args.Name)
+	}
+
+	kubeletConfig, err := builder.Build()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ocm/kubeletconfig_test.go
+++ b/pkg/ocm/kubeletconfig_test.go
@@ -291,6 +291,29 @@ var _ = Describe("KubeletConfig", Ordered, func() {
 						"The KubeletConfig with name 'notExisting' does not exist on cluster '%s'", clusterId)))
 		})
 	})
+
+	Context("toOcmConfig", func() {
+		It("Sets the name if it has been supplied", func() {
+			kubeletConfig, err := toOCMKubeletConfig(KubeletConfigArgs{
+				Name:         "testing",
+				PodPidsLimit: 10000,
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(kubeletConfig.Name()).To(Equal("testing"))
+			Expect(kubeletConfig.PodPidsLimit()).To(Equal(10000))
+		})
+
+		It("Does not set the name if it has not been supplied", func() {
+			kubeletConfig, err := toOCMKubeletConfig(KubeletConfigArgs{
+				PodPidsLimit: 10000,
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(kubeletConfig.Name()).To(BeEmpty())
+			Expect(kubeletConfig.PodPidsLimit()).To(Equal(10000))
+		})
+	})
 })
 
 func createKubeletConfig() (string, error) {


### PR DESCRIPTION
The `--name` arg is optional when creating a `KubeletConfig`. If omitted, it will be generated on the server-side. We need to ensure we do not send an empty string as the name if the user has not supplied the arg.