### PR TITLE
OCM-5092 | fix: remove empty line between mode descriptions in -h output

### DIFF
--- a/pkg/interactive/mode.go
+++ b/pkg/interactive/mode.go
@@ -41,7 +41,7 @@ func AddModeFlag(cmd *cobra.Command) {
 		"m",
 		"",
 		"How to perform the operation. Valid options are:\n"+
-			"auto: Resource changes will be automatic applied using the current AWS account\n\n"+
+			"auto: Resource changes will be automatic applied using the current AWS account\n"+
 			"manual: Commands necessary to modify AWS resources will be output to be run manually",
 	)
 	cmd.RegisterFlagCompletionFunc("mode", modeCompletion)


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-5092