### PR TITLE
OCM-8045 | test: automated ids:73765,73766 to support machinepool with kubeletconfig

### DIFF
--- a/tests/e2e/test_rosacli_node_pool.go
+++ b/tests/e2e/test_rosacli_node_pool.go
@@ -149,16 +149,6 @@ var _ = Describe("Edit nodepool",
 				Expect(len(common.ParseTaints(npDesc.Taints))).To(Equal(len(common.ParseTaints(newTaints))))
 				Expect(common.ParseTaints(npDesc.Taints)).To(BeEquivalentTo(common.ParseTaints(newTaints)))
 
-				By("Wait for nodepool replicas available")
-				err = wait.PollUntilContextTimeout(context.Background(), 30*time.Second, 20*time.Minute, false, func(context.Context) (bool, error) {
-					npDesc, err := machinePoolService.DescribeAndReflectNodePool(clusterID, nodePoolName)
-					if err != nil {
-						return false, err
-					}
-					return npDesc.CurrentReplicas == replicasNb, nil
-				})
-				common.AssertWaitPollNoErr(err, "Replicas are not ready after 600")
-
 				By("Delete nodepool")
 				output, err = machinePoolService.DeleteMachinePool(clusterID, nodePoolName)
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/utils/exec/rosacli/machinepool_service.go
+++ b/tests/utils/exec/rosacli/machinepool_service.go
@@ -109,6 +109,7 @@ type NodePoolDescription struct {
 	DesiredReplicas            string `yaml:"Desired replicas,omitempty"`
 	CurrentReplicas            string `yaml:"Current replicas,omitempty"`
 	InstanceType               string `yaml:"Instance type,omitempty"`
+	KubeletConfigs             string `yaml:"Kubelet configs,omitempty"`
 	Labels                     string `yaml:"Labels,omitempty"`
 	Tags                       string `yaml:"Tags,omitempty"`
 	Taints                     string `yaml:"Taints,omitempty"`


### PR DESCRIPTION
```
lixue@Xue-Lis-MacBook-Pro rosa % ginkgo -focus "(73766|73765)" tests/e2e
Running Suite: e2e tests suite - /Users/lixue/Workspace/rosa/tests/e2e
======================================================================
Random Seed: 1715860725

Will run 2 of 76 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS••S

Ran 2 of 76 Specs in 146.539 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 74 Skipped
PASS

Ginkgo ran 1 suite in 2m33.920982807s
Test Suite Passed
```