### PR TITLE
OCM-8930 | feat: support IMDSv2 in HCP

### DIFF
--- a/cmd/create/machinepool/cmd.go
+++ b/cmd/create/machinepool/cmd.go
@@ -223,6 +223,15 @@ func init() {
 			"Tags are comma separated, for example: 'key value, foo bar'",
 	)
 
+	flags.StringVar(
+		&args.EC2MetadataHttpTokens,
+		"ec2-metadata-http-tokens",
+		"",
+		"Should cluster nodes use both v1 and v2 endpoints or just v2 endpoint "+
+			"of EC2 Instance Metadata Service (IMDS)"+
+			"This flag is only supported for Hosted Control Planes.",
+	)
+
 	flags.StringVar(&args.MaxSurge,
 		"max-surge",
 		"1",

--- a/cmd/describe/machinepool/cmd_test.go
+++ b/cmd/describe/machinepool/cmd_test.go
@@ -33,6 +33,7 @@ Taints:
 Availability zone:                     us-east-1a
 Subnet:                                
 Version:                               4.12.24
+EC2 Metadata Http Tokens:              optional
 Autorepair:                            No
 Tuning configs:                        
 Kubelet configs:                       
@@ -57,6 +58,7 @@ Taints:
 Availability zone:                     us-east-1a
 Subnet:                                
 Version:                               4.12.24
+EC2 Metadata Http Tokens:              optional
 Autorepair:                            No
 Tuning configs:                        
 Kubelet configs:                       
@@ -82,6 +84,7 @@ Taints:
 Availability zone:                     us-east-1a
 Subnet:                                
 Version:                               4.12.24
+EC2 Metadata Http Tokens:              optional
 Autorepair:                            No
 Tuning configs:                        
 Kubelet configs:                       

--- a/pkg/machinepool/helper.go
+++ b/pkg/machinepool/helper.go
@@ -115,6 +115,7 @@ func getSecurityGroupsOption(r *rosa.Runtime, cmd *cobra.Command, cluster *cmv1.
 func createAwsNodePoolBuilder(
 	instanceType string,
 	securityGroupIds []string,
+	httpTokens string,
 	awsTags map[string]string,
 ) *cmv1.AWSNodePoolBuilder {
 	awsNpBuilder := cmv1.NewAWSNodePool().InstanceType(instanceType)
@@ -126,6 +127,8 @@ func createAwsNodePoolBuilder(
 	if len(awsTags) > 0 {
 		awsNpBuilder.Tags(awsTags)
 	}
+
+	awsNpBuilder.Ec2MetadataHttpTokens(cmv1.Ec2MetadataHttpTokens(httpTokens))
 
 	return awsNpBuilder
 }

--- a/pkg/machinepool/helper_test.go
+++ b/pkg/machinepool/helper_test.go
@@ -65,6 +65,7 @@ var _ = Describe("Machine pool helper", func() {
 			awsNpBuilder := createAwsNodePoolBuilder(
 				instanceType,
 				securityGroupIds,
+				"optional",
 				awsTags,
 			)
 			awsNodePool, err := awsNpBuilder.Build()
@@ -77,7 +78,7 @@ var _ = Describe("Machine pool helper", func() {
 			instanceType := "123"
 			securityGroupIds := []string{"123"}
 
-			awsNpBuilder := createAwsNodePoolBuilder(instanceType, securityGroupIds, map[string]string{})
+			awsNpBuilder := createAwsNodePoolBuilder(instanceType, securityGroupIds, "optional", map[string]string{})
 			awsNodePool, err := awsNpBuilder.Build()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(awsNodePool.AdditionalSecurityGroupIds()).To(Equal(securityGroupIds))
@@ -87,7 +88,7 @@ var _ = Describe("Machine pool helper", func() {
 		It("Create AWS node pool without security group IDs if not provided", func() {
 			instanceType := "123"
 
-			awsNpBuilder := createAwsNodePoolBuilder(instanceType, []string{}, map[string]string{})
+			awsNpBuilder := createAwsNodePoolBuilder(instanceType, []string{}, "optional", map[string]string{})
 			awsNodePool, err := awsNpBuilder.Build()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(awsNodePool.AdditionalSecurityGroupIds()).To(HaveLen(0))
@@ -385,13 +386,15 @@ var _ = Describe("CreateAwsNodePoolBuilder", func() {
 		instanceType := "t2.micro"
 		securityGroupIds := []string{"sg-12345"}
 		awsTags := map[string]string{"env": "test"}
+		httpTokens := "required"
 
-		builder := createAwsNodePoolBuilder(instanceType, securityGroupIds, awsTags)
+		builder := createAwsNodePoolBuilder(instanceType, securityGroupIds, httpTokens, awsTags)
 		built, err := builder.Build()
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(built.InstanceType()).To(Equal(instanceType))
 		Expect(built.AdditionalSecurityGroupIds()).To(ConsistOf(securityGroupIds))
+		Expect(string(built.Ec2MetadataHttpTokens())).To(Equal(httpTokens))
 		Expect(built.Tags()).To(Equal(awsTags))
 	})
 })

--- a/pkg/machinepool/machine_pool_args.go
+++ b/pkg/machinepool/machine_pool_args.go
@@ -24,4 +24,5 @@ type MachinePoolArgs struct {
 	Tags                  []string
 	MaxSurge              string
 	MaxUnavailable        string
+	EC2MetadataHttpTokens string
 }

--- a/pkg/machinepool/output.go
+++ b/pkg/machinepool/output.go
@@ -22,6 +22,7 @@ var nodePoolOutputString string = "\n" +
 	"Availability zone:                     %s\n" +
 	"Subnet:                                %s\n" +
 	"Version:                               %s\n" +
+	"EC2 Metadata Http Tokens:              %s\n" +
 	"Autorepair:                            %s\n" +
 	"Tuning configs:                        %s\n" +
 	"Kubelet configs:                       %s\n" +
@@ -77,6 +78,7 @@ func nodePoolOutput(clusterId string, nodePool *cmv1.NodePool) string {
 		nodePool.AvailabilityZone(),
 		nodePool.Subnet(),
 		ocmOutput.PrintNodePoolVersion(nodePool.Version()),
+		ocmOutput.PrintEC2MetadataHttpTokens(nodePool.AWSNodePool()),
 		ocmOutput.PrintNodePoolAutorepair(nodePool.AutoRepair()),
 		ocmOutput.PrintNodePoolConfigs(nodePool.TuningConfigs()),
 		ocmOutput.PrintNodePoolConfigs(nodePool.KubeletConfigs()),

--- a/pkg/machinepool/output_test.go
+++ b/pkg/machinepool/output_test.go
@@ -119,7 +119,7 @@ var _ = Describe("Output", Ordered, func() {
 
 			out := fmt.Sprintf(nodePoolOutputString,
 				"test-mp", "test-cluster", "Yes", replicasOutput, "", "", labelsOutput, "", taintsOutput, "test-az",
-				"test-subnets", "1", "No", "test-tc", "test-kc", "", "", managementUpgradeOutput, "")
+				"test-subnets", "1", "optional", "No", "test-tc", "test-kc", "", "", managementUpgradeOutput, "")
 
 			result := nodePoolOutput("test-cluster", nodePool)
 			Expect(out).To(Equal(result))
@@ -136,7 +136,7 @@ var _ = Describe("Output", Ordered, func() {
 
 			out := fmt.Sprintf(nodePoolOutputString,
 				"test-mp", "test-cluster", "No", "4", "", "", labelsOutput, "", taintsOutput, "test-az",
-				"test-subnets", "1", "No", "test-tc", "test-kc", "", "", "", "")
+				"test-subnets", "1", "optional", "No", "test-tc", "test-kc", "", "", "", "")
 
 			result := nodePoolOutput("test-cluster", nodePool)
 			Expect(out).To(Equal(result))

--- a/pkg/ocm/output/nodepools.go
+++ b/pkg/ocm/output/nodepools.go
@@ -68,6 +68,14 @@ func PrintNodePoolAdditionalSecurityGroups(aws *cmv1.AWSNodePool) string {
 	return output.PrintStringSlice(aws.AdditionalSecurityGroupIds())
 }
 
+func PrintEC2MetadataHttpTokens(aws *cmv1.AWSNodePool) cmv1.Ec2MetadataHttpTokens {
+	if aws == nil || aws.Ec2MetadataHttpTokens() == "" {
+		return cmv1.Ec2MetadataHttpTokensOptional
+	}
+
+	return aws.Ec2MetadataHttpTokens()
+}
+
 func PrintNodePoolCurrentReplicas(status *cmv1.NodePoolStatus) string {
 	if status != nil {
 		return fmt.Sprintf("%d", status.CurrentReplicas())


### PR DESCRIPTION
several changes:

- update cluster creation flow to allow set ec2metadatahttptokens for hcp cluster(https://issues.redhat.com/browse/OCM-9159)
- add ec2metadatahttptokens flag and following support in machinepool creation(https://issues.redhat.com/browse/OCM-9176)
- print out the ec2metadatahttptokens info in machinepool describe command(https://issues.redhat.com/browse/OCM-9160)

this PR should be hold until CS side change is merged: https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/8229