### PR TITLE
OCM-8053 | test: Automated id:43252 validating inputs for creating spot machinepools

### DIFF
--- a/tests/e2e/test_rosacli_machine_pool.go
+++ b/tests/e2e/test_rosacli_machine_pool.go
@@ -167,6 +167,26 @@ var _ = Describe("Create machinepool",
 
 			})
 
+		It("validate inputs for create spot machinepool - [id:43252]",
+			labels.Medium,
+			labels.Day2,
+			func() {
+				By("Create a spot machinepool with negative price")
+				machinePoolName := "spotmp"
+				output, err := machinePoolService.CreateMachinePool(clusterID, machinePoolName, "--spot-max-price", "-10.2", "--use-spot-instances",
+					"--replicas", "3")
+				Expect(err).To(HaveOccurred())
+				textData := rosaClient.Parser.TextData.Input(output).Parse().Tip()
+				Expect(textData).To(ContainSubstring("Spot max price must be positive"))
+
+				By("Create a machinepool without spot instances, but with spot price")
+				machinePoolName = "nospotmp"
+				output, err = machinePoolService.CreateMachinePool(clusterID, machinePoolName, "--replicas", "3", "--spot-max-price", "10.2", "--use-spot-instances=false")
+				Expect(err).To(HaveOccurred())
+				textData = rosaClient.Parser.TextData.Input(output).Parse().Tip()
+				Expect(textData).Should(ContainSubstring("Can't set max price when not using spot instances"))
+			})
+
 		It("can create machinepool with tags - [id:73469]",
 			labels.NonHCPCluster,
 			labels.Day2,


### PR DESCRIPTION
output:
```
$ CLUSTER_ID=2b99vnpc3u6ktad4ad28ana0m67o7j7f ginkgo -focus 43252 tests/e2e/
Running Suite: e2e tests suite - /home/jericho/work/repos/rosa/tests/e2e
========================================================================
Random Seed: 1715798790

Will run 1 of 67 specs
SSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 67 Specs in 4.411 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 66 Skipped
PASS

Ginkgo ran 1 suite in 5.371714118s
Test Suite Passed

```