### PR TITLE
OCM-9166 | fix: prevent same role arns for IAM roles of the same cluster

### DIFF
--- a/cmd/create/cluster/cmd_test.go
+++ b/cmd/create/cluster/cmd_test.go
@@ -512,6 +512,26 @@ var _ = Describe("clusterHasLongNameWithoutDomainPrefix()", func() {
 	)
 })
 
+var _ = Describe("validateUniqueIamRoleArnsForStsCluster()", func() {
+	It("returns error if duplicate arns for IAM roles are found", func() {
+		accountRoles := []string{"arn1", "arn2", "arn3", "arn4"}
+		operatorRoles := []ocm.OperatorIAMRole{
+			{RoleARN: "arn1"}, {RoleARN: "arn6"},
+		}
+		err := validateUniqueIamRoleArnsForStsCluster(accountRoles, operatorRoles)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal(fmt.Sprintf(duplicateIamRoleArnErrorMsg, "arn1")))
+	})
+	It("returns nil if duplicate arns for IAM roles are not found", func() {
+		accountRoles := []string{"arn1", "arn2", "arn3", "arn4"}
+		operatorRoles := []ocm.OperatorIAMRole{
+			{RoleARN: "arn5"}, {RoleARN: "arn6"},
+		}
+		err := validateUniqueIamRoleArnsForStsCluster(accountRoles, operatorRoles)
+		Expect(err).ToNot(HaveOccurred())
+	})
+})
+
 func mustParseCIDR(s string) *net.IPNet {
 	_, ipnet, err := net.ParseCIDR(s)
 	Expect(err).To(BeNil())


### PR DESCRIPTION
Example output after fix:
![image](https://github.com/openshift/rosa/assets/118839428/cd7fcebc-7d0e-4a7c-bdc0-0c750d1212ac)

Originally intended to import over IAM duplicate check function (https://github.com/openshift-online/ocm-common/commit/35b747cbb4b66396d4f6e650210dcc62b08713aa)  from ocm-common; however,
decided not to do this, due to needing to eval the IAM roles prior to the create request being sent.
