### PR TITLE
OCM-8587 | fix: colon not present in some field for describing autoscaler to a cluster

### DIFF
--- a/pkg/clusterautoscaler/output.go
+++ b/pkg/clusterautoscaler/output.go
@@ -13,7 +13,7 @@ func PrintAutoscaler(a *cmv1.ClusterAutoscaler) string {
 	out := "\n"
 	out += fmt.Sprintf("Balance Similar Node Groups:               %s\n",
 		output.PrintBool(a.BalanceSimilarNodeGroups()))
-	out += fmt.Sprintf("Skip Nodes With Local Storage              %s\n",
+	out += fmt.Sprintf("Skip Nodes With Local Storage:             %s\n",
 		output.PrintBool(a.SkipNodesWithLocalStorage()))
 	out += fmt.Sprintf("Log Verbosity:                             %d\n",
 		a.LogVerbosity())
@@ -60,7 +60,7 @@ func PrintAutoscaler(a *cmv1.ClusterAutoscaler) string {
 
 	//Scale Down
 	out += "Scale Down:\n"
-	out += fmt.Sprintf(" - Enabled                                 %s\n",
+	out += fmt.Sprintf(" - Enabled:                                %s\n",
 		output.PrintBool(a.ScaleDown().Enabled()))
 
 	if a.ScaleDown().UnneededTime() != "" {

--- a/pkg/clusterautoscaler/output_test.go
+++ b/pkg/clusterautoscaler/output_test.go
@@ -12,7 +12,7 @@ import (
 
 var optionalFieldOutput = `
 Balance Similar Node Groups:               No
-Skip Nodes With Local Storage              Yes
+Skip Nodes With Local Storage:             Yes
 Log Verbosity:                             2
 Labels Ignored For Node Balancing:         foo, bar
 Ignore DaemonSets Utilization:             Yes
@@ -30,7 +30,7 @@ Resource Limits:
    - Min:  10
    - Max:  20
 Scale Down:
- - Enabled                                 Yes
+ - Enabled:                                Yes
  - Node Unneeded Time:                     25m
  - Node Utilization Threshold:             20
  - Delay After Node Added:                 5m
@@ -40,7 +40,7 @@ Scale Down:
 
 var mandatoryFieldOutput = `
 Balance Similar Node Groups:               No
-Skip Nodes With Local Storage              Yes
+Skip Nodes With Local Storage:             Yes
 Log Verbosity:                             2
 Ignore DaemonSets Utilization:             Yes
 Maximum Pod Grace Period:                  10
@@ -52,7 +52,7 @@ Resource Limits:
  - Minimum Memory (GiB):                   5
  - Maximum Memory (GiB):                   10
 Scale Down:
- - Enabled                                 Yes
+ - Enabled:                                Yes
  - Node Utilization Threshold:             20
 `
 


### PR DESCRIPTION
```
$ rosa describe autoscaler -c 2bndda12o4i1neutfftama44j5ke87v1

Balance Similar Node Groups: Yes
Skip Nodes With Local Storage: Yes
Log Verbosity: 4
Labels Ignored For Node Balancing: aaa
Ignore DaemonSets Utilization: Yes
Maximum Node Provision Time: 10m
Maximum Pod Grace Period: 0
Pod Priority Threshold: 0
Resource Limits:

Maximum Nodes: 1000
Minimum Number of Cores: 0
Maximum Number of Cores: 100
Minimum Memory (GiB): 0
Maximum Memory (GiB): 4096
GPU Limitations:
Type: nvidia.com/gpu
Min: 0
Max: 10
Type: amd.com/gpu
Min: 1
Max: 5
Scale Down:
Enabled: Yes
Node Unneeded Time: 10s
Node Utilization Threshold: 0.500000
Delay After Node Added: 10s
Delay After Node Deleted: 10s
Delay After Node Deletion Failure: 10s
```