### PR TITLE
OCM-2730 | fix: Update error message for linking ocm-role/user-role with not existed entries

### DIFF
--- a/cmd/link/ocmrole/cmd.go
+++ b/cmd/link/ocmrole/cmd.go
@@ -124,7 +124,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	if *role.Arn != roleArn {
-		r.Reporter.Errorf("ARN '%s' did not match the existing role ARN", *role.Arn)
+		r.Reporter.Errorf("The role with '%s' cannot be found", roleArn)
 		os.Exit(1)
 	}
 

--- a/cmd/link/userrole/cmd.go
+++ b/cmd/link/userrole/cmd.go
@@ -124,7 +124,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	if *role.Arn != roleArn {
-		r.Reporter.Errorf("ARN '%s' did not match the existing role ARN", *role.Arn)
+		r.Reporter.Errorf("The role with '%s' cannot be found", roleArn)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-2730