### PR TITLE
OCM-8662 | test: fixing id:45161,68751,73492 ci failures

### DIFF
--- a/tests/e2e/test_rosacli_cluster.go
+++ b/tests/e2e/test_rosacli_cluster.go
@@ -348,6 +348,8 @@ var _ = Describe("Edit cluster",
 				if rosalCommand.GetFlagValue("--https-proxy", true) != "" {
 					err = rosalCommand.DeleteFlag("--https-proxy", true)
 					Expect(err).To(BeNil())
+				}
+				if rosalCommand.GetFlagValue("--no-proxy", true) != "" {
 					err = rosalCommand.DeleteFlag("--no-proxy", true)
 					Expect(err).To(BeNil())
 				}

--- a/tests/e2e/test_rosacli_network_verifier.go
+++ b/tests/e2e/test_rosacli_network_verifier.go
@@ -185,7 +185,7 @@ var _ = Describe("Network verifier",
 				output, err = networkService.CreateNetworkVerifierWithCluster(clusterID,
 					"--tags", "t1=v1")
 				Expect(err).To(HaveOccurred())
-				Expect(output.String()).To(ContainSubstring("ERR: invalid tag format for tag '[t1=v1]'. Expected tag format: 'key:value'"))
+				Expect(output.String()).To(ContainSubstring("ERR: invalid tag format for tag '[t1=v1]'. Expected tag format: 'key value'"))
 
 				By("Run the network verified without role")
 				output, err = networkService.CreateNetworkVerifierWithSubnets(

--- a/tests/e2e/test_rosacli_node_pool.go
+++ b/tests/e2e/test_rosacli_node_pool.go
@@ -923,6 +923,6 @@ var _ = Describe("Edit nodepool",
 				machinePoolName_3 := common.GenerateRandomName("mp-73492-2", 2)
 				output, err = machinePoolService.CreateMachinePool(clusterID, machinePoolName_3, "--replicas", "3", "--tags", "#.bar")
 				Expect(err).To(HaveOccurred())
-				Expect(rosaClient.Parser.TextData.Input(output).Parse().Tip()).To(ContainSubstring("ERR: invalid tag format for tag '[#.bar]'. Expected tag format: 'key:value'"))
+				Expect(rosaClient.Parser.TextData.Input(output).Parse().Tip()).To(ContainSubstring("ERR: invalid tag format for tag '[#.bar]'. Expected tag format: 'key value'"))
 			})
 	})


### PR DESCRIPTION
$ ginkgo --focus "(45161|68751|73492)" tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.14.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: ROSA CLI e2e tests suite - /home/aaraj/ocm-forked-code/rosa/tests/e2e
====================================================================================
Random Seed: 1717998698

Will run 3 of 99 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•

Ran 3 of 99 Specs in 194.853 seconds
SUCCESS! -- 3 Passed | 0 Failed | 0 Pending | 96 Skipped
PASS

Ginkgo ran 1 suite in 3m19.598561347s
Test Suite Passed