### PR TITLE
Update Stage URL for describe to console.dev.redhat.com

### DIFF
--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	StageURL      = "https://qaprodauth.console.redhat.com/openshift/details/s/"
+	StageURL      = "https://console.dev.redhat.com/openshift/details/s/"
 	ProductionURL = "https://console.redhat.com/openshift/details/s/"
 	StageEnv      = "https://api.stage.openshift.com"
 	ProductionEnv = "https://api.openshift.com"


### PR DESCRIPTION
This PR makes a small change to update the URL for Staging Clusters in describe command to console.dev.redhat.com as qaprodauth.redhat.com is deprecated