### PR TITLE
SDA-4924 | fix: error message for invalid username validation for idp creation

### DIFF
--- a/tests/e2e/test_rosacli_idp.go
+++ b/tests/e2e/test_rosacli_idp.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"regexp"
 	"strings"
@@ -395,8 +396,6 @@ var _ = Describe("Edit IDP",
 					"-y")
 				Expect(err).NotTo(BeNil())
 				textData = rosaClient.Parser.TextData.Input(output).Parse().Tip()
-				textData = strings.TrimSuffix(textData, "\n")
-				textData += "!(NOVERB)"
-				Expect(textData).Should(ContainSubstring("invalid username '%s': Username must not contain /, :, or %", clusterID, invalidUserName))
+				Expect(textData).Should(ContainSubstring(fmt.Sprintf("Failed to add IDP to cluster '%s': Invalid username '%s': Username must not contain /, :, or %%", clusterID, invalidUserName)))
 			})
 	})


### PR DESCRIPTION
[OCM-8299](https://issues.redhat.com/browse/OCM-8299) 

$ ginkgo --focus 53031 tests/e2e
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.11.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: e2e tests suite - /home/akanni/OCP-Repository/rosa/tests/e2e
===========================================================================
Random Seed: 1716804047

Will run 1 of 84 specs
SSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 84 Specs in 19.150 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 83 Skipped
PASS

Ginkgo ran 1 suite in 20.577024633s
Test Suite Passed
