### PR TITLE
OCM-9240 | test: fixing id:49137,53031

### DIFF
--- a/tests/e2e/test_rosacli_idp.go
+++ b/tests/e2e/test_rosacli_idp.go
@@ -15,6 +15,14 @@ import (
 	ph "github.com/openshift/rosa/tests/utils/profilehandler"
 )
 
+func validateIDPOutput(textData string, clusterID string, idpName string) {
+	Expect(textData).Should(ContainSubstring("Configuring IDP for cluster '%s'", clusterID))
+	Expect(textData).Should(ContainSubstring("Identity Provider '%s' has been created", idpName))
+	Expect(textData).Should(ContainSubstring("To log in to the console, open"))
+	Expect(textData).Should(ContainSubstring("and click on '%s'", idpName))
+
+}
+
 var _ = Describe("Edit IDP",
 	labels.Feature.IDP,
 	func() {
@@ -330,9 +338,7 @@ var _ = Describe("Edit IDP",
 					"-y")
 				Expect(err).To(BeNil())
 				textData = rosaClient.Parser.TextData.Input(output).Parse().Tip()
-				Expect(textData).Should(ContainSubstring("Identity Provider '%s' has been created", idpNames[0]))
-				Expect(textData).Should(ContainSubstring("To log in to the console, open"))
-				Expect(textData).Should(ContainSubstring("and click on '%s'", idpNames[0]))
+				validateIDPOutput(textData, clusterID, idpNames[0])
 
 				By("Create one htpasswd idp with single users")
 				multipleuserPasswd, err = common.GenerateMultipleHtpasswdPairs(2)
@@ -344,9 +350,7 @@ var _ = Describe("Edit IDP",
 					"-y")
 				Expect(err).To(BeNil())
 				textData = rosaClient.Parser.TextData.Input(output).Parse().Tip()
-				Expect(textData).Should(ContainSubstring("Identity Provider '%s' has been created", idpNames[1]))
-				Expect(textData).Should(ContainSubstring("To log in to the console, open"))
-				Expect(textData).Should(ContainSubstring("and click on '%s'", idpNames[1]))
+				validateIDPOutput(textData, clusterID, idpNames[1])
 
 				By("Create one htpasswd idp with multiple users from the file")
 				multipleuserPasswd, err = common.GenerateMultipleHtpasswdPairs(3)
@@ -361,9 +365,7 @@ var _ = Describe("Edit IDP",
 					"-y")
 				Expect(err).To(BeNil())
 				textData = rosaClient.Parser.TextData.Input(output).Parse().Tip()
-				Expect(textData).Should(ContainSubstring("Identity Provider '%s' has been created", idpNames[2]))
-				Expect(textData).Should(ContainSubstring("To log in to the console, open"))
-				Expect(textData).Should(ContainSubstring("and click on '%s'", idpNames[2]))
+				validateIDPOutput(textData, clusterID, idpNames[2])
 
 				By("List IDP")
 				idpTab, _, err := idpService.ListIDP(clusterID)
@@ -400,9 +402,7 @@ var _ = Describe("Edit IDP",
 					"-y")
 				Expect(err).To(BeNil())
 				textData := rosaClient.Parser.TextData.Input(output).Parse().Tip()
-				Expect(textData).Should(ContainSubstring("Identity Provider '%s' has been created", idpNames[0]))
-				Expect(textData).Should(ContainSubstring("To log in to the console, open"))
-				Expect(textData).Should(ContainSubstring("and click on '%s'", idpNames[0]))
+				validateIDPOutput(textData, clusterID, idpNames[0])
 
 				By("Try to create another htpasswd idp with single user")
 				_, validUserName, validUserPasswd, err = common.GenerateHtpasswdPair(validUserName, validUserPasswd)
@@ -415,9 +415,7 @@ var _ = Describe("Edit IDP",
 					"-y")
 				Expect(err).To(BeNil())
 				textData = rosaClient.Parser.TextData.Input(output).Parse().Tip()
-				Expect(textData).Should(ContainSubstring("Identity Provider '%s' has been created", idpNames[1]))
-				Expect(textData).Should(ContainSubstring("To log in to the console, open"))
-				Expect(textData).Should(ContainSubstring("and click on '%s'", idpNames[1]))
+				validateIDPOutput(textData, clusterID, idpNames[1])
 
 				By("Delete htpasswd idp")
 				output, err = idpService.DeleteIDP(


### PR DESCRIPTION
[ocm-9240](https://issues.redhat.com//browse/ocm-9240) [CI]Debug and fix: 49137, 53031

$ ginkgo --focus "(53031|49137)" tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.11.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: ROSA CLI e2e tests suite - /home/akanni/OCP-Repository/rosa/tests/e2e
====================================================================================
Random Seed: 1719825336

Will run 2 of 127 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS••SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 2 of 127 Specs in 68.811 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 125 Skipped
PASS

Ginkgo ran 1 suite in 1m9.848237088s
Test Suite Passed
