### PR TITLE
OCM-8257 | ci: Split creation out and split cluster waiting out and make autoscaler value to 10

### DIFF
--- a/tests/ci/config/config.go
+++ b/tests/ci/config/config.go
@@ -40,12 +40,13 @@ type TestConfig struct {
 	GlobalENV                     *GlobalENVVariables
 }
 type GlobalENVVariables struct {
-	ChannelGroup       string `env:"CHANNEL_GROUP" default:""`
-	Version            string `env:"VERSION" default:""`
-	Region             string `env:"REGION" default:""`
-	ProvisionShard     string `env:"PROVISION_SHARD" default:""`
-	NamePrefix         string `env:"NAME_PREFIX"`
-	ClusterWaitingTime int    `env:"CLUSTER_TIMEOUT" default:"60"`
+	ChannelGroup          string `env:"CHANNEL_GROUP" default:""`
+	Version               string `env:"VERSION" default:""`
+	Region                string `env:"REGION" default:""`
+	ProvisionShard        string `env:"PROVISION_SHARD" default:""`
+	NamePrefix            string `env:"NAME_PREFIX"`
+	ClusterWaitingTime    int    `env:"CLUSTER_TIMEOUT" default:"60"`
+	WaitSetupClusterReady bool   `env:"WAIT_SETUP_CLUSTER_READY" default:"true"`
 }
 
 func init() {
@@ -82,13 +83,15 @@ func init() {
 	if err != nil {
 		panic(fmt.Errorf("env variable CLUSTER_TIMEOUT must be set to an integer"))
 	}
+	waitSetupClusterReady, _ := strconv.ParseBool(common.ReadENVWithDefaultValue("WAIT_SETUP_CLUSTER_READY", "true"))
 	Test.GlobalENV = &GlobalENVVariables{
-		ChannelGroup:       os.Getenv("CHANNEL_GROUP"),
-		Version:            os.Getenv("VERSION"),
-		Region:             os.Getenv("REGION"),
-		ProvisionShard:     os.Getenv("PROVISION_SHARD"),
-		NamePrefix:         os.Getenv("NAME_PREFIX"),
-		ClusterWaitingTime: waitingTime,
+		ChannelGroup:          os.Getenv("CHANNEL_GROUP"),
+		Version:               os.Getenv("VERSION"),
+		Region:                os.Getenv("REGION"),
+		ProvisionShard:        os.Getenv("PROVISION_SHARD"),
+		NamePrefix:            os.Getenv("NAME_PREFIX"),
+		ClusterWaitingTime:    waitingTime,
+		WaitSetupClusterReady: waitSetupClusterReady,
 	}
 
 }

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -4,21 +4,28 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/openshift/rosa/tests/ci/config"
 	"github.com/openshift/rosa/tests/ci/labels"
 	"github.com/openshift/rosa/tests/utils/exec/rosacli"
 	"github.com/openshift/rosa/tests/utils/log"
-	PH "github.com/openshift/rosa/tests/utils/profilehandler"
+	"github.com/openshift/rosa/tests/utils/profilehandler"
 )
 
 var _ = Describe("ROSA CLI Test", func() {
 	It("PrepareClusterByProfile",
-		labels.Critical,
 		labels.Day1Prepare,
 		func() {
 			client := rosacli.NewClient()
-			profile := PH.LoadProfileYamlFileByENV()
-			cluster, err := PH.CreateClusterByProfile(profile, client, true)
+			profile := profilehandler.LoadProfileYamlFileByENV()
+			cluster, err := profilehandler.CreateClusterByProfile(profile, client, config.Test.GlobalENV.WaitSetupClusterReady)
 			Expect(err).ToNot(HaveOccurred())
 			log.Logger.Infof("Cluster prepared successfully with id %s", cluster.ID)
 		})
+
+	It("WaitClusterReady", func() {
+		clusterDetail, err := profilehandler.ParserClusterDetail()
+		Expect(err).ToNot(HaveOccurred())
+		client := rosacli.NewClient()
+		profilehandler.WaitForClusterReady(client, clusterDetail.ClusterID, config.Test.GlobalENV.ClusterWaitingTime)
+	})
 })

--- a/tests/utils/exec/rosacli/cmd_runner.go
+++ b/tests/utils/exec/rosacli/cmd_runner.go
@@ -186,7 +186,7 @@ func (r *runner) Run() (bytes.Buffer, error) {
 
 		err = cmd.Run()
 
-		log.Logger.Debugf("Get Combining Stdout and Stder is :\n%s", output.String())
+		log.Logger.Infof("Get Combining Stdout and Stder is :\n%s", output.String())
 
 		if strings.Contains(output.String(), "Not able to get authentication token") {
 			retry = retry + 1

--- a/tests/utils/log/logger.go
+++ b/tests/utils/log/logger.go
@@ -16,7 +16,7 @@ func GetLogger() *Log {
 	logger, _ := logging.
 		NewStdLoggerBuilder().
 		Streams(g.GinkgoWriter, g.GinkgoWriter).
-		Debug(true).
+		Debug(false).
 		Build()
 	return &Log{
 		logger:          logger,


### PR DESCRIPTION
What I did in the PR
When set `WAIT_SETUP_CLUSTER_READY=false` then the cluster preparation will only create the cluster and exit without waiting for cluster ready.
If want to wait for cluster ready after cluster is prepared run command `ginkgo -focus WaitClusterReady tests/e2e`
I split out the resources recording, so any resources need to be pass to destroy step will be recorded once created. It will make the risk of resource leak to the lowest for destroy