### PR TITLE
OCM-8221 | test: fixed id:43067,70859,45161,43070,61322 and enhanceme…

### DIFF
--- a/tests/utils/exec/rosacli/version_service.go
+++ b/tests/utils/exec/rosacli/version_service.go
@@ -2,6 +2,7 @@ package rosacli
 
 import (
 	"bytes"
+	"fmt"
 	"sort"
 
 	"github.com/Masterminds/semver"
@@ -239,6 +240,26 @@ func (vl *OpenShiftVersionTableList) FilterVersionsLowerThan(version string) (nv
 		OpenShiftVersions: filteredVersions,
 	}
 
+	return
+}
+
+func (vl *OpenShiftVersionTableList) DefaultVersion() (defaultVersion *OpenShiftVersionTableOutput) {
+	for _, version := range vl.OpenShiftVersions {
+		if version.Default == "yes" {
+			return version
+		}
+	}
+	return vl.OpenShiftVersions[0]
+}
+
+func (vl *OpenShiftVersionTableOutput) MajorMinor() (major int64, minor int64, majorMinorVersion string, err error) {
+	var semverVersion *semver.Version
+	if semverVersion, err = semver.NewVersion(vl.Version); err != nil {
+		return
+	}
+	major = semverVersion.Major()
+	minor = semverVersion.Minor()
+	majorMinorVersion = fmt.Sprintf("%d.%d", major, minor)
 	return
 }
 


### PR DESCRIPTION
[OCM-8221](https://issues.redhat.com//browse/OCM-8221) | test: fixed id:43067,70859,45161,43070,61322 and enhancement for 44511,45176
fix:
43070/61322/44511/45176 : to use dynamic version
43067 : update the error message
70859 : Add condition of checking if the cluster is reusing oidcConfigID
45161 : remove base-domain flag to avoid its conflict

logs: https://privatebin.corp.redhat.com/?3a0245e924c18cf6#AENDhTF5XE5BQDYr5KsEZ9MJLqiXH57abKx5o2H7Z98j
