### PR TITLE
OCM-8136 | fix: Delete should exit 1 if fails

### DIFF
--- a/cmd/dlt/machinepool/cmd.go
+++ b/cmd/dlt/machinepool/cmd.go
@@ -18,6 +18,7 @@ package machinepool
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -65,5 +66,6 @@ func run(_ *cobra.Command, argv []string) {
 	err := service.DeleteMachinePool(r, machinePoolId, clusterKey, cluster)
 	if err != nil {
 		r.Reporter.Errorf("Error deleting machinepool: %v", err)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
```
./rosa delete machinepool -c magchen-hcp workers -y
E: Error deleting machinepool: Failed to delete machine pool 'workers' on hosted cluster 'magchen-hcp': The last node pool can not be deleted from a cluster.
echo $?
1
```

https://issues.redhat.com/browse/OCM-8136