### PR TITLE
OCM-8152 | test: automated id:38816 List cluster ROSA cli will work

### DIFF
--- a/tests/e2e/test_rosacli_list.go
+++ b/tests/e2e/test_rosacli_list.go
@@ -1,0 +1,75 @@
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/rosa/tests/ci/labels"
+	"github.com/openshift/rosa/tests/utils/config"
+	"github.com/openshift/rosa/tests/utils/exec/rosacli"
+	"github.com/openshift/rosa/tests/utils/log"
+)
+
+var _ = Describe("List resources",
+	labels.Day2,
+	labels.FeatureMachinepool,
+	labels.NonHCPCluster,
+	func() {
+		defer GinkgoRecover()
+		var (
+			clusterID  string
+			rosaClient *rosacli.Client
+		)
+
+		BeforeEach(func() {
+			By("Get the cluster")
+			clusterID = config.GetClusterID()
+			Expect(clusterID).ToNot(Equal(""), "ClusterID is required. Please export CLUSTER_ID")
+
+			By("Init the client")
+			rosaClient = rosacli.NewClient()
+		})
+
+		AfterEach(func() {
+			By("Clean remaining resources")
+			rosaClient.CleanResources(clusterID)
+
+		})
+
+		It("List cluster via ROSA cli will work well - [id:38816]",
+			labels.Medium,
+			func() {
+				var (
+					clusterData    []string
+					ClusterService = rosaClient.Cluster
+				)
+
+				By("List all clusters")
+				clusterList, _, err := ClusterService.ListCluster()
+				Expect(err).To(BeNil())
+				if err != nil {
+					log.Logger.Errorf("Failed to fetch clusters: %v", err)
+					return
+				}
+
+				for _, it := range clusterList.ListCluster {
+					clusterData = append(clusterData, it.ID)
+				}
+				Expect(err).To(BeNil())
+				Expect(clusterData).Should(ContainElement(clusterID))
+
+				clusterData = []string{}
+				By("List clusters with '--all' flag")
+				clusterList, _, err = ClusterService.ListCluster("--all")
+				Expect(err).To(BeNil())
+				if err != nil {
+					log.Logger.Errorf("Failed to fetch clusters: %v", err)
+					return
+				}
+				for _, it := range clusterList.ListCluster {
+					clusterData = append(clusterData, it.ID)
+				}
+				Expect(err).To(BeNil())
+				Expect(clusterData).Should(ContainElement(clusterID))
+			})
+	})


### PR DESCRIPTION
[OCM-8152](https://issues.redhat.com/browse/OCM-8152) QE] Automate OCP-38816 [rosacli] List cluster via ROSA cli will work well

$ ginkgo --focus 38816 tests/e2e
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.11.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: e2e tests suite - /home/akanni/OCP-Repository/rosa/tests/e2e
===========================================================================
Random Seed: 1716211140

Will run 1 of 76 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSS

Ran 1 of 76 Specs in 5.456 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 75 Skipped
PASS

Ginkgo ran 1 suite in 7.115914938s
Test Suite Passed
