### PR TITLE
OCM-8059 | fix: Allow users to use positional args for specifying the name of kubeletconfig

### DIFF
--- a/cmd/create/kubeletconfig/cmd.go
+++ b/cmd/create/kubeletconfig/cmd.go
@@ -48,7 +48,7 @@ func NewCreateKubeletConfigCommand() *cobra.Command {
 		Long:    long,
 		Example: example,
 		Run:     rosa.DefaultRunner(rosa.RuntimeWithOCM(), CreateKubeletConfigRunner(options)),
-		Args:    cobra.NoArgs,
+		Args:    cobra.MaximumNArgs(1),
 	}
 
 	options.AddAllFlags(cmd)
@@ -59,6 +59,8 @@ func NewCreateKubeletConfigCommand() *cobra.Command {
 
 func CreateKubeletConfigRunner(options *KubeletConfigOptions) rosa.CommandRunner {
 	return func(ctx context.Context, r *rosa.Runtime, command *cobra.Command, args []string) error {
+
+		options.BindFromArgs(args)
 		clusterKey := r.GetClusterKey()
 		cluster, err := r.OCMClient.GetCluster(r.GetClusterKey(), r.Creator)
 		if err != nil {

--- a/cmd/describe/kubeletconfig/cmd.go
+++ b/cmd/describe/kubeletconfig/cmd.go
@@ -50,7 +50,7 @@ func NewDescribeKubeletConfigCommand() *cobra.Command {
 		Long:    long,
 		Example: example,
 		Run:     rosa.DefaultRunner(rosa.RuntimeWithOCM(), DescribeKubeletConfigRunner(options)),
-		Args:    cobra.NoArgs,
+		Args:    cobra.MaximumNArgs(1),
 	}
 
 	ocm.AddClusterFlag(cmd)
@@ -63,6 +63,7 @@ func NewDescribeKubeletConfigCommand() *cobra.Command {
 func DescribeKubeletConfigRunner(options *KubeletConfigOptions) rosa.CommandRunner {
 	return func(ctx context.Context, r *rosa.Runtime, command *cobra.Command, args []string) error {
 
+		options.BindFromArgs(args)
 		cluster, err := r.OCMClient.GetCluster(r.GetClusterKey(), r.Creator)
 		if err != nil {
 			return err

--- a/cmd/dlt/kubeletconfig/cmd.go
+++ b/cmd/dlt/kubeletconfig/cmd.go
@@ -52,7 +52,7 @@ func NewDeleteKubeletConfigCommand() *cobra.Command {
 		Long:    long,
 		Example: example,
 		Run:     rosa.DefaultRunner(rosa.RuntimeWithOCM(), DeleteKubeletConfigRunner(options)),
-		Args:    cobra.NoArgs,
+		Args:    cobra.MaximumNArgs(1),
 	}
 	ocm.AddClusterFlag(cmd)
 	confirm.AddFlag(cmd.Flags())
@@ -62,7 +62,7 @@ func NewDeleteKubeletConfigCommand() *cobra.Command {
 
 func DeleteKubeletConfigRunner(options *KubeletConfigOptions) rosa.CommandRunner {
 	return func(ctx context.Context, r *rosa.Runtime, command *cobra.Command, args []string) error {
-
+		options.BindFromArgs(args)
 		cluster, err := r.OCMClient.GetCluster(r.GetClusterKey(), r.Creator)
 		if err != nil {
 			return err

--- a/cmd/edit/kubeletconfig/cmd.go
+++ b/cmd/edit/kubeletconfig/cmd.go
@@ -54,7 +54,7 @@ func NewEditKubeletConfigCommand() *cobra.Command {
 		Long:    long,
 		Example: example,
 		Run:     rosa.DefaultRunner(rosa.RuntimeWithOCM(), EditKubeletConfigRunner(options)),
-		Args:    cobra.NoArgs,
+		Args:    cobra.MaximumNArgs(1),
 	}
 
 	flags := cmd.Flags()
@@ -68,6 +68,7 @@ func NewEditKubeletConfigCommand() *cobra.Command {
 
 func EditKubeletConfigRunner(options *KubeletConfigOptions) rosa.CommandRunner {
 	return func(ctx context.Context, r *rosa.Runtime, command *cobra.Command, args []string) error {
+		options.BindFromArgs(args)
 		cluster, err := r.OCMClient.GetCluster(r.GetClusterKey(), r.Creator)
 		if err != nil {
 			return err

--- a/pkg/kubeletconfig/options.go
+++ b/pkg/kubeletconfig/options.go
@@ -36,6 +36,16 @@ func (k *KubeletConfigOptions) AddAllFlags(cmd *cobra.Command) {
 	k.AddNameFlag(cmd)
 }
 
+// BindFromArgs allows the user to use positional args for the name. The --name flag
+// will take precedence
+func (k *KubeletConfigOptions) BindFromArgs(args []string) {
+	if k.Name == "" {
+		if len(args) > 0 {
+			k.Name = args[0]
+		}
+	}
+}
+
 func (k *KubeletConfigOptions) ValidateForHypershift() error {
 	if k.Name == "" {
 		return fmt.Errorf("The --name flag is required for Hosted Control Plane clusters.")

--- a/pkg/kubeletconfig/options_test.go
+++ b/pkg/kubeletconfig/options_test.go
@@ -55,6 +55,19 @@ var _ = Describe("KubeletConfigOptions", func() {
 		err := options.ValidateForHypershift()
 		Expect(err).NotTo(HaveOccurred())
 	})
+
+	It("Binds name from args if name not set by flag", func() {
+		options := NewKubeletConfigOptions()
+		options.BindFromArgs([]string{"bob"})
+		Expect(options.Name).To(Equal("bob"))
+	})
+
+	It("Does not bind name from args if set by --name flag", func() {
+		options := NewKubeletConfigOptions()
+		options.Name = "foo"
+		options.BindFromArgs([]string{"bob"})
+		Expect(options.Name).To(Equal("foo"))
+	})
 })
 
 func assertFlag(flag *flag.Flag, name string, usage string) {


### PR DESCRIPTION
This PR updates the `rosa create kubeletconfig`, `rosa edit kubeletconfig`, `rosa delete kubeletconfig` and `rosa describe kubeletconfig` commands to allow the user to specify the name of the kubeletconfig as a positional arg on the command line.

With this change, the following is now valid as an example:

- `rosa describe kubeletconfig -c mycluster high-pids`

The `--name` flag will always take precedence, so in the following, the name of the kubeletconfig will be `foo`

- `rosa create kubeletconfig -c mycluster --name foo bob`

This aligns us with the UX of other commands.