### PR TITLE
OCM-7855 | fix: return message if there is no breakglass can be revoked

### DIFF
--- a/cmd/revoke/breakglasscredential/breakglasscredential_suite_test.go
+++ b/cmd/revoke/breakglasscredential/breakglasscredential_suite_test.go
@@ -1,0 +1,13 @@
+package breakglasscredential_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestBreakGlassCredential(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Breakglasscredential Suite")
+}

--- a/cmd/revoke/breakglasscredential/cmd.go
+++ b/cmd/revoke/breakglasscredential/cmd.go
@@ -65,6 +65,16 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command, argv []string) error {
 		return err
 	}
 
+	breakGlassCredentials, err := r.OCMClient.GetBreakGlassCredentials(cluster.ID())
+	if err != nil {
+		return fmt.Errorf("failed to get break glass credentials for cluster '%s': %v", clusterKey, err)
+	}
+
+	if len(breakGlassCredentials) == 0 {
+		r.Reporter.Infof("There are no break glass credentials for cluster '%s'", clusterKey)
+		return nil
+	}
+
 	if confirm.Confirm("revoke all the break glass credentials on cluster '%s'", clusterKey) {
 		r.Reporter.Debugf("Revoking break glass credentials on cluster '%s'", clusterKey)
 		err := r.OCMClient.DeleteBreakGlassCredentials(cluster.ID())

--- a/cmd/revoke/breakglasscredential/cmd_test.go
+++ b/cmd/revoke/breakglasscredential/cmd_test.go
@@ -1,0 +1,43 @@
+package breakglasscredential
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+
+	"github.com/openshift/rosa/pkg/test"
+)
+
+var _ = Describe("Revoke break-glass-credential", func() {
+	var testRuntime test.TestingRuntime
+
+	Context("Revoke break glass credential command", func() {
+		mockClusterReady := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+			c.AWS(cmv1.NewAWS().SubnetIDs("subnet-0b761d44d3d9a4663", "subnet-0f87f640e56934cbc"))
+			c.Region(cmv1.NewCloudRegion().ID("us-east-1"))
+			c.State(cmv1.ClusterStateReady)
+			c.Hypershift(cmv1.NewHypershift().Enabled(true))
+			c.ExternalAuthConfig(cmv1.NewExternalAuthConfig().Enabled(true))
+		})
+		hypershiftClusterReady := test.FormatClusterList([]*cmv1.Cluster{mockClusterReady})
+
+		BeforeEach(func() {
+			testRuntime.InitRuntime()
+			// Reset flag to avoid any side effect on other tests
+			Cmd.Flags().Set("output", "")
+		})
+
+		It("Warning with zero results", func() {
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusNotFound, ""))
+			stdout, stderr, err := test.RunWithOutputCaptureAndArgv(runWithRuntime, testRuntime.RosaRuntime,
+				Cmd, &[]string{})
+			Expect(err).To(BeNil())
+			Expect(stderr).To(Equal(""))
+			Expect(stdout).To(Equal("INFO: There are no break glass credentials for cluster 'cluster1'\n"))
+		})
+	})
+})


### PR DESCRIPTION
```
./rosa revoke break-glass-credentials -c magchen-hcp2
I: There are no break glass credentials for cluster 'magchen-hcp2'
```