### PR TITLE
OCM-8706 | chore: Update to version 1.2.42 in master branch

### DIFF
--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,7 +18,7 @@ limitations under the License.
 
 package info
 
-const Version = "1.2.41"
+const Version = "1.2.42"
 
 // Build contains the short Git SHA of the CLI at the point it was build. Set via `-ldflags` at build time
 var Build = "local"


### PR DESCRIPTION
This PR updates master branch to `1.2.42` ahead of the next release.