### PR TITLE
OCM-8145 | test: Fix account role path in profile

### DIFF
--- a/tests/ci/data/profiles/rosa-hcp.yaml
+++ b/tests/ci/data/profiles/rosa-hcp.yaml
@@ -51,7 +51,7 @@ profiles:
     tag_enabled: false
     zones: ""
   account-role:
-    path: "/test-hcp/"
+    path: "/test/hcp/"
     permission_boundary: "arn:aws:iam::aws:policy/AdministratorAccess"
 - as: rosa-hcp-upgrade-z-stream
   version: "z-1"


### PR DESCRIPTION
[OCM-8145](https://issues.redhat.com//browse/OCM-8145) | test: Fix account role path in profile.
The CI would fail with the previous path config, https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/52699/rehearse-52699-periodic-ci-openshift-rosa-master-e2e-rosa-hcp-private-link-f3/1797601791043440640/artifacts/rosa-hcp-private-link-f3/rosa-cluster-setup/build-log.txt

$ ./rosa create account-roles --prefix yw0604acr --mode auto -y --path /test/hcp/ 
I: Logged in as 'sdqe-regular02' on 'https://api.stage.openshift.com'
I: Validating AWS credentials...
I: AWS credentials are valid!
I: Validating AWS quota...
I: AWS quota ok. If cluster installation fails, validate actual AWS resource usage against https://docs.openshift.com/rosa/rosa_getting_started/rosa-required-aws-service-quotas.html
I: Verifying whether OpenShift command-line tool is available...
I: Current OpenShift Client Version: 4.14.3
I: Creating account roles
I: By default, the create account-roles command creates two sets of account roles, one for classic ROSA clusters, and one for Hosted Control Plane clusters.
In order to create a single set, please set one of the following flags: --classic or --hosted-cp
I: Creating classic account roles using 'arn:aws:iam::301721915996:user/yuwan'
I: Created role 'yw0604acr-Installer-Role' with ARN 'arn:aws:iam::301721915996:role/test/hcp/yw0604acr-Installer-Role'
I: Created role 'yw0604acr-ControlPlane-Role' with ARN 'arn:aws:iam::301721915996:role/test/hcp/yw0604acr-ControlPlane-Role'
I: Created role 'yw0604acr-Worker-Role' with ARN 'arn:aws:iam::301721915996:role/test/hcp/yw0604acr-Worker-Role'
I: Created role 'yw0604acr-Support-Role' with ARN 'arn:aws:iam::301721915996:role/test/hcp/yw0604acr-Support-Role'
I: Creating hosted CP account roles using 'arn:aws:iam::301721915996:user/yuwan'
I: Created role 'yw0604acr-HCP-ROSA-Installer-Role' with ARN 'arn:aws:iam::301721915996:role/test/hcp/yw0604acr-HCP-ROSA-Installer-Role'
I: Created role 'yw0604acr-HCP-ROSA-Support-Role' with ARN 'arn:aws:iam::301721915996:role/test/hcp/yw0604acr-HCP-ROSA-Support-Role'
I: Created role 'yw0604acr-HCP-ROSA-Worker-Role' with ARN 'arn:aws:iam::301721915996:role/test/hcp/yw0604acr-HCP-ROSA-Worker-Role'