### PR TITLE
SDA-2922 | test: fixing id:35878 ci failures

### DIFF
--- a/tests/e2e/test_rosacli_idp.go
+++ b/tests/e2e/test_rosacli_idp.go
@@ -120,11 +120,16 @@ var _ = Describe("Edit IDP",
 				Expect(idpTab.IsExist("cluster-admin")).To(BeTrue())
 				Expect(idpTab.IsExist(idpName)).To(BeTrue())
 
-				By("login the cluster with the created cluster admin")
-				time.Sleep(3 * time.Minute)
-				stdout, err := rosaClient.Runner.RunCMD(strings.Split(command, " "))
+				isPrivate, err := rosaClient.Cluster.IsPrivateCluster(clusterID)
 				Expect(err).To(BeNil())
-				Expect(stdout.String()).Should(ContainSubstring("Login successful"))
+
+				if !isPrivate {
+					By("login the cluster with the created cluster admin")
+					time.Sleep(3 * time.Minute)
+					stdout, err := rosaClient.Runner.RunCMD(strings.Split(command, " "))
+					Expect(err).To(BeNil())
+					Expect(stdout.String()).Should(ContainSubstring("Login successful"))
+				}
 			})
 
 		It("can create/List/Delete IDPs for rosa clusters - [id:35896]",


### PR DESCRIPTION
$ ginkgo --focus 35878 tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.14.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: e2e tests suite - /home/aaraj/ocm-forked-code/rosa/tests/e2e
===========================================================================
Random Seed: 1717431235

Will run 1 of 94 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 94 Specs in 82.140 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 93 Skipped
PASS

Ginkgo ran 1 suite in 1m28.994747085s
Test Suite Passed
