### PR TITLE
OCM-8198 | fix: always add attach command for managed policy during r…

### DIFF
--- a/cmd/upgrade/roles/cmd.go
+++ b/cmd/upgrade/roles/cmd.go
@@ -663,21 +663,12 @@ func buildAccountRoleCommandsFromCluster(
 			}
 			_, err = awsClient.IsPolicyExists(policyARN)
 			policyExists := err == nil
-			policyAttached := false
-			if policyExists {
-				for _, policy := range rolePolicyDetails[accRoleName] {
-					if policy.PolicyArn == policyARN {
-						policyAttached = true
-					}
-				}
-			}
 			policyName := aws.GetPolicyName(accRoleName)
 			upgradeAccountPolicyCommands := awscbRoles.ManualCommandsForUpgradeAccountRolePolicy(
 				awscbRoles.ManualCommandsForUpgradeAccountRolePolicyInput{
 					DefaultPolicyVersion: defaultPolicyVersion,
 					RoleName:             accRoleName,
 					PolicyExists:         policyExists,
-					PolicyAttached:       policyAttached,
 					Prefix:               prefix,
 					File:                 file,
 					PolicyName:           policyName,
@@ -923,14 +914,6 @@ func buildOperatorRoleCommandsFromCluster(
 		)
 		_, err = awsClient.IsPolicyExists(policyARN)
 		policyExists := err == nil
-		policyAttached := false
-		if policyExists && operatorRoleName != "" {
-			for _, policy := range rolePolicyDetails[operatorRoleName] {
-				if policy.PolicyArn == policyARN {
-					policyAttached = true
-				}
-			}
-		}
 
 		isSharedVpc := cluster.AWS().PrivateHostedZoneRoleARN() != ""
 		fileName := aws.GetOperatorPolicyKey(credrequest, cluster.Hypershift().Enabled(), isSharedVpc)
@@ -939,7 +922,6 @@ func buildOperatorRoleCommandsFromCluster(
 		upgradePoliciesCommands := awscbRoles.ManualCommandsForUpgradeOperatorRolePolicy(
 			awscbRoles.ManualCommandsForUpgradeOperatorRolePolicyInput{
 				PolicyExists:             policyExists,
-				PolicyAttached:           policyAttached,
 				OperatorRolePolicyPrefix: operatorRolePolicyPrefix,
 				Operator:                 operator,
 				CredRequest:              credrequest,

--- a/pkg/aws/commandbuilder/helper/roles/roles.go
+++ b/pkg/aws/commandbuilder/helper/roles/roles.go
@@ -52,7 +52,6 @@ func ManualCommandsForMissingOperatorRole(input ManualCommandsForMissingOperator
 
 type ManualCommandsForUpgradeOperatorRolePolicyInput struct {
 	PolicyExists             bool
-	PolicyAttached           bool
 	OperatorRolePolicyPrefix string
 	Operator                 *cmv1.STSOperator
 	CredRequest              string
@@ -107,7 +106,7 @@ func ManualCommandsForUpgradeOperatorRolePolicy(input ManualCommandsForUpgradeOp
 			AddTags(policyTags).
 			AddParam(awscb.PolicyArn, input.PolicyARN).
 			Build()
-		if !input.PolicyAttached && input.OperatorRoleName != "" {
+		if input.OperatorRoleName != "" {
 			commands = append(commands, attachRolePolicy)
 		}
 		commands = append(commands, createPolicyVersion, tagPolicy)
@@ -119,7 +118,6 @@ type ManualCommandsForUpgradeAccountRolePolicyInput struct {
 	DefaultPolicyVersion string
 	RoleName             string
 	PolicyExists         bool
-	PolicyAttached       bool
 	Prefix               string
 	File                 string
 	PolicyName           string
@@ -172,10 +170,7 @@ func ManualCommandsForUpgradeAccountRolePolicy(input ManualCommandsForUpgradeAcc
 			AddTags(iamRoleTags).
 			AddParam(awscb.PolicyArn, input.PolicyARN).
 			Build()
-		if !input.PolicyAttached {
-			commands = append(commands, attachRolePolicy)
-		}
-		commands = append(commands, createPolicyVersion, tagPolicies, tagRole)
+		commands = append(commands, attachRolePolicy, createPolicyVersion, tagPolicies, tagRole)
 	}
 	return commands
 }


### PR DESCRIPTION
always add attach command for managed policy during rosa upgrade roles in manual mode
https://issues.redhat.com/browse/OCM-8198

Signed-off-by: marcolan018 <llan@redhat.com>