### PR TITLE
OCM-8632 | test: automate id:74225,73449 attach/detach/describe arbit…

### DIFF
--- a/tests/ci/labels/features.go
+++ b/tests/ci/labels/features.go
@@ -23,6 +23,7 @@ type featureLabels struct {
 	OIDCConfig           Labels
 	OIDCProvider         Labels
 	OperatorRoles        Labels
+	Policy               Labels
 	Regions              Labels
 	Token                Labels
 	TuningConfigs        Labels
@@ -51,6 +52,7 @@ func initFeatureLabels() *featureLabels {
 	fLabels.OIDCConfig = Label("feature-oidc-config")
 	fLabels.OIDCProvider = Label("feature-oidc-provider")
 	fLabels.OperatorRoles = Label("feature-operator-roles")
+	fLabels.Policy = Label("feature-policy")
 	fLabels.Token = Label("feature-token")
 	fLabels.TuningConfigs = Label("feature-tuning-configs")
 	fLabels.UserRole = Label("feature-user-role")

--- a/tests/e2e/test_rosacli_policy.go
+++ b/tests/e2e/test_rosacli_policy.go
@@ -1,0 +1,436 @@
+package e2e
+
+import (
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openshift-online/ocm-common/pkg/aws/aws_client"
+
+	"github.com/openshift/rosa/tests/ci/labels"
+	"github.com/openshift/rosa/tests/utils/common"
+	"github.com/openshift/rosa/tests/utils/config"
+	"github.com/openshift/rosa/tests/utils/exec/rosacli"
+)
+
+var _ = Describe("Attach and Detach arbitrary policies",
+	labels.Feature.Policy,
+	func() {
+		defer GinkgoRecover()
+
+		var (
+			clusterID                string
+			rosaClient               *rosacli.Client
+			arbitraryPolicyService   rosacli.PolicyService
+			clusterService           rosacli.ClusterService
+			arbitraryPoliciesToClean []string
+			awsClient                *aws_client.AWSClient
+			err                      error
+		)
+
+		BeforeEach(func() {
+			By("Get the cluster")
+			clusterID = config.GetClusterID()
+			Expect(clusterID).ToNot(Equal(""), "ClusterID is required. Please export CLUSTER_ID")
+
+			By("Init the client")
+			rosaClient = rosacli.NewClient()
+			arbitraryPolicyService = rosaClient.Policy
+			clusterService = rosaClient.Cluster
+			By("Prepare arbitray policies for testing")
+
+			awsClient, err = aws_client.CreateAWSClient("", "")
+			Expect(err).To(BeNil())
+			statement := map[string]interface{}{
+				"Effect":   "Allow",
+				"Action":   "*",
+				"Resource": "*",
+			}
+			for i := 0; i < 2; i++ {
+				arn, err := awsClient.CreatePolicy(fmt.Sprintf("ocmqe-arpolicy-%s-%d", common.GenerateRandomString(3), i), statement)
+				Expect(err).To(BeNil())
+				arbitraryPoliciesToClean = append(arbitraryPoliciesToClean, arn)
+			}
+
+		})
+
+		AfterEach(func() {
+			By("Clean remaining resources")
+			err := rosaClient.CleanResources(clusterID)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Delete arbitrary policies")
+			if len(arbitraryPoliciesToClean) > 0 {
+				for _, policyArn := range arbitraryPoliciesToClean {
+					err = awsClient.DeletePolicy(policyArn)
+					Expect(err).To(BeNil())
+				}
+			}
+		})
+
+		It("can attach and detach arbitrary policies on existing roles in auto mode - [id:73449]", labels.Critical, labels.Runtime.Day2, func() {
+			By("Get operator-roles arns")
+			output, err := clusterService.DescribeCluster(clusterID)
+			Expect(err).To(BeNil())
+			CD, err := clusterService.ReflectClusterDescription(output)
+			Expect(err).To(BeNil())
+			operatorRolesArns := CD.OperatorIAMRoles
+			_, operatorRoleName1, err := common.ParseRoleARN(operatorRolesArns[2])
+			Expect(err).To(BeNil())
+			operatorRolePoliciesMap1 := make(map[string][]string)
+			operatorRolePoliciesMap1[operatorRoleName1] = arbitraryPoliciesToClean[0:2]
+
+			By("Attach policies to operator-roles")
+			for roleName, policyArns := range operatorRolePoliciesMap1 {
+				out, err := arbitraryPolicyService.AttachPolicy(roleName, policyArns, "--mode", "auto")
+				Expect(err).To(BeNil())
+				for _, policyArn := range policyArns {
+					Expect(out.String()).To(ContainSubstring("Attached policy '%s' to role '%s'", policyArn, roleName))
+				}
+
+			}
+
+			_, operatorRoleName2, err := common.ParseRoleARN(operatorRolesArns[4])
+			Expect(err).To(BeNil())
+			operatorRolePoliciesMap2 := make(map[string][]string)
+			operatorRolePoliciesMap2[operatorRoleName2] = append(operatorRolePoliciesMap2[operatorRolesArns[4]], arbitraryPoliciesToClean[1])
+
+			for roleName, policyArns := range operatorRolePoliciesMap2 {
+				out, err := arbitraryPolicyService.AttachPolicy(roleName, policyArns, "--mode", "auto")
+				Expect(err).To(BeNil())
+				for _, policyArn := range policyArns {
+					Expect(out.String()).To(ContainSubstring("Attached policy '%s' to role '%s'", policyArn, roleName))
+				}
+
+			}
+
+			By("Check the arbitray is attached to operator roles")
+			output, err = clusterService.DescribeCluster(clusterID, "--get-role-policy-bindings")
+			Expect(err).To(BeNil())
+			arbitraryCD, err := clusterService.ReflectClusterDescription(output)
+			Expect(err).To(BeNil())
+			operatorRolesArnsWithArbitrary := arbitraryCD.OperatorIAMRoles
+			for _, v := range operatorRolesArnsWithArbitrary {
+				if strings.Contains(v, operatorRolesArns[2]) {
+					for _, arbitrayPolicyArn := range operatorRolePoliciesMap1[operatorRoleName1] {
+						Expect(v).To(ContainSubstring(arbitrayPolicyArn))
+					}
+				}
+				if strings.Contains(v, operatorRolesArns[4]) {
+					for _, arbitrayPolicyArn := range operatorRolePoliciesMap2[operatorRoleName2] {
+						Expect(v).To(ContainSubstring(arbitrayPolicyArn))
+					}
+				}
+			}
+
+			By("Detach policies from operator-roles")
+			for roleName, policyArns := range operatorRolePoliciesMap1 {
+				out, err := arbitraryPolicyService.DetachPolicy(roleName, policyArns, "--mode", "auto")
+				Expect(err).To(BeNil())
+				for _, policyArn := range policyArns {
+					Expect(out.String()).To(ContainSubstring("Detached policy '%s' from role '%s'", policyArn, roleName))
+				}
+
+			}
+			for roleName, policyArns := range operatorRolePoliciesMap2 {
+				out, err := arbitraryPolicyService.DetachPolicy(roleName, policyArns, "--mode", "auto")
+				Expect(err).To(BeNil())
+				for _, policyArn := range policyArns {
+					Expect(out.String()).To(ContainSubstring("Detached policy '%s' from role '%s'", policyArn, roleName))
+				}
+
+			}
+
+			By("Check the arbitray is detached from operator roles")
+			output, err = clusterService.DescribeCluster(clusterID, "--get-role-policy-bindings")
+			Expect(err).To(BeNil())
+			arbitraryCD, err = clusterService.ReflectClusterDescription(output)
+			Expect(err).To(BeNil())
+			operatorRolesArnsWithArbitrary = arbitraryCD.OperatorIAMRoles
+			for _, v := range operatorRolesArnsWithArbitrary {
+				if strings.Contains(v, operatorRolesArns[2]) {
+					for _, arbitrayPolicyArn := range operatorRolePoliciesMap1[operatorRoleName1] {
+						Expect(v).ToNot(ContainSubstring(arbitrayPolicyArn))
+					}
+				}
+				if strings.Contains(v, operatorRolesArns[4]) {
+					for _, arbitrayPolicyArn := range operatorRolePoliciesMap2[operatorRoleName2] {
+						Expect(v).ToNot(ContainSubstring(arbitrayPolicyArn))
+					}
+				}
+			}
+
+			By("Get account-roles arns for testing")
+			var workerRoleARN string
+			supportRoleARN := CD.SupportRoleARN
+			for _, rolePolicyMap := range CD.InstanceIAMRoles {
+				for k, v := range rolePolicyMap {
+					if k == "Worker" {
+						workerRoleARN = v
+					} else {
+						break
+					}
+				}
+			}
+			_, workerRoleName, err := common.ParseRoleARN(workerRoleARN)
+			Expect(err).To(BeNil())
+			_, supportRoleName, err := common.ParseRoleARN(supportRoleARN)
+			Expect(err).To(BeNil())
+
+			accountRolePoliciesMap1 := make(map[string][]string)
+			accountRolePoliciesMap1[workerRoleName] = arbitraryPoliciesToClean[0:2]
+
+			accountRolePoliciesMap2 := make(map[string][]string)
+			accountRolePoliciesMap2[supportRoleName] = append(accountRolePoliciesMap2[operatorRolesArns[1]], arbitraryPoliciesToClean[1])
+
+			By("Attach policies to account-roles")
+			for roleName, policyArns := range accountRolePoliciesMap1 {
+				out, err := arbitraryPolicyService.AttachPolicy(roleName, policyArns, "--mode", "auto")
+				Expect(err).To(BeNil())
+				for _, policyArn := range policyArns {
+					Expect(out.String()).To(ContainSubstring("Attached policy '%s' to role '%s'", policyArn, roleName))
+				}
+
+			}
+
+			for roleName, policyArns := range accountRolePoliciesMap2 {
+				out, err := arbitraryPolicyService.AttachPolicy(roleName, policyArns, "--mode", "auto")
+				Expect(err).To(BeNil())
+				for _, policyArn := range policyArns {
+					Expect(out.String()).To(ContainSubstring("Attached policy '%s' to role '%s'", policyArn, roleName))
+				}
+
+			}
+
+			By("Check the arbitray is attached to account roles")
+			output, err = clusterService.DescribeCluster(clusterID, "--get-role-policy-bindings")
+			Expect(err).To(BeNil())
+			arbitraryCD, err = clusterService.ReflectClusterDescription(output)
+			Expect(err).To(BeNil())
+			for _, rolePolicyMap := range arbitraryCD.InstanceIAMRoles {
+				for k, v := range rolePolicyMap {
+					if k == "Worker" {
+						Expect(v).To(ContainSubstring(workerRoleARN))
+						for _, arbitrayPolicy := range accountRolePoliciesMap1[workerRoleName] {
+							Expect(v).To(ContainSubstring(arbitrayPolicy))
+						}
+					} else {
+						break
+					}
+				}
+			}
+
+			Expect(arbitraryCD.SupportRoleARN).To(ContainSubstring(supportRoleARN))
+			Expect(arbitraryCD.SupportRoleARN).To(ContainSubstring(arbitraryPoliciesToClean[1]))
+
+			By("Detach policies from accout-roles")
+			for roleName, policyArns := range accountRolePoliciesMap1 {
+				out, err := arbitraryPolicyService.DetachPolicy(roleName, policyArns, "--mode", "auto")
+				Expect(err).To(BeNil())
+				for _, policyArn := range policyArns {
+					Expect(out.String()).To(ContainSubstring("Detached policy '%s' from role '%s'", policyArn, roleName))
+				}
+
+			}
+
+			for roleName, policyArns := range accountRolePoliciesMap2 {
+				out, err := arbitraryPolicyService.DetachPolicy(roleName, policyArns, "--mode", "auto")
+				Expect(err).To(BeNil())
+				for _, policyArn := range policyArns {
+					Expect(out.String()).To(ContainSubstring("Detached policy '%s' from role '%s'", policyArn, roleName))
+				}
+
+			}
+
+			By("Check the arbitray is detached from account roles")
+			output, err = clusterService.DescribeCluster(clusterID, "--get-role-policy-bindings")
+			Expect(err).To(BeNil())
+			arbitraryCD, err = clusterService.ReflectClusterDescription(output)
+			Expect(err).To(BeNil())
+			for _, rolePolicyMap := range arbitraryCD.InstanceIAMRoles {
+				for k, v := range rolePolicyMap {
+					if k == "Worker" {
+						Expect(v).To(ContainSubstring(workerRoleARN))
+						for _, arbitrayPolicy := range accountRolePoliciesMap1[workerRoleName] {
+							Expect(v).ToNot(ContainSubstring(arbitrayPolicy))
+						}
+					} else {
+						break
+					}
+				}
+			}
+			Expect(arbitraryCD.SupportRoleARN).To(ContainSubstring(supportRoleARN))
+			Expect(arbitraryCD.SupportRoleARN).ToNot(ContainSubstring(arbitraryPoliciesToClean[1]))
+		})
+	})
+
+var _ = Describe("Validation testing",
+	labels.Feature.Policy,
+	func() {
+		defer GinkgoRecover()
+
+		var (
+			clusterID                string
+			rosaClient               *rosacli.Client
+			arbitraryPolicyService   rosacli.PolicyService
+			clusterService           rosacli.ClusterService
+			arbitraryPoliciesToClean []string
+			testingRolesToClean      []string
+			awsClient                *aws_client.AWSClient
+			err                      error
+		)
+
+		BeforeEach(func() {
+			By("Get the cluster")
+			clusterID = config.GetClusterID()
+			Expect(clusterID).ToNot(Equal(""), "ClusterID is required. Please export CLUSTER_ID")
+
+			By("Init the client")
+			rosaClient = rosacli.NewClient()
+			arbitraryPolicyService = rosaClient.Policy
+			clusterService = rosaClient.Cluster
+			By("Prepare arbitray policies for testing")
+
+			awsClient, err = aws_client.CreateAWSClient("", "")
+			Expect(err).To(BeNil())
+			statement := map[string]interface{}{
+				"Effect":   "Allow",
+				"Action":   "*",
+				"Resource": "*",
+			}
+			for i := 0; i < 10; i++ {
+				arn, err := awsClient.CreatePolicy(fmt.Sprintf("ocmqe-arpolicy-%s-%d", common.GenerateRandomString(3), i), statement)
+				Expect(err).To(BeNil())
+				arbitraryPoliciesToClean = append(arbitraryPoliciesToClean, arn)
+			}
+
+		})
+
+		AfterEach(func() {
+			By("Clean remaining resources")
+			err := rosaClient.CleanResources(clusterID)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Delete arbitrary policies")
+			if len(arbitraryPoliciesToClean) > 0 {
+				for _, policyArn := range arbitraryPoliciesToClean {
+					err = awsClient.DeletePolicy(policyArn)
+					Expect(err).To(BeNil())
+				}
+			}
+
+			By("Delete the testing role")
+			if len(testingRolesToClean) > 0 {
+				for _, roleName := range testingRolesToClean {
+					err = awsClient.DeleteRole(roleName)
+					Expect(err).To(BeNil())
+				}
+			}
+		})
+
+		It("to check the validations for attaching and detaching arbitrary policies - [id:74225]", labels.Critical, labels.Runtime.Day2, func() {
+			By("Prepare a role wihtout red-hat-managed=true label for testing")
+			notRHManagedRoleName := fmt.Sprintf("ocmqe-role-%s", common.GenerateRandomString(3))
+			_, err := awsClient.CreateRegularRole(notRHManagedRoleName)
+			Expect(err).To(BeNil())
+			testingRolesToClean = append(testingRolesToClean, notRHManagedRoleName)
+
+			By("Prepare 10 arbitrary policies for testing")
+			awsClient, err = aws_client.CreateAWSClient("", "")
+			Expect(err).To(BeNil())
+			statement := map[string]interface{}{
+				"Effect":   "Allow",
+				"Action":   "*",
+				"Resource": "*",
+			}
+			for i := 0; i < 10; i++ {
+				arn, err := awsClient.CreatePolicy(fmt.Sprintf("ocmqe-arpolicy-%s-%d", common.GenerateRandomString(3), i), statement)
+				Expect(err).To(BeNil())
+				arbitraryPoliciesToClean = append(arbitraryPoliciesToClean, arn)
+			}
+
+			By("Get one managed role for testing,using support role in this case")
+			output, err := clusterService.DescribeCluster(clusterID)
+			Expect(err).To(BeNil())
+			CD, err := clusterService.ReflectClusterDescription(output)
+			Expect(err).To(BeNil())
+			supportRoleARN := CD.SupportRoleARN
+			_, supportRoleName, err := common.ParseRoleARN(supportRoleARN)
+			Expect(err).To(BeNil())
+
+			By("policy arn with invalid format when attach")
+			policyArnsWithOneInValidFormat := []string{
+				"arn:aws:polict:invalidformat",
+				arbitraryPoliciesToClean[0],
+				arbitraryPoliciesToClean[1],
+			}
+			out, err := arbitraryPolicyService.AttachPolicy(supportRoleName, policyArnsWithOneInValidFormat, "--mode", "auto")
+			Expect(err).NotTo(BeNil())
+			Expect(out.String()).To(ContainSubstring("Invalid policy arn"))
+
+			By("not-existed policies arn when attach")
+			policyArnsWithNotExistedOne := []string{
+				"arn:aws:iam::123456789012:policy/ocmqe-arpolicy-rta-0",
+				arbitraryPoliciesToClean[0],
+				arbitraryPoliciesToClean[1],
+			}
+			out, err = arbitraryPolicyService.AttachPolicy(supportRoleName, policyArnsWithNotExistedOne, "--mode", "auto")
+			Expect(err).NotTo(BeNil())
+			Expect(out.String()).To(ContainSubstring("not found"))
+
+			By("not-existed role name when attach")
+			notExistedRoleName := "notExistedRoleName"
+			policyArns := []string{
+				arbitraryPoliciesToClean[0],
+				arbitraryPoliciesToClean[1],
+			}
+			out, err = arbitraryPolicyService.AttachPolicy(notExistedRoleName, policyArns, "--mode", "auto")
+			Expect(err).NotTo(BeNil())
+			Expect(out.String()).To(ContainSubstring("role with name %s cannot be found", notExistedRoleName))
+
+			By("number of the attaching policies exceed the quote (L-0DA4ABF3) when attach")
+			policyArnsWithTen := arbitraryPoliciesToClean[0:10]
+			out, err = arbitraryPolicyService.AttachPolicy(supportRoleName, policyArnsWithTen, "--mode", "auto")
+			Expect(err).NotTo(BeNil())
+			Expect(out.String()).To(ContainSubstring("Failed to attach policies due to quota limitations (total limit: 10"))
+
+			By("role has no red-hat-managed=true tag when attach")
+			out, err = arbitraryPolicyService.AttachPolicy(notRHManagedRoleName, policyArns, "--mode", "auto")
+			Expect(err).NotTo(BeNil())
+			Expect(out.String()).To(ContainSubstring("Cannot attach/detach policies to non-ROSA roles"))
+
+			By("empry string in the policy-arn when attach")
+			policyArnsWithEmptyString := []string{""}
+			out, err = arbitraryPolicyService.AttachPolicy(supportRoleName, policyArnsWithEmptyString, "--mode", "auto")
+			Expect(err).NotTo(BeNil())
+			Expect(out.String()).To(ContainSubstring("expected a valid policy"))
+
+			By("policy arn with invalid format when detach")
+
+			out, err = arbitraryPolicyService.DetachPolicy(supportRoleName, policyArnsWithOneInValidFormat, "--mode", "auto")
+			Expect(err).NotTo(BeNil())
+			Expect(out.String()).To(ContainSubstring("Invalid policy arn"))
+
+			By("not-existed policies arn when detach")
+			out, err = arbitraryPolicyService.DetachPolicy(supportRoleName, policyArnsWithNotExistedOne, "--mode", "auto")
+			Expect(err).NotTo(BeNil())
+			Expect(out.String()).To(ContainSubstring("not found"))
+
+			By("not-existed role name when detach")
+			out, err = arbitraryPolicyService.DetachPolicy(notExistedRoleName, policyArns, "--mode", "auto")
+			Expect(err).NotTo(BeNil())
+			Expect(out.String()).To(ContainSubstring("role with name %s cannot be found", notExistedRoleName))
+
+			By("role has no red-hat-managed=true tag when detach")
+			out, err = arbitraryPolicyService.DetachPolicy(notRHManagedRoleName, policyArns, "--mode", "auto")
+			Expect(err).NotTo(BeNil())
+			Expect(out.String()).To(ContainSubstring("Cannot attach/detach policies to non-ROSA roles"))
+
+			By("empry string in the policy-arn when detach")
+			out, err = arbitraryPolicyService.DetachPolicy(supportRoleName, policyArnsWithEmptyString, "--mode", "auto")
+			Expect(err).NotTo(BeNil())
+			Expect(out.String()).To(ContainSubstring("expected a valid policy"))
+		})
+
+	})

--- a/tests/utils/common/arn.go
+++ b/tests/utils/common/arn.go
@@ -1,0 +1,24 @@
+package common
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// Function to parse the ARN of a role, return rolePath,roleName and err
+func ParseRoleARN(arn string) (string, string, error) {
+	parts := strings.SplitN(arn, "role/", 2)
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("invalid ARN format")
+	}
+	u, err := url.Parse("/" + parts[1])
+	if err != nil {
+		return "", "", err
+	}
+	pathParts := strings.Split(u.Path, "/")
+	roleName := pathParts[len(pathParts)-1]
+	rolePath := strings.Join(pathParts[:len(pathParts)-1], "/")
+
+	return rolePath, roleName, nil
+}

--- a/tests/utils/exec/rosacli/cluster_service.go
+++ b/tests/utils/exec/rosacli/cluster_service.go
@@ -15,7 +15,7 @@ import (
 type ClusterService interface {
 	ResourcesCleaner
 
-	DescribeCluster(clusterID string) (bytes.Buffer, error)
+	DescribeCluster(clusterID string, flags ...string) (bytes.Buffer, error)
 	ReflectClusterDescription(result bytes.Buffer) (*ClusterDescription, error)
 	DescribeClusterAndReflect(clusterID string) (*ClusterDescription, error)
 	List() (bytes.Buffer, error)
@@ -96,11 +96,11 @@ type ClusterDescription struct {
 	ExternalAuthentication   string              `yaml:"External Authentication,omitempty"`
 }
 
-func (c *clusterService) DescribeCluster(clusterID string) (bytes.Buffer, error) {
+func (c *clusterService) DescribeCluster(clusterID string, flags ...string) (bytes.Buffer, error) {
+	combflags := append([]string{"-c", clusterID}, flags...)
 	describe := c.client.Runner.
 		Cmd("describe", "cluster").
-		CmdFlags("-c", clusterID)
-
+		CmdFlags(combflags...)
 	return describe.Run()
 }
 

--- a/tests/utils/exec/rosacli/cmd_client.go
+++ b/tests/utils/exec/rosacli/cmd_client.go
@@ -43,6 +43,7 @@ type Client struct {
 	Version              VersionService
 	BreakGlassCredential BreakGlassCredentialService
 	ExternalAuthProvider ExternalAuthProviderService
+	Policy               PolicyService
 	AutoScaler           AutoScalerService
 }
 
@@ -69,6 +70,7 @@ func NewClient() *Client {
 	client.Version = NewVersionService(client)
 	client.BreakGlassCredential = NewBreakGlassCredentialService(client)
 	client.ExternalAuthProvider = NewExternalAuthProviderService(client)
+	client.Policy = NewPolicyService(client)
 	client.AutoScaler = NewAutoScalerService(client)
 
 	return client
@@ -92,6 +94,7 @@ func (c *Client) CleanResources(clusterID string) error {
 	errorList = append(errorList, c.BreakGlassCredential.CleanResources(clusterID)...)
 	errorList = append(errorList, c.ExternalAuthProvider.CleanResources(clusterID)...)
 	errorList = append(errorList, c.AutoScaler.CleanResources(clusterID)...)
+	errorList = append(errorList, c.Policy.CleanResources(clusterID)...)
 
 	return errors.Join(errorList...)
 

--- a/tests/utils/exec/rosacli/policies_service.go
+++ b/tests/utils/exec/rosacli/policies_service.go
@@ -1,0 +1,47 @@
+package rosacli
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/openshift/rosa/tests/utils/log"
+)
+
+type PolicyService interface {
+	ResourcesCleaner
+	AttachPolicy(roleName string, policyArn []string, flags ...string) (bytes.Buffer, error)
+	DetachPolicy(roleName string, policyArn []string, flags ...string) (bytes.Buffer, error)
+}
+
+type policyService struct {
+	ResourcesService
+}
+
+func NewPolicyService(client *Client) PolicyService {
+	return &policyService{
+		ResourcesService: ResourcesService{
+			client: client,
+		},
+	}
+}
+
+// Attach policies to a role
+func (ps *policyService) AttachPolicy(roleName string, policyArn []string, flags ...string) (bytes.Buffer, error) {
+	attachPolicy := ps.client.Runner.Cmd("attach", "policy")
+	// join policyArn with ,
+	attachPolicy.CmdFlags(append(flags, "--role-name", roleName, "--policy-arns", strings.Join(policyArn, ","))...)
+	return attachPolicy.Run()
+}
+
+// Detach policies to a role
+func (ps *policyService) DetachPolicy(roleName string, policyArn []string, flags ...string) (bytes.Buffer, error) {
+	detachPolicy := ps.client.Runner.Cmd("detach", "policy")
+	// join policyArn with ,
+	detachPolicy.CmdFlags(append(flags, "--role-name", roleName, "--policy-arns", strings.Join(policyArn, ","))...)
+	return detachPolicy.Run()
+}
+
+func (ps *policyService) CleanResources(clusterID string) (errors []error) {
+	log.Logger.Debugf("Nothing to clean in Version Service")
+	return
+}


### PR DESCRIPTION
[OCM-8632](https://issues.redhat.com//browse/OCM-8632) | test: automate id:74225,73449 attach/detach/describe arbitrary policy
```
yuwan1-mac:rosa yuwan$ ginkgo --focus id:74225 tests/e2e/
Running Suite: ROSA CLI e2e tests suite - /Users/yuwan/workplace/rosacli_automation/rosa/tests/e2e
==================================================================================================
Random Seed: 1717741932

Will run 1 of 97 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 97 Specs in 106.394 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 96 Skipped
You're using deprecated Ginkgo functionality:
=============================================
  --ginkgo.slow-spec-threshold is deprecated --slow-spec-threshold has been deprecated and will be removed in a future version of Ginkgo.  This feature has proved to be more noisy than useful.  You can use --poll-progress-after, instead, to get more actionable feedback about potentially slow specs and understand where they might be getting stuck.

To silence deprecations that can be silenced set the following environment variable:
  ACK_GINKGO_DEPRECATIONS=2.17.1

PASS

Ginkgo ran 1 suite in 1m56.127219167s
Test Suite Passed



c:rosa yuwan$ ginkgo --focus id:73449 tests/e2e/
Running Suite: ROSA CLI e2e tests suite - /Users/yuwan/workplace/rosacli_automation/rosa/tests/e2e
==================================================================================================
Random Seed: 1717729050

Will run 1 of 96 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSarn:aws:iam::301721915996:role/yuwan-0607h1-savk-kube-system-capa-controller-manager
arn:aws:iam::301721915996:role/yuwan-0607h1-savk-kube-system-control-plane-operator
arn:aws:iam::301721915996:role/yuwan-0607h1-savk-kube-system-kms-provider
arn:aws:iam::301721915996:role/yuwan-0607h1-savk-openshift-image-registry-installer-cloud-crede
arn:aws:iam::301721915996:role/yuwan-0607h1-savk-openshift-ingress-operator-cloud-credentials
arn:aws:iam::301721915996:role/yuwan-0607h1-savk-openshift-cluster-csi-drivers-ebs-cloud-creden
arn:aws:iam::301721915996:role/yuwan-0607h1-savk-openshift-cloud-network-config-controller-clou
arn:aws:iam::301721915996:role/yuwan-0607h1-savk-kube-system-kube-controller-manager
[map[Worker:arn:aws:iam::301721915996:role/20240607accr-HCP-ROSA-Worker-Role]]
•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 96 Specs in 112.695 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 95 Skipped
PASS
You're using deprecated Ginkgo functionality:
=============================================
  --ginkgo.slow-spec-threshold is deprecated --slow-spec-threshold has been deprecated and will be removed in a future version of Ginkgo.  This feature has proved to be more noisy than useful.  You can use --poll-progress-after, instead, to get more actionable feedback about potentially slow specs and understand where they might be getting stuck.

To silence deprecations that can be silenced set the following environment variable:
  ACK_GINKGO_DEPRECATIONS=2.17.1


Ginkgo ran 1 suite in 1m58.40536229s
Test Suite Passed
```