### PR TITLE
OCM-8283 | fix: kubelet-config edit prompt no longer shows up when kubelet-configs are not targeted

### DIFF
--- a/cmd/edit/machinepool/nodepool.go
+++ b/cmd/edit/machinepool/nodepool.go
@@ -176,7 +176,7 @@ func editNodePool(cmd *cobra.Command, nodePoolID string,
 				inputKubeletConfig = nodePool.KubeletConfigs()
 			}
 
-			// Skip if no tuning configs are available
+			// Skip if no kubelet configs are available
 			if len(availableKubeletConfigs) > 0 {
 				inputKubeletConfig, err = interactive.GetMultipleOptions(interactive.Input{
 					Question: "Kubelet config",
@@ -199,6 +199,7 @@ func editNodePool(cmd *cobra.Command, nodePoolID string,
 			os.Exit(1)
 		}
 		npBuilder.KubeletConfigs(inputKubeletConfig...)
+		isKubeletConfigSet = true
 	}
 
 	if isNodeDrainGracePeriodSet || interactive.Enabled() {
@@ -234,7 +235,7 @@ func editNodePool(cmd *cobra.Command, nodePoolID string,
 		return fmt.Errorf("Failed to create machine pool for hosted cluster '%s': %v", clusterKey, err)
 	}
 
-	if !promptForNodePoolNodeRecreate(nodePool, update, PromptToAcceptNodePoolNodeRecreate, r) {
+	if isKubeletConfigSet && !promptForNodePoolNodeRecreate(nodePool, update, PromptToAcceptNodePoolNodeRecreate, r) {
 		return nil
 	}
 


### PR DESCRIPTION
[OCM-8283 ](https://issues.redhat.com/browse/OCM-8283)- Fixing bug to stop kubelet-config warning showing up when kubelet configs are not specified.