### PR TITLE
OCM-8220 | test: Automated case id:52691 User can set availability zones

### DIFF
--- a/tests/ci/data/profiles/rosa-classic.yaml
+++ b/tests/ci/data/profiles/rosa-classic.yaml
@@ -120,7 +120,7 @@ profiles:
     networking: false
     proxy_enabled: false
     label_enabled: true
-    zones: ""
+    zones: "us-east-1a,us-east-1b,us-east-1c"
     tag_enabled: true
     etcd_kms: false
     fips: false


### PR DESCRIPTION
zhewang@fedora:~/go/src/rosa$ ginkgo -focus 52691 tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.14.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: e2e tests suite - /home/zhewang/go/src/rosa/tests/e2e
====================================================================
Random Seed: 1716455435

Will run 1 of 80 specs
SSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 80 Specs in 2741.719 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 79 Skipped
PASS

Ginkgo ran 1 suite in 45m42.676623092s
Test Suite Passed
