### PR TITLE
OCM-8055 | fix: Check kubeletconfig exists by name if user specifies it for Classic cluster

### DIFF
--- a/cmd/describe/kubeletconfig/cmd.go
+++ b/cmd/describe/kubeletconfig/cmd.go
@@ -84,7 +84,12 @@ func DescribeKubeletConfigRunner(options *KubeletConfigOptions) rosa.CommandRunn
 			}
 			kubeletconfig, exists, err = r.OCMClient.FindKubeletConfigByName(ctx, cluster.ID(), options.Name)
 		} else {
-			kubeletconfig, exists, err = r.OCMClient.GetClusterKubeletConfig(cluster.ID())
+			// Name isn't required for Classic clusters, but for correctness, if the user has set it, lets check things
+			if options.Name != "" {
+				kubeletconfig, exists, err = r.OCMClient.FindKubeletConfigByName(ctx, cluster.ID(), options.Name)
+			} else {
+				kubeletconfig, exists, err = r.OCMClient.GetClusterKubeletConfig(cluster.ID())
+			}
 		}
 
 		if err != nil {

--- a/cmd/dlt/kubeletconfig/cmd.go
+++ b/cmd/dlt/kubeletconfig/cmd.go
@@ -85,7 +85,11 @@ func DeleteKubeletConfigRunner(options *KubeletConfigOptions) rosa.CommandRunner
 			}
 			err = r.OCMClient.DeleteKubeletConfigByName(ctx, cluster.ID(), options.Name)
 		} else {
-			err = r.OCMClient.DeleteKubeletConfig(ctx, cluster.ID())
+			if options.Name != "" {
+				err = r.OCMClient.DeleteKubeletConfigByName(ctx, cluster.ID(), options.Name)
+			} else {
+				err = r.OCMClient.DeleteKubeletConfig(ctx, cluster.ID())
+			}
 		}
 
 		if err != nil {

--- a/cmd/edit/kubeletconfig/cmd.go
+++ b/cmd/edit/kubeletconfig/cmd.go
@@ -92,7 +92,12 @@ func EditKubeletConfigRunner(options *KubeletConfigOptions) rosa.CommandRunner {
 			}
 			kubeletconfig, exists, err = r.OCMClient.FindKubeletConfigByName(ctx, cluster.ID(), options.Name)
 		} else {
-			kubeletconfig, exists, err = r.OCMClient.GetClusterKubeletConfig(cluster.ID())
+			// Name isn't required for Classic clusters, but for correctness, if the user has set it, lets check things
+			if options.Name != "" {
+				kubeletconfig, exists, err = r.OCMClient.FindKubeletConfigByName(ctx, cluster.ID(), options.Name)
+			} else {
+				kubeletconfig, exists, err = r.OCMClient.GetClusterKubeletConfig(cluster.ID())
+			}
 		}
 
 		if err != nil {


### PR DESCRIPTION
For ROSA Classic clusters, the user does not need to pass the `--name` flag to any of the `rosa kubeletconfig` command e.g `rosa create kubeletconfig` because there is only ever a single KubeletConfig for ROSA classic.

However, if the user does decide to pass the `--name` flag, we should verify the KubeletConfig matches so that they get the correct failure and we don't just change things that don't meet their expectations.