### PR TITLE
OCM-8072 | test: automated ids:60082,42188

### DIFF
--- a/tests/e2e/dummy_test.go
+++ b/tests/e2e/dummy_test.go
@@ -26,8 +26,8 @@ var _ = Describe("ROSA CLI Test", func() {
 	Describe("Profile test", func() {
 		It("ProfileParserTest", func() {
 			profile := PH.LoadProfileYamlFileByENV()
-			log.Logger.Infof("Got configured profile prefix: %v", *profile)
-			log.Logger.Infof("Got configured profile: %v", profile.NamePrefix)
+			log.Logger.Infof("Got configured profile: %v", *profile)
+			log.Logger.Infof("Got configured profile prefix: %v", profile.NamePrefix)
 			log.Logger.Infof("Got configured cluster profile: %v", *profile.ClusterConfig)
 			log.Logger.Infof("Got configured account role profile: %v", *profile.AccountRoleConfig)
 		})


### PR DESCRIPTION
Tests succeed locally on clusters that have the prerequisites and fail on clusters that do not:
##Success for 60082 with kms key cluster##
```
oaharoni-mac:rosa oaharoni$ export CLUSTER_ID=oa-byok3
oaharoni-mac:rosa oaharoni$ ginkgo -focus id:60082 tests/e2e/
Running Suite: e2e tests suite - /Users/oaharoni/rosa_workspace/rosa/tests/e2e
==============================================================================
Random Seed: 1716392444

Will run 1 of 79 specs
SSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 79 Specs in 0.900 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 78 Skipped
PASS

Ginkgo ran 1 suite in 4.311993292s
Test Suite Passed
```
##Failure for 60082 with non-kms key cluster##
```
oaharoni-mac:rosa oaharoni$ export CLUSTER_ID=oa-0521-etcd
oaharoni-mac:rosa oaharoni$ ginkgo -focus id:60082 tests/e2e/
Running Suite: e2e tests suite - /Users/oaharoni/rosa_workspace/rosa/tests/e2e
==============================================================================
Random Seed: 1716392393

Will run 1 of 79 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
• [FAILED] [1.308 seconds]
Verify [It] bring your own kms key functionality works on cluster creation - [id:60082] [day1-post, Critical, NonHCPCluster]
/Users/oaharoni/rosa_workspace/rosa/tests/e2e/test_rosacli_verify.go:202

  Timeline >>
  STEP: Get the cluster @ 05/22/24 11:39:56.63
  STEP: Init the client @ 05/22/24 11:39:56.63
  STEP: Confirm current cluster profile uses kms keys @ 05/22/24 11:39:56.63
  2024-05-22T11:39:56-04:00 - INFO : Loaded cluster profile configuration from origional profile rosa-advanced : {candidate rosa-advanced  us-west-2 latest 0x140003e4d60 0x14000164790}
  2024-05-22T11:39:56-04:00 - INFO : Loaded cluster profile configuration from origional cluster rosa-advanced : { required r5.xlarge  unmanaged   3 0 54 150 0 false false true true true true true false false true false true false true true true true true false false true true false false}
  2024-05-22T11:39:56-04:00 - INFO : Loaded cluster profile configuration from origional account-roles rosa-advanced : {/test/ arn:aws:iam::aws:policy/AdministratorAccess}
  STEP: Check the help message of 'rosa create cluster -h' @ 05/22/24 11:39:56.632
  2024-05-22T11:39:56-04:00 - INFO : Running command: rosa create cluster -c oa-0521-etcd --dry-run -h
  Got need redacted string from log match regex (--cluster-admin-password\s+)([^\n\t\\\s]+)([\n\\\s]*)
  Got need redacted string from log match regex (--billing-account\s+)([^\n\t\\\s]+)([\n\\\s]*)
  2024-05-22T11:39:56-04:00 - DEBUG : Get Combining Stdout and Stder is :
  Create cluster.

  Usage:
    rosa create cluster [flags]

  Examples:
    # Create a cluster named "mycluster"
    rosa create cluster --cluster-name=mycluster

    # Create a cluster in the us-east-2 region
    rosa create cluster --cluster-name=mycluster --region=us-east-2

  Flags:
    -c, --cluster-name string                                   The unique name of the cluster. The name can be used as the identifier of the cluster. The maximum length is 54 characters.Once set, the cluster name cannot be changed
        --domain-prefix string                                  An optional unique domain prefix of the cluster. This will be used when generating a sub-domain for your cluster on openshiftapps.com. It must be unique per organization and consist of lowercase alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character. The maximum length is 15 characters. Once set, the cluster domain prefix cannot be changed
        --sts                                                   Use AWS Security Token Service (STS) instead of IAM credentials to deploy your cluster.
        --non-sts                                               Use legacy method of creating clusters (IAM mode).
        --mint-mode                                             Use legacy method of creating clusters (IAM mode). This is an alias for --non-sts.
        --role-arn string                                       The Amazon Resource Name of the role that OpenShift Cluster Manager will assume to create the cluster.
        --external-id string                                    An optional unique identifier that might be required when you assume a role in another account.
        --support-role-arn string                               The Amazon Resource Name of the role used by Red Hat SREs to enable access to the cluster account in order to provide support.
        --controlplane-iam-role-arn string                      The IAM role ARN that will be attached to control plane instances.
        --worker-iam-role-arn string                            The IAM role ARN that will be attached to worker instances.
        --operator-roles-prefix string                          Prefix to use for all IAM roles used by the operators needed in the OpenShift installer. Leave empty to use an auto-generated one.
        --oidc-config-id string                                 Registered OIDC Configuration ID to use for cluster creation
        --tags strings                                          Apply user defined tags to all resources created by ROSA in AWS. Tags are comma separated, for example: 'key value, foo bar'
        --multi-az                                              Deploy to multiple data centers.
        --region string                                         Use a specific AWS region, overriding the AWS_REGION environment variable.
        --version string                                        Version of OpenShift that will be used to install the cluster, for example "4.3.10"
        --etcd-encryption                                       Add etcd encryption. By default etcd data is encrypted at rest. This option configures etcd encryption on top of existing storage encryption.
        --fips                                                  Create cluster that uses FIPS Validated / Modules in Process cryptographic libraries.
        --http-proxy string                                     A proxy URL to use for creating HTTP connections outside the cluster. The URL scheme must be http.
        --https-proxy string                                    A proxy URL to use for creating HTTPS connections outside the cluster.
        --no-proxy strings                                      A comma-separated list of destination domain names, domains, IP addresses or other network CIDRs to exclude proxying.
        --additional-trust-bundle-file string                   A file contains a PEM-encoded X.509 certificate bundle that will be added to the nodes' trusted certificate store.
        --enable-customer-managed-key                           Enable to specify your KMS Key to encrypt EBS instance volumes. By default account’s default KMS key for that particular region is used.
        --kms-key-arn string                                    The key ARN is the Amazon Resource Name (ARN) of a CMK. It is a unique, fully qualified identifier for the CMK. A key ARN includes the AWS account, Region, and the key ID.
        --etcd-encryption-kms-arn string                        The etcd encryption kms key ARN is the key used to encrypt etcd. If set it will override etcd-encryption flag to true. It is a unique, fully qualified identifier for the CMK. A key ARN includes the AWS account, Region, and the key ID.
        --private-link                                          Provides private connectivity between VPCs, AWS services, and your on-premises networks, without exposing your traffic to the public internet.
        --ec2-metadata-http-tokens string                       Should cluster nodes use both v1 and v2 endpoints or just v2 endpoint of EC2 Instance Metadata Service (IMDS)
        --subnet-ids strings                                    The Subnet IDs to use when installing the cluster. Format should be a comma-separated list. Leave empty for installer provisioned subnet IDs.
        --availability-zones strings                            The availability zones to use when installing a non-BYOVPC cluster. Format should be a comma-separated list. Leave empty for the installer to pick availability zones
        --compute-machine-type string                           Instance type for the compute nodes. Determines the amount of memory and vCPU allocated to each compute node.
        --replicas int                                          Number of worker nodes to provision. Single zone clusters need at least 2 nodes, multizone clusters need at least 3 nodes. Hosted clusters require that the number of worker nodes be a multiple of the number of private subnets. (default 2)
        --enable-autoscaling                                    Enable autoscaling of compute nodes.
        --autoscaler-balance-similar-node-groups                Identify node groups with the same instance type and label set, and aim to balance respective sizes of those node groups.
        --autoscaler-skip-nodes-with-local-storage              If true cluster autoscaler will never delete nodes with pods with local storage, e.g. EmptyDir or HostPath.
        --autoscaler-log-verbosity int                          Autoscaler log level. Default is 1, 4 is a good option when trying to debug the autoscaler. (default 1)
        --autoscaler-max-pod-grace-period int                   Gives pods graceful termination time before scaling down, measured in seconds. (default 600)
        --autoscaler-pod-priority-threshold int                 The priority that a pod must exceed to cause the cluster autoscaler to deploy additional nodes. Expects an integer, can be negative. (default -10)
        --autoscaler-ignore-daemonsets-utilization              Should cluster-autoscaler ignore DaemonSet pods when calculating resource utilization for scaling down.
        --autoscaler-max-node-provision-time string             Maximum time cluster-autoscaler waits for node to be provisioned. Expects string comprised of an integer and time unit (ns|us|µs|ms|s|m|h), examples: 20m, 1h.
        --autoscaler-balancing-ignored-labels strings           A comma-separated list of label keys that cluster autoscaler should ignore when considering node group similarity.
        --autoscaler-max-nodes-total int                        Total amount of nodes that can exist in the cluster, including non-scaled nodes. (default 180)
        --autoscaler-min-cores int                              Minimum limit for the amount of cores to deploy in the cluster.
        --autoscaler-max-cores int                              Maximum limit for the amount of cores to deploy in the cluster. (default 11520)
        --autoscaler-min-memory int                             Minimum limit for the amount of memory, in GiB, in the cluster.
        --autoscaler-max-memory int                             Maximum limit for the amount of memory, in GiB, in the cluster. (default 230400)
        --autoscaler-gpu-limit stringArray                      Limit GPUs consumption. It should be comprised of 3 values separated with commas: the GPU hardware type, a minimal count for that type and a maximal count for that type. This option can be repeated multiple times in order to apply multiple restrictions for different GPU types. For example: --autoscaler-gpu-limit nvidia.com/gpu,0,10 --autoscaler-gpu-limit amd.com/gpu,1,5
        --autoscaler-scale-down-enabled                         Should cluster-autoscaler be able to scale down the cluster.
        --autoscaler-scale-down-unneeded-time string            Increasing value will make nodes stay up longer, waiting for pods to be scheduled while decreasing value will make nodes be deleted sooner.
        --autoscaler-scale-down-utilization-threshold float     Node utilization level, defined as sum of requested resources divided by capacity, below which a node can be considered for scale down. Value should be between 0 and 1. (default 0.5)
        --autoscaler-scale-down-delay-after-add string          After a scale-up, consider scaling down only after this amount of time.
        --autoscaler-scale-down-delay-after-delete string       After a scale-down, consider scaling down again only after this amount of time.
        --autoscaler-scale-down-delay-after-failure string      After a failing scale-down, consider scaling down again only after this amount of time.
        --min-replicas int                                      Minimum number of compute nodes. (default 2)
        --max-replicas int                                      Maximum number of compute nodes. (default 2)
        --worker-mp-labels string                               Labels for the worker machine pool. Format should be a comma-separated list of 'key=value'. This list will overwrite any modifications made to Node labels on an ongoing basis.
        --machine-cidr ipNet                                    Block of IP addresses used by OpenShift while installing the cluster, for example "10.0.0.0/16".
        --service-cidr ipNet                                    Block of IP addresses for services, for example "172.30.0.0/16".
        --pod-cidr ipNet                                        Block of IP addresses from which Pod IP addresses are allocated, for example "10.128.0.0/14".
        --host-prefix int                                       Subnet prefix length to assign to each individual node. For example, if host prefix is set to "23", then each node is assigned a /23 subnet out of the given CIDR.
        --private                                               Restrict master API endpoint and application routes to direct, private connectivity.
        --disable-scp-checks                                    Indicates if cloud permission checks are disabled when attempting installation of the cluster.
        --disable-workload-monitoring                           Enables you to monitor your own projects in isolation from Red Hat Site Reliability Engineer (SRE) platform metrics.
    -w, --watch                                                 Watch cluster installation logs.
        --dry-run                                               Simulate creating the cluster.
        --permissions-boundary string                           The ARN of the policy that is used to set the permissions boundary for the operator roles in STS clusters.
        --hosted-cp                                             Enable the use of Hosted Control Planes
        --worker-disk-size string                               Default worker machine pool root disk size with a **unit suffix** like GiB or TiB, e.g. 200GiB.
        --billing-account *************                                Account used for billing subscriptions purchased via the AWS marketplace
        --create-admin-user                                     Create cluster admin named "cluster-admin"
        --cluster-admin-password *************                         The password must
                                                                		- Be at least 14 characters (ASCII-standard) without whitespaces
                                                                		- Include uppercase letters, lowercase letters, and numbers or symbols (ASCII-standard characters only)
        --audit-log-arn string                                  The ARN of the role that is used to forward audit logs to AWS CloudWatch.
        --default-ingress-route-selector string                 Route Selector for ingress. Format should be a comma-separated list of 'key=value'. If no label is specified, all routes will be exposed on both routers. For legacy ingress support these are inclusion labels, otherwise they are treated as exclusion label.
        --default-ingress-excluded-namespaces string            Excluded namespaces for ingress. Format should be a comma-separated list 'value1, value2...'. If no values are specified, all namespaces will be exposed.
        --default-ingress-wildcard-policy string                Wildcard Policy for ingress. Options are WildcardsDisallowed,WildcardsAllowed. Default is 'WildcardsDisallowed'.
        --default-ingress-namespace-ownership-policy string     Namespace Ownership Policy for ingress. Options are Strict,InterNamespaceAllowed. Default is 'Strict'.
        --private-hosted-zone-id string                         ID assigned by AWS to private Route 53 hosted zone associated with intended shared VPC, e.g., 'Z05646003S02O1ENCDCSN'.
        --shared-vpc-role-arn string                            AWS IAM role ARN with a policy attached, granting permissions necessary to create and manage Route 53 DNS records in private Route 53 hosted zone associated with intended shared VPC.
        --base-domain string                                    Base DNS domain name previously reserved and matching the hosted zone name of the private Route 53 hosted zone associated with intended shared VPC, e.g., '1vo8.p1.openshiftapps.com'.
        --additional-compute-security-group-ids strings         The additional Security Group IDs to be added to the default worker machine pool. Format should be a comma-separated list.
        --additional-infra-security-group-ids strings           The additional Security Group IDs to be added to the infra worker nodes. Format should be a comma-separated list.
        --additional-control-plane-security-group-ids strings   The additional Security Group IDs to be added to the control plane nodes. Format should be a comma-separated list.
    -m, --mode string                                           How to perform the operation. Valid options are:
                                                                auto: Resource changes will be automatic applied using the current AWS account
                                                                
                                                                manual: Commands necessary to modify AWS resources will be output to be run manually
    -i, --interactive                                           Enable interactive mode.
    -o, --output string                                         Output format. Allowed formats are [json yaml]
    -y, --yes                                                   Automatically answer yes to confirm operation.
    -h, --help                                                  help for cluster

  Global Flags:
        --color string     Surround certain characters with escape sequences to display them in color on the terminal. Allowed options are [auto never always] (default "auto")
        --debug            Enable debug mode.
        --profile string   Use a specific AWS profile from your credential file.

  STEP: Confirm KMS key is present @ 05/22/24 11:39:56.668
  2024-05-22T11:39:56-04:00 - INFO : Running command: rosa describe cluster -c oa-0521-etcd --output json
  Got need redacted string from log match regex (arn:aws:[a-z]+:[a-z0-9-]*:)([0-9]{12})(:)
  2024-05-22T11:39:57-04:00 - DEBUG : Get Combining Stdout and Stder is :
  {
    "addons": {
      "items": []
    },
    "api": {
      "listening": "external",
      "url": "https://api.oa-0521-etcd.ds3y.s1.devshift.org:6443"
    },
    "aws": {
      "audit_log": {
        "role_arn": ""
      },
      "ec2_metadata_http_tokens": "optional",
      "private_link": false,
      "private_link_configuration": {},
      "tags": {
        "red-hat-clustertype": "rosa",
        "red-hat-managed": "true"
      }
    },
    "aws_infrastructure_access_role_grants": {
      "items": []
    },
    "billing_model": "standard",
    "byo_oidc": {
      "enabled": false
    },
    "ccs": {
      "disable_scp_checks": false,
      "enabled": true,
      "kind": "CCS"
    },
    "cloud_provider": {
      "href": "/api/clusters_mgmt/v1/cloud_providers/aws",
      "id": "aws",
      "kind": "CloudProviderLink"
    },
    "console": {
      "url": "https://console-openshift-console.apps.oa-0521-etcd.ds3y.s1.devshift.org"
    },
    "creation_timestamp": "2024-05-21T14:30:27Z",
    "delete_protection": {
      "enabled": false
    },
    "disable_user_workload_monitoring": false,
    "displayName": "oa-0521-etcd",
    "dns": {
      "base_domain": "ds3y.s1.devshift.org"
    },
    "domain_prefix": "oa-0521-etcd",
    "etcd_encryption": true,
    "expiration_timestamp": "2024-05-23T02:30:24Z",
    "external_auth_config": {
      "enabled": false,
      "external_auths": {
        "items": []
      }
    },
    "external_configuration": {
      "labels": {
        "items": []
      },
      "manifests": {
        "items": []
      },
      "syncsets": {
        "items": []
      }
    },
    "external_id": "0f411c9f-7bf0-47d0-865d-b2a7a5f58b55",
    "flavour": {
      "href": "/api/clusters_mgmt/v1/flavours/osd-4",
      "id": "osd-4",
      "kind": "FlavourLink"
    },
    "groups": {
      "items": []
    },
    "href": "/api/clusters_mgmt/v1/clusters/2bd6400bd44oue21f8h0c87p75pvco4h",
    "hypershift": {
      "enabled": false
    },
    "id": "2bd6400bd44oue21f8h0c87p75pvco4h",
    "identity_providers": {
      "items": []
    },
    "inflight_checks": {
      "items": []
    },
    "infra_id": "oa-0521-etcd-t6jck",
    "ingresses": {
      "items": []
    },
    "kind": "Cluster",
    "machine_pools": {
      "items": []
    },
    "managed": true,
    "managed_service": {
      "enabled": false
    },
    "multi_az": false,
    "name": "oa-0521-etcd",
    "network": {
      "host_prefix": 23,
      "machine_cidr": "10.0.0.0/16",
      "pod_cidr": "10.128.0.0/14",
      "service_cidr": "172.30.0.0/16",
      "type": "OVNKubernetes"
    },
    "node_drain_grace_period": {
      "unit": "minutes",
      "value": 60
    },
    "nodes": {
      "availability_zones": [
        "us-east-2a"
      ],
      "compute": 2,
      "compute_machine_type": {
        "href": "/api/clusters_mgmt/v1/machine_types/m5.xlarge",
        "id": "m5.xlarge",
        "kind": "MachineTypeLink"
      },
      "compute_root_volume": {
        "aws": {
          "size": 300
        }
      },
      "infra": 2,
      "infra_machine_type": {
        "href": "/api/clusters_mgmt/v1/machine_types/r5.xlarge",
        "id": "r5.xlarge",
        "kind": "MachineTypeLink"
      },
      "master": 3
    },
    "openshift_version": "4.15.12",
    "product": {
      "href": "/api/clusters_mgmt/v1/products/rosa",
      "id": "rosa",
      "kind": "ProductLink"
    },
    "properties": {
      "rosa_cli_version": "1.2.39",
      "rosa_creator_arn": "arn:aws:iam::*************:user/oaharoni"
    },
    "region": {
      "href": "/api/clusters_mgmt/v1/cloud_providers/aws/regions/us-east-2",
      "id": "us-east-2",
      "kind": "CloudRegionLink"
    },
    "state": "ready",
    "status": {
      "configuration_mode": "full",
      "dns_ready": true,
      "kind": "ClusterStatus",
      "limited_support_reason_count": 0,
      "oidc_ready": false,
      "provision_error_code": "",
      "provision_error_message": "",
      "state": "ready"
    },
    "subscription": {
      "href": "/api/accounts_mgmt/v1/subscriptions/2gmTbuOTbPtthRt8O19vWinmn7m",
      "id": "2gmTbuOTbPtthRt8O19vWinmn7m",
      "kind": "SubscriptionLink"
    },
    "version": {
      "channel_group": "stable",
      "end_of_life_timestamp": "2025-06-30T00:00:00Z",
      "href": "/api/clusters_mgmt/v1/versions/openshift-v4.15.12",
      "id": "openshift-v4.15.12",
      "kind": "Version",
      "raw_id": "4.15.12"
    }
  }

  [FAILED] in [It] - /Users/oaharoni/rosa_workspace/rosa/tests/e2e/test_rosacli_verify.go:222 @ 05/22/24 11:39:57.937
  STEP: Clean the cluster @ 05/22/24 11:39:57.937
  2024-05-22T11:39:57-04:00 - DEBUG : Nothing to clean in Version Service
  2024-05-22T11:39:57-04:00 - DEBUG : Nothing to clean in NetworkVerifierService Service
  2024-05-22T11:39:57-04:00 - DEBUG : Nothing releated to cluster was done there
  2024-05-22T11:39:57-04:00 - DEBUG : Nothing releated to cluster was done there
  << Timeline

  [FAILED] Expected
      <string>: 
  not to be empty
  In [It] at: /Users/oaharoni/rosa_workspace/rosa/tests/e2e/test_rosacli_verify.go:222 @ 05/22/24 11:39:57.937
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Summarizing 1 Failure:
  [FAIL] Verify [It] bring your own kms key functionality works on cluster creation - [id:60082] [day1-post, Critical, NonHCPCluster]
  /Users/oaharoni/rosa_workspace/rosa/tests/e2e/test_rosacli_verify.go:222

Ran 1 of 79 Specs in 1.311 seconds
FAIL! -- 0 Passed | 1 Failed | 0 Pending | 78 Skipped
--- FAIL: TestROSACLIProvider (1.31s)
FAIL

Ginkgo ran 1 suite in 4.721979041s

Test Suite Failed
```

##Success for 42188 with etcd enabled cluster##
```
oaharoni-mac:rosa oaharoni$ export CLUSTER_ID=oa-0521-etcd
oaharoni-mac:rosa oaharoni$ ginkgo -focus id:42188 tests/e2e/
Running Suite: e2e tests suite - /Users/oaharoni/rosa_workspace/rosa/tests/e2e
==============================================================================
Random Seed: 1716392356

Will run 1 of 79 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 79 Specs in 1.041 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 78 Skipped
PASS

Ginkgo ran 1 suite in 4.4809275s
Test Suite Passed
```

##Failure for 42188 without etcd enabled cluster##
```
oaharoni-mac:rosa oaharoni$ export CLUSTER_ID=oa-byok3
oaharoni-mac:rosa oaharoni$ ginkgo -focus id:42188 tests/e2e/
Running Suite: e2e tests suite - /Users/oaharoni/rosa_workspace/rosa/tests/e2e
==============================================================================
Random Seed: 1716393262

Will run 1 of 80 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
• [FAILED] [0.963 seconds]
Verify [It] etcd encryption works on cluster creation - [id:42188] [day1-post, Critical, NonHCPCluster]
/Users/oaharoni/rosa_workspace/rosa/tests/e2e/test_rosacli_verify.go:224

  Timeline >>
  STEP: Get the cluster @ 05/22/24 11:54:25.905
  STEP: Init the client @ 05/22/24 11:54:25.905
  STEP: Confirm current cluster profile uses etcd encryption @ 05/22/24 11:54:25.906
  2024-05-22T11:54:25-04:00 - INFO : Loaded cluster profile configuration from origional profile rosa-advanced : {candidate rosa-advanced  us-west-2 latest 0x140005145a0 0x14000edc210}
  2024-05-22T11:54:25-04:00 - INFO : Loaded cluster profile configuration from origional cluster rosa-advanced : { required r5.xlarge  unmanaged   3 0 54 150 0 false false true true true true true false false true false true false true true true true true false false true true false false}
  2024-05-22T11:54:25-04:00 - INFO : Loaded cluster profile configuration from origional account-roles rosa-advanced : {/test/ arn:aws:iam::aws:policy/AdministratorAccess}
  STEP: Check the help message of 'rosa create cluster -h' @ 05/22/24 11:54:25.907
  2024-05-22T11:54:25-04:00 - INFO : Running command: rosa create cluster -c oa-byok3 --dry-run -h
  Got need redacted string from log match regex (--cluster-admin-password\s+)([^\n\t\\\s]+)([\n\\\s]*)
  Got need redacted string from log match regex (--billing-account\s+)([^\n\t\\\s]+)([\n\\\s]*)
  2024-05-22T11:54:25-04:00 - DEBUG : Get Combining Stdout and Stder is :
  Create cluster.

  Usage:
    rosa create cluster [flags]

  Examples:
    # Create a cluster named "mycluster"
    rosa create cluster --cluster-name=mycluster

    # Create a cluster in the us-east-2 region
    rosa create cluster --cluster-name=mycluster --region=us-east-2

  Flags:
    -c, --cluster-name string                                   The unique name of the cluster. The name can be used as the identifier of the cluster. The maximum length is 54 characters.Once set, the cluster name cannot be changed
        --domain-prefix string                                  An optional unique domain prefix of the cluster. This will be used when generating a sub-domain for your cluster on openshiftapps.com. It must be unique per organization and consist of lowercase alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character. The maximum length is 15 characters. Once set, the cluster domain prefix cannot be changed
        --sts                                                   Use AWS Security Token Service (STS) instead of IAM credentials to deploy your cluster.
        --non-sts                                               Use legacy method of creating clusters (IAM mode).
        --mint-mode                                             Use legacy method of creating clusters (IAM mode). This is an alias for --non-sts.
        --role-arn string                                       The Amazon Resource Name of the role that OpenShift Cluster Manager will assume to create the cluster.
        --external-id string                                    An optional unique identifier that might be required when you assume a role in another account.
        --support-role-arn string                               The Amazon Resource Name of the role used by Red Hat SREs to enable access to the cluster account in order to provide support.
        --controlplane-iam-role-arn string                      The IAM role ARN that will be attached to control plane instances.
        --worker-iam-role-arn string                            The IAM role ARN that will be attached to worker instances.
        --operator-roles-prefix string                          Prefix to use for all IAM roles used by the operators needed in the OpenShift installer. Leave empty to use an auto-generated one.
        --oidc-config-id string                                 Registered OIDC Configuration ID to use for cluster creation
        --tags strings                                          Apply user defined tags to all resources created by ROSA in AWS. Tags are comma separated, for example: 'key value, foo bar'
        --multi-az                                              Deploy to multiple data centers.
        --region string                                         Use a specific AWS region, overriding the AWS_REGION environment variable.
        --version string                                        Version of OpenShift that will be used to install the cluster, for example "4.3.10"
        --etcd-encryption                                       Add etcd encryption. By default etcd data is encrypted at rest. This option configures etcd encryption on top of existing storage encryption.
        --fips                                                  Create cluster that uses FIPS Validated / Modules in Process cryptographic libraries.
        --http-proxy string                                     A proxy URL to use for creating HTTP connections outside the cluster. The URL scheme must be http.
        --https-proxy string                                    A proxy URL to use for creating HTTPS connections outside the cluster.
        --no-proxy strings                                      A comma-separated list of destination domain names, domains, IP addresses or other network CIDRs to exclude proxying.
        --additional-trust-bundle-file string                   A file contains a PEM-encoded X.509 certificate bundle that will be added to the nodes' trusted certificate store.
        --enable-customer-managed-key                           Enable to specify your KMS Key to encrypt EBS instance volumes. By default account’s default KMS key for that particular region is used.
        --kms-key-arn string                                    The key ARN is the Amazon Resource Name (ARN) of a CMK. It is a unique, fully qualified identifier for the CMK. A key ARN includes the AWS account, Region, and the key ID.
        --etcd-encryption-kms-arn string                        The etcd encryption kms key ARN is the key used to encrypt etcd. If set it will override etcd-encryption flag to true. It is a unique, fully qualified identifier for the CMK. A key ARN includes the AWS account, Region, and the key ID.
        --private-link                                          Provides private connectivity between VPCs, AWS services, and your on-premises networks, without exposing your traffic to the public internet.
        --ec2-metadata-http-tokens string                       Should cluster nodes use both v1 and v2 endpoints or just v2 endpoint of EC2 Instance Metadata Service (IMDS)
        --subnet-ids strings                                    The Subnet IDs to use when installing the cluster. Format should be a comma-separated list. Leave empty for installer provisioned subnet IDs.
        --availability-zones strings                            The availability zones to use when installing a non-BYOVPC cluster. Format should be a comma-separated list. Leave empty for the installer to pick availability zones
        --compute-machine-type string                           Instance type for the compute nodes. Determines the amount of memory and vCPU allocated to each compute node.
        --replicas int                                          Number of worker nodes to provision. Single zone clusters need at least 2 nodes, multizone clusters need at least 3 nodes. Hosted clusters require that the number of worker nodes be a multiple of the number of private subnets. (default 2)
        --enable-autoscaling                                    Enable autoscaling of compute nodes.
        --autoscaler-balance-similar-node-groups                Identify node groups with the same instance type and label set, and aim to balance respective sizes of those node groups.
        --autoscaler-skip-nodes-with-local-storage              If true cluster autoscaler will never delete nodes with pods with local storage, e.g. EmptyDir or HostPath.
        --autoscaler-log-verbosity int                          Autoscaler log level. Default is 1, 4 is a good option when trying to debug the autoscaler. (default 1)
        --autoscaler-max-pod-grace-period int                   Gives pods graceful termination time before scaling down, measured in seconds. (default 600)
        --autoscaler-pod-priority-threshold int                 The priority that a pod must exceed to cause the cluster autoscaler to deploy additional nodes. Expects an integer, can be negative. (default -10)
        --autoscaler-ignore-daemonsets-utilization              Should cluster-autoscaler ignore DaemonSet pods when calculating resource utilization for scaling down.
        --autoscaler-max-node-provision-time string             Maximum time cluster-autoscaler waits for node to be provisioned. Expects string comprised of an integer and time unit (ns|us|µs|ms|s|m|h), examples: 20m, 1h.
        --autoscaler-balancing-ignored-labels strings           A comma-separated list of label keys that cluster autoscaler should ignore when considering node group similarity.
        --autoscaler-max-nodes-total int                        Total amount of nodes that can exist in the cluster, including non-scaled nodes. (default 180)
        --autoscaler-min-cores int                              Minimum limit for the amount of cores to deploy in the cluster.
        --autoscaler-max-cores int                              Maximum limit for the amount of cores to deploy in the cluster. (default 11520)
        --autoscaler-min-memory int                             Minimum limit for the amount of memory, in GiB, in the cluster.
        --autoscaler-max-memory int                             Maximum limit for the amount of memory, in GiB, in the cluster. (default 230400)
        --autoscaler-gpu-limit stringArray                      Limit GPUs consumption. It should be comprised of 3 values separated with commas: the GPU hardware type, a minimal count for that type and a maximal count for that type. This option can be repeated multiple times in order to apply multiple restrictions for different GPU types. For example: --autoscaler-gpu-limit nvidia.com/gpu,0,10 --autoscaler-gpu-limit amd.com/gpu,1,5
        --autoscaler-scale-down-enabled                         Should cluster-autoscaler be able to scale down the cluster.
        --autoscaler-scale-down-unneeded-time string            Increasing value will make nodes stay up longer, waiting for pods to be scheduled while decreasing value will make nodes be deleted sooner.
        --autoscaler-scale-down-utilization-threshold float     Node utilization level, defined as sum of requested resources divided by capacity, below which a node can be considered for scale down. Value should be between 0 and 1. (default 0.5)
        --autoscaler-scale-down-delay-after-add string          After a scale-up, consider scaling down only after this amount of time.
        --autoscaler-scale-down-delay-after-delete string       After a scale-down, consider scaling down again only after this amount of time.
        --autoscaler-scale-down-delay-after-failure string      After a failing scale-down, consider scaling down again only after this amount of time.
        --min-replicas int                                      Minimum number of compute nodes. (default 2)
        --max-replicas int                                      Maximum number of compute nodes. (default 2)
        --worker-mp-labels string                               Labels for the worker machine pool. Format should be a comma-separated list of 'key=value'. This list will overwrite any modifications made to Node labels on an ongoing basis.
        --machine-cidr ipNet                                    Block of IP addresses used by OpenShift while installing the cluster, for example "10.0.0.0/16".
        --service-cidr ipNet                                    Block of IP addresses for services, for example "172.30.0.0/16".
        --pod-cidr ipNet                                        Block of IP addresses from which Pod IP addresses are allocated, for example "10.128.0.0/14".
        --host-prefix int                                       Subnet prefix length to assign to each individual node. For example, if host prefix is set to "23", then each node is assigned a /23 subnet out of the given CIDR.
        --private                                               Restrict master API endpoint and application routes to direct, private connectivity.
        --disable-scp-checks                                    Indicates if cloud permission checks are disabled when attempting installation of the cluster.
        --disable-workload-monitoring                           Enables you to monitor your own projects in isolation from Red Hat Site Reliability Engineer (SRE) platform metrics.
    -w, --watch                                                 Watch cluster installation logs.
        --dry-run                                               Simulate creating the cluster.
        --permissions-boundary string                           The ARN of the policy that is used to set the permissions boundary for the operator roles in STS clusters.
        --hosted-cp                                             Enable the use of Hosted Control Planes
        --worker-disk-size string                               Default worker machine pool root disk size with a **unit suffix** like GiB or TiB, e.g. 200GiB.
        --billing-account *************                                Account used for billing subscriptions purchased via the AWS marketplace
        --create-admin-user                                     Create cluster admin named "cluster-admin"
        --cluster-admin-password *************                         The password must
                                                                		- Be at least 14 characters (ASCII-standard) without whitespaces
                                                                		- Include uppercase letters, lowercase letters, and numbers or symbols (ASCII-standard characters only)
        --audit-log-arn string                                  The ARN of the role that is used to forward audit logs to AWS CloudWatch.
        --default-ingress-route-selector string                 Route Selector for ingress. Format should be a comma-separated list of 'key=value'. If no label is specified, all routes will be exposed on both routers. For legacy ingress support these are inclusion labels, otherwise they are treated as exclusion label.
        --default-ingress-excluded-namespaces string            Excluded namespaces for ingress. Format should be a comma-separated list 'value1, value2...'. If no values are specified, all namespaces will be exposed.
        --default-ingress-wildcard-policy string                Wildcard Policy for ingress. Options are WildcardsDisallowed,WildcardsAllowed. Default is 'WildcardsDisallowed'.
        --default-ingress-namespace-ownership-policy string     Namespace Ownership Policy for ingress. Options are Strict,InterNamespaceAllowed. Default is 'Strict'.
        --private-hosted-zone-id string                         ID assigned by AWS to private Route 53 hosted zone associated with intended shared VPC, e.g., 'Z05646003S02O1ENCDCSN'.
        --shared-vpc-role-arn string                            AWS IAM role ARN with a policy attached, granting permissions necessary to create and manage Route 53 DNS records in private Route 53 hosted zone associated with intended shared VPC.
        --base-domain string                                    Base DNS domain name previously reserved and matching the hosted zone name of the private Route 53 hosted zone associated with intended shared VPC, e.g., '1vo8.p1.openshiftapps.com'.
        --additional-compute-security-group-ids strings         The additional Security Group IDs to be added to the default worker machine pool. Format should be a comma-separated list.
        --additional-infra-security-group-ids strings           The additional Security Group IDs to be added to the infra worker nodes. Format should be a comma-separated list.
        --additional-control-plane-security-group-ids strings   The additional Security Group IDs to be added to the control plane nodes. Format should be a comma-separated list.
    -m, --mode string                                           How to perform the operation. Valid options are:
                                                                auto: Resource changes will be automatic applied using the current AWS account
                                                                
                                                                manual: Commands necessary to modify AWS resources will be output to be run manually
    -i, --interactive                                           Enable interactive mode.
    -o, --output string                                         Output format. Allowed formats are [json yaml]
    -y, --yes                                                   Automatically answer yes to confirm operation.
    -h, --help                                                  help for cluster

  Global Flags:
        --color string     Surround certain characters with escape sequences to display them in color on the terminal. Allowed options are [auto never always] (default "auto")
        --debug            Enable debug mode.
        --profile string   Use a specific AWS profile from your credential file.

  STEP: Confirm etcd encryption is enabled @ 05/22/24 11:54:25.973
  2024-05-22T11:54:25-04:00 - INFO : Running command: rosa describe cluster -c oa-byok3 --output json
  Got need redacted string from log match regex (arn:aws:[a-z]+:[a-z0-9-]*:)([0-9]{12})(:)
  2024-05-22T11:54:26-04:00 - DEBUG : Get Combining Stdout and Stder is :
  {
    "addons": {
      "items": []
    },
    "api": {
      "listening": "external"
    },
    "aws": {
      "audit_log": {
        "role_arn": ""
      },
      "ec2_metadata_http_tokens": "optional",
      "kms_key_arn": "arn:aws:kms:us-east-2:*************:key/41fb8415-47b2-48fb-aa96-274bad5a6565",
      "private_link": false,
      "private_link_configuration": {},
      "tags": {
        "red-hat-clustertype": "rosa",
        "red-hat-managed": "true"
      }
    },
    "aws_infrastructure_access_role_grants": {
      "items": []
    },
    "billing_model": "standard",
    "byo_oidc": {
      "enabled": false
    },
    "ccs": {
      "disable_scp_checks": false,
      "enabled": true,
      "kind": "CCS"
    },
    "cloud_provider": {
      "href": "/api/clusters_mgmt/v1/cloud_providers/aws",
      "id": "aws",
      "kind": "CloudProviderLink"
    },
    "creation_timestamp": "2024-05-22T15:34:30Z",
    "delete_protection": {
      "enabled": false
    },
    "disable_user_workload_monitoring": false,
    "displayName": "oa-byok3",
    "dns": {
      "base_domain": "e9cq.s1.devshift.org"
    },
    "domain_prefix": "oa-byok3",
    "etcd_encryption": false,
    "expiration_timestamp": "2024-05-24T03:34:27Z",
    "external_auth_config": {
      "enabled": false,
      "external_auths": {
        "items": []
      }
    },
    "external_configuration": {
      "labels": {
        "items": []
      },
      "manifests": {
        "items": []
      },
      "syncsets": {
        "items": []
      }
    },
    "external_id": "9ece8d5d-9ccb-44b3-a4d9-bfdc6b6b1913",
    "flavour": {
      "href": "/api/clusters_mgmt/v1/flavours/osd-4",
      "id": "osd-4",
      "kind": "FlavourLink"
    },
    "groups": {
      "items": []
    },
    "href": "/api/clusters_mgmt/v1/clusters/2bds50voiose41g4ohckrar1nivdq1ou",
    "hypershift": {
      "enabled": false
    },
    "id": "2bds50voiose41g4ohckrar1nivdq1ou",
    "identity_providers": {
      "items": []
    },
    "inflight_checks": {
      "items": []
    },
    "infra_id": "oa-byok3-km727",
    "ingresses": {
      "items": []
    },
    "kind": "Cluster",
    "machine_pools": {
      "items": []
    },
    "managed": true,
    "managed_service": {
      "enabled": false
    },
    "multi_az": false,
    "name": "oa-byok3",
    "network": {
      "host_prefix": 23,
      "machine_cidr": "10.0.0.0/16",
      "pod_cidr": "10.128.0.0/14",
      "service_cidr": "172.30.0.0/16",
      "type": "OVNKubernetes"
    },
    "node_drain_grace_period": {
      "unit": "minutes",
      "value": 60
    },
    "nodes": {
      "availability_zones": [
        "us-east-2a"
      ],
      "compute": 2,
      "compute_machine_type": {
        "href": "/api/clusters_mgmt/v1/machine_types/m5.xlarge",
        "id": "m5.xlarge",
        "kind": "MachineTypeLink"
      },
      "compute_root_volume": {
        "aws": {
          "size": 300
        }
      },
      "infra": 2,
      "infra_machine_type": {
        "href": "/api/clusters_mgmt/v1/machine_types/r5.xlarge",
        "id": "r5.xlarge",
        "kind": "MachineTypeLink"
      },
      "master": 3
    },
    "product": {
      "href": "/api/clusters_mgmt/v1/products/rosa",
      "id": "rosa",
      "kind": "ProductLink"
    },
    "properties": {
      "rosa_cli_version": "1.2.39",
      "rosa_creator_arn": "arn:aws:iam::*************:user/oaharoni"
    },
    "region": {
      "href": "/api/clusters_mgmt/v1/cloud_providers/aws/regions/us-east-2",
      "id": "us-east-2",
      "kind": "CloudRegionLink"
    },
    "state": "installing",
    "status": {
      "configuration_mode": "full",
      "dns_ready": true,
      "kind": "ClusterStatus",
      "limited_support_reason_count": 0,
      "oidc_ready": false,
      "provision_error_code": "",
      "provision_error_message": "",
      "state": "installing"
    },
    "subscription": {
      "href": "/api/accounts_mgmt/v1/subscriptions/2gpQWMkQMZifr4Nf3ZmJZfKSAoj",
      "id": "2gpQWMkQMZifr4Nf3ZmJZfKSAoj",
      "kind": "SubscriptionLink"
    },
    "version": {
      "channel_group": "stable",
      "end_of_life_timestamp": "2025-06-30T00:00:00Z",
      "href": "/api/clusters_mgmt/v1/versions/openshift-v4.15.12",
      "id": "openshift-v4.15.12",
      "kind": "Version",
      "raw_id": "4.15.12"
    }
  }

  [FAILED] in [It] - /Users/oaharoni/rosa_workspace/rosa/tests/e2e/test_rosacli_verify.go:243 @ 05/22/24 11:54:26.868
  STEP: Clean the cluster @ 05/22/24 11:54:26.868
  2024-05-22T11:54:26-04:00 - DEBUG : Nothing to clean in Version Service
  2024-05-22T11:54:26-04:00 - DEBUG : Nothing to clean in NetworkVerifierService Service
  2024-05-22T11:54:26-04:00 - DEBUG : Nothing releated to cluster was done there
  2024-05-22T11:54:26-04:00 - DEBUG : Nothing releated to cluster was done there
  << Timeline

  [FAILED] Expected
      <bool>: false
  to be true
  In [It] at: /Users/oaharoni/rosa_workspace/rosa/tests/e2e/test_rosacli_verify.go:243 @ 05/22/24 11:54:26.868
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Summarizing 1 Failure:
  [FAIL] Verify [It] etcd encryption works on cluster creation - [id:42188] [day1-post, Critical, NonHCPCluster]
  /Users/oaharoni/rosa_workspace/rosa/tests/e2e/test_rosacli_verify.go:243

Ran 1 of 80 Specs in 0.966 seconds
FAIL! -- 0 Passed | 1 Failed | 0 Pending | 79 Skipped
--- FAIL: TestROSACLIProvider (0.97s)
FAIL

Ginkgo ran 1 suite in 4.540169625s

Test Suite Failed
```