### PR TITLE
OCM-9178 | test: automate id:74430,74387 create/edit/describe nodepool with maxsurge/maxunavailable

### DIFF
--- a/tests/utils/exec/rosacli/machinepool_service.go
+++ b/tests/utils/exec/rosacli/machinepool_service.go
@@ -103,25 +103,26 @@ type NodePoolList struct {
 }
 
 type NodePoolDescription struct {
-	ID                         string `yaml:"ID,omitempty"`
-	ClusterID                  string `yaml:"Cluster ID,omitempty"`
-	AutoScaling                string `yaml:"Autoscaling,omitempty"`
-	DesiredReplicas            string `yaml:"Desired replicas,omitempty"`
-	CurrentReplicas            string `yaml:"Current replicas,omitempty"`
-	InstanceType               string `yaml:"Instance type,omitempty"`
-	KubeletConfigs             string `yaml:"Kubelet configs,omitempty"`
-	Labels                     string `yaml:"Labels,omitempty"`
-	Tags                       string `yaml:"Tags,omitempty"`
-	Taints                     string `yaml:"Taints,omitempty"`
-	AvalaiblityZones           string `yaml:"Availability zone,omitempty"`
-	Subnet                     string `yaml:"Subnet,omitempty"`
-	Version                    string `yaml:"Version,omitempty"`
-	AutoRepair                 string `yaml:"Autorepair,omitempty"`
-	TuningConfigs              string `yaml:"Tuning configs,omitempty"`
-	Message                    string `yaml:"Message,omitempty"`
-	ScheduledUpgrade           string `yaml:"Scheduled upgrade,omitempty"`
-	AdditionalSecurityGroupIDs string `yaml:"Additional security group IDs,omitempty"`
-	NodeDrainGracePeriod       string `yaml:"Node drain grace period,omitempty"`
+	ID                         string              `yaml:"ID,omitempty"`
+	ClusterID                  string              `yaml:"Cluster ID,omitempty"`
+	AutoScaling                string              `yaml:"Autoscaling,omitempty"`
+	DesiredReplicas            string              `yaml:"Desired replicas,omitempty"`
+	CurrentReplicas            string              `yaml:"Current replicas,omitempty"`
+	InstanceType               string              `yaml:"Instance type,omitempty"`
+	KubeletConfigs             string              `yaml:"Kubelet configs,omitempty"`
+	Labels                     string              `yaml:"Labels,omitempty"`
+	Tags                       string              `yaml:"Tags,omitempty"`
+	Taints                     string              `yaml:"Taints,omitempty"`
+	AvalaiblityZones           string              `yaml:"Availability zone,omitempty"`
+	Subnet                     string              `yaml:"Subnet,omitempty"`
+	Version                    string              `yaml:"Version,omitempty"`
+	AutoRepair                 string              `yaml:"Autorepair,omitempty"`
+	TuningConfigs              string              `yaml:"Tuning configs,omitempty"`
+	ManagementUpgrade          []map[string]string `yaml:"Management upgrade,omitempty"`
+	Message                    string              `yaml:"Message,omitempty"`
+	ScheduledUpgrade           string              `yaml:"Scheduled upgrade,omitempty"`
+	AdditionalSecurityGroupIDs string              `yaml:"Additional security group IDs,omitempty"`
+	NodeDrainGracePeriod       string              `yaml:"Node drain grace period,omitempty"`
 }
 
 // Create MachinePool


### PR DESCRIPTION
`$ ginkgo --focus "(74430|74387)" tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.14.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: ROSA CLI e2e tests suite - /home/aaraj/ocm-forked-code/rosa/tests/e2e
====================================================================================
Random Seed: 1719541968

Will run 2 of 123 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS••SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 2 of 123 Specs in 681.547 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 121 Skipped
PASS

Ginkgo ran 1 suite in 11m27.184358664s
Test Suite Passed
`