### PR TITLE
OCM-8145 | test: Fix the non-oidc cluster preparation issue due to parser error

### DIFF
--- a/tests/utils/exec/rosacli/cluster_service.go
+++ b/tests/utils/exec/rosacli/cluster_service.go
@@ -126,6 +126,7 @@ func (c *clusterService) ReflectClusterDescription(result bytes.Buffer) (res *Cl
 			// It will consider
 			newStr = strings.Replace(str, "Failed Inflight Checks:", "Failed Inflight Checks: |", 1)
 			newStr = strings.ReplaceAll(newStr, "\t", "  ")
+			newStr = strings.ReplaceAll(newStr, "not found: Role name", "not found:Role name")
 			return
 		}).
 		YamlToMap()

--- a/tests/utils/profilehandler/data_preparation.go
+++ b/tests/utils/profilehandler/data_preparation.go
@@ -64,7 +64,7 @@ func PrepareVersion(client *rosacli.Client, versionRequirement string, channelGr
 		log.Logger.Infof("Going to prepare version for %s stream %v versions lower", stream, versionStep)
 		switch stream {
 		case "y":
-			version, err := versionList.FindNearestBackwardMinorVersion(latestVersion.Version, int64(versionStep), true)
+			version, err := versionList.FindNearestBackwardMinorVersion(latestVersion.Version, int64(versionStep), true, true)
 			return version, err
 		case "z":
 			version, err := versionList.FindNearestBackwardOptionalVersion(latestVersion.Version, versionStep, true)


### PR DESCRIPTION
```
lixue@Xue-Lis-MacBook-Pro rosa % ginkgo -label-filter day1-prepare tests/e2e
Running Suite: e2e tests suite - /Users/lixue/Workspace/rosa/tests/e2e
======================================================================
Random Seed: 1717415423

Will run 1 of 91 specs
SSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 91 Specs in 2542.600 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 90 Skipped
PASS

Ginkgo ran 1 suite in 42m29.657290157s
Test Suite Passed
```
And cluster is in version of
```
{
  "kind": "Version",
  "id": "openshift-v4.15.11-candidate",
  "href": "/api/clusters_mgmt/v1/versions/openshift-v4.15.11-candidate",
  "raw_id": "4.15.11",
  "channel_group": "candidate",
  "available_upgrades": [
    "4.15.12",
    "4.15.13",
    "4.15.14",
    "4.15.15",
    "4.15.16",
    "4.16.0-ec.6",
    "4.16.0-rc.0",
    "4.16.0-rc.1",
    "4.16.0-rc.2",
    "4.16.0-rc.3"
  ],
  "end_of_life_timestamp": "2025-06-30T00:00:00Z"
}
```