### PR TITLE
OCM-8057 | fix: Ensure the ID of the KubeletConfig is printed by `rosa describe kubeletconfig`

### DIFF
--- a/pkg/kubeletconfig/output.go
+++ b/pkg/kubeletconfig/output.go
@@ -38,8 +38,10 @@ func PrintKubeletConfigForHcp(config *cmv1.KubeletConfig, nodePools []*cmv1.Node
 
 func PrintKubeletConfigForClassic(config *cmv1.KubeletConfig) string {
 	return fmt.Sprintf("\n"+
+		"ID:                                   %s\n"+
 		"Name:                                 %s\n"+
 		"Pod Pids Limit:                       %d\n",
+		config.ID(),
 		getName(config),
 		config.PodPidsLimit(),
 	)

--- a/pkg/kubeletconfig/output_test.go
+++ b/pkg/kubeletconfig/output_test.go
@@ -1,8 +1,6 @@
 package kubeletconfig
 
 import (
-	"fmt"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -11,16 +9,19 @@ import (
 )
 
 var classicOutputWithName = `
+ID:                                   bar
 Name:                                 foo
 Pod Pids Limit:                       10000
 `
 
 var classicOutPutNoName = `
+ID:                                   bar
 Name:                                 -
 Pod Pids Limit:                       10000
 `
 
 var hcpOutputWithName = `
+ID:                                   bar
 Name:                                 foo
 Pod Pids Limit:                       10000
 MachinePools Using This KubeletConfig:
@@ -28,6 +29,7 @@ MachinePools Using This KubeletConfig:
 `
 
 var hcpOutputNoName = `
+ID:                                   bar
 Name:                                 -
 Pod Pids Limit:                       10000
 MachinePools Using This KubeletConfig:
@@ -55,7 +57,6 @@ var _ = Describe("KubeletConfig Output", func() {
 		})
 
 		output := PrintKubeletConfigForClassic(kubeletConfig)
-		fmt.Print(output)
 		Expect(output).To(Equal(classicOutputWithName))
 	})
 
@@ -65,7 +66,6 @@ var _ = Describe("KubeletConfig Output", func() {
 		})
 
 		output := PrintKubeletConfigForClassic(kubeletConfig)
-		fmt.Print(output)
 		Expect(output).To(Equal(classicOutPutNoName))
 	})
 


### PR DESCRIPTION
Ensure we print the `ID` of the `KubeletConfig` in `rosa describe kubeletconfig`.