### PR TITLE
OCM-8129 | fix: hide unnecessary kubeconfig info

### DIFF
--- a/cmd/describe/breakglasscredential/cmd.go
+++ b/cmd/describe/breakglasscredential/cmd.go
@@ -96,16 +96,17 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command, argv []string) error {
 	}
 
 	r.Reporter.Debugf("Fetching the break glass credential '%s' for cluster '%s'", breakGlassCredentialId, clusterKey)
-	if !getKubeconfig {
-		r.Reporter.Infof(
-			"To retrieve only the kubeconfig for this credential "+
-				"use: 'rosa describe break-glass-credential %s -c %s --kubeconfig'",
-			breakGlassCredentialId, clusterKey)
-	}
 
 	breakGlassCredentialConfig, err := r.OCMClient.GetBreakGlassCredential(cluster.ID(), breakGlassCredentialId)
 	if err != nil {
 		return err
+	}
+
+	if !getKubeconfig && breakGlassCredentialConfig.Status() == cmv1.BreakGlassCredentialStatusIssued {
+		r.Reporter.Infof(
+			"To retrieve only the kubeconfig for this credential "+
+				"use: 'rosa describe break-glass-credential %s -c %s --kubeconfig'",
+			breakGlassCredentialId, clusterKey)
 	}
 
 	if breakGlassCredentialConfig.Status() == cmv1.BreakGlassCredentialStatusRevoked {

--- a/cmd/describe/breakglasscredential/cmd_test.go
+++ b/cmd/describe/breakglasscredential/cmd_test.go
@@ -78,6 +78,28 @@ var _ = Describe("Break glass credential", func() {
 				"INFO: The credential is not ready yet. Please wait a few minutes for it to be fully ready.\n"))
 		})
 
+		It("Pass a break glass credential id through parameter and it is found, but it is awaiting revocation", func() {
+			args.id = breakGlassCredentialId
+			args.kubeconfig = false
+			const breakGlassCredentialId = "test-id-1"
+			revokedCredential, err := cmv1.NewBreakGlassCredential().
+				ID(breakGlassCredentialId).Username("username").
+				Status(cmv1.BreakGlassCredentialStatusAwaitingRevocation).Kubeconfig("testkubeconfig").
+				Build()
+			Expect(err).To(BeNil())
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
+			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK,
+				test.FormatResource(revokedCredential)))
+			stdout, stderr, err := test.RunWithOutputCaptureAndArgv(runWithRuntime, testRuntime.RosaRuntime,
+				Cmd, &[]string{})
+			Expect(err).To(BeNil())
+			Expect(stderr).To(Equal(""))
+			Expect(stdout).To(Equal("\nID:                                    test-id-1" +
+				"\nUsername:                              username\n" +
+				"Expire at:                             Jan  1 0001 00:00:00 UTC" +
+				"\nStatus:                                awaiting_revocation\n"))
+		})
+
 		It("Pass a break glass credential id through parameter and it is found, but it has been revoked", func() {
 			args.id = breakGlassCredentialId
 			const breakGlassCredentialId = "test-id-1"


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-8129