### PR TITLE
OCM-8142 | test: Fix the rosa-private-link and rosa-non-sts-advanced creation issue

### DIFF
--- a/tests/ci/data/profiles/rosa-classic.yaml
+++ b/tests/ci/data/profiles/rosa-classic.yaml
@@ -111,7 +111,7 @@ profiles:
     instance_type: "r5.xlarge"
     hcp: false
     sts: false
-    byo_vpc: true
+    byo_vpc: false
     private_link: false
     private: false
     etcd_encryption: true


### PR DESCRIPTION
```
2024-05-21T19:26:54+08:00 - INFO : Running command: rosa describe cluster -c 2bd2l8jg9tofg8eufp4d79tcvsjptivv
  Got need redacted string from log match regex (arn:aws:[a-z]+:[a-z0-9-]*:)([0-9]{12})(:)
  Got need redacted string from log match regex (AWS Account:\s*)([0-9]{12})([\n\\n].)
  2024-05-21T19:26:59+08:00 - DEBUG : Get Combining Stdout and Stder is :

  Name:                       xueli-wiahroj31
  Domain Prefix:              xueli-wiahroj31
  Display Name:               xueli-wiahroj31
  ID:                         2bd2l8jg9tofg8eufp4d79tcvsjptivv
  External ID:                
  Control Plane:              Customer Hosted
  OpenShift Version:          
  Channel Group:              candidate
  DNS:                        Not ready
  AWS Account:                *************
  API URL:                    
  Console URL:                
  Region:                     ap-northeast-1
  Multi-AZ:                   true

  Nodes:
   - Control plane:           3
   - Infra:                   3
   - Compute (Autoscaled):    3-6
  Network:
   - Type:                    OVNKubernetes
   - Service CIDR:            172.30.0.0/16
   - Machine CIDR:            10.0.0.0/16
   - Pod CIDR:                10.128.0.0/14
   - Host Prefix:             /23
   - Subnets:                 subnet-0e91c6e49545ae894, subnet-056776c3730a394ae, subnet-0ef953c5f3e568afc
  EC2 Metadata Http Tokens:   optional
  Role (STS) ARN:             arn:aws:iam::*************:role/test/xueli-wiahroj31-Installer-Role
  Support Role ARN:           arn:aws:iam::*************:role/test/xueli-wiahroj31-Support-Role
  Instance IAM Roles:
   - Control plane:           arn:aws:iam::*************:role/test/xueli-wiahroj31-ControlPlane-Role
   - Worker:                  arn:aws:iam::*************:role/test/xueli-wiahroj31-Worker-Role
  Operator IAM Roles:
   - arn:aws:iam::*************:role/test/xueli-wiahroj31-openshift-cloud-credential-operator-cloud-creden
   - arn:aws:iam::*************:role/test/xueli-wiahroj31-openshift-image-registry-installer-cloud-credent
   - arn:aws:iam::*************:role/test/xueli-wiahroj31-openshift-ingress-operator-cloud-credentials
   - arn:aws:iam::*************:role/test/xueli-wiahroj31-openshift-cluster-csi-drivers-ebs-cloud-credenti
   - arn:aws:iam::*************:role/test/xueli-wiahroj31-openshift-cloud-network-config-controller-cloud-
   - arn:aws:iam::*************:role/test/xueli-wiahroj31-openshift-machine-api-aws-cloud-credentials
  Managed Policies:           No
  State:                      pending (Preparing account)
  Private:                    Yes
  Delete Protection:          Disabled
  Created:                    May 21 2024 10:34:15 UTC
  User Workload Monitoring:   Enabled
  Details Page:               https://qaprodauth.console.redhat.com/openshift/details/s/2gm0swzTuSuG5rqwRYIF8BZvMaW
  OIDC Endpoint URL:          https://oidc.os1.devshift.org/2bd2jr3p0897ige4m2h4trd6d7ngobcu (Managed)
```