### PR TITLE
OCM-9139 | fix: Enable maxSurge and maxUnavailable for interactive mode

### DIFF
--- a/cmd/create/machinepool/nodepool.go
+++ b/cmd/create/machinepool/nodepool.go
@@ -474,7 +474,7 @@ func addNodePool(cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster, r
 
 	isMaxSurgeSet := cmd.Flags().Changed("max-surge")
 	isMaxUnavailableSet := cmd.Flags().Changed("max-unavailable")
-	if isMaxSurgeSet && isMaxUnavailableSet {
+	if isMaxSurgeSet || isMaxUnavailableSet || interactive.Enabled() {
 		maxSurge := args.maxSurge
 		if interactive.Enabled() {
 			maxSurge, err = interactive.GetString(interactive.Input{

--- a/pkg/machinepool/machinepool.go
+++ b/pkg/machinepool/machinepool.go
@@ -779,7 +779,7 @@ func editNodePool(cmd *cobra.Command, nodePoolID string,
 		}
 	}
 
-	if isUpgradeMaxSurgeSet && isUpgradeMaxUnavailableSet {
+	if isUpgradeMaxSurgeSet || isUpgradeMaxUnavailableSet || interactive.Enabled() {
 		maxSurge := cmd.Flags().Lookup("max-surge").Value.String()
 		if maxSurge == "" && nodePool.ManagementUpgrade().MaxSurge() != "" {
 			maxSurge = nodePool.ManagementUpgrade().MaxSurge()


### PR DESCRIPTION
Expose maxSurge and maxUnavailable in interactive mode without both being specified in the args, which was intentionally done to make it less accessible until it's been in production for a while.

https://issues.redhat.com/browse/OCM-9139