### PR TITLE
OCM-8076 | fix: Ensure the user is prompted if they change the kubeletconfig on their HCP MachinePool

### DIFF
--- a/pkg/kubeletconfig/input.go
+++ b/pkg/kubeletconfig/input.go
@@ -10,10 +10,14 @@ import (
 const (
 	promptMessage = "%s the KubeletConfig for cluster '%s' will cause all non-Control Plane " +
 		"nodes to reboot. This may cause outages to your applications. Do you wish to continue?"
-	abortMessage                     = "%s of KubeletConfig for cluster '%s' aborted."
-	OperationDelete KubeletOperation = "delete"
-	OperationEdit   KubeletOperation = "edit"
-	OperationCreate KubeletOperation = "create"
+	abortMessage                      = "%s of KubeletConfig for cluster '%s' aborted."
+	OperationDelete  KubeletOperation = "delete"
+	OperationEdit    KubeletOperation = "edit"
+	OperationCreate  KubeletOperation = "create"
+	hcpPromptMessage                  = "Editing the kubelet config will cause the Nodes" +
+		" for your Machine Pool to be recreated. " +
+		"This may cause outages to your applications. Do you wish to continue?"
+	hcpAbortMessage = "Edit of Machine Pool aborted."
 )
 
 type KubeletOperation string
@@ -31,6 +35,15 @@ var (
 		OperationCreate: "Creating",
 	}
 )
+
+func PromptToAcceptNodePoolNodeRecreate(r *rosa.Runtime) bool {
+	if !confirm.ConfirmRaw(hcpPromptMessage) {
+		r.Reporter.Infof(hcpAbortMessage)
+		return false
+	}
+
+	return true
+}
 
 func PromptUserToAcceptWorkerNodeReboot(operation KubeletOperation, r *rosa.Runtime) bool {
 	if !confirm.ConfirmRaw(buildPromptMessage(operation, r.GetClusterKey())) {


### PR DESCRIPTION
When a user edits the `kubeletconfigs` on their HCP `Machinepool`, we must show them a warning as this will cause all nodes in the nodepool to be recreated to adjust to the new PIDs limit.