### PR TITLE
OCM-9094 | feat: support multi-arch-enabled parameter

### DIFF
--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -489,6 +489,8 @@ func run(cmd *cobra.Command, argv []string) {
 				"Additional Principals:      %s\n", str,
 				strings.Join(cluster.AWS().AdditionalAllowedPrincipals(), ","))
 		}
+		str = fmt.Sprintf("%s"+
+			"Multi Architecture Workers: %s\n", str, getMultiArchEnabledStatus(cluster))
 	}
 
 	if cluster.Status().State() == cmv1.ClusterStateError {
@@ -837,6 +839,14 @@ func getExternalAuthConfigStatus(cluster *cmv1.Cluster) string {
 		externalAuthConfigStatus = EnabledOutput
 	}
 	return externalAuthConfigStatus
+}
+
+func getMultiArchEnabledStatus(cluster *cmv1.Cluster) string {
+	multiArchEnabledStatus := DisabledOutput
+	if cluster.MultiArchEnabled() {
+		multiArchEnabledStatus = EnabledOutput
+	}
+	return multiArchEnabledStatus
 }
 
 func getRolePolicyBindings(roleARN string, rolePolicyDetails map[string][]aws.PolicyDetail,

--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -174,6 +174,9 @@ type Spec struct {
 
 	// Control Plane Machine Pool attributes
 	AdditionalControlPlaneSecurityGroupIds []string
+
+	// Workers with arm64 architecture
+	MultiArchEnabled bool
 }
 
 // Volume represents a volume property for a disk
@@ -1063,6 +1066,10 @@ func (c *Client) createClusterSpec(config Spec) (*cmv1.Cluster, error) {
 
 	if config.AutoscalerConfig != nil {
 		clusterBuilder.Autoscaler(BuildClusterAutoscaler(config.AutoscalerConfig))
+	}
+
+	if config.MultiArchEnabled {
+		clusterBuilder.MultiArchEnabled(config.MultiArchEnabled)
 	}
 
 	clusterSpec, err := clusterBuilder.Build()


### PR DESCRIPTION
This PR updates the "create" and "describe" commands to support the "multi-arch-enabled" flag.