### PR TITLE
OCM-8051 | test: Automated id:66372 create cluster with invalid volume sizes

### DIFF
--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -1,11 +1,14 @@
 package e2e
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/openshift/rosa/tests/ci/config"
 	"github.com/openshift/rosa/tests/ci/labels"
+	utilConfig "github.com/openshift/rosa/tests/utils/config"
 	"github.com/openshift/rosa/tests/utils/exec/rosacli"
 	"github.com/openshift/rosa/tests/utils/log"
 	"github.com/openshift/rosa/tests/utils/profilehandler"
@@ -29,5 +32,63 @@ var _ = Describe("Cluster preparation", labels.Feature.Cluster, func() {
 			Expect(err).ToNot(HaveOccurred())
 			client := rosacli.NewClient()
 			profilehandler.WaitForClusterReady(client, clusterDetail.ClusterID, config.Test.GlobalENV.ClusterWaitingTime)
+		})
+
+	It("Create cluster with invalid volume size [id:66372]",
+		labels.Medium,
+		labels.Runtime.Day1Negative,
+		func() {
+			minSize := 128
+			maxSize := 16384
+			// Setup
+			client := rosacli.NewClient()
+			rosaCommand, err := utilConfig.RetrieveClusterCreationCommand(config.Test.CreateCommandFile)
+			Expect(err).To(BeNil())
+			if !rosaCommand.CheckFlagExist("--worker-disk-size") {
+				rosaCommand.AddFlags("--worker-disk-size", "300GiB")
+			}
+
+			var values map[string]string
+			var cmd string
+
+			By("Try a worker disk size that's too small")
+			values = map[string]string{
+				"--worker-disk-size": fmt.Sprintf("%dGiB", minSize-1),
+			}
+			rosaCommand.ReplaceFlagValue(values)
+			cmd = rosaCommand.GetFullCommand()
+			out, err := client.Runner.RunCMD([]string{"/bin/sh", "-c", cmd})
+			stdout := client.Parser.TextData.Input(out).Parse().Tip()
+			Expect(stdout).To(ContainSubstring("Invalid root disk size: %d GiB. Must be between %d GiB and %d GiB.", minSize-1, minSize, maxSize))
+
+			By("Try a worker disk size that's too big")
+			values = map[string]string{
+				"--worker-disk-size": fmt.Sprintf("%dGiB", maxSize+1),
+			}
+			rosaCommand.ReplaceFlagValue(values)
+			cmd = rosaCommand.GetFullCommand()
+			out, err = client.Runner.RunCMD([]string{"/bin/sh", "-c", cmd})
+			stdout = client.Parser.TextData.Input(out).Parse().Tip()
+			Expect(stdout).To(ContainSubstring("Invalid root disk size: %d GiB. Must be between %d GiB and %d GiB.", maxSize+1, minSize, maxSize))
+
+			By("Try a worker disk size that's negative")
+			values = map[string]string{
+				"--worker-disk-size": "-1GiB",
+			}
+			rosaCommand.ReplaceFlagValue(values)
+			cmd = rosaCommand.GetFullCommand()
+			out, err = client.Runner.RunCMD([]string{"/bin/sh", "-c", cmd})
+			stdout = client.Parser.TextData.Input(out).Parse().Tip()
+			Expect(stdout).To(ContainSubstring("Expected a valid machine pool root disk size value '-1GiB': invalid disk size: '-1Gi'. positive size required"))
+
+			By("Try a worker disk size that's a string")
+			values = map[string]string{
+				"--worker-disk-size": "invalid",
+			}
+			rosaCommand.ReplaceFlagValue(values)
+			cmd = rosaCommand.GetFullCommand()
+			out, err = client.Runner.RunCMD([]string{"/bin/sh", "-c", cmd})
+			stdout = client.Parser.TextData.Input(out).Parse().Tip()
+			Expect(stdout).To(ContainSubstring("Expected a valid machine pool root disk size value 'invalid': invalid disk size format: 'invalid'. accepted units are Giga or Tera in the form of g, G, GB, GiB, Gi, t, T, TB, TiB, Ti"))
 		})
 })


### PR DESCRIPTION
output:
```
$ TEST_PROFILE=rosa-upgrade-z-stream ginkgo -focus 66372 tests/e2e/
Running Suite: e2e tests suite - /home/jericho/work/repos/rosa/tests/e2e
========================================================================
Random Seed: 1716222234

Will run 1 of 78 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 78 Specs in 124.927 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 77 Skipped
PASS

Ginkgo ran 1 suite in 2m9.195225649s
Test Suite Passed
```