### PR TITLE
OCM-8121 | fix: Show correct describe message for expired breakglass

### DIFF
--- a/cmd/describe/breakglasscredential/cmd.go
+++ b/cmd/describe/breakglasscredential/cmd.go
@@ -114,6 +114,12 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command, argv []string) error {
 		return nil
 	}
 
+	if breakGlassCredentialConfig.Status() == cmv1.BreakGlassCredentialStatusExpired {
+		r.Reporter.Warnf("Break glass credential '%s' for cluster '%s' is now expired.",
+			breakGlassCredentialId, clusterKey)
+		return nil
+	}
+
 	if output.HasFlag() {
 		var formattedOutput map[string]interface{}
 		formattedOutput, err = breakglasscredential.FormatBreakGlassCredentialOutput(breakGlassCredentialConfig)

--- a/cmd/describe/breakglasscredential/cmd_test.go
+++ b/cmd/describe/breakglasscredential/cmd_test.go
@@ -94,5 +94,22 @@ var _ = Describe("Break glass credential", func() {
 			Expect(stderr).To(Equal("WARN: Break glass credential 'test-id' for cluster 'cluster1' has been revoked.\n"))
 			Expect(stdout).To(Equal(""))
 		})
+
+		It("Pass a break glass credential id through parameter and it is found, but it is now expired", func() {
+			args.id = breakGlassCredentialId
+			const breakGlassCredentialId = "test-id-1"
+			revokedCredential, err := cmv1.NewBreakGlassCredential().
+				ID(breakGlassCredentialId).Username("username").Status(cmv1.BreakGlassCredentialStatusExpired).
+				Build()
+			Expect(err).To(BeNil())
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK,
+				test.FormatResource(revokedCredential)))
+			stdout, stderr, err := test.RunWithOutputCaptureAndArgv(runWithRuntime, testRuntime.RosaRuntime,
+				Cmd, &[]string{})
+			Expect(err).To(BeNil())
+			Expect(stderr).To(Equal("WARN: Break glass credential 'test-id' for cluster 'cluster1' is now expired.\n"))
+			Expect(stdout).To(Equal(""))
+		})
 	})
 })


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-8121
```
➜  rosa git:(OCM-8121) ✗ ./rosa list break-glass-credentials -c magchen-hcp2
ID                                USERNAME                              STATUS
2baig810g13ubbnspfehadar43v1jdou  39ceefd8-1461-11ef-a9e0-1eb8df358bc1  expired
➜  rosa git:(OCM-8121) ✗ ./rosa describe break-glass-credential 2baig810g13ubbnspfehadar43v1jdou -c magchen-hcp2 --kubeconfig

W: Break glass credential '2baig810g13ubbnspfehadar43v1jdou' for cluster 'magchen-hcp2' is now expired.
➜  rosa git:(OCM-8121) ✗ 
```