### PR TITLE
OCM-7918 | fix: use space delimiter in AWS tags error msg to avoid confusion

### DIFF
--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -302,7 +302,7 @@ func UserTagValidator(input interface{}) error {
 	for _, t := range inputTags {
 		tag := strings.Split(t, delimiter)
 		if len(tag) != 2 {
-			return fmt.Errorf("invalid tag format for tag '%s'. Expected tag format: 'key%svalue'", tag, delimiter)
+			return fmt.Errorf("invalid tag format for tag '%s'. Expected tag format: 'key value'", tag)
 		}
 
 		if tag[0] == "" || tag[1] == "" {

--- a/pkg/aws/helpers_test.go
+++ b/pkg/aws/helpers_test.go
@@ -36,6 +36,11 @@ var _ = Describe("UserTagValidator", func() {
 				Expect(err).To(MatchError("invalid tag format for tag '[tag2=value2]'. Expected tag format: 'key value'"))
 			})
 
+			It("should return an error if the tag has too many elements", func() {
+				err := UserTagValidator("a:b:c")
+				Expect(err).To(MatchError("invalid tag format for tag '[a b c]'. Expected tag format: 'key value'"))
+			})
+
 			It("should return an error if a tag is missing a key", func() {
 				err := UserTagValidator(":value1,tag2:value2")
 				Expect(err).To(MatchError("invalid tag format, tag key or tag value can not be empty"))


### PR DESCRIPTION
In https://issues.redhat.com/browse/OCM-7918 the code is working as intended, it just parses the tag as having too many delimiters because the value is not separated by a space. Since spaces are not allowed in tag key/values but `:` is, it makes more sense to use a space as a delimiter in the error message to avoid confusion on how the tags are parsed.