### PR TITLE
OCM-8072 | test: fixing id:60082,42188 ci failures

### DIFF
--- a/tests/e2e/test_rosacli_verify.go
+++ b/tests/e2e/test_rosacli_verify.go
@@ -14,7 +14,6 @@ import (
 	"github.com/openshift/rosa/tests/utils/common/constants"
 	"github.com/openshift/rosa/tests/utils/config"
 	"github.com/openshift/rosa/tests/utils/exec/rosacli"
-	"github.com/openshift/rosa/tests/utils/profilehandler"
 )
 
 var _ = Describe("Verify",
@@ -199,13 +198,14 @@ var _ = Describe("Verify",
 				}
 
 			})
+
 		It("bring your own kms key functionality works on cluster creation - [id:60082]",
 			labels.Day1Post,
 			labels.Critical,
+			labels.NonHCPCluster,
 			func() {
 				By("Confirm current cluster profile uses kms keys")
-				curProfile := profilehandler.LoadProfileYamlFileByENV()
-				if !curProfile.ClusterConfig.KMSKey {
+				if !clusterConfig.EnableCustomerManagedKey {
 					Skip("No KMS key defined. Skipping...")
 				}
 				By("Check the help message of 'rosa create cluster -h'")
@@ -218,15 +218,16 @@ var _ = Describe("Verify",
 				jsonData, err := clusterService.GetJSONClusterDescription(clusterID)
 				Expect(err).To(BeNil())
 				kmsKey := jsonData.DigString("aws", "kms_key_arn")
-				Expect(kmsKey).ToNot(BeEmpty())
+				Expect(clusterConfig.Encryption.KmsKeyArn).To(Equal(kmsKey))
 			})
+
 		It("etcd encryption works on cluster creation - [id:42188]",
 			labels.Day1Post,
 			labels.Critical,
+			labels.NonHCPCluster,
 			func() {
 				By("Confirm current cluster profile uses etcd encryption")
-				curProfile := profilehandler.LoadProfileYamlFileByENV()
-				if !curProfile.ClusterConfig.EtcdEncryption {
+				if !clusterConfig.EtcdEncryption {
 					Skip("No etcd encryption defined. Skipping...")
 				}
 				By("Check the help message of 'rosa create cluster -h'")

--- a/tests/utils/profilehandler/profile_handler.go
+++ b/tests/utils/profilehandler/profile_handler.go
@@ -503,7 +503,7 @@ func GenerateClusterCreateFlags(profile *Profile, client *rosacli.Client) ([]str
 		if clusterConfiguration.Encryption == nil {
 			clusterConfiguration.Encryption = &ClusterConfigure.Encryption{}
 		}
-		clusterConfiguration.EnableCustomerManagedKey = profile.ClusterConfig.EtcdKMS
+		clusterConfiguration.EnableCustomerManagedKey = profile.ClusterConfig.KMSKey
 		clusterConfiguration.Encryption.KmsKeyArn = kmsKeyArn
 	}
 	if profile.ClusterConfig.LabelEnabled {


### PR DESCRIPTION
`$ ginkgo --focus 60082 tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.14.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: e2e tests suite - /home/aaraj/ocm-forked-code/rosa/tests/e2e
===========================================================================
Random Seed: 1717079121

Will run 1 of 92 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS2024/05/30 19:55:34 &{arn:aws:kms:us-east-1:301721915996:key/d57a63f2-1ab9-42c9-8422-fe1a478c6dc5 }
•SSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 92 Specs in 6.638 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 91 Skipped
PASS

Ginkgo ran 1 suite in 19.325901517s
Test Suite Passed
`

`$ ginkgo --focus 42188 tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.14.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: e2e tests suite - /home/aaraj/ocm-forked-code/rosa/tests/e2e
===========================================================================
Random Seed: 1717077370

Will run 1 of 87 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSS

Ran 1 of 87 Specs in 4.536 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 86 Skipped
PASS

Ginkgo ran 1 suite in 9.968965786s
Test Suite Passed
`