### PR TITLE
OCM-6900 | chore: bump version to 1.2.41

### DIFF
--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,7 +18,7 @@ limitations under the License.
 
 package info
 
-const Version = "1.2.40"
+const Version = "1.2.41"
 
 // Build contains the short Git SHA of the CLI at the point it was build. Set via `-ldflags` at build time
 var Build = "local"


### PR DESCRIPTION
*WHAT*
Bumping version to current release +1 for master branch