### PR TITLE
OCM-8796 | test: fixing id:67275 test case enhancement

### DIFF
--- a/tests/e2e/rosa_autoscaler_test.go
+++ b/tests/e2e/rosa_autoscaler_test.go
@@ -1,6 +1,8 @@
 package e2e
 
 import (
+	"strconv"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -20,11 +22,6 @@ var _ = Describe("Autoscaler", labels.Feature.Autoscaler, func() {
 		rosaClient = rosacli.NewClient()
 		clusterService = rosaClient.Cluster
 	})
-	AfterEach(func() {
-		By("Clean remaining resources")
-		err := rosaClient.CleanResources(clusterID)
-		Expect(err).ToNot(HaveOccurred())
-	})
 
 	Describe("creation testing", func() {
 		BeforeEach(func() {
@@ -39,10 +36,6 @@ var _ = Describe("Autoscaler", labels.Feature.Autoscaler, func() {
 				SkipNotClassic()
 			}
 
-			By("Check if cluster is autoscaler enabled")
-			if clusterConfig.Autoscaler != nil {
-				Skip("The feature autoscaler must be disabled for 67275")
-			}
 		})
 
 		It("create/describe/edit/delete cluster autoscaler by rosacli - [id:67275]",
@@ -58,81 +51,140 @@ var _ = Describe("Autoscaler", labels.Feature.Autoscaler, func() {
 				_, err = rosaClient.AutoScaler.RetrieveHelpForDelete()
 				Expect(err).ToNot(HaveOccurred())
 
-				By("Create the autoscaler to the cluster")
-				resp, err := rosaClient.AutoScaler.CreateAutoScaler(clusterID, "--balance-similar-node-groups",
-					"--skip-nodes-with-local-storage",
-					"--log-verbosity", "4",
-					"--max-pod-grace-period", "0",
-					"--pod-priority-threshold", "1",
-					"--ignore-daemonsets-utilization",
-					"--max-node-provision-time", "10m",
-					"--balancing-ignored-labels", "aaa",
-					"--max-nodes-total", "1000",
-					"--min-cores", "0",
-					"--scale-down-delay-after-add", "10s",
-					"--max-cores", "100",
-					"--min-memory", "0",
-					"--max-memory", "4096",
-					"--scale-down-enabled",
-					"--scale-down-utilization-threshold", "1",
-					"--scale-down-delay-after-delete", "10s",
-					"--scale-down-delay-after-failure", "10s",
-					"--gpu-limit", "nvidia.com/gpu,0,10",
-					"--gpu-limit", "amd.com/gpu,1,5",
-					"--scale-down-unneeded-time", "10s")
-				Expect(err).ToNot(HaveOccurred())
-				textData := rosaClient.Parser.TextData.Input(resp).Parse().Tip()
-				Expect(textData).To(ContainSubstring("INFO: Successfully created autoscaler configuration for cluster '%s'", clusterID))
+				By("Check if cluster is autoscaler enabled")
+				if clusterConfig.Autoscaler != nil {
 
-				By("Describe the autoscaler of the cluster")
-				rosaClient.Runner.YamlFormat()
-				yamlOutput, err := rosaClient.AutoScaler.DescribeAutoScaler(clusterID)
-				Expect(err).ToNot(HaveOccurred())
-				rosaClient.Runner.UnsetFormat()
-				yamlData, err := rosaClient.Parser.TextData.Input(yamlOutput).Parse().YamlToMap()
-				Expect(err).ToNot(HaveOccurred())
-				Expect(yamlData["balance_similar_node_groups"]).To(Equal(true))
-				Expect(yamlData["skip_nodes_with_local_storage"]).To(Equal(true))
-				Expect(yamlData["log_verbosity"]).To(Equal(4))
-				Expect(yamlData["balancing_ignored_labels"]).To(ContainElement("aaa"))
-				Expect(yamlData["ignore_daemonsets_utilization"]).To(Equal(true))
-				Expect(yamlData["max_node_provision_time"]).To(Equal("10m"))
-				Expect(yamlData["max_pod_grace_period"]).To(Equal(0))
-				Expect(yamlData["pod_priority_threshold"]).To(Equal(1))
-				Expect(yamlData["resource_limits"].(map[string]interface{})["cores"].(map[string]interface{})["min"]).To(Equal(0))
-				Expect(yamlData["resource_limits"].(map[string]interface{})["cores"].(map[string]interface{})["max"]).To(Equal(100))
-				Expect(yamlData["resource_limits"].(map[string]interface{})["memory"].(map[string]interface{})["min"]).To(Equal(0))
-				Expect(yamlData["resource_limits"].(map[string]interface{})["memory"].(map[string]interface{})["max"]).To(Equal(4096))
-				Expect(yamlData["resource_limits"].(map[string]interface{})["gpus"].([]interface{})[0].(map[string]interface{})["range"].(map[string]interface{})["max"]).To(Equal(10))
-				Expect(yamlData["resource_limits"].(map[string]interface{})["gpus"].([]interface{})[0].(map[string]interface{})["range"].(map[string]interface{})["min"]).To(Equal(0))
-				Expect(yamlData["resource_limits"].(map[string]interface{})["gpus"].([]interface{})[0].(map[string]interface{})["type"]).To(Equal("nvidia.com/gpu"))
-				Expect(yamlData["resource_limits"].(map[string]interface{})["gpus"].([]interface{})[1].(map[string]interface{})["range"].(map[string]interface{})["max"]).To(Equal(5))
-				Expect(yamlData["resource_limits"].(map[string]interface{})["gpus"].([]interface{})[1].(map[string]interface{})["range"].(map[string]interface{})["min"]).To(Equal(1))
-				Expect(yamlData["resource_limits"].(map[string]interface{})["gpus"].([]interface{})[1].(map[string]interface{})["type"]).To(Equal("amd.com/gpu"))
-				Expect(yamlData["resource_limits"].(map[string]interface{})["max_nodes_total"]).To(Equal(1000))
-				Expect(yamlData["scale_down"].(map[string]interface{})["delay_after_add"]).To(Equal("10s"))
-				Expect(yamlData["scale_down"].(map[string]interface{})["delay_after_delete"]).To(Equal("10s"))
-				Expect(yamlData["scale_down"].(map[string]interface{})["delay_after_failure"]).To(Equal("10s"))
-				Expect(yamlData["scale_down"].(map[string]interface{})["enabled"]).To(Equal(true))
-				Expect(yamlData["scale_down"].(map[string]interface{})["unneeded_time"]).To(Equal("10s"))
-				Expect(yamlData["scale_down"].(map[string]interface{})["utilization_threshold"]).To(Equal("1.000000"))
+					By("Describe the autoscaler to the cluster")
+					rosaClient.Runner.YamlFormat()
+					yamlOutput, err := rosaClient.AutoScaler.DescribeAutoScaler(clusterID)
+					Expect(err).ToNot(HaveOccurred())
+					rosaClient.Runner.UnsetFormat()
+					yamlData, err := rosaClient.Parser.TextData.Input(yamlOutput).Parse().YamlToMap()
+					Expect(err).ToNot(HaveOccurred())
+					logVerbosity := yamlData["log_verbosity"].(int)
+					balancingIgnoredLabels := yamlData["balancing_ignored_labels"].([]interface{})[0]
+					maxNodeProvisionTime := yamlData["max_node_provision_time"].(string)
+					maxPodGracePeriod := yamlData["max_pod_grace_period"].(int)
+					podPriorityThresold := yamlData["pod_priority_threshold"].(int)
+					coreMin := yamlData["resource_limits"].(map[string]interface{})["cores"].(map[string]interface{})["min"].(int)
+					coreMax := yamlData["resource_limits"].(map[string]interface{})["cores"].(map[string]interface{})["max"].(int)
+					memoryMin := yamlData["resource_limits"].(map[string]interface{})["memory"].(map[string]interface{})["min"].(int)
+					memoryMax := yamlData["resource_limits"].(map[string]interface{})["memory"].(map[string]interface{})["max"].(int)
+					maxNodesTotal := yamlData["resource_limits"].(map[string]interface{})["max_nodes_total"].(int)
+					sdDelayAfterAdd := yamlData["scale_down"].(map[string]interface{})["delay_after_add"].(string)
+					sdDelayAfterDelete := yamlData["scale_down"].(map[string]interface{})["delay_after_delete"].(string)
+					sdDelayAfterFailure := yamlData["scale_down"].(map[string]interface{})["delay_after_failure"].(string)
+					sdUtilizationThreshold := yamlData["scale_down"].(map[string]interface{})["utilization_threshold"].(string)
+
+					defer func() {
+						By("Create the autoscaler to the cluster")
+						resp, err := rosaClient.AutoScaler.CreateAutoScaler(clusterID, "--balance-similar-node-groups",
+							"--skip-nodes-with-local-storage",
+							"--log-verbosity", strconv.Itoa(logVerbosity),
+							"--max-pod-grace-period", strconv.Itoa(maxPodGracePeriod),
+							"--pod-priority-threshold", strconv.Itoa(podPriorityThresold),
+							"--ignore-daemonsets-utilization",
+							"--max-node-provision-time", maxNodeProvisionTime,
+							"--balancing-ignored-labels", balancingIgnoredLabels.(string),
+							"--max-nodes-total", strconv.Itoa(maxNodesTotal),
+							"--min-cores", strconv.Itoa(coreMin),
+							"--scale-down-delay-after-add", sdDelayAfterAdd,
+							"--max-cores", strconv.Itoa(coreMax),
+							"--min-memory", strconv.Itoa(memoryMin),
+							"--max-memory", strconv.Itoa(memoryMax),
+							"--scale-down-enabled",
+							"--scale-down-utilization-threshold", sdUtilizationThreshold,
+							"--scale-down-delay-after-delete", sdDelayAfterDelete,
+							"--scale-down-delay-after-failure", sdDelayAfterFailure)
+						Expect(err).ToNot(HaveOccurred())
+						textData := rosaClient.Parser.TextData.Input(resp).Parse().Tip()
+						Expect(textData).To(ContainSubstring("INFO: Successfully created autoscaler configuration for cluster '%s'", clusterID))
+					}()
+				} else {
+
+					By("Create the autoscaler to the cluster")
+					resp, err := rosaClient.AutoScaler.CreateAutoScaler(clusterID, "--balance-similar-node-groups",
+						"--skip-nodes-with-local-storage",
+						"--log-verbosity", "4",
+						"--max-pod-grace-period", "0",
+						"--pod-priority-threshold", "1",
+						"--ignore-daemonsets-utilization",
+						"--max-node-provision-time", "10m",
+						"--balancing-ignored-labels", "aaa",
+						"--max-nodes-total", "1000",
+						"--min-cores", "0",
+						"--scale-down-delay-after-add", "10s",
+						"--max-cores", "100",
+						"--min-memory", "0",
+						"--max-memory", "4096",
+						"--scale-down-enabled",
+						"--scale-down-utilization-threshold", "1",
+						"--scale-down-delay-after-delete", "10s",
+						"--scale-down-delay-after-failure", "10s",
+						"--gpu-limit", "nvidia.com/gpu,0,10",
+						"--gpu-limit", "amd.com/gpu,1,5",
+						"--scale-down-unneeded-time", "10s")
+					Expect(err).ToNot(HaveOccurred())
+					textData := rosaClient.Parser.TextData.Input(resp).Parse().Tip()
+					Expect(textData).To(ContainSubstring("INFO: Successfully created autoscaler configuration for cluster '%s'", clusterID))
+
+					defer func() {
+						By("Delete the autoscaler of the cluster")
+						resp, err = rosaClient.AutoScaler.DeleteAutoScaler(clusterID)
+						Expect(err).ToNot(HaveOccurred())
+					}()
+
+					By("Describe the autoscaler of the cluster")
+					rosaClient.Runner.YamlFormat()
+					yamlOutput, err := rosaClient.AutoScaler.DescribeAutoScaler(clusterID)
+					Expect(err).ToNot(HaveOccurred())
+					rosaClient.Runner.UnsetFormat()
+					yamlData, err := rosaClient.Parser.TextData.Input(yamlOutput).Parse().YamlToMap()
+					Expect(err).ToNot(HaveOccurred())
+					Expect(yamlData["balance_similar_node_groups"]).To(Equal(true))
+					Expect(yamlData["skip_nodes_with_local_storage"]).To(Equal(true))
+					Expect(yamlData["log_verbosity"]).To(Equal(4))
+					Expect(yamlData["balancing_ignored_labels"]).To(ContainElement("aaa"))
+					Expect(yamlData["ignore_daemonsets_utilization"]).To(Equal(true))
+					Expect(yamlData["max_node_provision_time"]).To(Equal("10m"))
+					Expect(yamlData["max_pod_grace_period"]).To(Equal(0))
+					Expect(yamlData["pod_priority_threshold"]).To(Equal(1))
+					Expect(yamlData["resource_limits"].(map[string]interface{})["cores"].(map[string]interface{})["min"]).To(Equal(0))
+					Expect(yamlData["resource_limits"].(map[string]interface{})["cores"].(map[string]interface{})["max"]).To(Equal(100))
+					Expect(yamlData["resource_limits"].(map[string]interface{})["memory"].(map[string]interface{})["min"]).To(Equal(0))
+					Expect(yamlData["resource_limits"].(map[string]interface{})["memory"].(map[string]interface{})["max"]).To(Equal(4096))
+					Expect(yamlData["resource_limits"].(map[string]interface{})["gpus"].([]interface{})[0].(map[string]interface{})["range"].(map[string]interface{})["max"]).To(Equal(10))
+					Expect(yamlData["resource_limits"].(map[string]interface{})["gpus"].([]interface{})[0].(map[string]interface{})["range"].(map[string]interface{})["min"]).To(Equal(0))
+					Expect(yamlData["resource_limits"].(map[string]interface{})["gpus"].([]interface{})[0].(map[string]interface{})["type"]).To(Equal("nvidia.com/gpu"))
+					Expect(yamlData["resource_limits"].(map[string]interface{})["gpus"].([]interface{})[1].(map[string]interface{})["range"].(map[string]interface{})["max"]).To(Equal(5))
+					Expect(yamlData["resource_limits"].(map[string]interface{})["gpus"].([]interface{})[1].(map[string]interface{})["range"].(map[string]interface{})["min"]).To(Equal(1))
+					Expect(yamlData["resource_limits"].(map[string]interface{})["gpus"].([]interface{})[1].(map[string]interface{})["type"]).To(Equal("amd.com/gpu"))
+					Expect(yamlData["resource_limits"].(map[string]interface{})["max_nodes_total"]).To(Equal(1000))
+					Expect(yamlData["scale_down"].(map[string]interface{})["delay_after_add"]).To(Equal("10s"))
+					Expect(yamlData["scale_down"].(map[string]interface{})["delay_after_delete"]).To(Equal("10s"))
+					Expect(yamlData["scale_down"].(map[string]interface{})["delay_after_failure"]).To(Equal("10s"))
+					Expect(yamlData["scale_down"].(map[string]interface{})["enabled"]).To(Equal(true))
+					Expect(yamlData["scale_down"].(map[string]interface{})["unneeded_time"]).To(Equal("10s"))
+					Expect(yamlData["scale_down"].(map[string]interface{})["utilization_threshold"]).To(Equal("1.000000"))
+
+				}
 
 				By("Edit the autoscaler of the cluster")
-				resp, err = rosaClient.AutoScaler.EditAutoScaler(clusterID, "--ignore-daemonsets-utilization",
+				resp, err := rosaClient.AutoScaler.EditAutoScaler(clusterID, "--ignore-daemonsets-utilization",
 					"--min-cores", "0",
 					"--max-cores", "10",
 					"--scale-down-delay-after-add", "0s",
 					"--gpu-limit", "amd.com/gpu,1,5")
 				Expect(err).ToNot(HaveOccurred())
-				textData = rosaClient.Parser.TextData.Input(resp).Parse().Tip()
+				textData := rosaClient.Parser.TextData.Input(resp).Parse().Tip()
 				Expect(textData).To(ContainSubstring("INFO: Successfully updated autoscaler configuration for cluster '%s'", clusterID))
 
 				By("Describe autoscaler to check the edited value is correct")
 				rosaClient.Runner.YamlFormat()
-				yamlOutput, err = rosaClient.AutoScaler.DescribeAutoScaler(clusterID)
+				yamlOutput, err := rosaClient.AutoScaler.DescribeAutoScaler(clusterID)
 				Expect(err).ToNot(HaveOccurred())
 				rosaClient.Runner.UnsetFormat()
-				yamlData, err = rosaClient.Parser.TextData.Input(yamlOutput).Parse().YamlToMap()
+				yamlData, err := rosaClient.Parser.TextData.Input(yamlOutput).Parse().YamlToMap()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(yamlData["ignore_daemonsets_utilization"]).To(Equal(true))
 				Expect(yamlData["resource_limits"].(map[string]interface{})["cores"].(map[string]interface{})["max"]).To(Equal(10))

--- a/tests/utils/exec/rosacli/autoscaler_service.go
+++ b/tests/utils/exec/rosacli/autoscaler_service.go
@@ -110,10 +110,12 @@ func (a *autoscalerService) ReflectAutoScalerDescription(result bytes.Buffer) (a
 
 // Delete AutoScaler
 func (a *autoscalerService) DeleteAutoScaler(clusterID string) (output bytes.Buffer, err error) {
-	output, err = a.client.Runner.
-		Cmd("delete", "autoscaler").
-		CmdFlags("-c", clusterID, "-y").
-		Run()
+	if a.created[clusterID] {
+		output, err = a.client.Runner.
+			Cmd("delete", "autoscaler").
+			CmdFlags("-c", clusterID, "-y").
+			Run()
+	}
 	if err == nil {
 		a.created[clusterID] = false
 	}


### PR DESCRIPTION
$ ginkgo --focus 67275 tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.14.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: ROSA CLI e2e tests suite - /home/aaraj/ocm-forked-code/rosa/tests/e2e
====================================================================================
Random Seed: 1718345112

Will run 1 of 105 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•S

Ran 1 of 105 Specs in 23.386 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 104 Skipped
PASS

Ginkgo ran 1 suite in 1m9.883822752s
Test Suite Passed
