### PR TITLE
OCM-8337 | fix: [HCP] always set replicas when updating machinepools

### DIFF
--- a/cmd/edit/machinepool/nodepool.go
+++ b/cmd/edit/machinepool/nodepool.go
@@ -84,13 +84,7 @@ func editNodePool(cmd *cobra.Command, nodePoolID string,
 		npBuilder = npBuilder.Taints(taintBuilders...)
 	}
 
-	if autoscaling {
-		npBuilder.Autoscaling(editAutoscaling(nodePool, minReplicas, maxReplicas))
-	} else {
-		if nodePool.Replicas() != replicas {
-			npBuilder.Replicas(replicas)
-		}
-	}
+	fillAutoScalingAndReplicas(npBuilder, autoscaling, nodePool, minReplicas, maxReplicas, replicas)
 
 	if isAutorepairSet || interactive.Enabled() {
 		autorepair := args.autorepair
@@ -246,6 +240,16 @@ func editNodePool(cmd *cobra.Command, nodePoolID string,
 	}
 	r.Reporter.Infof("Updated machine pool '%s' on hosted cluster '%s'", nodePool.ID(), clusterKey)
 	return nil
+}
+
+// fillAutoScalingAndReplicas is filling either autoscaling or replicas value in the builder
+func fillAutoScalingAndReplicas(npBuilder *cmv1.NodePoolBuilder, autoscaling bool, existingNodepool *cmv1.NodePool,
+	minReplicas int, maxReplicas int, replicas int) {
+	if autoscaling {
+		npBuilder.Autoscaling(editAutoscaling(existingNodepool, minReplicas, maxReplicas))
+	} else {
+		npBuilder.Replicas(replicas)
+	}
 }
 
 // promptForNodePoolNodeRecreate - prompts the user to accept that their changes will cause the nodes

--- a/cmd/edit/machinepool/nodepool_test.go
+++ b/cmd/edit/machinepool/nodepool_test.go
@@ -145,4 +145,30 @@ var _ = Describe("Nodepool", func() {
 		})
 
 	})
+
+	Context("fillAutoScalingAndReplicas", func() {
+		var npBuilder *cmv1.NodePoolBuilder
+		existingNodepool, err := cmv1.NewNodePool().
+			Autoscaling(cmv1.NewNodePoolAutoscaling().MaxReplica(4).MinReplica(1)).
+			Build()
+		Expect(err).To(BeNil())
+		It("Autoscaling set", func() {
+			npBuilder = cmv1.NewNodePool()
+			fillAutoScalingAndReplicas(npBuilder, true, existingNodepool, 1, 3, 2)
+			npPatch, err := npBuilder.Build()
+			Expect(err).To(BeNil())
+			Expect(npPatch.Autoscaling()).ToNot(BeNil())
+			// Default (zero) value
+			Expect(npPatch.Replicas()).To(Equal(0))
+		})
+		It("Replicas set", func() {
+			npBuilder = cmv1.NewNodePool()
+			fillAutoScalingAndReplicas(npBuilder, false, existingNodepool, 0, 0, 2)
+			npPatch, err := npBuilder.Build()
+			Expect(err).To(BeNil())
+			Expect(npPatch.Autoscaling()).To(BeNil())
+			Expect(npPatch.Replicas()).To(Equal(2))
+		})
+
+	})
 })


### PR DESCRIPTION
We always pass the replicas when editing a machinepool, even if the value has not changed, as this will then be a no-op. Right now we are not setting replicas if they are the same as the current value and this result in an error returned to the user.

Related: [OCM-8337](https://issues.redhat.com//browse/OCM-8337)