### PR TITLE
OCM-8112 | fix: Force users into interactive mode if omitting a name when creating a KubeletConfig for HCP clusters

### DIFF
--- a/cmd/create/kubeletconfig/cmd.go
+++ b/cmd/create/kubeletconfig/cmd.go
@@ -82,7 +82,7 @@ func CreateKubeletConfigRunner(options *KubeletConfigOptions) rosa.CommandRunner
 					"You should edit it via 'rosa edit kubeletconfig'", clusterKey)
 			}
 		} else {
-			options.Name, err = PromptForName(options.Name)
+			options.Name, err = PromptForName(options.Name, true)
 			if err != nil {
 				return err
 			}

--- a/cmd/create/kubeletconfig/cmd_test.go
+++ b/cmd/create/kubeletconfig/cmd_test.go
@@ -124,30 +124,6 @@ var _ = Describe("create kubeletconfig", func() {
 				ContainSubstring("Failed getting KubeletConfig for cluster 'cluster'"))
 		})
 
-		It("Returns an error if no name specified for HCP KubeletConfig", func() {
-			cluster := MockCluster(func(c *cmv1.ClusterBuilder) {
-				c.State(cmv1.ClusterStateReady)
-				b := cmv1.HypershiftBuilder{}
-				b.Enabled(true)
-				c.Hypershift(&b)
-
-			})
-
-			t.ApiServer.AppendHandlers(
-				testing.RespondWithJSON(
-					http.StatusOK, FormatClusterList([]*cmv1.Cluster{cluster})))
-			t.SetCluster("cluster", cluster)
-
-			options := NewKubeletConfigOptions()
-			options.PodPidsLimit = 10000
-
-			runner := CreateKubeletConfigRunner(options)
-
-			err := runner(context.Background(), t.RosaRuntime, nil, nil)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("The --name flag is required for Hosted Control Plane clusters."))
-		})
-
 		It("Creates the KubeletConfig for HCP clusters", func() {
 			cluster := MockCluster(func(c *cmv1.ClusterBuilder) {
 				c.State(cmv1.ClusterStateReady)

--- a/cmd/describe/kubeletconfig/cmd.go
+++ b/cmd/describe/kubeletconfig/cmd.go
@@ -73,7 +73,7 @@ func DescribeKubeletConfigRunner(options *KubeletConfigOptions) rosa.CommandRunn
 		var exists bool
 
 		if cluster.Hypershift().Enabled() {
-			options.Name, err = PromptForName(options.Name)
+			options.Name, err = PromptForName(options.Name, false)
 			if err != nil {
 				return err
 			}

--- a/cmd/dlt/kubeletconfig/cmd.go
+++ b/cmd/dlt/kubeletconfig/cmd.go
@@ -75,7 +75,7 @@ func DeleteKubeletConfigRunner(options *KubeletConfigOptions) rosa.CommandRunner
 		}
 
 		if cluster.Hypershift().Enabled() {
-			options.Name, err = PromptForName(options.Name)
+			options.Name, err = PromptForName(options.Name, false)
 			if err != nil {
 				return err
 			}

--- a/cmd/edit/kubeletconfig/cmd.go
+++ b/cmd/edit/kubeletconfig/cmd.go
@@ -81,7 +81,7 @@ func EditKubeletConfigRunner(options *KubeletConfigOptions) rosa.CommandRunner {
 		var exists bool
 
 		if cluster.Hypershift().Enabled() {
-			options.Name, err = PromptForName(options.Name)
+			options.Name, err = PromptForName(options.Name, false)
 			if err != nil {
 				return err
 			}

--- a/pkg/kubeletconfig/config.go
+++ b/pkg/kubeletconfig/config.go
@@ -53,9 +53,10 @@ func GetInteractiveInput(maxPidsLimit int, kubeletConfig *v1.KubeletConfig) inte
 	}
 }
 
-func PromptForName(requestedName string) (string, error) {
+func PromptForName(requestedName string, forceInteractive bool) (string, error) {
 
-	if requestedName == "" && interactive.Enabled() {
+	if requestedName == "" && forceInteractive {
+		interactive.Enable()
 		return interactive.GetString(interactive.Input{
 			Question: InteractiveNameHelpPrompt,
 			Help:     InteractiveNameHelp,


### PR DESCRIPTION
If users omit the `--name` flag when creating a KubeletConfig for HCP clusters, this will force them into interactive mode. This aligns us with other commands e.g `create machinepool`.