### PR TITLE
OCM-9535 | test: fix id:73731 fix to use an available upgrading versi…

### DIFF
--- a/tests/e2e/test_rosacli_upgrade.go
+++ b/tests/e2e/test_rosacli_upgrade.go
@@ -244,7 +244,7 @@ var _ = Describe("Cluster Upgrade testing",
 			// and to check the `rosa describe/list upgrade` in both of these two case.
 			output, err = clusterService.Upgrade(
 				"-c", clusterID,
-				"--version", "4.15.14",
+				"--version", upgradingVersion,
 				"--mode", "auto",
 				"-y",
 			)


### PR DESCRIPTION
[OCM-9535](https://issues.redhat.com//browse/OCM-9535) | test: fix id:73731 fix to use an available upgrading version based on the cluster version.