### PR TITLE
OCM-7259 | feat: E2E delete machinepool cmd tests; new runner

### DIFF
--- a/cmd/describe/machinepool/cmd.go
+++ b/cmd/describe/machinepool/cmd.go
@@ -63,23 +63,15 @@ func NewDescribeMachinePoolCommand() *cobra.Command {
 	return cmd
 }
 
-func DescribeMachinePoolRunner(userOptions DescribeMachinepoolUserOptions) rosa.CommandRunner {
+func DescribeMachinePoolRunner(userOptions *DescribeMachinepoolUserOptions) rosa.CommandRunner {
 	return func(_ context.Context, runtime *rosa.Runtime, cmd *cobra.Command, argv []string) error {
 		options := NewDescribeMachinepoolOptions()
-		// Allow the use also directly the machine pool id as positional parameter
-		if len(argv) == 1 && !cmd.Flag("machinepool").Changed {
-			userOptions.machinepool = argv[0]
-		} else {
-			err := cmd.ParseFlags(argv)
-			userOptions.machinepool = cmd.Flag("machinepool").Value.String()
-			if err != nil {
-				return fmt.Errorf("Unable to parse flags: %s", err)
-			}
-		}
-		err := options.Bind(userOptions)
+
+		err := options.Bind(userOptions, argv)
 		if err != nil {
 			return err
 		}
+
 		clusterKey := runtime.GetClusterKey()
 		cluster := runtime.FetchCluster()
 		if cluster.State() != cmv1.ClusterStateReady {

--- a/cmd/describe/machinepool/cmd_test.go
+++ b/cmd/describe/machinepool/cmd_test.go
@@ -189,7 +189,8 @@ var _ = Describe("Upgrade machine pool", func() {
 				err := t.StdOutReader.Record()
 				Expect(err).ToNot(HaveOccurred())
 				cmd := NewDescribeMachinePoolCommand()
-				cmd.Flag("cluster").Value.Set(clusterId)
+				err = cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
 				err = runner(context.Background(), t.RosaRuntime, cmd,
 					[]string{nodePoolName})
 				Expect(err).To(BeNil())
@@ -205,8 +206,11 @@ var _ = Describe("Upgrade machine pool", func() {
 				runner := DescribeMachinePoolRunner(args)
 				err := t.StdOutReader.Record()
 				Expect(err).ToNot(HaveOccurred())
-				err = runner(context.Background(), t.RosaRuntime, NewDescribeMachinePoolCommand(),
-					[]string{"--machinepool", nodePoolName, "-c", clusterId})
+				cmd := NewDescribeMachinePoolCommand()
+				err = cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd,
+					[]string{"--machinepool", nodePoolName})
 				Expect(err).ToNot(BeNil())
 				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("Machine pool '%s' not found", nodePoolName)))
 				stdout, err := t.StdOutReader.Read()
@@ -225,8 +229,10 @@ var _ = Describe("Upgrade machine pool", func() {
 				args := NewDescribeMachinepoolUserOptions()
 				args.machinepool = nodePoolName
 				runner := DescribeMachinePoolRunner(args)
-				err = runner(context.Background(), t.RosaRuntime, NewDescribeMachinePoolCommand(),
-					[]string{"--machinepool", nodePoolName, "-c", clusterId})
+				cmd := NewDescribeMachinePoolCommand()
+				cmd.Flag("cluster").Value.Set(clusterId)
+				err = runner(context.Background(), t.RosaRuntime, cmd,
+					[]string{"--machinepool", nodePoolName})
 				Expect(err).To(BeNil())
 				stdout, err := t.StdOutReader.Read()
 				Expect(err).ToNot(HaveOccurred())
@@ -244,8 +250,11 @@ var _ = Describe("Upgrade machine pool", func() {
 				runner := DescribeMachinePoolRunner(args)
 				err := t.StdOutReader.Record()
 				Expect(err).ToNot(HaveOccurred())
-				err = runner(context.Background(), t.RosaRuntime, NewDescribeMachinePoolCommand(),
-					[]string{"--machinepool", nodePoolName, "-c", clusterId})
+				cmd := NewDescribeMachinePoolCommand()
+				err = cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd,
+					[]string{"--machinepool", nodePoolName})
 				Expect(err).To(BeNil())
 				stdout, err := t.StdOutReader.Read()
 				Expect(err).ToNot(HaveOccurred())
@@ -263,8 +272,13 @@ var _ = Describe("Upgrade machine pool", func() {
 				runner := DescribeMachinePoolRunner(args)
 				err := t.StdOutReader.Record()
 				Expect(err).ToNot(HaveOccurred())
-				err = runner(context.Background(), t.RosaRuntime, NewDescribeMachinePoolCommand(),
-					[]string{"--output", "yaml", "--machinepool", nodePoolName, "-c", clusterId})
+				cmd := NewDescribeMachinePoolCommand()
+				err = cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = cmd.Flag("output").Value.Set("yaml")
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd,
+					[]string{"--machinepool", nodePoolName})
 				Expect(err).To(BeNil())
 				stdout, err := t.StdOutReader.Read()
 				Expect(err).ToNot(HaveOccurred())
@@ -282,8 +296,11 @@ var _ = Describe("Upgrade machine pool", func() {
 				runner := DescribeMachinePoolRunner(args)
 				err := t.StdOutReader.Record()
 				Expect(err).ToNot(HaveOccurred())
-				err = runner(context.Background(), t.RosaRuntime, NewDescribeMachinePoolCommand(),
-					[]string{"--machinepool", nodePoolName, "-c", clusterId})
+				cmd := NewDescribeMachinePoolCommand()
+				err = cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd,
+					[]string{"--machinepool", nodePoolName})
 				Expect(err).To(BeNil())
 				stdout, err := t.StdOutReader.Read()
 				Expect(err).ToNot(HaveOccurred())
@@ -299,8 +316,11 @@ var _ = Describe("Upgrade machine pool", func() {
 				runner := DescribeMachinePoolRunner(args)
 				err := t.StdOutReader.Record()
 				Expect(err).ToNot(HaveOccurred())
-				err = runner(context.Background(), t.RosaRuntime, NewDescribeMachinePoolCommand(),
-					[]string{"--machinepool", nodePoolName, "-c", clusterId})
+				cmd := NewDescribeMachinePoolCommand()
+				err = cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd,
+					[]string{"--machinepool", nodePoolName})
 				Expect(err).ToNot(BeNil())
 				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("Machine pool '%s' not found", nodePoolName)))
 				stdout, err := t.StdOutReader.Read()
@@ -315,8 +335,11 @@ var _ = Describe("Upgrade machine pool", func() {
 				runner := DescribeMachinePoolRunner(args)
 				err := t.StdOutReader.Record()
 				Expect(err).ToNot(HaveOccurred())
-				err = runner(context.Background(), t.RosaRuntime, NewDescribeMachinePoolCommand(),
-					[]string{"--machinepool", nodePoolName, "-c", clusterId})
+				cmd := NewDescribeMachinePoolCommand()
+				err = cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd,
+					[]string{"--machinepool", nodePoolName})
 				Expect(err).ToNot(BeNil())
 				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("Machine pool '%s' not found", nodePoolName)))
 				stdout, err := t.StdOutReader.Read()
@@ -331,8 +354,11 @@ var _ = Describe("Upgrade machine pool", func() {
 				runner := DescribeMachinePoolRunner(args)
 				err := t.StdOutReader.Record()
 				Expect(err).ToNot(HaveOccurred())
-				err = runner(context.Background(), t.RosaRuntime, NewDescribeMachinePoolCommand(),
-					[]string{"--machinepool", nodePoolName, "-c", clusterId})
+				cmd := NewDescribeMachinePoolCommand()
+				err = cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd,
+					[]string{"--machinepool", nodePoolName})
 				Expect(err).To(BeNil())
 				stdout, err := t.StdOutReader.Read()
 				Expect(err).ToNot(HaveOccurred())
@@ -361,8 +387,13 @@ var _ = Describe("Upgrade machine pool", func() {
 				runner := DescribeMachinePoolRunner(args)
 				err := t.StdOutReader.Record()
 				Expect(err).ToNot(HaveOccurred())
-				err = runner(context.Background(), t.RosaRuntime, NewDescribeMachinePoolCommand(),
-					[]string{"--machinepool", nodePoolName, "--output", "yaml", "-c", clusterId})
+				cmd := NewDescribeMachinePoolCommand()
+				err = cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = cmd.Flag("output").Value.Set("yaml")
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd,
+					[]string{"--machinepool", nodePoolName})
 				Expect(err).To(BeNil())
 				stdout, err := t.StdOutReader.Read()
 				Expect(err).ToNot(HaveOccurred())

--- a/cmd/describe/machinepool/options.go
+++ b/cmd/describe/machinepool/options.go
@@ -13,17 +13,17 @@ type DescribeMachinepoolUserOptions struct {
 type DescribeMachinepoolOptions struct {
 	reporter *reporter.Object
 
-	args DescribeMachinepoolUserOptions
+	args *DescribeMachinepoolUserOptions
 }
 
-func NewDescribeMachinepoolUserOptions() DescribeMachinepoolUserOptions {
-	return DescribeMachinepoolUserOptions{machinepool: ""}
+func NewDescribeMachinepoolUserOptions() *DescribeMachinepoolUserOptions {
+	return &DescribeMachinepoolUserOptions{machinepool: ""}
 }
 
 func NewDescribeMachinepoolOptions() *DescribeMachinepoolOptions {
 	return &DescribeMachinepoolOptions{
 		reporter: reporter.CreateReporter(),
-		args:     DescribeMachinepoolUserOptions{},
+		args:     &DescribeMachinepoolUserOptions{},
 	}
 }
 
@@ -31,10 +31,17 @@ func (m *DescribeMachinepoolOptions) Machinepool() string {
 	return m.args.machinepool
 }
 
-func (m *DescribeMachinepoolOptions) Bind(args DescribeMachinepoolUserOptions) error {
-	if args.machinepool == "" {
+func (m *DescribeMachinepoolOptions) Bind(args *DescribeMachinepoolUserOptions, argv []string) error {
+	m.args = args
+	if m.args.machinepool == "" {
+		if len(argv) > 0 {
+			m.args.machinepool = argv[0]
+		}
+	}
+
+	if m.args.machinepool == "" {
 		return fmt.Errorf("you need to specify a machine pool name")
 	}
-	m.args.machinepool = args.machinepool
+
 	return nil
 }

--- a/cmd/describe/machinepool/options_test.go
+++ b/cmd/describe/machinepool/options_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 var _ = Describe("Test describe machinepool options", func() {
-	var args DescribeMachinepoolUserOptions
+	var args *DescribeMachinepoolUserOptions
 	Context("Describe Machinepool User Options", func() {
 		It("Creates default options", func() {
 			args = NewDescribeMachinepoolUserOptions()
@@ -19,15 +19,21 @@ var _ = Describe("Test describe machinepool options", func() {
 			// Set value then bind
 			testMachinepool := "test"
 			args.machinepool = testMachinepool
-			err := options.Bind(args)
+			err := options.Bind(args, []string{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(options.Machinepool()).To(Equal(testMachinepool))
 		})
 		It("Fail to bind args due to empty machinepool name", func() {
 			args.machinepool = ""
-			err := options.Bind(args)
+			err := options.Bind(args, []string{})
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("you need to specify a machine pool name"))
+		})
+		It("Test Bind with argv instead of normal args (single arg, no flag for machinepool)", func() {
+			argv := []string{"test-id"}
+			args.machinepool = ""
+			options.Bind(args, argv)
+			Expect(options.Machinepool()).To(Equal(argv[0]))
 		})
 	})
 })

--- a/cmd/dlt/cmd.go
+++ b/cmd/dlt/cmd.go
@@ -54,7 +54,8 @@ func init() {
 	Cmd.AddCommand(cluster.Cmd)
 	Cmd.AddCommand(idp.Cmd)
 	Cmd.AddCommand(ingress.Cmd)
-	Cmd.AddCommand(machinepool.Cmd)
+	machinepoolCommand := machinepool.NewDeleteMachinePoolCommand()
+	Cmd.AddCommand(machinepoolCommand)
 	Cmd.AddCommand(upgrade.Cmd)
 	Cmd.AddCommand(oidcconfig.Cmd)
 	Cmd.AddCommand(oidcprovider.Cmd)
@@ -81,7 +82,7 @@ func init() {
 		oidcprovider.Cmd, upgrade.Cmd, admin.Cmd,
 		service.Cmd, autoscaler.Cmd, idp.Cmd,
 		cluster.Cmd, dnsdomains.Cmd, externalauthprovider.Cmd,
-		kubeletconfig, machinepool.Cmd, tuningconfigs.Cmd,
+		kubeletconfig, machinepoolCommand, tuningconfigs.Cmd,
 	}
 	arguments.MarkRegionDeprecated(Cmd, globallyAvailableCommands)
 }

--- a/cmd/dlt/machinepool/cmd_test.go
+++ b/cmd/dlt/machinepool/cmd_test.go
@@ -1,0 +1,216 @@
+package machinepool
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+
+	. "github.com/openshift/rosa/pkg/output"
+	"github.com/openshift/rosa/pkg/test"
+)
+
+const (
+	nodePoolName = "nodepool85"
+	clusterId    = "24vf9iitg3p6tlml88iml6j6mu095mh8"
+)
+
+var _ = Describe("Delete machine pool", func() {
+	Context("Delete machine pool command", func() {
+		// Full diff for long string to help debugging
+		format.TruncatedDiff = false
+
+		mockClusterReady := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+			c.AWS(cmv1.NewAWS().SubnetIDs("subnet-0b761d44d3d9a4663", "subnet-0f87f640e56934cbc"))
+			c.Region(cmv1.NewCloudRegion().ID("us-east-1"))
+			c.State(cmv1.ClusterStateReady)
+			c.Hypershift(cmv1.NewHypershift().Enabled(true))
+		})
+
+		hypershiftClusterReady := test.FormatClusterList([]*cmv1.Cluster{mockClusterReady})
+
+		mockClassicClusterReady := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+			c.AWS(cmv1.NewAWS().SubnetIDs("subnet-0b761d44d3d9a4663", "subnet-0f87f640e56934cbc"))
+			c.Region(cmv1.NewCloudRegion().ID("us-east-1"))
+			c.State(cmv1.ClusterStateReady)
+			c.Hypershift(cmv1.NewHypershift().Enabled(false))
+		})
+		classicClusterReady := test.FormatClusterList([]*cmv1.Cluster{mockClassicClusterReady})
+
+		nodePoolResponse := formatNodePool()
+		mpResponse := formatMachinePool()
+
+		var t *test.TestingRuntime
+
+		BeforeEach(func() {
+			t = test.NewTestRuntime()
+			SetOutput("")
+		})
+		It("Fails if we are not specifying a machine pool name", func() {
+			runner := DeleteMachinePoolRunner(NewDeleteMachinepoolUserOptions())
+			err := runner(context.Background(), t.RosaRuntime, NewDeleteMachinePoolCommand(), []string{})
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring("You need to specify a machine pool name"))
+		})
+		Context("Hypershift", func() {
+			It("Works without passing `--machinepool`", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
+				// First get
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, nodePoolResponse))
+				// Delete
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, ""))
+				args := NewDeleteMachinepoolUserOptions()
+				args.machinepool = nodePoolName
+				runner := DeleteMachinePoolRunner(args)
+				err := t.StdOutReader.Record()
+				Expect(err).ToNot(HaveOccurred())
+				cmd := NewDeleteMachinePoolCommand()
+				err = cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = cmd.Flag("yes").Value.Set("true")
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd,
+					[]string{"--machinepool", nodePoolName, "-y"})
+				Expect(err).To(BeNil())
+				stdout, err := t.StdOutReader.Read()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stdout).To(Equal(fmt.Sprintf("INFO: Successfully deleted machine pool '%s' from "+
+					"hosted cluster '%s'\n", nodePoolName, clusterId)))
+			})
+			It("Pass a machine pool name through argv but it is not found", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusNotFound, ""))
+				args := NewDeleteMachinepoolUserOptions()
+				args.machinepool = nodePoolName
+				runner := DeleteMachinePoolRunner(args)
+				err := t.StdOutReader.Record()
+				Expect(err).ToNot(HaveOccurred())
+				cmd := NewDeleteMachinePoolCommand()
+				err = cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd,
+					[]string{"--machinepool", nodePoolName, "-y"})
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("Machine pool '%s' does not "+
+					"exist for hosted cluster '%s'", nodePoolName, clusterId)))
+				stdout, err := t.StdOutReader.Read()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stdout).To(Equal(""))
+			})
+			It("Pass only machine pool name, gives prompt successfully", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
+				// First get
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, nodePoolResponse))
+				err := t.StdOutReader.Record()
+				Expect(err).ToNot(HaveOccurred())
+				args := NewDeleteMachinepoolUserOptions()
+				args.machinepool = nodePoolName
+				runner := DeleteMachinePoolRunner(args)
+				cmd := NewDeleteMachinePoolCommand()
+				err = cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd,
+					[]string{nodePoolName})
+				Expect(err).To(BeNil())
+				stdout, err := t.StdOutReader.Read()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stdout).To(ContainSubstring(fmt.Sprintf("Are you sure you want to delete machine pool "+
+					"'%s' on hosted cluster '%s'?", nodePoolName, clusterId)))
+			})
+		})
+		Context("ROSA Classic", func() {
+			It("Works without passing `--machinepool`", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, classicClusterReady))
+				// First get
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, mpResponse))
+				// Delete
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, ""))
+				args := NewDeleteMachinepoolUserOptions()
+				args.machinepool = nodePoolName
+				runner := DeleteMachinePoolRunner(args)
+				err := t.StdOutReader.Record()
+				Expect(err).ToNot(HaveOccurred())
+				cmd := NewDeleteMachinePoolCommand()
+				err = cmd.Flag("yes").Value.Set("true")
+				Expect(err).ToNot(HaveOccurred())
+				err = cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd,
+					[]string{nodePoolName})
+				Expect(err).To(BeNil())
+				stdout, err := t.StdOutReader.Read()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stdout).To(Equal(fmt.Sprintf("INFO: Successfully deleted machine pool '%s' from "+
+					"cluster '%s'\n", nodePoolName, clusterId)))
+			})
+			It("Pass a machine pool name through argv but it is not found", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, classicClusterReady))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusNotFound, ""))
+				args := NewDeleteMachinepoolUserOptions()
+				args.machinepool = nodePoolName
+				runner := DeleteMachinePoolRunner(args)
+				err := t.StdOutReader.Record()
+				Expect(err).ToNot(HaveOccurred())
+				cmd := NewDeleteMachinePoolCommand()
+				err = cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd,
+					[]string{"--machinepool", nodePoolName, "-y"})
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("Error deleting machinepool: Failed to "+
+					"get machine pool '%s' for cluster '%s'", nodePoolName,
+					clusterId)))
+				stdout, err := t.StdOutReader.Read()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stdout).To(Equal(""))
+			})
+			It("Pass only machine pool name, gives prompt successfully", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, classicClusterReady))
+				// First get
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, mpResponse))
+				err := t.StdOutReader.Record()
+				Expect(err).ToNot(HaveOccurred())
+				args := NewDeleteMachinepoolUserOptions()
+				args.machinepool = nodePoolName
+				runner := DeleteMachinePoolRunner(args)
+				cmd := NewDeleteMachinePoolCommand()
+				err = cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd,
+					[]string{nodePoolName})
+				Expect(err).To(BeNil())
+				stdout, err := t.StdOutReader.Read()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stdout).To(ContainSubstring(fmt.Sprintf("Are you sure you want to delete machine pool "+
+					"'%s' on cluster '%s'?", nodePoolName, clusterId)))
+			})
+		})
+	})
+})
+
+// formatNodePool simulates the output of APIs for a fake node pool list
+func formatNodePool() string {
+	version := cmv1.NewVersion().ID("4.12.24").RawID("openshift-4.12.24")
+	awsNodePool := cmv1.NewAWSNodePool().InstanceType("m5.xlarge")
+	nodeDrain := cmv1.NewValue().Value(1).Unit("minute")
+	nodePool, err := cmv1.NewNodePool().ID(nodePoolName).Version(version).
+		AWSNodePool(awsNodePool).AvailabilityZone("us-east-1a").NodeDrainGracePeriod(nodeDrain).Build()
+	Expect(err).ToNot(HaveOccurred())
+	return fmt.Sprintf("{\n  \"items\": [\n    %s\n  ],\n  \"page\": 0,\n  \"size\": 1,\n  \"total\": 1\n}",
+		test.FormatResource(nodePool))
+}
+
+// formatMachinePool simulates the output of APIs for a fake machine pool list
+func formatMachinePool() string {
+	awsMachinePoolPool := cmv1.NewAWSMachinePool().SpotMarketOptions(cmv1.NewAWSSpotMarketOptions().MaxPrice(5))
+	machinePool, err := cmv1.NewMachinePool().ID(nodePoolName).AWS(awsMachinePoolPool).InstanceType("m5.xlarge").
+		AvailabilityZones("us-east-1a", "us-east-1b", "us-east-1c").Build()
+	Expect(err).ToNot(HaveOccurred())
+	return fmt.Sprintf("{\n  \"items\": [\n    %s\n  ],\n  \"page\": 0,\n  \"size\": 1,\n  \"total\": 1\n}",
+		test.FormatResource(machinePool))
+}

--- a/cmd/dlt/machinepool/main_test.go
+++ b/cmd/dlt/machinepool/main_test.go
@@ -1,0 +1,13 @@
+package machinepool
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDescribeMachinePool(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Delete machine pool suite")
+}

--- a/cmd/dlt/machinepool/options.go
+++ b/cmd/dlt/machinepool/options.go
@@ -1,0 +1,50 @@
+package machinepool
+
+import (
+	"fmt"
+
+	"github.com/openshift/rosa/pkg/machinepool"
+	"github.com/openshift/rosa/pkg/reporter"
+)
+
+type DeleteMachinepoolUserOptions struct {
+	machinepool string
+}
+
+type DeleteMachinepoolOptions struct {
+	reporter *reporter.Object
+
+	args *DeleteMachinepoolUserOptions
+}
+
+func NewDeleteMachinepoolUserOptions() *DeleteMachinepoolUserOptions {
+	return &DeleteMachinepoolUserOptions{machinepool: ""}
+}
+
+func NewDeleteMachinepoolOptions() *DeleteMachinepoolOptions {
+	return &DeleteMachinepoolOptions{
+		reporter: reporter.CreateReporter(),
+		args:     &DeleteMachinepoolUserOptions{},
+	}
+}
+
+func (m *DeleteMachinepoolOptions) Machinepool() string {
+	return m.args.machinepool
+}
+
+func (m *DeleteMachinepoolOptions) Bind(args *DeleteMachinepoolUserOptions, argv []string) error {
+	m.args = args
+	if m.Machinepool() == "" {
+		if len(argv) > 0 {
+			m.args.machinepool = argv[0]
+		}
+	}
+	if args.machinepool == "" {
+		return fmt.Errorf("You need to specify a machine pool name")
+	}
+	if !machinepool.MachinePoolKeyRE.MatchString(args.machinepool) {
+		return fmt.Errorf("Expected a valid identifier for the machine pool")
+	}
+	m.args.machinepool = args.machinepool
+	return nil
+}

--- a/cmd/dlt/machinepool/options_test.go
+++ b/cmd/dlt/machinepool/options_test.go
@@ -1,0 +1,56 @@
+package machinepool
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Test delete machinepool options", func() {
+	var args *DeleteMachinepoolUserOptions
+	var options *DeleteMachinepoolOptions
+	BeforeEach(func() {
+		options = NewDeleteMachinepoolOptions()
+	})
+	Context("Delete Machinepool User Options", func() {
+		It("Creates default options", func() {
+			args = NewDeleteMachinepoolUserOptions()
+			Expect(args.machinepool).To(Equal(""))
+		})
+	})
+	Context("Delete Machinepool Options", func() {
+		It("Create args from options using Bind (also tests MachinePool func)", func() {
+			// Set value then bind
+			testMachinepool := "test"
+			args.machinepool = testMachinepool
+			err := options.Bind(args, []string{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(options.Machinepool()).To(Equal(testMachinepool))
+		})
+		It("Fail to bind args due to empty machinepool name", func() {
+			args.machinepool = ""
+			err := options.Bind(args, []string{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("You need to specify a machine pool name"))
+		})
+		It("Fail to bind args due to invalid machinepool name", func() {
+			args.machinepool = "%asd"
+			err := options.Bind(args, []string{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Expected a valid identifier for the machine pool"))
+			args.machinepool = "1asd"
+			err = options.Bind(args, []string{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Expected a valid identifier for the machine pool"))
+			args.machinepool = "asd123$"
+			err = options.Bind(args, []string{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Expected a valid identifier for the machine pool"))
+		})
+		It("Test Bind with argv instead of normal args (single arg, no flag for machinepool)", func() {
+			argv := []string{"test-id"}
+			args.machinepool = ""
+			options.Bind(args, argv)
+			Expect(options.Machinepool()).To(Equal(argv[0]))
+		})
+	})
+})


### PR DESCRIPTION
[OCM-7259](https://issues.redhat.com//browse/OCM-7259)
---

* E2E tests for high coverage of command + associated functions
* Every route covered AFAIK
* Testing of new options files + validations including regex validation for both hypershift and classic
* New runner for `delete machinepool` command