### PR TITLE
OCM-9293 | test: automate id:60956,57408,74761

### DIFF
--- a/tests/e2e/test_rosacli_account_roles.go
+++ b/tests/e2e/test_rosacli_account_roles.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/openshift-online/ocm-common/pkg/aws/aws_client"
 
 	"github.com/openshift/rosa/tests/ci/labels"
 	"github.com/openshift/rosa/tests/utils/common"
@@ -474,6 +475,143 @@ var _ = Describe("Edit account roles", labels.Feature.AccountRoles, func() {
 			Expect(err).ToNot(HaveOccurred())
 			textData = rosaClient.Parser.TextData.Input(output).Parse().Tip()
 			Expect(textData).To(ContainSubstring("WARN: There are no hosted CP account roles to be deleted"))
+		})
+	It("create/delete classic account roles with managed policies - [id:57408]",
+		labels.Critical, labels.Runtime.OCMResources,
+		func() {
+
+			var (
+				rolePrefixAuto      = "ar57408a"
+				rolePrefixManual    = "ar57408m"
+				roleVersion         string
+				path                = "/fd/sd/"
+				policiesArn         []string
+				managedPoliciesName = []string{
+					"ROSAInstallerCorePolicy",
+					"ROSAInstallerVPCPolicy",
+					"ROSAInstallerPrivateLinkPolicy",
+					"ROSAControlPlanePolicy",
+					"ROSAWorkerPolicy",
+					"ROSASRESupportPolicy",
+				}
+			)
+			awsClient, err := aws_client.CreateAWSClient("", "")
+			Expect(err).To(BeNil())
+			defer func() {
+				By("Cleanup created account-roles in the test case")
+				_, err := ocmResourceService.DeleteAccountRole("--mode", "auto",
+					"--prefix", rolePrefixManual,
+					"-y")
+
+				Expect(err).To(BeNil())
+				_, err = ocmResourceService.DeleteAccountRole("--mode", "auto",
+					"--prefix", rolePrefixAuto,
+					"-y")
+
+				Expect(err).To(BeNil())
+
+				By("Check managed policies not deleted by rosa command")
+				for _, policyArn := range policiesArn {
+					policy, err := awsClient.GetIAMPolicy(policyArn)
+					Expect(err).To(BeNil())
+					Expect(policy).ToNot(BeNil())
+				}
+
+				By("Delete fake managed policies")
+				for _, policyArn := range policiesArn {
+					err := awsClient.DeletePolicy(policyArn)
+					Expect(err).To(BeNil())
+				}
+			}()
+
+			By("Prepare fake managed policies")
+			statement := map[string]interface{}{
+				"Effect":   "Allow",
+				"Action":   "*",
+				"Resource": "*",
+			}
+			for _, pName := range managedPoliciesName {
+				pArn, err := awsClient.CreatePolicy(pName, statement)
+				Expect(err).To(BeNil())
+				policiesArn = append(policiesArn, pArn)
+			}
+
+			By("Prepare verson for testing")
+			versionService := rosaClient.Version
+			versionList, err := versionService.ListAndReflectVersions(rosacli.VersionChannelGroupStable, true)
+			Expect(err).To(BeNil())
+			defaultVersion := versionList.DefaultVersion()
+			Expect(defaultVersion).ToNot(BeNil())
+			version, err := versionList.FindNearestBackwardMinorVersion(defaultVersion.Version, 1, true)
+			Expect(err).To(BeNil())
+			Expect(version).NotTo(BeNil())
+			_, _, roleVersion, err = version.MajorMinor()
+			Expect(err).To(BeNil())
+
+			By("Create classic account-roles with managed policies in manual mode")
+			output, err := ocmResourceService.CreateAccountRole("--mode", "manual",
+				"--prefix", rolePrefixManual,
+				"--path", path,
+				"--permissions-boundary", permissionsBoundaryArn,
+				"--version", roleVersion,
+				"--managed-policies",
+				"-y")
+			Expect(err).To(BeNil())
+			commands := common.ExtractCommandsToCreateAccountRoles(output)
+
+			for _, command := range commands {
+				_, err := rosaClient.Runner.RunCMD(strings.Split(command, " "))
+				Expect(err).To(BeNil())
+			}
+
+			By("List the account roles created in manual mode")
+			accountRoleList, _, err := ocmResourceService.ListAccountRole()
+			Expect(err).To(BeNil())
+			accountRoles := accountRoleList.AccountRoles(rolePrefixManual)
+			Expect(len(accountRoles)).To(Equal(4))
+			for _, ar := range accountRoles {
+				Expect(ar.AWSManaged).To(Equal("Yes"))
+			}
+
+			By("Delete the account-roles in manual mode")
+			output, err = ocmResourceService.DeleteAccountRole("--mode", "auto",
+				"--prefix", rolePrefixManual,
+				"-y")
+
+			Expect(err).To(BeNil())
+			commands = common.ExtractCommandsToCreateAccountRoles(output)
+
+			for _, command := range commands {
+				_, err := rosaClient.Runner.RunCMD(strings.Split(command, " "))
+				Expect(err).To(BeNil())
+			}
+
+			By("Create classic account-roles with managed policies in auto mode")
+			output, err = ocmResourceService.CreateAccountRole("--mode", "auto",
+				"--prefix", rolePrefixAuto,
+				"--path", path,
+				"--permissions-boundary", permissionsBoundaryArn,
+				"--version", roleVersion,
+				"--managed-policies",
+				"-y")
+			Expect(err).To(BeNil())
+			Expect(output.String()).To(ContainSubstring("Created role"))
+
+			By("List the account roles created in auto mode")
+			accountRoleList, _, err = ocmResourceService.ListAccountRole()
+			Expect(err).To(BeNil())
+			accountRoles = accountRoleList.AccountRoles(rolePrefixAuto)
+			Expect(len(accountRoles)).To(Equal(4))
+			for _, ar := range accountRoles {
+				Expect(ar.AWSManaged).To(Equal("Yes"))
+			}
+
+			By("Delete the account-roles in auto mode")
+			output, err = ocmResourceService.DeleteAccountRole("--mode", "auto",
+				"--prefix", rolePrefixAuto,
+				"-y")
+			Expect(err).To(BeNil())
+			Expect(output.String()).To(ContainSubstring("Successfully deleted"))
 		})
 
 	It("Validation for account-role creation by user - [id:43067]",

--- a/tests/e2e/test_rosacli_operator_roles.go
+++ b/tests/e2e/test_rosacli_operator_roles.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/rosa/tests/utils/common"
 	"github.com/openshift/rosa/tests/utils/config"
 	"github.com/openshift/rosa/tests/utils/exec/rosacli"
+	"github.com/openshift/rosa/tests/utils/profilehandler"
 )
 
 var _ = Describe("Edit operator roles", labels.Feature.OperatorRoles, func() {
@@ -49,7 +50,60 @@ var _ = Describe("Edit operator roles", labels.Feature.OperatorRoles, func() {
 			err := rosaClient.CleanResources(clusterID)
 			Expect(err).ToNot(HaveOccurred())
 		})
+		It("to delete in-used operator-roles and byo oidc-config  [id:74761]",
+			labels.Critical, labels.Runtime.Day2, func() {
+				By("Check if the cluster is using BYO oidc config")
+				profile := profilehandler.LoadProfileYamlFileByENV()
+				if profile.ClusterConfig.OIDCConfig == "" {
+					SkipTestOnFeature("This testing only work for byo oidc cluster")
+				}
 
+				By("Describe cluster")
+				clusterService := rosaClient.Cluster
+				rosaClient.Runner.JsonFormat()
+				jsonOutput, err := clusterService.DescribeCluster(clusterID)
+				Expect(err).To(BeNil())
+				rosaClient.Runner.UnsetFormat()
+				jsonData := rosaClient.Parser.JsonData.Input(jsonOutput).Parse()
+				oidcConfigID := jsonData.DigString("aws", "sts", "oidc_config", "id")
+				operatorRolePrefix := jsonData.DigString("aws", "sts", "operator_role_prefix")
+
+				By("Delete in-used operator roles by prefix in auto mode")
+				output, err := ocmResourceService.DeleteOperatorRoles(
+					"--prefix", operatorRolePrefix,
+					"-y",
+					"--mode", "auto",
+				)
+				Expect(err).To(HaveOccurred())
+				Expect(output.String()).To(ContainSubstring("There are clusters using Operator Roles Prefix"))
+
+				By("Delete in-used operator roles by prefix in manual mode")
+				output, err = ocmResourceService.DeleteOperatorRoles(
+					"--prefix", operatorRolePrefix,
+					"-y",
+					"--mode", "manual",
+				)
+				Expect(err).To(HaveOccurred())
+				Expect(output.String()).To(ContainSubstring("There are clusters using Operator Roles Prefix"))
+
+				By("Delete in-used oidc config in auto mode")
+				output, err = ocmResourceService.DeleteOIDCConfig(
+					"--oidc-config-id", oidcConfigID,
+					"--mode", "auto",
+					"-y",
+				)
+				Expect(err).To(HaveOccurred())
+				Expect(output.String()).To(ContainSubstring("There are clusters using OIDC config"))
+
+				By("Delete in-used oidc config in manual mode")
+				output, err = ocmResourceService.DeleteOIDCConfig(
+					"--oidc-config-id", oidcConfigID,
+					"--mode", "manual",
+					"-y",
+				)
+				Expect(err).To(HaveOccurred())
+				Expect(output.String()).To(ContainSubstring("There are clusters using OIDC config"))
+			})
 		It("can validate when user create operator-roles to cluster - [id:43051]",
 			labels.High, labels.Runtime.Day2,
 			func() {
@@ -721,3 +775,136 @@ var _ = Describe("create IAM roles forcely testing",
 				}
 			})
 	})
+var _ = Describe("Detele operator roles with byo oidc", labels.Feature.OperatorRoles, func() {
+	defer GinkgoRecover()
+	var (
+		rosaClient          *rosacli.Client
+		ocmResourceService  rosacli.OCMResourceService
+		awsClient           *aws_client.AWSClient
+		err                 error
+		accountRolePrefix   string
+		operatorRolePrefixC string
+		operatorRolePrefixH string
+		managedOIDCConfigID string
+
+		installerRoleArnC string
+		installerRoleArnH string
+	)
+	BeforeEach(func() {
+		By("Init the client")
+		rosaClient = rosacli.NewClient()
+		ocmResourceService = rosaClient.OCMResource
+
+		awsClient, err = aws_client.CreateAWSClient("", "")
+		Expect(err).To(BeNil())
+
+	})
+	AfterEach(func() {
+
+		By("Delete testing operator-roles")
+		_, err = ocmResourceService.DeleteOperatorRoles(
+			"--prefix", operatorRolePrefixC,
+			"--mode", "auto",
+			"-y",
+		)
+		Expect(err).To(BeNil())
+
+		_, err = ocmResourceService.DeleteOperatorRoles(
+			"--prefix", operatorRolePrefixH,
+			"--mode", "auto",
+			"-y",
+		)
+		Expect(err).To(BeNil())
+
+		By("Detete testing oidc condig")
+		output, err := ocmResourceService.DeleteOIDCConfig(
+			"--oidc-config-id", managedOIDCConfigID,
+			"--mode", "manual",
+			"-y",
+		)
+		Expect(err).To(BeNil())
+		commands := common.ExtractCommandsToDeleteOpRoles(output)
+		for k, v := range commands {
+			fmt.Printf("the %d command is %s\n", k, v)
+		}
+		By("Delete the testing account-roles")
+		_, err = ocmResourceService.DeleteAccountRole("--mode", "auto",
+			"--prefix", accountRolePrefix,
+			"-y",
+		)
+		Expect(err).To(BeNil())
+	})
+	It("to delete operator-roles and byo oidc-config in manual mode - [id:60956]",
+		labels.Critical, labels.Runtime.OCMResources, func() {
+			By("Create account-roles")
+			accountRolePrefix = "arp60956"
+			output, err := ocmResourceService.CreateAccountRole("--mode", "auto",
+				"--prefix", accountRolePrefix,
+				"-y",
+			)
+			Expect(err).To(BeNil())
+			Expect(output.String()).To(ContainSubstring("Created role"))
+			installerRoleC, err := awsClient.GetRole(fmt.Sprintf("%s-Installer-Role", accountRolePrefix))
+			Expect(err).To(BeNil())
+			installerRoleArnC = *installerRoleC.Arn
+
+			installerRoleH, err := awsClient.GetRole(fmt.Sprintf("%s-HCP-ROSA-Installer-Role", accountRolePrefix))
+			Expect(err).To(BeNil())
+			installerRoleArnH = *installerRoleH.Arn
+
+			By("Create oidc-config")
+			output, err = ocmResourceService.CreateOIDCConfig("--mode", "auto", "-y")
+			Expect(err).To(BeNil())
+			Expect(output.String()).To(ContainSubstring("Created OIDC provider with ARN"))
+			oidcPrivodeARNFromOutputMessage := common.ExtractOIDCProviderARN(output.String())
+			oidcPrivodeIDFromOutputMessage := common.ExtractOIDCProviderIDFromARN(oidcPrivodeARNFromOutputMessage)
+
+			managedOIDCConfigID, err = ocmResourceService.GetOIDCIdFromList(oidcPrivodeIDFromOutputMessage)
+			Expect(err).To(BeNil())
+
+			By("Create hosted-cp operator-roles")
+			operatorRolePrefixH = "opp60956h"
+			output, err = ocmResourceService.CreateOperatorRoles(
+				"--oidc-config-id", managedOIDCConfigID,
+				"--installer-role-arn", installerRoleArnH,
+				"--mode", "auto",
+				"--prefix", operatorRolePrefixH,
+				"--hosted-cp",
+				"-y",
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(output.String()).Should(ContainSubstring("Created role"))
+
+			By("Delete the hosted-cp operator-roles by prefix in manual mode")
+			output, err = ocmResourceService.DeleteOperatorRoles("--prefix", operatorRolePrefixH, "-y", "--mode", "manual")
+			Expect(err).NotTo(HaveOccurred())
+			commands := common.ExtractCommandsToDeleteOpRoles(output)
+			for _, command := range commands {
+				_, err := rosaClient.Runner.RunCMD(strings.Split(command, " "))
+				Expect(err).To(BeNil())
+			}
+
+			By("Create classic operator-roles")
+			operatorRolePrefixC = "opp60956c"
+			output, err = ocmResourceService.CreateOperatorRoles(
+				"--oidc-config-id", managedOIDCConfigID,
+				"--installer-role-arn", installerRoleArnC,
+				"--mode", "auto",
+				"--prefix", operatorRolePrefixC,
+				"-y",
+			)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(output.String()).Should(ContainSubstring("Created role"))
+
+			By("Delete the classic operator-roles by prefix in manual mode")
+			output, err = ocmResourceService.DeleteOperatorRoles("--prefix", operatorRolePrefixC, "-y", "--mode", "manual")
+			Expect(err).NotTo(HaveOccurred())
+			commands = common.ExtractCommandsToDeleteOpRoles(output)
+			for _, command := range commands {
+				_, err := rosaClient.Runner.RunCMD(strings.Split(command, " "))
+				Expect(err).To(BeNil())
+			}
+		})
+
+})

--- a/tests/utils/common/role.go
+++ b/tests/utils/common/role.go
@@ -1,0 +1,55 @@
+package common
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Extract aws commands from `rosa create account-role --mode manual`
+func ExtractCommandsToCreateAccountRoles(bf bytes.Buffer) []string {
+	var commands []string
+	output := strings.Split(bf.String(), "\n\n")
+	for _, message := range output {
+		if strings.HasPrefix(message, "aws iam") {
+			commands = append(commands, message)
+		}
+	}
+	var newCommands []string
+	for _, command := range commands {
+		command = strings.ReplaceAll(command, "\\", "")
+		command = strings.ReplaceAll(command, "\n", " ")
+		spaceRegex := regexp.MustCompile(`\s+`)
+		command = spaceRegex.ReplaceAllString(command, " ")
+		command = strings.ReplaceAll(command, "'", "")
+		newCommands = append(newCommands, command)
+
+	}
+	return newCommands
+}
+
+// Extract aws commands from `rosa delete operator-roles --mode manual`
+func ExtractCommandsToDeleteOpRoles(bf bytes.Buffer) []string {
+	var commands []string
+	output := strings.Split(bf.String(), "\naws")
+	for _, message := range output {
+		if strings.HasPrefix(message, "aws iam") {
+			commands = append(commands, message)
+		} else {
+			commands = append(commands, fmt.Sprintf("aws %s", message))
+		}
+
+	}
+	var newCommands []string
+	for _, command := range commands {
+		command = strings.ReplaceAll(command, "\\", "")
+		command = strings.ReplaceAll(command, "\n", " ")
+		spaceRegex := regexp.MustCompile(`\s+`)
+		command = spaceRegex.ReplaceAllString(command, " ")
+		command = strings.ReplaceAll(command, "'", "")
+		newCommands = append(newCommands, command)
+
+	}
+	return newCommands
+}


### PR DESCRIPTION
OCP-57408 - Create/Delete/List account-roles with managed account-roles policies
OCP-60956 - Delete BYO operator-roles/oidc via rosacli by command
OCP-74761 - Delete in-used BYO operator-roles/oidc via rosacli by command 
logs:  https://privatebin.corp.redhat.com/?3741e71914dc73e1#7KaAHJRzix1edFUYYwKae5iuZKzmCymzDGPXowfkShCd