### PR TITLE
OCM-9596 | test: fix ids:72162,64620 fix failures on PROW CI testing

### DIFF
--- a/tests/e2e/test_rosacli_token.go
+++ b/tests/e2e/test_rosacli_token.go
@@ -34,7 +34,7 @@ var _ = Describe("rosacli token",
 					[]string{"rosa", "token"},
 					[]string{"cut", "-d", ".", "-f", "1"},
 					[]string{"tr", "_-", "/+"},
-					[]string{"base64", "-D"},
+					[]string{"base64", "-d"},
 				)
 				Expect(err).To(BeNil())
 				headerOutput, err := ocmService.Token("--header")
@@ -54,7 +54,7 @@ var _ = Describe("rosacli token",
 					[]string{"rosa", "token"},
 					[]string{"cut", "-d", ".", "-f", "2"},
 					[]string{"tr", "_-", "/+"},
-					[]string{"base64", "-D"},
+					[]string{"base64", "-d"},
 				)
 				Expect(err).To(BeNil())
 				payloadOutput, err := ocmService.Token("--payload")
@@ -68,7 +68,7 @@ var _ = Describe("rosacli token",
 					[]string{"rosa", "token"},
 					[]string{"cut", "-d", ".", "-f", "3"},
 					[]string{"tr", "_-", "/+"},
-					[]string{"base64", "-D"},
+					[]string{"base64", "-d"},
 				)
 				Expect(err).To(BeNil())
 				signatureOutput, err := ocmService.Token("--signature")

--- a/tests/utils/exec/rosacli/cmd_runner.go
+++ b/tests/utils/exec/rosacli/cmd_runner.go
@@ -23,6 +23,7 @@ type runner struct {
 	cmdArgs   []string
 	envs      []string
 	runnerCfg *runnerConfig
+	dir       string
 }
 
 type runnerConfig struct {
@@ -32,6 +33,7 @@ type runnerConfig struct {
 }
 
 func NewRunner() *runner {
+	pwd, _ := os.Getwd()
 	runner := &runner{
 		runnerCfg: &runnerConfig{
 			format: "text",
@@ -39,6 +41,7 @@ func NewRunner() *runner {
 			color:  "auto",
 		},
 		envs: os.Environ(),
+		dir:  pwd,
 	}
 	return runner
 }
@@ -69,6 +72,11 @@ func (r *runner) Debug(debug bool) *runner {
 
 func (r *runner) Color(color string) *runner {
 	r.runnerCfg.color = color
+	return r
+}
+
+func (r *runner) Dir(dir string) *runner {
+	r.dir = dir
 	return r
 }
 
@@ -194,6 +202,7 @@ func (r *runner) Run() (bytes.Buffer, error) {
 		cmd.Env = append(cmd.Env, r.envs...)
 		cmd.Stdout = &output
 		cmd.Stderr = cmd.Stdout
+		cmd.Dir = r.dir
 
 		err = cmd.Run()
 		if err != nil {
@@ -225,6 +234,7 @@ func (r *runner) RunCMD(command []string) (bytes.Buffer, error) {
 	cmd := exec.Command(command[0], command[1:]...) // #nosec G204
 	cmd.Stdout = &output
 	cmd.Stderr = cmd.Stdout
+	cmd.Dir = r.dir
 
 	err = cmd.Run()
 	if err != nil {


### PR DESCRIPTION
[OCM-9596](https://issues.redhat.com//browse/OCM-9596) | test: fix ids:72162,64620 fix failures on PROW CI testing

72162: use '-d' as the original '-D' only supports on MacOS
64620: Add function and to run command in manual mode in tmp dir to avoid the failure of missing permission

Logs are here,https://privatebin.corp.redhat.com/?6de329c37662c528#DLdY23pjwPy7gV13Lh8tP2B5KDgfaTkbHG4rPgbXmZHr