### PR TITLE
OCM-9653 | test: automate id:42832 hibernate and resume then delete cluster via rosacli

### DIFF
--- a/tests/ci/labels/features.go
+++ b/tests/ci/labels/features.go
@@ -32,6 +32,7 @@ type featureLabels struct {
 	Version              Labels
 	Upgrade              Labels
 	Config               Labels
+	Hibernation          Labels
 }
 
 var Feature = initFeatureLabels()
@@ -62,6 +63,7 @@ func initFeatureLabels() *featureLabels {
 	fLabels.Version = Label("feature-version")
 	fLabels.Upgrade = Label("feature-upgrade")
 	fLabels.Config = Label("feature-config")
+	fLabels.Hibernation = Label("feature-hibernation")
 
 	return fLabels
 }

--- a/tests/ci/labels/runtime.go
+++ b/tests/ci/labels/runtime.go
@@ -27,6 +27,9 @@ type runtimeLabels struct {
 	Day1Supplemental Labels
 	Day1Negative     Labels
 	OCMResources     Labels
+
+	// Test case for hibernation full cycle
+	Hibernate Labels
 }
 
 var Runtime = initRuntime()
@@ -45,6 +48,7 @@ func initRuntime() *runtimeLabels {
 	rLabels.Day1Supplemental = Label("day1-supplemental")
 	rLabels.OCMResources = Label("ocm-resources")
 	rLabels.Day1Negative = Label("day1-negative")
+	rLabels.Hibernate = Label("hibernate")
 
 	return rLabels
 }

--- a/tests/e2e/test_rosacli_hibernate.go
+++ b/tests/e2e/test_rosacli_hibernate.go
@@ -1,0 +1,77 @@
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/rosa/tests/ci/labels"
+	"github.com/openshift/rosa/tests/utils/config"
+	"github.com/openshift/rosa/tests/utils/exec/rosacli"
+)
+
+var _ = Describe("hibernate and resume cluster testing", labels.Feature.Hibernation, func() {
+	defer GinkgoRecover()
+	var (
+		clusterID      string
+		rosaClient     *rosacli.Client
+		clusterService rosacli.ClusterService
+	)
+
+	BeforeEach(func() {
+		By("Init the client")
+		rosaClient = rosacli.NewClient()
+		clusterService = rosaClient.Cluster
+		clusterID = config.GetClusterID()
+	})
+
+	AfterEach(func() {
+		By("Clean remaining resources")
+		rosaClient.CleanResources(clusterID)
+
+	})
+
+	It("to hibernate and resume then delete cluster via rosacli - [id:42832]",
+		labels.Critical, labels.Runtime.Hibernate,
+		func() {
+			By("Skip testing if the cluster is a hosted-cp cluster")
+			isHostedCP, err := clusterService.IsHostedCPCluster(clusterID)
+			Expect(err).To(BeNil())
+			if isHostedCP {
+				Skip("Skip this case as it only supports on not-hosted-cp clusters")
+			}
+
+			By("hibernate cluster")
+			out, err := clusterService.HibernateCluster(clusterID, "-y")
+			Expect(err).To(BeNil())
+			Expect(out.String()).To(ContainSubstring("is hibernating"))
+			rosaClient.Runner.UnsetArgs()
+
+			err = clusterService.WaitClusterStatus(clusterID, "hibernating", 3, 30)
+			Expect(err).To(BeNil(), "It met error or timeout when waiting cluster to hibernating status")
+
+			By("resume cluster")
+			out, err = clusterService.ResumeCluster(clusterID, "-y")
+			Expect(err).To(BeNil())
+			Expect(out.String()).To(ContainSubstring("is resuming"))
+			rosaClient.Runner.UnsetArgs()
+
+			err = clusterService.WaitClusterStatus(clusterID, "ready", 3, 30)
+			Expect(err).To(BeNil(), "It met error or timeout when waiting cluster to ready status")
+
+			By("hibernate the cluster again then delete the cluster in not hibernating status")
+			out, err = clusterService.HibernateCluster(clusterID, "-y")
+			Expect(err).To(BeNil())
+			Expect(out.String()).To(ContainSubstring("is hibernating"))
+			rosaClient.Runner.UnsetArgs()
+
+			err = clusterService.WaitClusterStatus(clusterID, "hibernating", 3, 30)
+			Expect(err).To(BeNil(), "It met error or timeout when waiting cluster to hibernating status")
+
+			_, err = clusterService.DeleteCluster(clusterID, "-y")
+			Expect(err).To(BeNil())
+
+			rosaClient.Runner.UnsetArgs()
+			err = clusterService.WaitClusterDeleted(clusterID, 3, 30)
+			Expect(err).To(BeNil(), "It failed to delete the cluster or met timeout")
+		})
+})

--- a/tests/utils/exec/rosacli/cluster_service.go
+++ b/tests/utils/exec/rosacli/cluster_service.go
@@ -2,11 +2,15 @@ package rosacli
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
+
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	config "github.com/openshift/rosa/tests/utils/config"
 	. "github.com/openshift/rosa/tests/utils/log"
@@ -36,6 +40,11 @@ type ClusterService interface {
 	IsBYOVPCCluster(clusterID string) (bool, error)
 	IsExternalAuthenticationEnabled(clusterID string) (bool, error)
 	GetJSONClusterDescription(clusterID string) (*jsonData, error)
+	HibernateCluster(clusterID string, flags ...string) (bytes.Buffer, error)
+	ResumeCluster(clusterID string, flags ...string) (bytes.Buffer, error)
+	ReflectClusterList(result bytes.Buffer) (clusterList ClusterList, err error)
+	WaitClusterStatus(clusterID string, status string, interval int, duration int) error
+	WaitClusterDeleted(clusterID string, interval int, duration int) error
 }
 
 type clusterService struct {
@@ -48,6 +57,17 @@ func NewClusterService(client *Client) ClusterService {
 			client: client,
 		},
 	}
+}
+
+// Struct for the 'rosa list cluster' output
+type ClusterListItem struct {
+	ID       string `yaml:"ID,omitempty"`
+	Name     string `yaml:"NAME,omitempty"`
+	STATE    string `yaml:"STATE,omitempty"`
+	TOPOLOGY string `yaml:"TOPOLOGY,omitempty"`
+}
+type ClusterList struct {
+	Clusters []ClusterListItem `yaml:"Clusters,omitempty"`
 }
 
 // Struct for the 'rosa describe cluster' output
@@ -95,6 +115,43 @@ type ClusterDescription struct {
 	AuditLogRoleARN          string              `yaml:"Audit Log Role ARN,omitempty"`
 	FailedInflightChecks     string              `yaml:"Failed Inflight Checks,omitempty"`
 	ExternalAuthentication   string              `yaml:"External Authentication,omitempty"`
+}
+
+// Pasrse the result of 'rosa list cluster' to the ClusterList struct
+func (c *clusterService) ReflectClusterList(result bytes.Buffer) (clusterList ClusterList, err error) {
+	clusterList = ClusterList{}
+	theMap := c.client.Parser.TableData.Input(result).Parse().Output()
+	for _, cItem := range theMap {
+		cluster := &ClusterListItem{}
+		err = MapStructure(cItem, cluster)
+		if err != nil {
+			return
+		}
+		clusterList.Clusters = append(clusterList.Clusters, *cluster)
+	}
+	return clusterList, err
+}
+
+// Check the cluster with the id exists in the ClusterList
+func (clusterList ClusterList) IsExist(clusterID string) (existed bool) {
+	existed = false
+	for _, c := range clusterList.Clusters {
+		if c.ID == clusterID {
+			existed = true
+			break
+		}
+	}
+	return
+}
+
+// Get specified cluster by cluster id
+func (clusterList ClusterList) Cluster(clusterID string) (cluster ClusterListItem) {
+	for _, c := range clusterList.Clusters {
+		if c.ID == clusterID {
+			return c
+		}
+	}
+	return
 }
 
 func (c *clusterService) DescribeCluster(clusterID string, flags ...string) (bytes.Buffer, error) {
@@ -318,4 +375,69 @@ func (c *clusterService) IsExternalAuthenticationEnabled(clusterID string) (bool
 		return false, err
 	}
 	return jsonData.DigBool("external_auth_config", "enabled"), nil
+}
+
+func (c *clusterService) HibernateCluster(clusterID string, flags ...string) (bytes.Buffer, error) {
+	combflags := append([]string{"-c", clusterID}, flags...)
+	hibernate := c.client.Runner.
+		Cmd("hibernate", "cluster").
+		CmdFlags(combflags...)
+	return hibernate.Run()
+}
+
+func (c *clusterService) ResumeCluster(clusterID string, flags ...string) (bytes.Buffer, error) {
+	combflags := append([]string{"-c", clusterID}, flags...)
+	resume := c.client.Runner.
+		Cmd("resume", "cluster").
+		CmdFlags(combflags...)
+	return resume.Run()
+}
+
+// Wait cluster to some status, the inerval and duration are using minute
+func (c *clusterService) WaitClusterStatus(clusterID string, status string, interval int, duration int) error {
+	err := wait.PollUntilContextTimeout(
+		context.Background(),
+		time.Duration(interval)*time.Minute,
+		time.Duration(duration)*time.Minute,
+		false,
+		func(context.Context) (bool, error) {
+			clusterListB, err := c.List()
+			if err != nil {
+				return false, err
+			}
+			clusterList, err := c.ReflectClusterList(clusterListB)
+			if err != nil {
+				return false, err
+			}
+			clusterItem := clusterList.Cluster(clusterID)
+			if err != nil {
+				return false, err
+			}
+			if clusterItem.STATE == status {
+				return true, nil
+			}
+			return false, err
+		})
+	return err
+}
+
+// Wait for cluster deleted
+func (c *clusterService) WaitClusterDeleted(clusterID string, interval int, duration int) error {
+	err := wait.PollUntilContextTimeout(
+		context.Background(),
+		time.Duration(interval)*time.Minute,
+		time.Duration(duration)*time.Minute,
+		false,
+		func(context.Context) (bool, error) {
+			clusterListB, err := c.List()
+			if err != nil {
+				return false, err
+			}
+			clusterList, err := c.ReflectClusterList(clusterListB)
+			if err != nil {
+				return false, err
+			}
+			return clusterList.IsExist(clusterID), err
+		})
+	return err
 }

--- a/tests/utils/exec/rosacli/cmd_runner.go
+++ b/tests/utils/exec/rosacli/cmd_runner.go
@@ -110,6 +110,10 @@ func (r *runner) AddCmdFlags(cmdFlags ...string) *runner {
 	return r
 }
 
+func (r *runner) UnsetArgs() {
+	r.cmdArgs = []string{}
+}
+
 func (r *runner) UnsetBoolFlag(flag string) *runner {
 	var newCmdArgs []string
 	cmdArgs := r.cmdArgs


### PR DESCRIPTION
[OCM-9653](https://issues.redhat.com//browse/OCM-9653) | test: automate id:42832 hibernate and resume then delete cluster via rosacli
Logs: https://privatebin.corp.redhat.com/?c2f3d22d760d093a#HT8AbcXPmEdXGFCaqqfSZ554TVpj1gCCYHbz1qKQwx98