### PR TITLE
OCM-4459 | test: automate id:72536 create/list/describe/delete external_auth_provider for hcp cluster

### DIFF
--- a/tests/utils/exec/rosacli/cmd_client.go
+++ b/tests/utils/exec/rosacli/cmd_client.go
@@ -42,6 +42,7 @@ type Client struct {
 	User                 UserService
 	Version              VersionService
 	BreakGlassCredential BreakGlassCredentialService
+	ExternalAuthProvider ExternalAuthProviderService
 }
 
 func NewClient() *Client {
@@ -66,6 +67,7 @@ func NewClient() *Client {
 	client.User = NewUserService(client)
 	client.Version = NewVersionService(client)
 	client.BreakGlassCredential = NewBreakGlassCredentialService(client)
+	client.ExternalAuthProvider = NewExternalAuthProviderService(client)
 
 	return client
 }
@@ -86,6 +88,7 @@ func (c *Client) CleanResources(clusterID string) error {
 	errorList = append(errorList, c.OCMResource.CleanResources(clusterID)...)
 	errorList = append(errorList, c.Cluster.CleanResources(clusterID)...)
 	errorList = append(errorList, c.BreakGlassCredential.CleanResources(clusterID)...)
+	errorList = append(errorList, c.ExternalAuthProvider.CleanResources(clusterID)...)
 
 	return errors.Join(errorList...)
 

--- a/tests/utils/exec/rosacli/external_auth_provider_service.go
+++ b/tests/utils/exec/rosacli/external_auth_provider_service.go
@@ -1,0 +1,177 @@
+package rosacli
+
+import (
+	"bytes"
+
+	"gopkg.in/yaml.v3"
+
+	. "github.com/openshift/rosa/tests/utils/log"
+)
+
+type ExternalAuthProviderService interface {
+	ResourcesCleaner
+
+	CreateExternalAuthProvider(clusterID string, flags ...string) (bytes.Buffer, error)
+	DeleteExternalAuthProvider(clusterID string, eapID string) (bytes.Buffer, error)
+	ListExternalAuthProvider(clusterID string) (bytes.Buffer, error)
+	ReflectExternalAuthProviderLists(result bytes.Buffer) (eapl *ExternalAuthProviderList, err error)
+	DescribeExternalAuthProvider(clusterID string, eapID string) (bytes.Buffer, error)
+	ReflectExternalAuthProviderDescription(result bytes.Buffer) (eapd *ExternalAuthProviderDescription, err error)
+
+	ListExternalAuthProviderAndReflect(clusterID string) (*ExternalAuthProviderList, error)
+	DescribeExternalAuthProviderAndReflect(clusterID string, eapID string) (*ExternalAuthProviderDescription, error)
+
+	RetrieveHelpForList() (output bytes.Buffer, err error)
+	RetrieveHelpForDescribe() (output bytes.Buffer, err error)
+	RetrieveHelpForDelete() (output bytes.Buffer, err error)
+}
+
+type externalauthproviderService struct {
+	ResourcesService
+	created map[string]bool
+}
+
+type ExternalAuthProvider struct {
+	Name      string `json:"NAME,omitempty"`
+	IssuerUrl string `json:"ISSUER URL,omitempty"`
+}
+
+type ExternalAuthProviderList struct {
+	ExternalAuthProviders []ExternalAuthProvider `json:"ExternalAuthProviders,omitempty"`
+}
+
+type ExternalAuthProviderDescription struct {
+	ID                    string   `yaml:"ID,omitempty"`
+	ClusterID             string   `yaml:"Cluster ID,omitempty"`
+	IssuerAudiences       []string `yaml:"Issuer audiences,omitempty"`
+	IssuerUrl             string   `yaml:"Issuer Url,omitempty"`
+	ClaimMappingsGroup    string   `yaml:"Claim mappings group,omitempty"`
+	ClaimMappingsUserName string   `yaml:"Claim mappings username,omitempty"`
+	ClaimValidationRules  []string `yaml:"Claim validation rules,omitempty"`
+	ConsoleClientID       string   `yaml:"Console client id,omitempty"`
+}
+
+func NewExternalAuthProviderService(client *Client) ExternalAuthProviderService {
+	return &externalauthproviderService{
+		ResourcesService: ResourcesService{
+			client: client,
+		},
+		created: make(map[string]bool),
+	}
+}
+
+// Create ExternalAuthProvider
+func (e *externalauthproviderService) CreateExternalAuthProvider(clusterID string, flags ...string) (output bytes.Buffer, err error) {
+	output, err = e.client.Runner.
+		Cmd("create", "external-auth-provider").
+		CmdFlags(append(flags, "-c", clusterID)...).
+		Run()
+	if err == nil {
+		e.created[clusterID] = true
+	}
+	return
+}
+
+// List ExternalAuthProviders
+func (e *externalauthproviderService) ListExternalAuthProvider(clusterID string) (output bytes.Buffer, err error) {
+	output, err = e.client.Runner.
+		Cmd("list", "external-auth-provider").
+		CmdFlags("-c", clusterID).
+		Run()
+	return
+}
+
+func (e *externalauthproviderService) ReflectExternalAuthProviderLists(result bytes.Buffer) (eapl *ExternalAuthProviderList, err error) {
+	eapl = &ExternalAuthProviderList{}
+	theMap := e.client.Parser.TableData.Input(result).Parse().Output()
+	for _, eapItem := range theMap {
+		externalAuthProvider := &ExternalAuthProvider{}
+		err = MapStructure(eapItem, externalAuthProvider)
+		if err != nil {
+			return
+		}
+		eapl.ExternalAuthProviders = append(eapl.ExternalAuthProviders, *externalAuthProvider)
+	}
+	return
+}
+
+func (e *externalauthproviderService) ListExternalAuthProviderAndReflect(clusterID string) (*ExternalAuthProviderList, error) {
+	output, err := e.ListExternalAuthProvider(clusterID)
+	if err != nil {
+		return nil, err
+	}
+	return e.ReflectExternalAuthProviderLists(output)
+}
+
+// Describe ExternalAuthProvider
+func (e *externalauthproviderService) DescribeExternalAuthProvider(clusterID string, eapID string) (bytes.Buffer, error) {
+	describe := e.client.Runner.
+		Cmd("describe", "external-auth-provider", eapID).
+		CmdFlags("-c", clusterID)
+
+	return describe.Run()
+}
+
+func (e *externalauthproviderService) DescribeExternalAuthProviderAndReflect(clusterID string, eapID string) (*ExternalAuthProviderDescription, error) {
+	output, err := e.DescribeExternalAuthProvider(clusterID, eapID)
+	if err != nil {
+		return nil, err
+	}
+	return e.ReflectExternalAuthProviderDescription(output)
+}
+
+func (e *externalauthproviderService) ReflectExternalAuthProviderDescription(result bytes.Buffer) (eapd *ExternalAuthProviderDescription, err error) {
+	var data []byte
+	res := &ExternalAuthProviderDescription{}
+	theMap, err := e.client.Parser.TextData.Input(result).Parse().YamlToMap()
+	if err != nil {
+		return
+	}
+	data, err = yaml.Marshal(&theMap)
+	if err != nil {
+		return
+	}
+	err = yaml.Unmarshal(data, res)
+	return res, err
+}
+
+// Delete ExternalAuthProvider
+func (e *externalauthproviderService) DeleteExternalAuthProvider(clusterID string, eapID string) (output bytes.Buffer, err error) {
+	output, err = e.client.Runner.
+		Cmd("delete", "external-auth-provider", eapID).
+		CmdFlags("-c", clusterID, "-y").
+		Run()
+	return
+}
+
+func (e *externalauthproviderService) CleanResources(clusterID string) (errors []error) {
+	if e.created[clusterID] {
+		Logger.Infof("Remove remaining extrenal-auth-providers")
+		externalaAuthProviders, err := e.ListExternalAuthProviderAndReflect(clusterID)
+		if err != nil {
+			return
+		}
+		for _, externalAuthProvider := range externalaAuthProviders.ExternalAuthProviders {
+			_, err := e.DeleteExternalAuthProvider(clusterID, externalAuthProvider.Name)
+			if err != nil {
+				errors = append(errors, err)
+			}
+		}
+	}
+	return
+}
+
+// Help for List ExternalAuthProvider
+func (e *externalauthproviderService) RetrieveHelpForList() (output bytes.Buffer, err error) {
+	return e.client.Runner.Cmd("list", "external-auth-provider").CmdFlags("-h").Run()
+}
+
+// Help for Describe ExternalAuthProvider
+func (e *externalauthproviderService) RetrieveHelpForDescribe() (output bytes.Buffer, err error) {
+	return e.client.Runner.Cmd("describe", "external-auth-provider").CmdFlags("-h").Run()
+}
+
+// Help for Delete ExternalAuthProvider
+func (e *externalauthproviderService) RetrieveHelpForDelete() (output bytes.Buffer, err error) {
+	return e.client.Runner.Cmd("delete", "external-auth-provider").CmdFlags("-h").Run()
+}


### PR DESCRIPTION
$ ginkgo --focus 72536 tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.14.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: e2e tests suite - /home/aaraj/ocm-forked-code/rosa/tests/e2e
===========================================================================
Random Seed: 1717166482

Will run 1 of 93 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 93 Specs in 77.469 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 92 Skipped
PASS

Ginkgo ran 1 suite in 1m22.483280865s
Test Suite Passed