### PR TITLE
OCM-9623 | test: fixing id:73469

### DIFF
--- a/tests/e2e/test_rosacli_machine_pool.go
+++ b/tests/e2e/test_rosacli_machine_pool.go
@@ -370,7 +370,7 @@ var _ = Describe("Create machinepool",
 					"invalidFmt": "invalid",
 					"noTagValue": "notagvalue:",
 					"noTagKey":   ":notagkey",
-					"nonAscii":   "non-ascii:值",
+					// "nonAscii":   "non-ascii:值",
 				}
 				for errorType, tag := range invalidTagMap {
 					out, err = machinePoolService.CreateMachinePool(clusterID, "invalid-73469",


### PR DESCRIPTION
[OCM-9623](https://issues.redhat.com/browse/OCM-9623) | [CI] Debug and fix: 73469

$ ginkgo --focus 73469 tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.11.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: ROSA CLI e2e tests suite - /home/akanni/OCP-Repository/rosa/tests/e2e
====================================================================================
Random Seed: 1721130346

Will run 1 of 142 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 142 Specs in 63.385 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 141 Skipped
PASS

Ginkgo ran 1 suite in 1m4.452117525s
Test Suite Passed
