### PR TITLE
OCM-9340 | fix: Fix incorrect autoscaling enablement flag usage

### DIFF
--- a/pkg/machinepool/machinepool.go
+++ b/pkg/machinepool/machinepool.go
@@ -342,7 +342,7 @@ func getMachinePoolReplicas(cmd *cobra.Command,
 		err = fmt.Errorf("Failed to get inputted max replicas: %s", err)
 		return
 	}
-	autoscaling, err = cmd.Flags().GetBool("autoscaling")
+	autoscaling, err = cmd.Flags().GetBool("enable-autoscaling")
 	if err != nil {
 		err = fmt.Errorf("Failed to get inputted autoscaling: %s", err)
 		return
@@ -842,7 +842,7 @@ func getNodePoolReplicas(cmd *cobra.Command,
 		err = fmt.Errorf("Failed to get inputted max replicas: %s", err)
 		return
 	}
-	autoscaling, err = cmd.Flags().GetBool("autoscaling")
+	autoscaling, err = cmd.Flags().GetBool("enable-autoscaling")
 	if err != nil {
 		err = fmt.Errorf("Failed to get inputted autoscaling: %s", err)
 		return


### PR DESCRIPTION
When moving files over, the incorrect flag name (`"autoscaling"`) was used for `enable-autoscaling`, causing the flag value to not be found

https://issues.redhat.com/browse/OCM-9340