### PR TITLE
OCM-6569 | fix: Hide the duplicate output of operator roles

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1790,7 +1790,7 @@ func run(cmd *cobra.Command, _ []string) {
 				os.Exit(1)
 			} else {
 				err = ocm.ValidateOperatorRolesMatchOidcProvider(r.Reporter, awsClient, computedOperatorIamRoleList,
-					oidcConfig.IssuerUrl(), ocm.GetVersionMinor(version), expectedOperatorRolePath, managedPolicies)
+					oidcConfig.IssuerUrl(), ocm.GetVersionMinor(version), expectedOperatorRolePath, managedPolicies, true)
 				if err != nil {
 					r.Reporter.Errorf("%v", err)
 					os.Exit(1)

--- a/cmd/create/operatorroles/by_clusterkey.go
+++ b/cmd/create/operatorroles/by_clusterkey.go
@@ -434,5 +434,5 @@ func validateOperatorRolesMatchOidcProvider(r *rosa.Runtime, cluster *cmv1.Clust
 	}
 	return ocm.ValidateOperatorRolesMatchOidcProvider(r.Reporter, r.AWSClient,
 		operatorRolesList, cluster.AWS().STS().OidcConfig().IssuerUrl(),
-		ocm.GetVersionMinor(cluster.Version().RawID()), expectedPath, cluster.AWS().STS().ManagedPolicies())
+		ocm.GetVersionMinor(cluster.Version().RawID()), expectedPath, cluster.AWS().STS().ManagedPolicies(), false)
 }

--- a/cmd/create/operatorroles/by_prefix.go
+++ b/cmd/create/operatorroles/by_prefix.go
@@ -165,7 +165,7 @@ func handleOperatorRoleCreationByPrefix(r *rosa.Runtime, env string,
 		os.Exit(1)
 	}
 	err = ocm.ValidateOperatorRolesMatchOidcProvider(r.Reporter, r.AWSClient,
-		operatorRolesList, oidcConfig.IssuerUrl(), "4.0", path, managedPolicies)
+		operatorRolesList, oidcConfig.IssuerUrl(), "4.0", path, managedPolicies, true)
 	if err != nil && !awserr.IsNoSuchEntityException(err) {
 		r.Reporter.Errorf("%v", err)
 		os.Exit(1)

--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -854,13 +854,14 @@ func (c *Client) GetVersionsList(channelGroup string, defaultFirst bool) ([]stri
 
 func ValidateOperatorRolesMatchOidcProvider(reporter *reporter.Object, awsClient aws.Client,
 	operatorIAMRoleList []OperatorIAMRole, oidcEndpointUrl string,
-	clusterVersion string, expectedOperatorRolePath string, accountRolesHasManagedPolicies bool) error {
+	clusterVersion string, expectedOperatorRolePath string,
+	accountRolesHasManagedPolicies bool, logOperatorRoles bool) error {
 	operatorIAMRoles := operatorIAMRoleList
 	parsedUrl, err := url.Parse(oidcEndpointUrl)
 	if err != nil {
 		return err
 	}
-	printInfo := reporter.IsTerminal() && !output.HasFlag()
+	printInfo := reporter.IsTerminal() && !output.HasFlag() && logOperatorRoles
 	if printInfo {
 		reporter.Infof("Reusable OIDC Configuration detected. Validating trusted relationships to operator roles: ")
 	}


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-6569