### PR TITLE
OCM-7985 | fix: add attach policy command for rosa upgrade roles

### DIFF
--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -335,13 +335,13 @@ func buildCommands(prefix string, partition string, accountID string, isUpgradeN
 			accRoleName := common.GetRoleName(prefix, role.Name)
 			policyARN := aws.GetPolicyARN(partition, accountID, accRoleName, policyPath)
 			_, err := awsClient.IsPolicyExists(policyARN)
-			hasPolicy := err == nil
+			policyExists := err == nil
 			policyName := aws.GetPolicyName(accRoleName)
 			upgradeAccountPolicyCommands := awscbRoles.ManualCommandsForUpgradeAccountRolePolicy(
 				awscbRoles.ManualCommandsForUpgradeAccountRolePolicyInput{
 					DefaultPolicyVersion: defaultPolicyVersion,
 					RoleName:             accRoleName,
-					HasPolicy:            hasPolicy,
+					PolicyExists:         policyExists,
 					Prefix:               prefix,
 					File:                 file,
 					PolicyName:           policyName,

--- a/pkg/aws/sts.go
+++ b/pkg/aws/sts.go
@@ -190,13 +190,13 @@ func BuildOperatorRoleCommands(prefix string, partition string, accountID string
 			operator.Name(),
 		)
 		_, err := awsClient.IsPolicyExists(policyARN)
-		hasPolicy := err == nil
+		policyExists := err == nil
 		isSharedVpc := cluster.AWS().PrivateHostedZoneRoleARN() != ""
 		fileName := GetOperatorPolicyKey(credrequest, cluster.Hypershift().Enabled(), isSharedVpc)
 		fileName = GetFormattedFileName(fileName)
 		upgradePoliciesCommands := awscbRoles.ManualCommandsForUpgradeOperatorRolePolicy(
 			awscbRoles.ManualCommandsForUpgradeOperatorRolePolicyInput{
-				HasPolicy:                hasPolicy,
+				PolicyExists:             policyExists,
 				OperatorRolePolicyPrefix: prefix,
 				Operator:                 operator,
 				CredRequest:              credrequest,


### PR DESCRIPTION
fixed two problems in current upgrade flow:
1. for manual mode, add the attach policy command if the policy not attache to the target role
2. always find the account/operator-role's default policy by awsClient's function: GetAccountRoleDefaultPolicy/GetOperatorRoleDefaultPolicy. Current logic will regard the only attached policy as the default policy and upgrade it.

https://issues.redhat.com/browse/OCM-7985
https://issues.redhat.com/browse/OCM-7986
https://issues.redhat.com/browse/OCM-7987
Signed-off-by: marcolan018 <llan@redhat.com>