### PR TITLE
OCM-8075 | fix: Ensure users can only supply a single kubeletconfig for HCP MachinePools

### DIFF
--- a/cmd/create/machinepool/cmd.go
+++ b/cmd/create/machinepool/cmd.go
@@ -212,9 +212,9 @@ func init() {
 		&args.kubeletConfigs,
 		"kubelet-configs",
 		"",
-		"Name of the kubelet configs to be applied to the machine pool. Format should be a comma-separated list. "+
+		"Name of the kubelet config to be applied to the machine pool. A single kubelet config is allowed. "+
 			"Kubelet config must already exist. "+
-			"This list will overwrite any modifications made to node kubelet configs on an ongoing basis.",
+			"This will overwrite any modifications made to node kubelet configs on an ongoing basis.",
 	)
 
 	flags.StringVar(&args.rootDiskSize,

--- a/cmd/edit/machinepool/cmd.go
+++ b/cmd/edit/machinepool/cmd.go
@@ -140,9 +140,9 @@ func init() {
 		&args.kubeletConfigs,
 		"kubelet-configs",
 		"",
-		"Name of the kubelet configs to be applied to the machine pool. Format should be a comma-separated list. "+
+		"Name of the kubelet config to be applied to the machine pool.  A single kubelet config is allowed. "+
 			"Kubelet config must already exist. "+
-			"This list will overwrite any modifications made to node kubelet configs on an ongoing basis.",
+			"This will overwrite any modifications made to node kubelet configs on an ongoing basis.",
 	)
 
 	flags.StringVar(&args.nodeDrainGracePeriod,

--- a/pkg/machinepool/validation.go
+++ b/pkg/machinepool/validation.go
@@ -1,0 +1,24 @@
+package machinepool
+
+import (
+	"fmt"
+
+	"github.com/AlecAivazis/survey/v2/core"
+)
+
+func ValidateKubeletConfig(input interface{}) error {
+	if strings, ok := input.([]string); ok {
+		return validateCount(strings)
+	} else if answers, ok := input.([]core.OptionAnswer); ok {
+		return validateCount(answers)
+	}
+
+	return fmt.Errorf("Input for kubelet config flag is not valid")
+}
+
+func validateCount[K any](kubeletConfigs []K) error {
+	if len(kubeletConfigs) > 1 {
+		return fmt.Errorf("Only a single kubelet config is supported for Machine Pools")
+	}
+	return nil
+}

--- a/pkg/machinepool/validation_test.go
+++ b/pkg/machinepool/validation_test.go
@@ -1,0 +1,68 @@
+package machinepool
+
+import (
+	"github.com/AlecAivazis/survey/v2/core"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("MachinePool validation", func() {
+	Context("KubeletConfigs", func() {
+
+		It("Fails if customer requests more than 1 kubelet config via []string", func() {
+			kubeletConfigs := []string{"foo", "bar"}
+			err := ValidateKubeletConfig(kubeletConfigs)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Only a single kubelet config is supported for Machine Pools"))
+		})
+
+		It("Fails if customer requests more than 1 kubelet config via []core.OptionAnswer", func() {
+			kubeletConfigs := []core.OptionAnswer{
+				{
+					Value: "foo",
+					Index: 0,
+				},
+				{
+					Value: "bar",
+					Index: 1,
+				},
+			}
+			err := ValidateKubeletConfig(kubeletConfigs)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Only a single kubelet config is supported for Machine Pools"))
+		})
+
+		It("Passes if a customer selects only a single kubelet config via []core.OptionAnswer", func() {
+			kubeletConfigs := []core.OptionAnswer{
+				{
+					Value: "foo",
+					Index: 0,
+				},
+			}
+			err := ValidateKubeletConfig(kubeletConfigs)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Passes if a customer selects only a single kubelet config via []string", func() {
+			kubeletConfigs := []string{"foo"}
+			err := ValidateKubeletConfig(kubeletConfigs)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Passes with empty selection via []string", func() {
+			err := ValidateKubeletConfig([]string{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Passes with empty selection via []core.OptionAnswer", func() {
+			err := ValidateKubeletConfig([]core.OptionAnswer{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Fails if the input is not a []string or []core.OptionAnswer", func() {
+			err := ValidateKubeletConfig("foo")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Input for kubelet config flag is not valid"))
+		})
+	})
+})


### PR DESCRIPTION
This PR tidies up the presentation and validation of the allowed kubelet-configs for a HCP machinepool. Currently whilst the flag is named `--kubelet-configs`, we only support a single entry. This allows us to proceed without having to rename the flag in the future, but makes it much clearer to the user, that at this time, a single kubeletconfig is supported.

This is enforced on the backend, but this provides a better UX for customers using `rosa`.