### PR TITLE
OCM-8636 | test: automate id:67275 create/describe/edit/delete cluster autoscaler by rosacli

### DIFF
--- a/tests/e2e/rosa_autoscaler_test.go
+++ b/tests/e2e/rosa_autoscaler_test.go
@@ -1,0 +1,151 @@
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/rosa/tests/ci/labels"
+	"github.com/openshift/rosa/tests/utils/config"
+	"github.com/openshift/rosa/tests/utils/exec/rosacli"
+)
+
+var _ = Describe("Autoscaler", labels.Feature.Autoscaler, func() {
+
+	var rosaClient *rosacli.Client
+	var clusterService rosacli.ClusterService
+	var clusterConfig *config.ClusterConfig
+
+	BeforeEach(func() {
+		Expect(clusterID).ToNot(BeEmpty(), "Cluster ID is empty, please export the env variable CLUSTER_ID")
+		rosaClient = rosacli.NewClient()
+		clusterService = rosaClient.Cluster
+	})
+	AfterEach(func() {
+		By("Clean remaining resources")
+		err := rosaClient.CleanResources(clusterID)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Describe("creation testing", func() {
+		BeforeEach(func() {
+			hostedCluster, err := clusterService.IsHostedCPCluster(clusterID)
+			Expect(err).ToNot(HaveOccurred())
+
+			clusterConfig, err = config.ParseClusterProfile()
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Skip testing if the cluster is not a Classic cluster")
+			if hostedCluster {
+				SkipNotClassic()
+			}
+
+			By("Check if cluster is autoscaler enabled")
+			if clusterConfig.Autoscaler != nil {
+				Skip("The feature autoscaler must be disabled for 67275")
+			}
+		})
+
+		It("create/describe/edit/delete cluster autoscaler by rosacli - [id:67275]",
+			labels.Critical, labels.Runtime.Day2,
+			func() {
+				By("Retrieve help for create/list/describe/delete autoscaler")
+				_, err := rosaClient.AutoScaler.CreateAutoScaler(clusterID, "-h")
+				Expect(err).ToNot(HaveOccurred())
+				_, err = rosaClient.AutoScaler.EditAutoScaler(clusterID, "-h")
+				Expect(err).ToNot(HaveOccurred())
+				_, err = rosaClient.AutoScaler.RetrieveHelpForDescribe()
+				Expect(err).ToNot(HaveOccurred())
+				_, err = rosaClient.AutoScaler.RetrieveHelpForDelete()
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Create the autoscaler to the cluster")
+				resp, err := rosaClient.AutoScaler.CreateAutoScaler(clusterID, "--balance-similar-node-groups",
+					"--skip-nodes-with-local-storage",
+					"--log-verbosity", "4",
+					"--max-pod-grace-period", "0",
+					"--pod-priority-threshold", "1",
+					"--ignore-daemonsets-utilization",
+					"--max-node-provision-time", "10m",
+					"--balancing-ignored-labels", "aaa",
+					"--max-nodes-total", "1000",
+					"--min-cores", "0",
+					"--scale-down-delay-after-add", "10s",
+					"--max-cores", "100",
+					"--min-memory", "0",
+					"--max-memory", "4096",
+					"--scale-down-enabled",
+					"--scale-down-utilization-threshold", "1",
+					"--scale-down-delay-after-delete", "10s",
+					"--scale-down-delay-after-failure", "10s",
+					"--gpu-limit", "nvidia.com/gpu,0,10",
+					"--gpu-limit", "amd.com/gpu,1,5",
+					"--scale-down-unneeded-time", "10s")
+				Expect(err).ToNot(HaveOccurred())
+				textData := rosaClient.Parser.TextData.Input(resp).Parse().Tip()
+				Expect(textData).To(ContainSubstring("INFO: Successfully created autoscaler configuration for cluster '%s'", clusterID))
+
+				By("Describe the autoscaler of the cluster")
+				rosaClient.Runner.YamlFormat()
+				yamlOutput, err := rosaClient.AutoScaler.DescribeAutoScaler(clusterID)
+				Expect(err).ToNot(HaveOccurred())
+				rosaClient.Runner.UnsetFormat()
+				yamlData, err := rosaClient.Parser.TextData.Input(yamlOutput).Parse().YamlToMap()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(yamlData["balance_similar_node_groups"]).To(Equal(true))
+				Expect(yamlData["skip_nodes_with_local_storage"]).To(Equal(true))
+				Expect(yamlData["log_verbosity"]).To(Equal(4))
+				Expect(yamlData["balancing_ignored_labels"]).To(ContainElement("aaa"))
+				Expect(yamlData["ignore_daemonsets_utilization"]).To(Equal(true))
+				Expect(yamlData["max_node_provision_time"]).To(Equal("10m"))
+				Expect(yamlData["max_pod_grace_period"]).To(Equal(0))
+				Expect(yamlData["pod_priority_threshold"]).To(Equal(1))
+				Expect(yamlData["resource_limits"].(map[string]interface{})["cores"].(map[string]interface{})["min"]).To(Equal(0))
+				Expect(yamlData["resource_limits"].(map[string]interface{})["cores"].(map[string]interface{})["max"]).To(Equal(100))
+				Expect(yamlData["resource_limits"].(map[string]interface{})["memory"].(map[string]interface{})["min"]).To(Equal(0))
+				Expect(yamlData["resource_limits"].(map[string]interface{})["memory"].(map[string]interface{})["max"]).To(Equal(4096))
+				Expect(yamlData["resource_limits"].(map[string]interface{})["gpus"].([]interface{})[0].(map[string]interface{})["range"].(map[string]interface{})["max"]).To(Equal(10))
+				Expect(yamlData["resource_limits"].(map[string]interface{})["gpus"].([]interface{})[0].(map[string]interface{})["range"].(map[string]interface{})["min"]).To(Equal(0))
+				Expect(yamlData["resource_limits"].(map[string]interface{})["gpus"].([]interface{})[0].(map[string]interface{})["type"]).To(Equal("nvidia.com/gpu"))
+				Expect(yamlData["resource_limits"].(map[string]interface{})["gpus"].([]interface{})[1].(map[string]interface{})["range"].(map[string]interface{})["max"]).To(Equal(5))
+				Expect(yamlData["resource_limits"].(map[string]interface{})["gpus"].([]interface{})[1].(map[string]interface{})["range"].(map[string]interface{})["min"]).To(Equal(1))
+				Expect(yamlData["resource_limits"].(map[string]interface{})["gpus"].([]interface{})[1].(map[string]interface{})["type"]).To(Equal("amd.com/gpu"))
+				Expect(yamlData["resource_limits"].(map[string]interface{})["max_nodes_total"]).To(Equal(1000))
+				Expect(yamlData["scale_down"].(map[string]interface{})["delay_after_add"]).To(Equal("10s"))
+				Expect(yamlData["scale_down"].(map[string]interface{})["delay_after_delete"]).To(Equal("10s"))
+				Expect(yamlData["scale_down"].(map[string]interface{})["delay_after_failure"]).To(Equal("10s"))
+				Expect(yamlData["scale_down"].(map[string]interface{})["enabled"]).To(Equal(true))
+				Expect(yamlData["scale_down"].(map[string]interface{})["unneeded_time"]).To(Equal("10s"))
+				Expect(yamlData["scale_down"].(map[string]interface{})["utilization_threshold"]).To(Equal("1.000000"))
+
+				By("Edit the autoscaler of the cluster")
+				resp, err = rosaClient.AutoScaler.EditAutoScaler(clusterID, "--ignore-daemonsets-utilization",
+					"--min-cores", "0",
+					"--max-cores", "10",
+					"--scale-down-delay-after-add", "0s",
+					"--gpu-limit", "amd.com/gpu,1,5")
+				Expect(err).ToNot(HaveOccurred())
+				textData = rosaClient.Parser.TextData.Input(resp).Parse().Tip()
+				Expect(textData).To(ContainSubstring("INFO: Successfully updated autoscaler configuration for cluster '%s'", clusterID))
+
+				By("Describe autoscaler to check the edited value is correct")
+				rosaClient.Runner.YamlFormat()
+				yamlOutput, err = rosaClient.AutoScaler.DescribeAutoScaler(clusterID)
+				Expect(err).ToNot(HaveOccurred())
+				rosaClient.Runner.UnsetFormat()
+				yamlData, err = rosaClient.Parser.TextData.Input(yamlOutput).Parse().YamlToMap()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(yamlData["ignore_daemonsets_utilization"]).To(Equal(true))
+				Expect(yamlData["resource_limits"].(map[string]interface{})["cores"].(map[string]interface{})["max"]).To(Equal(10))
+				Expect(yamlData["resource_limits"].(map[string]interface{})["gpus"].([]interface{})[0].(map[string]interface{})["range"].(map[string]interface{})["max"]).To(Equal(5))
+				Expect(yamlData["resource_limits"].(map[string]interface{})["gpus"].([]interface{})[0].(map[string]interface{})["range"].(map[string]interface{})["min"]).To(Equal(1))
+				Expect(yamlData["resource_limits"].(map[string]interface{})["gpus"].([]interface{})[0].(map[string]interface{})["type"]).To(Equal("amd.com/gpu"))
+				Expect(yamlData["scale_down"].(map[string]interface{})["delay_after_add"]).To(Equal("0s"))
+
+				By("Delete the autoscaler of the cluster")
+				resp, err = rosaClient.AutoScaler.DeleteAutoScaler(clusterID)
+				Expect(err).ToNot(HaveOccurred())
+				textData = rosaClient.Parser.TextData.Input(resp).Parse().Tip()
+				Expect(textData).To(ContainSubstring("INFO: Successfully deleted autoscaler configuration for cluster '%s'", clusterID))
+			})
+	})
+})

--- a/tests/utils/exec/rosacli/autoscaler_service.go
+++ b/tests/utils/exec/rosacli/autoscaler_service.go
@@ -1,0 +1,142 @@
+package rosacli
+
+import (
+	"bytes"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	. "github.com/openshift/rosa/tests/utils/log"
+)
+
+type AutoScalerService interface {
+	ResourcesCleaner
+
+	CreateAutoScaler(clusterID string, flags ...string) (bytes.Buffer, error)
+	DeleteAutoScaler(clusterID string) (bytes.Buffer, error)
+	DescribeAutoScaler(clusterID string) (bytes.Buffer, error)
+	EditAutoScaler(clusterID string, flags ...string) (bytes.Buffer, error)
+	ReflectAutoScalerDescription(result bytes.Buffer) (asd *AutoScalerDescription, err error)
+	DescribeAutoScalerAndReflect(clusterID string) (*AutoScalerDescription, error)
+
+	RetrieveHelpForDescribe() (output bytes.Buffer, err error)
+	RetrieveHelpForDelete() (output bytes.Buffer, err error)
+}
+
+type autoscalerService struct {
+	ResourcesService
+	created map[string]bool
+}
+
+type AutoScalerDescription struct {
+	BalanceSimilarNodeGroups      string                   `yaml:"Balance Similar Node Groups,omitempty"`
+	SkipNodesWithLocalStorage     string                   `yaml:"Skip Nodes With Local Storage,omitempty"`
+	LogVerbosity                  string                   `yaml:"Log Verbosity,omitempty"`
+	LabelsIgnoredForNodeBalancing string                   `yaml:"Labels Ignored For Node Balancing,omitempty"`
+	IgnoreDaemonSetsUtilization   string                   `yaml:"Ignore DaemonSets Utilization,omitempty"`
+	MaxNodeProvisionTime          string                   `yaml:"Maximum Node Provision Time,omitempty"`
+	MaxPodGracePeriod             string                   `yaml:"Max Pod Grace Period,omitempty"`
+	PodPriorityThreshold          string                   `yaml:"Pod Priority Threshold,omitempty"`
+	ResourceLimits                []map[string]interface{} `yaml:"Resource Limits,omitempty"`
+	ScaleDown                     []map[string]interface{} `yaml:"Scale Down,omitempty"`
+}
+
+func NewAutoScalerService(client *Client) AutoScalerService {
+	return &autoscalerService{
+		ResourcesService: ResourcesService{
+			client: client,
+		},
+		created: make(map[string]bool),
+	}
+}
+
+// Create AutoScaler
+func (a *autoscalerService) CreateAutoScaler(clusterID string, flags ...string) (output bytes.Buffer, err error) {
+	output, err = a.client.Runner.
+		Cmd("create", "autoscaler").
+		CmdFlags(append(flags, "-c", clusterID)...).
+		Run()
+	if err == nil {
+		a.created[clusterID] = true
+	}
+	return
+}
+
+// Edit AutoScaler
+func (a *autoscalerService) EditAutoScaler(clusterID string, flags ...string) (output bytes.Buffer, err error) {
+	output, err = a.client.Runner.
+		Cmd("edit", "autoscaler").
+		CmdFlags(append(flags, "-c", clusterID)...).
+		Run()
+	return
+}
+
+// Describe AutoScaler
+func (a *autoscalerService) DescribeAutoScaler(clusterID string) (bytes.Buffer, error) {
+	describe := a.client.Runner.
+		Cmd("describe", "autoscaler").
+		CmdFlags("-c", clusterID)
+
+	return describe.Run()
+}
+
+func (a *autoscalerService) DescribeAutoScalerAndReflect(clusterID string) (*AutoScalerDescription, error) {
+	output, err := a.DescribeAutoScaler(clusterID)
+	if err != nil {
+		return nil, err
+	}
+	return a.ReflectAutoScalerDescription(output)
+}
+
+func (a *autoscalerService) ReflectAutoScalerDescription(result bytes.Buffer) (asd *AutoScalerDescription, err error) {
+	var data []byte
+	res := new(AutoScalerDescription)
+	theMap, err := a.client.Parser.TextData.Input(result).Parse().TransformOutput(func(str string) (newStr string) {
+		// Apply transformation to avoid issue with the list of min or max field parsing
+		newStr = strings.ReplaceAll(str, "- Min:", " Min:")
+		newStr = strings.ReplaceAll(newStr, "- Max:", " Max:")
+		return
+	}).YamlToMap()
+	if err != nil {
+		return
+	}
+	data, err = yaml.Marshal(&theMap)
+	if err != nil {
+		return
+	}
+	err = yaml.Unmarshal(data, res)
+	return res, err
+}
+
+// Delete AutoScaler
+func (a *autoscalerService) DeleteAutoScaler(clusterID string) (output bytes.Buffer, err error) {
+	output, err = a.client.Runner.
+		Cmd("delete", "autoscaler").
+		CmdFlags("-c", clusterID, "-y").
+		Run()
+	if err == nil {
+		a.created[clusterID] = false
+	}
+	return
+}
+
+// Help for Describe AutoSCaler
+func (a *autoscalerService) RetrieveHelpForDescribe() (output bytes.Buffer, err error) {
+	return a.client.Runner.Cmd("describe", "autoscaler").CmdFlags("-h").Run()
+}
+
+// Help for Delete AutoScaler
+func (a *autoscalerService) RetrieveHelpForDelete() (output bytes.Buffer, err error) {
+	return a.client.Runner.Cmd("delete", "autoscaler").CmdFlags("-h").Run()
+}
+
+func (a *autoscalerService) CleanResources(clusterID string) (errors []error) {
+	if a.created[clusterID] {
+		Logger.Infof("Remove the autoscaler")
+		_, err := a.DeleteAutoScaler(clusterID)
+		if err != nil {
+			errors = append(errors, err)
+		}
+	}
+	return
+}

--- a/tests/utils/exec/rosacli/cmd_client.go
+++ b/tests/utils/exec/rosacli/cmd_client.go
@@ -43,6 +43,7 @@ type Client struct {
 	Version              VersionService
 	BreakGlassCredential BreakGlassCredentialService
 	ExternalAuthProvider ExternalAuthProviderService
+	AutoScaler           AutoScalerService
 }
 
 func NewClient() *Client {
@@ -68,6 +69,7 @@ func NewClient() *Client {
 	client.Version = NewVersionService(client)
 	client.BreakGlassCredential = NewBreakGlassCredentialService(client)
 	client.ExternalAuthProvider = NewExternalAuthProviderService(client)
+	client.AutoScaler = NewAutoScalerService(client)
 
 	return client
 }
@@ -89,6 +91,7 @@ func (c *Client) CleanResources(clusterID string) error {
 	errorList = append(errorList, c.Cluster.CleanResources(clusterID)...)
 	errorList = append(errorList, c.BreakGlassCredential.CleanResources(clusterID)...)
 	errorList = append(errorList, c.ExternalAuthProvider.CleanResources(clusterID)...)
+	errorList = append(errorList, c.AutoScaler.CleanResources(clusterID)...)
 
 	return errors.Join(errorList...)
 


### PR DESCRIPTION
$ ginkgo --focus 67275 tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.14.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: ROSA CLI e2e tests suite - /home/aaraj/ocm-forked-code/rosa/tests/e2e
====================================================================================
Random Seed: 1717751016

Will run 1 of 96 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 96 Specs in 27.483 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 95 Skipped
PASS

Ginkgo ran 1 suite in 35.886123922s
Test Suite Passed