### PR TITLE
SDA-7166 | test: automate id:56782 removed validation checkpoint

### DIFF
--- a/tests/e2e/test_rosacli_node_pool.go
+++ b/tests/e2e/test_rosacli_node_pool.go
@@ -168,13 +168,6 @@ var _ = Describe("Edit nodepool",
 				npList, err = machinePoolService.ListAndReflectNodePools(clusterID)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(npList.Nodepool(nodePoolName)).To(BeNil())
-
-				if len(npList.NodePools) == 1 {
-					By("Try to delete remaining nodepool")
-					output, err = machinePoolService.DeleteMachinePool(clusterID, npList.NodePools[0].ID)
-					Expect(err).To(HaveOccurred())
-					Expect(rosaClient.Parser.TextData.Input(output).Parse().Tip()).Should(ContainSubstring("Failed to delete machine pool '%s' on hosted cluster '%s': The last node pool can not be deleted from a cluster.", npList.NodePools[0].ID, clusterID))
-				}
 			})
 
 		It("can create nodepool with defined subnets - [id:60202]",


### PR DESCRIPTION
$ ginkgo --focus 56782 tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.14.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: e2e tests suite - /home/aaraj/ocm-forked-code/rosa/tests/e2e
===========================================================================
Random Seed: 1716200842

Will run 1 of 75 specs
SSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 75 Specs in 541.891 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 74 Skipped
PASS

Ginkgo ran 1 suite in 9m7.369469658s
Test Suite Passed
