### PR TITLE
OCM-8336 | fix: only check redhat managed policies when upgrade roles

### DIFF
--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -1802,7 +1802,8 @@ func (c *awsClient) IsUpgradedNeededForOperatorRolePoliciesUsingCluster(
 
 func (c *awsClient) validateRolePolicyUpgradeVersionCompatibility(roleName string,
 	version string) (bool, error) {
-	attachedPolicies, err := c.GetAttachedPolicy(aws.String(roleName))
+	attachedPolicies, _, err := c.GetAttachedPolicyWithTags(aws.String(roleName),
+		map[string]string{tags.RedHatManaged: TrueString})
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-8336

Don't check arbitrary policies when checking whether a roles needs to be upgraded or not

Signed-off-by: marcolan018 <llan@redhat.com>