### PR TITLE
OCM-8315 | feat: add additional allowed principals config for hcp clusters

### DIFF
--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -483,6 +483,12 @@ func run(cmd *cobra.Command, argv []string) {
 			str = fmt.Sprintf("%s"+
 				"Audit Log Role ARN:         %s\n", str, cluster.AWS().AuditLog().RoleArn())
 		}
+		if len(cluster.AWS().AdditionalAllowedPrincipals()) > 0 {
+			// Omitted the 'Allowed' due to formatting
+			str = fmt.Sprintf("%s"+
+				"Additional Principals:      %s\n", str,
+				strings.Join(cluster.AWS().AdditionalAllowedPrincipals(), ","))
+		}
 	}
 
 	if cluster.Status().State() == cmv1.ClusterStateError {

--- a/cmd/describe/cluster/cmd_test.go
+++ b/cmd/describe/cluster/cmd_test.go
@@ -23,6 +23,8 @@ var (
 		`{"displayName":"displayname","id":"bar","kind":"Cluster","name":"foo"}`)
 	expectClusterWithExternalAuthConfig = []byte(
 		`{"displayName":"displayname","external_auth_config":{"enabled":true},"kind":"Cluster"}`)
+	expectClusterWithAap = []byte(
+		`{"aws":{"additional_allowed_principals":["foobar"]},"displayName":"displayname","kind":"Cluster"}`)
 	expectClusterWithNameAndValueAndUpgradeInformation = []byte(
 		`{"displayName":"displayname","id":"bar","kind":"Cluster","name":"foo","scheduledUpgrade":{"nextRun":"` +
 			now.Format("2006-01-02 15:04 MST") + `","state":"` + state + `","version":"` +
@@ -32,9 +34,9 @@ var (
 			now.Format("2006-01-02 15:04 MST") + `","state":"` +
 			state + `","version":"` +
 			version + `"}}`)
-	clusterWithNameAndID, emptyCluster, clusterWithExternalAuthConfig *cmv1.Cluster
-	emptyUpgradePolicy, upgradePolicyWithVersionAndNextRun            *cmv1.UpgradePolicy
-	emptyUpgradeState, upgradePolicyWithState                         *cmv1.UpgradePolicyState
+	clusterWithNameAndID, emptyCluster, clusterWithExternalAuthConfig, clusterWithAap *cmv1.Cluster
+	emptyUpgradePolicy, upgradePolicyWithVersionAndNextRun                            *cmv1.UpgradePolicy
+	emptyUpgradeState, upgradePolicyWithState                                         *cmv1.UpgradePolicyState
 
 	berr error
 )
@@ -45,6 +47,9 @@ var _ = BeforeSuite(func() {
 	Expect(berr).NotTo(HaveOccurred())
 	externalAuthConfig := cmv1.NewExternalAuthConfig().Enabled(true)
 	clusterWithExternalAuthConfig, berr = cmv1.NewCluster().ExternalAuthConfig(externalAuthConfig).Build()
+	Expect(berr).NotTo(HaveOccurred())
+	additionalAllowedPrincipals := cmv1.NewAWS().AdditionalAllowedPrincipals("foobar")
+	clusterWithAap, berr = cmv1.NewCluster().AWS(additionalAllowedPrincipals).Build()
 	Expect(berr).NotTo(HaveOccurred())
 	emptyUpgradePolicy, berr = cmv1.NewUpgradePolicy().Build()
 	Expect(berr).NotTo(HaveOccurred())
@@ -108,6 +113,11 @@ var _ = Describe("Cluster description", Ordered, func() {
 				func() *cmv1.Cluster { return clusterWithExternalAuthConfig },
 				func() *cmv1.UpgradePolicy { return emptyUpgradePolicy },
 				func() *cmv1.UpgradePolicyState { return nil }, expectClusterWithExternalAuthConfig, nil),
+
+			Entry("Prints cluster information with the additional allowed principals",
+				func() *cmv1.Cluster { return clusterWithAap },
+				func() *cmv1.UpgradePolicy { return emptyUpgradePolicy },
+				func() *cmv1.UpgradePolicyState { return nil }, expectClusterWithAap, nil),
 		)
 	})
 })

--- a/pkg/helper/roles/helpers.go
+++ b/pkg/helper/roles/helpers.go
@@ -281,3 +281,19 @@ func upgradeMissingOperatorRole(missingRoles map[string]*cmv1.STSOperator, clust
 	}
 	return nil
 }
+
+func ValidateAdditionalAllowedPrincipals(aapARNs []string) error {
+	duplicate, found := aws.HasDuplicates(aapARNs)
+	if found {
+		return fmt.Errorf("Invalid additional allowed principals list, duplicate key '%s' found",
+			duplicate)
+	}
+	for _, aap := range aapARNs {
+		err := aws.ARNValidator(aap)
+		if err != nil {
+			return fmt.Errorf("Expected valid ARNs for additional allowed principals list: %s",
+				err)
+		}
+	}
+	return nil
+}

--- a/pkg/helper/roles/helpers_test.go
+++ b/pkg/helper/roles/helpers_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package roles
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestRolesHelper(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Roles Helper Suite")
+}
+
+var _ = Describe("Roles Helper", func() {
+	Context("Validate Additional Allowed Principals", func() {
+		It("should pass when valid ARNs", func() {
+			aapARNs := []string{
+				"arn:aws:iam::123456789012:role/role1",
+				"arn:aws:iam::123456789012:role/role2",
+			}
+			err := ValidateAdditionalAllowedPrincipals(aapARNs)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("should error when containing duplicate ARNs", func() {
+			aapARNs := []string{
+				"arn:aws:iam::123456789012:role/role1",
+				"arn:aws:iam::123456789012:role/role2",
+				"arn:aws:iam::123456789012:role/role1",
+			}
+			err := ValidateAdditionalAllowedPrincipals(aapARNs)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal(
+				"Invalid additional allowed principals list, " +
+					"duplicate key 'arn:aws:iam::123456789012:role/role1' found"))
+		})
+
+		It("should error when contain invalid ARN", func() {
+			aapARNs := []string{
+				"arn:aws:iam::123456789012:role/role1",
+				"foobar",
+			}
+			err := ValidateAdditionalAllowedPrincipals(aapARNs)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(
+				"Expected valid ARNs for additional allowed principals list"))
+		})
+
+	})
+})


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-8315

Expose a new param: additional-allowed-principals for hcp create/edit clusters. This param allows users to set the additional allowed principals for their HCP.