### PR TITLE
OCM-8058 | fix: Ensure --name option is required for working with KubeletConfigs on HCP clusters

### DIFF
--- a/cmd/describe/kubeletconfig/cmd.go
+++ b/cmd/describe/kubeletconfig/cmd.go
@@ -73,7 +73,7 @@ func DescribeKubeletConfigRunner(options *KubeletConfigOptions) rosa.CommandRunn
 		var exists bool
 
 		if cluster.Hypershift().Enabled() {
-			options.Name, err = PromptForName(options.Name, true)
+			options.Name, err = PromptForName(options.Name)
 			if err != nil {
 				return err
 			}

--- a/cmd/describe/kubeletconfig/cmd_test.go
+++ b/cmd/describe/kubeletconfig/cmd_test.go
@@ -129,6 +129,30 @@ var _ = Describe("Describe KubeletConfig", func() {
 				Equal("The KubeletConfig specified does not exist for cluster 'cluster'"))
 		})
 
+		It("Returns an error if no name specified for HCP KubeletConfig", func() {
+			cluster := MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateReady)
+				b := cmv1.HypershiftBuilder{}
+				b.Enabled(true)
+				c.Hypershift(&b)
+
+			})
+
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(
+					http.StatusOK, FormatClusterList([]*cmv1.Cluster{cluster})))
+			t.SetCluster("cluster", cluster)
+
+			options := NewKubeletConfigOptions()
+			options.PodPidsLimit = 10000
+
+			runner := DescribeKubeletConfigRunner(options)
+
+			err := runner(context.Background(), t.RosaRuntime, nil, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("The --name flag is required for Hosted Control Plane clusters."))
+		})
+
 		It("Returns an error if failing to read HCP KubeletConfig", func() {
 			cluster := MockCluster(func(c *cmv1.ClusterBuilder) {
 				c.State(cmv1.ClusterStateReady)

--- a/cmd/dlt/kubeletconfig/cmd.go
+++ b/cmd/dlt/kubeletconfig/cmd.go
@@ -75,11 +75,14 @@ func DeleteKubeletConfigRunner(options *KubeletConfigOptions) rosa.CommandRunner
 		}
 
 		if cluster.Hypershift().Enabled() {
-			options.Name, err = PromptForName(options.Name, true)
+			options.Name, err = PromptForName(options.Name)
 			if err != nil {
 				return err
 			}
-			options.ValidateForHypershift()
+			err = options.ValidateForHypershift()
+			if err != nil {
+				return err
+			}
 			err = r.OCMClient.DeleteKubeletConfigByName(ctx, cluster.ID(), options.Name)
 		} else {
 			err = r.OCMClient.DeleteKubeletConfig(ctx, cluster.ID())

--- a/cmd/edit/kubeletconfig/cmd.go
+++ b/cmd/edit/kubeletconfig/cmd.go
@@ -81,12 +81,15 @@ func EditKubeletConfigRunner(options *KubeletConfigOptions) rosa.CommandRunner {
 		var exists bool
 
 		if cluster.Hypershift().Enabled() {
-			options.Name, err = PromptForName(options.Name, true)
+			options.Name, err = PromptForName(options.Name)
 			if err != nil {
 				return err
 			}
 
-			options.ValidateForHypershift()
+			err = options.ValidateForHypershift()
+			if err != nil {
+				return err
+			}
 			kubeletconfig, exists, err = r.OCMClient.FindKubeletConfigByName(ctx, cluster.ID(), options.Name)
 		} else {
 			kubeletconfig, exists, err = r.OCMClient.GetClusterKubeletConfig(cluster.ID())

--- a/pkg/kubeletconfig/config.go
+++ b/pkg/kubeletconfig/config.go
@@ -53,19 +53,15 @@ func GetInteractiveInput(maxPidsLimit int, kubeletConfig *v1.KubeletConfig) inte
 	}
 }
 
-func PromptForName(requestedName string, nameRequired bool) (string, error) {
+func PromptForName(requestedName string) (string, error) {
 
-	if requestedName == "" && nameRequired {
-		interactive.Enable()
-	}
-
-	if interactive.Enabled() {
+	if requestedName == "" && interactive.Enabled() {
 		return interactive.GetString(interactive.Input{
 			Question: InteractiveNameHelpPrompt,
 			Help:     InteractiveNameHelp,
 			Options:  nil,
 			Default:  requestedName,
-			Required: false,
+			Required: true,
 		})
 	}
 

--- a/pkg/kubeletconfig/consts.go
+++ b/pkg/kubeletconfig/consts.go
@@ -6,7 +6,7 @@ const (
 	MaxUnsafePodPidsLimit          = 3694303
 	NameOption                     = "name"
 	NameOptionDefaultValue         = ""
-	NameOptionUsage                = "Name of the KubeletConfig"
+	NameOptionUsage                = "Name of the KubeletConfig (required for Hosted Control Plane clusters)"
 	PodPidsLimitOption             = "pod-pids-limit"
 	PodPidsLimitOptionUsage        = "Sets the requested pod_pids_limit for this KubeletConfig."
 	PodPidsLimitOptionDefaultValue = 0


### PR DESCRIPTION
Without the `--name` option, we rely on the generated name from the server-side which can be a little cumbersome. This enforces a better practice in `rosa` where we encourage customers to explicitly name their `KubeletConfig` for better readability.