### PR TITLE
OCM-9645 | fix: Add back maxSurge and maxUnavailabe for create HCP NPs

### DIFF
--- a/cmd/create/machinepool/cmd.go
+++ b/cmd/create/machinepool/cmd.go
@@ -223,6 +223,20 @@ func init() {
 			"Tags are comma separated, for example: 'key value, foo bar'",
 	)
 
+	flags.StringVar(&args.MaxSurge,
+		"max-surge",
+		"1",
+		"The maximum number of nodes that can be provisioned above the desired number of nodes in the machinepool during "+
+			"the upgrade. It can be an absolute number i.e. 1, or a percentage i.e. '20%'.",
+	)
+
+	flags.StringVar(&args.MaxUnavailable,
+		"max-unavailable",
+		"0",
+		"The maximum number of nodes in the machinepool that can be unavailable during the upgrade. It can be an "+
+			"absolute number i.e. 1, or a percentage i.e. '20%'.",
+	)
+
 	interactive.AddFlag(flags)
 	output.AddFlag(Cmd)
 }


### PR DESCRIPTION
maxSurge and maxUnavailable for create HCP NPs were accidentally removed in MR: 
https://github.com/openshift/rosa/pull/2142

Adding it back.

Jira: https://issues.redhat.com/browse/OCM-9645