### PR TITLE
OCM-9225 | test: fixing id:67275 ci fix

### DIFF
--- a/tests/e2e/rosa_autoscaler_test.go
+++ b/tests/e2e/rosa_autoscaler_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Autoscaler", labels.Feature.Autoscaler, func() {
 							"--pod-priority-threshold", strconv.Itoa(originalAutoscaler.PodPriorityThresold),
 							"--ignore-daemonsets-utilization",
 							"--max-node-provision-time", originalAutoscaler.MaxNodeProvisionTime,
-							"--balancing-ignored-labels", originalAutoscaler.BalancingIgnoredLabels,
+							"--balancing-ignored-labels", originalAutoscaler.BalancingIgnoredLabels[0],
 							"--max-nodes-total", strconv.Itoa(originalAutoscaler.ResourcesLimits.MaxNodesTotal),
 							"--min-cores", strconv.Itoa(originalAutoscaler.ResourcesLimits.Cores.Min),
 							"--scale-down-delay-after-add", originalAutoscaler.ScaleDown.DelayAfterAdd,
@@ -147,15 +147,15 @@ var _ = Describe("Autoscaler", labels.Feature.Autoscaler, func() {
 					Expect(autoscaler.MaxPodGracePeriod).To(Equal(0))
 					Expect(autoscaler.PodPriorityThresold).To(Equal(1))
 					Expect(autoscaler.ResourcesLimits.Cores.Min).To(Equal(0))
-					Expect(autoscaler.ResourcesLimits.Cores.Min).To(Equal(100))
+					Expect(autoscaler.ResourcesLimits.Cores.Max).To(Equal(100))
 					Expect(autoscaler.ResourcesLimits.Memory.Min).To(Equal(0))
-					Expect(autoscaler.ResourcesLimits.Cores.Max).To(Equal(4096))
+					Expect(autoscaler.ResourcesLimits.Memory.Max).To(Equal(4096))
 					Expect(autoscaler.ResourcesLimits.GPUs[0].Range.Max).To(Equal(10))
 					Expect(autoscaler.ResourcesLimits.GPUs[0].Range.Min).To(Equal(0))
 					Expect(autoscaler.ResourcesLimits.GPUs[0].Type).To(Equal("nvidia.com/gpu"))
-					Expect(autoscaler.ResourcesLimits.GPUs[0].Range.Max).To(Equal(5))
-					Expect(autoscaler.ResourcesLimits.GPUs[0].Range.Min).To(Equal(1))
-					Expect(autoscaler.ResourcesLimits.GPUs[0].Type).To(Equal("amd.com/gpu"))
+					Expect(autoscaler.ResourcesLimits.GPUs[1].Range.Max).To(Equal(5))
+					Expect(autoscaler.ResourcesLimits.GPUs[1].Range.Min).To(Equal(1))
+					Expect(autoscaler.ResourcesLimits.GPUs[1].Type).To(Equal("amd.com/gpu"))
 					Expect(autoscaler.ResourcesLimits.MaxNodesTotal).To(Equal(1000))
 					Expect(autoscaler.ScaleDown.DelayAfterAdd).To(Equal("10s"))
 					Expect(autoscaler.ScaleDown.DelayAfterDelete).To(Equal("10s"))
@@ -189,6 +189,7 @@ var _ = Describe("Autoscaler", labels.Feature.Autoscaler, func() {
 				err = rosaClient.Parser.TextData.Input(yamlOutput).Parse().YamlToObj(&autoscaler)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(autoscaler.IgnoreDaemonSetsUtilization).To(Equal(true))
+				Expect(autoscaler.ResourcesLimits.Cores.Min).To(Equal(0))
 				Expect(autoscaler.ResourcesLimits.Cores.Max).To(Equal(10))
 				Expect(autoscaler.ResourcesLimits.GPUs[0].Range.Max).To(Equal(5))
 				Expect(autoscaler.ResourcesLimits.GPUs[0].Range.Min).To(Equal(1))

--- a/tests/utils/config/support.go
+++ b/tests/utils/config/support.go
@@ -68,7 +68,7 @@ func DeployCilium(ocClient *occli.Client, podCIDR string, hostPrefix string, out
 		return err
 	}
 
-	stdout, err := ocClient.Run(fmt.Sprintf("oc apply -f %s", resultFile))
+	stdout, err := ocClient.Run(fmt.Sprintf("envsubst < %s | oc apply -f -", resultFile))
 	time.Sleep(3 * time.Second)
 	if err != nil {
 		log.Logger.Errorf("%s", stdout)

--- a/tests/utils/exec/rosacli/autoscaler_service.go
+++ b/tests/utils/exec/rosacli/autoscaler_service.go
@@ -43,7 +43,7 @@ type AutoScalerDescription struct {
 
 type Autoscaler struct {
 	LogVerbosity                int                       `yaml:"log_verbosity,omitempty"`
-	BalancingIgnoredLabels      string                    `yaml:"balancing_ignored_labels,omitempty"`
+	BalancingIgnoredLabels      []string                  `yaml:"balancing_ignored_labels,omitempty"`
 	BalanceSimilarNodeGroups    bool                      `yaml:"balance_similar_node_groups,omitempty"`
 	MaxNodeProvisionTime        string                    `yaml:"max_node_provision_time,omitempty"`
 	MaxPodGracePeriod           int                       `yaml:"max_pod_grace_period,omitempty"`


### PR DESCRIPTION
[OCM-9242](https://issues.redhat.com//browse/OCM-9242)
rosa-hcp-external-auth-profile ouput log :- https://privatebin.corp.redhat.com/?3dba00b04ae84ce3#D6nobqyF6TCoUVizR7uiif8NYAifp5JCkvJ4kdQajdkB 

67275 output log :- 

$ ginkgo --focus 67275 tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.14.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: ROSA CLI e2e tests suite - /home/aaraj/ocm-forked-code/rosa/tests/e2e
====================================================================================
Random Seed: 1719831399

Will run 1 of 126 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 126 Specs in 29.045 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 125 Skipped
PASS

Ginkgo ran 1 suite in 38.71988612s
Test Suite Passed
