### PR TITLE
OCM-6706 | ci: Use CLI logger

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,8 +1,10 @@
 # ROSA CLI Function Verification Testing
-This package is the automation package for Function Verification Testing on the ROSA CLI. 
+
+This package is the automation package for Function Verification Testing on the ROSA CLI.
 
 ## Structure of tests
-```sh
+
+```bash
 tests
 |____e2e      
     |____e2e_suite_test.go                        ---- test suite for all the e2e tests
@@ -22,7 +24,9 @@ tests
 ## Contibute to ROSA CLI tests
 
 Please read the structure and contribute code to the correct place
+
 ### Contribute to day1
+
 1. Enable the configuration in _[profiles](./ci/data/profiles)_
 2. Mapping the configuration in _[ClusterConfig](./utils/profilehandler/interface.go)_
 3. Define the userdata preparation function in _[data_preparation](./utils/profilehandler/data_preparation.go)_
@@ -38,9 +42,10 @@ Please read the structure and contribute code to the correct place
 * Every case need to recover the cluster after the case run finished unless it's un-recoverable
 * Case format should follow 
   * _main feature description in Describe level_ at the same time _testing purpose in It level_.
-  * `id` of the case is included which will follow the fmt of _[id:<id>]_
+  * `id` of the case is included which will follow the fmt of _[id:\<id\>]_
   * Use `By("")` to describe the steps
   * An example as below
+
 ```golang
 var _ = Describe("Create Machine Pool", func() {
   It("to hosted cluster with additional security group IDs will work - [id:72195]",func(){
@@ -55,8 +60,9 @@ var _ = Describe("Create Machine Pool", func() {
   })
 }
 ```
+
   * The commit and PR should follow
-    * Only one commit is allowed per PR, if multiple commits created please squash them with command 
+    * Only one commit is allowed per PR, if multiple commits created please squash them with command
     `git rebase -i HEAD~N`(_N_ is the commits number you would squashed)
     * The commit and PR title should follow rule of [contributing-to-rosa](../CONTRIBUTING.md#contributing-to-rosa)
     * Case id must be included in the PR/commit title if new automated or updated. Comma-separated if multiple included in same PR/commit. For example
@@ -120,6 +126,7 @@ For the test cases, we need `$ make install` to make the rosa command line insta
 > * **CLUSTER_TIMEOUT** if it is set, the process will exit if cluster cannot be ready in setting time. Unit is minute
 
 ### Running a local CI test simulation
+
 This feature allows for running tests through a case filter to simulate CI. Anyone can customize the case label filter to select the specific cases that would be run. 
 
 1. To declare the cluster id, use the below variable
@@ -132,6 +139,7 @@ This feature allows for running tests through a case filter to simulate CI. Anyo
       * `$ ginkgo run -focus <case id> tests/e2e`
 
 ### Resources destroy
+
 1. Export the profile name as an environment variable
 * `$ export TEST_PROFILE=<PROFILE NAME>`
 
@@ -144,8 +152,8 @@ This feature allows for running tests through a case filter to simulate CI. Anyo
 > Environment variables setting
 > * **SHARED_DIR** if you have the env variable setting, resource destroy will read information from cluster-detail.json and resources.json under it, otherwise it will read the two files from _output/${TEST_PROFILE}_
 
-
 ## Additional configuration
+
 > [!TIP]
 > Set log level
 > Log level defined in rosa/tests/utils/log/logger.go
@@ -154,13 +162,16 @@ This feature allows for running tests through a case filter to simulate CI. Anyo
 > ```
 
 ## Running with presubmit jobs
+
 The [presubmit jobs](https://github.com/openshift/release/blob/master/ci-operator/config/openshift/rosa/openshift-rosa-master__e2e-presubmits.yaml) are used for validating the changes in the pull request before merging. The lifecycle of a presubmit job is `create a cluster` -> `do testing` -> `release resources`. The tester needs to select the corresponding configuration to trigger the job manually. These jobs are set to `optional: true` which means even if it is failed, it is not considered as a merging blocker.
 
 Regularly, `do testing` focuses on the test case IDs that are gotten from the commit title in the format `<card id> | test: automated cases id:123456,123457`. If there is no test case ID, it will pick up the `Critical` ones. The testing results will be recorded in a junit.xml under `rosa-test-e2e-pull-request/${ARTIFACT_DIR}`. 
 
 ### Help
+
 Type `/test ?` to list the defined jobs.
-```
+
+```text
 The following commands are available to trigger optional jobs:
 
     /test e2e-presubmits-pr-rosa-hcp

--- a/tests/e2e/dummy_test.go
+++ b/tests/e2e/dummy_test.go
@@ -7,12 +7,12 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	TC "github.com/openshift/rosa/tests/ci/config"
+	ciConfig "github.com/openshift/rosa/tests/ci/config"
 	"github.com/openshift/rosa/tests/utils/common"
 	"github.com/openshift/rosa/tests/utils/config"
 	"github.com/openshift/rosa/tests/utils/exec/rosacli"
-	"github.com/openshift/rosa/tests/utils/log"
-	PH "github.com/openshift/rosa/tests/utils/profilehandler"
+	. "github.com/openshift/rosa/tests/utils/log"
+	"github.com/openshift/rosa/tests/utils/profilehandler"
 )
 
 var _ = Describe("ROSA CLI Test", func() {
@@ -20,24 +20,24 @@ var _ = Describe("ROSA CLI Test", func() {
 		It("Dummy", func() {
 			str := "dummy string"
 			Expect(str).ToNot(BeEmpty())
-			log.Logger.Infof("This is a dummy test to check everything is fine by executing jobs. Please remove me once other tests are added")
+			Logger.Infof("This is a dummy test to check everything is fine by executing jobs. Please remove me once other tests are added")
 		})
 	})
 	Describe("Profile test", func() {
 		It("ProfileParserTest", func() {
-			profile := PH.LoadProfileYamlFileByENV()
-			log.Logger.Infof("Got configured profile: %v", *profile)
-			log.Logger.Infof("Got configured profile prefix: %v", profile.NamePrefix)
-			log.Logger.Infof("Got configured cluster profile: %v", *profile.ClusterConfig)
-			log.Logger.Infof("Got configured account role profile: %v", *profile.AccountRoleConfig)
+			profile := profilehandler.LoadProfileYamlFileByENV()
+			Logger.Infof("Got configured profile: %v", *profile)
+			Logger.Infof("Got configured profile prefix: %v", profile.NamePrefix)
+			Logger.Infof("Got configured cluster profile: %v", *profile.ClusterConfig)
+			Logger.Infof("Got configured account role profile: %v", *profile.AccountRoleConfig)
 		})
 		It("TestENVSetup", func() {
-			log.Logger.Infof("Got dir of out: %v", TC.Test.OutputDir)
+			Logger.Infof("Got dir of out: %v", ciConfig.Test.OutputDir)
 		})
 		It("TestPrepareClusterByProfile", func() {
 			client := rosacli.NewClient()
-			profile := PH.LoadProfileYamlFileByENV()
-			cluster, err := PH.CreateClusterByProfile(profile, client, true)
+			profile := profilehandler.LoadProfileYamlFileByENV()
+			cluster, err := profilehandler.CreateClusterByProfile(profile, client, true)
 			Expect(err).ToNot(HaveOccurred())
 			fmt.Println(cluster.ID)
 		})
@@ -49,19 +49,19 @@ var _ = Describe("ROSA CLI Test", func() {
 	})
 	Describe("ocm-common test", func() {
 		It("VPCClientTesting", func() {
-			vpcClient, err := PH.PrepareVPC("us-east-1", "xueli-test", "10.0.0.0/16")
+			vpcClient, err := profilehandler.PrepareVPC("us-east-1", "xueli-test", "10.0.0.0/16")
 			Expect(err).ToNot(HaveOccurred())
 			defer vpcClient.DeleteVPCChain(true)
-			subnets, err := PH.PrepareSubnets(vpcClient, "us-east-1", []string{}, true)
+			subnets, err := profilehandler.PrepareSubnets(vpcClient, "us-east-1", []string{}, true)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(subnets)).To(Equal(2))
-			_, ip, ca, err := vpcClient.LaunchProxyInstance("us-east-1a", "xueli-test", TC.Test.OutputDir)
+			_, ip, ca, err := vpcClient.LaunchProxyInstance("us-east-1a", "xueli-test", ciConfig.Test.OutputDir)
 
 			Expect(err).ToNot(HaveOccurred())
 			fmt.Println(ip)
 			fmt.Println(ca)
-			log.Logger.Infof("Got configured proxy ip: %v", ip)
-			log.Logger.Infof("Got configured proxy ca: %v", ca)
+			Logger.Infof("Got configured proxy ip: %v", ip)
+			Logger.Infof("Got configured proxy ca: %v", ca)
 		})
 
 	})
@@ -86,7 +86,7 @@ var _ = Describe("ROSA CLI Test", func() {
 		It("", func() {
 			funcA := func(causeError bool) error {
 				rosacli.NewClient().OCMResource.ListRegion()
-				log.Logger.Debugf("I am debug message with caseuError %v", causeError)
+				Logger.Debugf("I am debug message with caseuError %v", causeError)
 				if causeError {
 					return fmt.Errorf("test")
 				}
@@ -94,6 +94,15 @@ var _ = Describe("ROSA CLI Test", func() {
 			}
 			// Expect(funcA(true)).ToNot(HaveOccurred())
 			Expect(funcA(false)).ToNot(HaveOccurred())
+		})
+	})
+	// Used to check the sensitive data filterting
+	Describe("logstreamsensitivedata", func() {
+		It("", func() {
+			Logger.Info("rosa create cluster --billing-account 012345678912")
+			Logger.Info("--password antyhingoutofordinary endofpassword")
+			Logger.Info("beginning --client-id thisisclient end")
+			Expect(false).To(BeTrue())
 		})
 	})
 })

--- a/tests/e2e/e2e_tear_down_test.go
+++ b/tests/e2e/e2e_tear_down_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/openshift/rosa/tests/ci/labels"
 	"github.com/openshift/rosa/tests/utils/exec/rosacli"
-	ph "github.com/openshift/rosa/tests/utils/profilehandler"
+	"github.com/openshift/rosa/tests/utils/profilehandler"
 )
 
 var _ = Describe("ROSA CLI Test", func() {
@@ -15,8 +15,8 @@ var _ = Describe("ROSA CLI Test", func() {
 		labels.Destroy,
 		func() {
 			client := rosacli.NewClient()
-			profile := ph.LoadProfileYamlFileByENV()
-			var errs = ph.DestroyResourceByProfile(profile, client)
+			profile := profilehandler.LoadProfileYamlFileByENV()
+			var errs = profilehandler.DestroyResourceByProfile(profile, client)
 			Expect(len(errs)).To(Equal(0))
 		})
 })

--- a/tests/utils/log/constants.go
+++ b/tests/utils/log/constants.go
@@ -7,13 +7,6 @@ import (
 const (
 	RedactValue = "*************"
 )
-const (
-	info  = "INFO"
-	debug = "DEBUG"
-	fatal = "FATAL"
-	warn  = "WARN"
-	err   = "ERROR"
-)
 
 var RedactKeyList = []*regexp.Regexp{
 	regexp.MustCompile(`(\\?"password\\?":\\?")([^"]*)(\\?")`),

--- a/tests/utils/log/logger.go
+++ b/tests/utils/log/logger.go
@@ -1,109 +1,35 @@
 package log
 
 import (
-	"context"
-	"fmt"
-	"regexp"
+	"os"
 	"time"
 
-	// logging "github.com/sirupsen/logrus"
 	g "github.com/onsi/ginkgo/v2"
-	"github.com/openshift-online/ocm-sdk-go/logging"
+	"github.com/sirupsen/logrus"
 )
 
-func GetLogger() *Log {
-	// Create the logger
-	logger, _ := logging.
-		NewStdLoggerBuilder().
-		Streams(g.GinkgoWriter, g.GinkgoWriter).
-		Debug(false).
-		Build()
-	return &Log{
-		logger:          logger,
-		logContext:      context.TODO(),
-		format:          time.RFC3339,
-		redActSensitive: true,
+func GetLogger() *logrus.Logger {
+	logger := logrus.New()
+	logger.SetFormatter(&logrus.TextFormatter{
+		DisableColors:   true,
+		DisableQuote:    true,
+		FullTimestamp:   true,
+		TimestampFormat: time.RFC3339,
+	})
+	logger.SetOutput(g.GinkgoWriter)
+
+	// Export `DEBUG=true` to enable debug level
+	debug := os.Getenv("DEBUG")
+	if debug == "true" {
+		logger.SetLevel(logrus.DebugLevel)
 	}
-}
 
-var Logger *Log = GetLogger()
-
-type Log struct {
-	logger          *logging.StdLogger
-	logContext      context.Context
-	format          string
-	redActSensitive bool
-}
-
-func (l *Log) NeedRedact(originalString string, regexP *regexp.Regexp) bool {
-	return regexP.MatchString(originalString)
-}
-
-func (l *Log) DecorateLog(level string, message string) string {
-	now := time.Now().Format(l.format)
-	return fmt.Sprintf("%s - %s : %s", now, level, message)
-}
-func (l *Log) Redact(fmtedString string) string {
-	if !l.redActSensitive {
-		return fmtedString
+	sensitiveHook := &SensitiveHook{
+		regexes: RedactKeyList,
 	}
-	for _, regexP := range RedactKeyList {
-		if l.NeedRedact(fmtedString, regexP) {
-			l.logger.Debug(l.logContext, "Got need redacted string from log match regex %s", regexP.String())
-			fmtedString = regexP.ReplaceAllString(fmtedString, fmt.Sprintf(`$1%s$3`, RedactValue))
-		}
-	}
-	return fmtedString
-}
-func (l *Log) Infof(fmtString string, args ...interface{}) {
-	if len(args) != 0 {
-		fmtString = fmt.Sprintf(fmtString, args...)
-	}
-	l.Info(fmtString)
+	logger.AddHook(sensitiveHook)
+
+	return logger
 }
 
-func (l *Log) Info(fmtString string) {
-	fmtString = l.DecorateLog(info, l.Redact(fmtString))
-	l.logger.Info(l.logContext, fmtString)
-}
-
-func (l *Log) Errorf(fmtString string, args ...interface{}) {
-	if len(args) != 0 {
-		fmtString = fmt.Sprintf(fmtString, args...)
-	}
-	l.Error(fmtString)
-}
-
-func (l *Log) Error(fmtString string) {
-	fmtString = l.DecorateLog(err, l.Redact(fmtString))
-	l.logger.Error(l.logContext, fmtString)
-}
-
-func (l *Log) Warnf(fmtString string, args ...interface{}) {
-	if len(args) != 0 {
-		fmtString = fmt.Sprintf(fmtString, args...)
-	}
-	l.Warn(fmtString)
-}
-
-func (l *Log) Warn(fmtString string) {
-	fmtString = l.DecorateLog(warn, l.Redact(fmtString))
-	l.logger.Warn(l.logContext, fmtString)
-}
-
-func (l *Log) Debugf(fmtString string, args ...interface{}) {
-	if len(args) != 0 {
-		fmtString = fmt.Sprintf(fmtString, args...)
-	}
-	l.Debug(fmtString)
-}
-
-func (l *Log) Debug(fmtString string) {
-	fmtString = l.DecorateLog(debug, l.Redact(fmtString))
-	l.logger.Debug(l.logContext, fmtString)
-}
-
-func (l *Log) Fatal(fmtString string) {
-	fmtString = l.DecorateLog(fatal, l.Redact(fmtString))
-	l.logger.Fatal(l.logContext, fmtString)
-}
+var Logger *logrus.Logger = GetLogger()

--- a/tests/utils/log/sensitive_hook.go
+++ b/tests/utils/log/sensitive_hook.go
@@ -1,0 +1,76 @@
+package log
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Inspired from https://github.com/whuang8/redactrus/blob/master/redactrus.go
+
+// SensitiveHook is a logrus hook for redacting information from logs via regexp
+type SensitiveHook struct {
+	// List of regex to match. They should be returning 3 groups, the second one
+	// being the one which contains the sensitive data and which will be
+	// redacted
+	regexes []*regexp.Regexp
+}
+
+// All logrus levels are returned
+func (h *SensitiveHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+// LevelThreshold returns a []logrus.Level including all levels
+// above and including the level given. If the provided level does not exit,
+// an empty slice is returned.
+func LevelThreshold(l logrus.Level) []logrus.Level {
+	if int(l) > len(logrus.AllLevels) {
+		return []logrus.Level{}
+	}
+	return logrus.AllLevels[:l+1]
+}
+
+// Fire redacts values in an log Entry that match the regex
+func (h *SensitiveHook) Fire(e *logrus.Entry) error {
+	for _, regexP := range h.regexes {
+		// Redact based on key matching in Data fields
+		for k, v := range e.Data {
+			// Logrus Field values can be nil
+			if v == nil {
+				continue
+			}
+
+			// Redact based on value matching in Data fields
+			switch reflect.TypeOf(v).Kind() {
+			case reflect.String:
+				switch vv := v.(type) {
+				case string:
+					e.Data[k] = regexP.ReplaceAllString(vv, fmt.Sprintf(`$1%s$3`, RedactValue))
+				default:
+					e.Data[k] = regexP.ReplaceAllString(fmt.Sprint(v), fmt.Sprintf(`$1%s$3`, RedactValue))
+				}
+				continue
+			// prevent nil *fmt.Stringer from reaching handler below
+			case reflect.Ptr:
+				if reflect.ValueOf(v).IsNil() {
+					continue
+				}
+			}
+
+			// Handle fmt.Stringer type.
+			if vv, ok := v.(fmt.Stringer); ok {
+				e.Data[k] = regexP.ReplaceAllString(vv.String(), fmt.Sprintf(`$1%s$3`, RedactValue))
+				continue
+			}
+
+		}
+
+		// Redact based on text matching in the Message field
+		e.Message = regexP.ReplaceAllString(e.Message, fmt.Sprintf(`$1%s$3`, RedactValue))
+	}
+
+	return nil
+}


### PR DESCRIPTION
aka logrus instead of ocm-sdk logging
and added a sensitive hook to filter out sensitive data

https://issues.redhat.com/browse/OCM-6706

<details>
<summary>Logs</summary>
$ ginkgo -focus logstreamsensitivedata tests/e2e/
[...]
ROSA CLI Test logstreamsensitivedata [It] 
/home/tradisso/projects/openshift/rosa/tests/e2e/dummy_test.go:101

  Timeline >>
  time=2024-06-03T14:40:53+02:00 level=info msg=rosa create cluster --billing-account *************
  time=2024-06-03T14:40:53+02:00 level=info msg=--password ************* endofpassword
  time=2024-06-03T14:40:53+02:00 level=info msg=beginning --client-id ************* end
</details>