### PR TITLE
OCM-9409 | test: automate id:52106,64620

### DIFF
--- a/tests/e2e/test_rosacli_ocm_role.go
+++ b/tests/e2e/test_rosacli_ocm_role.go
@@ -25,6 +25,33 @@ var _ = Describe("Edit ocm role", labels.Feature.OCMRole,
 			rosaClient = rosacli.NewClient()
 			ocmResourceService = rosaClient.OCMResource
 		})
+		It("make sure no ocm-role and user role linked - [id:52106]", labels.High, labels.Runtime.Day2, func() {
+			By("Check if there is the ocm-role linked, and delete it")
+			ocmRoleList, _, err := ocmResourceService.ListOCMRole()
+			ocmRole := ocmRoleList.FindLinkedOCMRole()
+			Expect(err).To(BeNil())
+			if (ocmRole != rosacli.OCMRole{}) {
+				output, err := ocmResourceService.DeleteOCMRole(
+					"--role-arn", ocmRole.RoleArn,
+					"--mode", "auto",
+					"-y")
+				Expect(err).To(BeNil())
+				Expect(output.String()).Should(ContainSubstring("Successfully deleted the OCM role"))
+			}
+			By("Check if there is the user-role linked, and delete it")
+			userRoleList, _, err := ocmResourceService.ListUserRole()
+			Expect(err).To(BeNil())
+			userRole := userRoleList.FindLinkedUserRole()
+			Expect(err).To(BeNil())
+			if (userRole != rosacli.UserRole{}) {
+				output, err := ocmResourceService.DeleteUserRole(
+					"--role-arn", userRole.RoleArn,
+					"--mode", "auto",
+					"-y")
+				Expect(err).To(BeNil())
+				Expect(output.String()).Should(ContainSubstring("Successfully deleted the user role"))
+			}
+		})
 
 		It("can create/delete/unlink/link ocm-roles in auto mode - [id:46187]",
 			labels.High, labels.Runtime.OCMResources,

--- a/tests/e2e/test_rosacli_oidc_config.go
+++ b/tests/e2e/test_rosacli_oidc_config.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -191,4 +192,103 @@ var _ = Describe("Edit OIDC config",
 				textData = rosaClient.Parser.TextData.Input(output).Parse().Tip()
 				Expect(textData).To(ContainSubstring("not found"))
 			})
+	})
+var _ = Describe("Register ummanaged oidc config testing",
+	labels.Feature.OIDCConfig,
+	func() {
+		defer GinkgoRecover()
+		var (
+			accountRolePrefix  string
+			oidcConfigID       string
+			rosaClient         *rosacli.Client
+			ocmResourceService rosacli.OCMResourceService
+		)
+
+		BeforeEach(func() {
+			By("Init the client")
+			rosaClient = rosacli.NewClient()
+			ocmResourceService = rosaClient.OCMResource
+			rosaClient = rosacli.NewClient()
+
+		})
+		AfterEach(func() {
+			By("Delete oidc config")
+			output, err := ocmResourceService.DeleteOIDCConfig(
+				"--oidc-config-id", oidcConfigID,
+				"--mode", "auto",
+				"-y",
+			)
+			Expect(err).To(BeNil())
+			Expect(output.String()).To(ContainSubstring("Successfully deleted the OIDC provider"))
+
+			By("Cleanup created account-roles")
+			_, err = ocmResourceService.DeleteAccountRole("--mode", "auto",
+				"--prefix", accountRolePrefix,
+				"-y")
+			Expect(err).To(BeNil())
+		})
+
+		It("to register successfully - [id:64620]", labels.High, labels.Runtime.OCMResources, func() {
+			var (
+				secretArn string
+				issuerUrl string
+			)
+			By("Create account-roles for testing")
+			accountRolePrefix = fmt.Sprintf("QEAuto-ar64620-%s", time.Now().UTC().Format("20060102"))
+			_, err := ocmResourceService.CreateAccountRole("--mode", "auto",
+				"--prefix", accountRolePrefix,
+				"-y")
+			Expect(err).To(BeNil())
+
+			By("Get the installer role arn")
+			accountRoleList, _, err := ocmResourceService.ListAccountRole()
+			Expect(err).To(BeNil())
+			installerRole := accountRoleList.InstallerRole(accountRolePrefix, false)
+			Expect(installerRole).ToNot(BeNil())
+			roleArn := installerRole.RoleArn
+
+			By("Create unmanaged oidc config")
+			oidcConfigPrefix := "ocp64620oc"
+			output, err := ocmResourceService.CreateOIDCConfig(
+				"--mode", "manual",
+				"--prefix", oidcConfigPrefix,
+				"--role-arn", roleArn,
+				"--managed=false",
+				"-y")
+			Expect(err).To(BeNil())
+			commands := common.ExtractCommandsFromOIDCRegister(output)
+
+			By("Execute commands to create unmanaged oidc-config")
+			var commandArgs []string
+			for _, command := range commands {
+				if strings.Contains(command, "aws secretsmanager create-secret") {
+					commandArgs = common.ParseCommandToArgs(command)
+					stdout, err := rosaClient.Runner.RunCMD(commandArgs)
+					Expect(err).To(BeNil())
+					secretArn = common.ParseSecretArnFromOutput(stdout.String())
+					continue
+				}
+				if strings.Contains(command, "aws iam create-open-id-connect-provider") {
+					issuerUrl = common.ParseIssuerURLFromCommand(command)
+				}
+				_, err := rosaClient.Runner.RunCMD(strings.Split(command, " "))
+				Expect(err).To(BeNil())
+			}
+
+			By("Register oidc config")
+			_, err = ocmResourceService.RegisterOIDCConfig(
+				"--mode", "auto",
+				"--issuer-url", issuerUrl,
+				"--role-arn", roleArn,
+				"--secret-arn", secretArn,
+				"-y")
+			Expect(err).To(BeNil())
+
+			By("List oidc config to check if above one is registered")
+			oidcConfigList, _, err := ocmResourceService.ListOIDCConfig()
+			Expect(err).To(BeNil())
+			foundOIDCConfig := oidcConfigList.IssuerUrl(issuerUrl)
+			Expect(foundOIDCConfig).ToNot(Equal(rosacli.OIDCConfig{}))
+			oidcConfigID = foundOIDCConfig.ID
+		})
 	})

--- a/tests/utils/common/oidc.go
+++ b/tests/utils/common/oidc.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"bytes"
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -48,4 +50,58 @@ func ExtractOIDCProviderARN(output string) string {
 func ExtractOIDCProviderIDFromARN(arn string) string {
 	spliptElements := SplitARNResources(arn)
 	return spliptElements[len(spliptElements)-1]
+}
+
+func ExtractCommandsFromOIDCRegister(bf bytes.Buffer) []string {
+	var commands []string
+	commands = strings.Split(bf.String(), "\n\n")
+	for k, command := range commands {
+		if strings.Contains(command, "\naws") {
+			splitCommands := strings.Split(command, "\naws")
+			commands[k] = splitCommands[0]
+			commands = append(commands, fmt.Sprintf("aws %s", splitCommands[1]))
+		}
+	}
+	var newCommands []string
+	for _, command := range commands {
+		command = strings.ReplaceAll(command, "\\", "")
+		command = strings.ReplaceAll(command, "\n", " ")
+		spaceRegex := regexp.MustCompile(`\s+`)
+		command = spaceRegex.ReplaceAllString(command, " ")
+		// remove '' in the value
+		command = strings.ReplaceAll(command, "'", "")
+		newCommands = append(newCommands, command)
+
+	}
+	return newCommands
+}
+
+// Parse command string to args array. NOTE:If the flag value contains spaces, put the whole value into the array
+func ParseCommandToArgs(command string) []string {
+	var args []string
+	re := regexp.MustCompile(`'[^']*'|"[^"]*"|\S+`)
+	matches := re.FindAllString(command, -1)
+
+	for _, match := range matches {
+		cleanedMatch := strings.Trim(match, `"'`)
+		args = append(args, cleanedMatch)
+	}
+	return args
+}
+
+func ParseSecretArnFromOutput(output string) string {
+	re := regexp.MustCompile(`"ARN":\s*"([^"]+)"`)
+	matches := re.FindStringSubmatch(output)
+
+	if len(matches) > 1 {
+		return matches[1]
+	} else {
+		Logger.Warnf("sercret manager ARN not found in %s", output)
+		return ""
+	}
+}
+
+func ParseIssuerURLFromCommand(command string) string {
+	re := regexp.MustCompile(`https://[^\s]+`)
+	return re.FindString(command)
 }


### PR DESCRIPTION
[OCM-9409](https://issues.redhat.com//browse/OCM-9409) | test: automate id:52106,64620
logs: https://privatebin.corp.redhat.com/?b62fe62ded1eb759#7pMG4yBTU1bXNGKLA5KekJGNDndC2RsMBtP27M7NNKLy

52106 is checking and removing ocm-role and user-role to make sure the operation via rosacli should work well without the linked ocm-role and user -role.
64620: test for registering unmanaged oidc-config