### PR TITLE
OCM-9626 | fix: Fixed slow tests for break glass credential implementation

### DIFF
--- a/cmd/create/breakglasscredential/cmd.go
+++ b/cmd/create/breakglasscredential/cmd.go
@@ -73,7 +73,8 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command, argv []string) error {
 		return err
 	}
 
-	kubeconfig, err := r.OCMClient.PollKubeconfig(cluster.ID(), credentialResponse.ID())
+	kubeconfig, err := r.OCMClient.PollKubeconfig(
+		cluster.ID(), credentialResponse.ID(), ocm.DefaultKubeConfigPollInterval, ocm.DefaultKubeConfigTimeout)
 	if err != nil {
 		return fmt.Errorf("An error occurred while polling for kubeconfig: %v", err)
 	}

--- a/pkg/ocm/break_glass_credential_test.go
+++ b/pkg/ocm/break_glass_credential_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo/v2/dsl/core"
-	. "github.com/onsi/ginkgo/v2/dsl/decorators"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
 	sdk "github.com/openshift-online/ocm-sdk-go"
@@ -19,7 +18,7 @@ const (
 	breakGlassCredentialId = "test-break-glass-credential"
 )
 
-var _ = Describe("BreakGlassCredential", Ordered, func() {
+var _ = Describe("BreakGlassCredential", func() {
 
 	var ssoServer, apiServer *ghttp.Server
 	var ocmClient *Client
@@ -176,7 +175,7 @@ var _ = Describe("BreakGlassCredential", Ordered, func() {
 				body,
 			),
 		)
-		_, err := ocmClient.PollKubeconfig(clusterId, breakGlassCredential.ID())
+		_, err := ocmClient.PollKubeconfig(clusterId, breakGlassCredential.ID(), time.Millisecond*100, time.Second*5)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -187,7 +186,7 @@ var _ = Describe("BreakGlassCredential", Ordered, func() {
 				body,
 			),
 		)
-		_, err := ocmClient.PollKubeconfig(clusterId, breakGlassCredential.ID())
+		_, err := ocmClient.PollKubeconfig(clusterId, breakGlassCredential.ID(), time.Millisecond*100, time.Second*5)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal(
 			"Failed to poll kubeconfig for cluster 'foo' with break glass credential 'test-break-glass-credential': " +


### PR DESCRIPTION
This PR updates the break glass credential implementation to allow the caller to specify the poll interval and timeout. This allows us more control in the tests to avoid the long timeouts.