### PR TITLE
OCM-9619 | fix: Re-add incorrectly removed edit machinepool command

### DIFF
--- a/cmd/edit/cmd.go
+++ b/cmd/edit/cmd.go
@@ -57,6 +57,7 @@ func init() {
 	confirm.AddFlag(flags)
 
 	machinepoolCommand := machinepool.NewEditMachinePoolCommand()
+	Cmd.AddCommand(machinepoolCommand)
 	globallyAvailableCommands := []*cobra.Command{
 		autoscaler.Cmd, addon.Cmd,
 		service.Cmd, cluster.Cmd,


### PR DESCRIPTION
This PR re-adds the `edit machinepool` command that was incorrectly removed in #2236 