### PR TITLE
OCM-9690 | test: update id:74387,64078

### DIFF
--- a/tests/e2e/test_rosacli_cluster.go
+++ b/tests/e2e/test_rosacli_cluster.go
@@ -1262,7 +1262,7 @@ var _ = Describe("HCP cluster creation negative testing",
 							"ERR: Expected a valid http tokens value : " +
 								"ec2-metadata-http-tokens value should be one of 'required', 'optional'"))
 
-				By("Craete HCP cluster  with httpTokens=Required")
+				By("Create HCP cluster  with invalid httpTokens")
 				replacingFlags := map[string]string{
 					"-c":              clusterName,
 					"--cluster-name":  clusterName,
@@ -1270,13 +1270,14 @@ var _ = Describe("HCP cluster creation negative testing",
 				}
 
 				rosalCommand.ReplaceFlagValue(replacingFlags)
-				rosalCommand.AddFlags("--dry-run", "--ec2-metadata-http-tokens=required", "-y")
+				rosalCommand.AddFlags("--dry-run", "--ec2-metadata-http-tokens=invalid", "-y")
 				out, err := rosaClient.Runner.RunCMD(strings.Split(rosalCommand.GetFullCommand(), " "))
 				Expect(err).NotTo(BeNil())
 				Expect(out.String()).
 					To(
 						ContainSubstring(
-							"ERR: 'ec2-metadata-http-tokens' is not available for Hosted Control Plane clusters"))
+							"ERR: Expected a valid http tokens value : " +
+								"ec2-metadata-http-tokens value should be one of 'required', 'optional'"))
 			})
 
 		It("expose additional allowed principals for HCP negative - [id:74433]",

--- a/tests/e2e/test_rosacli_node_pool.go
+++ b/tests/e2e/test_rosacli_node_pool.go
@@ -1163,6 +1163,48 @@ var _ = Describe("Edit nodepool",
 					}
 				}
 
+				By("Create a nodepool with just max surge set")
+				machinePool_Name := common.GenerateRandomName("ocp-74387", 2)
+				output, err = machinePoolService.CreateMachinePool(
+					clusterID,
+					machinePool_Name,
+					"--replicas", "3",
+					"--max-surge", "2")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(rosaClient.Parser.TextData.Input(output).Parse().Tip()).
+					To(ContainSubstring(
+						"Machine pool '%s' created successfully on hosted cluster '%s'",
+						machinePool_Name,
+						clusterID))
+
+				By("Describe the nodepool to see max surge and max unavailable is set correctly")
+				out, err := machinePoolService.DescribeAndReflectNodePool(clusterID, machinePool_Name)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(out.ManagementUpgrade[0]["Type"]).To(Equal("Replace"))
+				Expect(out.ManagementUpgrade[1]["Max surge"]).To(Equal("2"))
+				Expect(out.ManagementUpgrade[2]["Max unavailable"]).To(Equal("0"))
+
+				By("Create a nodepool with just max unavailable set")
+				machinePool_Name = common.GenerateRandomName("ocp-74387", 2)
+				output, err = machinePoolService.CreateMachinePool(
+					clusterID,
+					machinePool_Name,
+					"--replicas", "3",
+					"--max-unavailable", "2")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(rosaClient.Parser.TextData.Input(output).Parse().Tip()).
+					To(ContainSubstring(
+						"Machine pool '%s' created successfully on hosted cluster '%s'",
+						machinePool_Name,
+						clusterID))
+
+				By("Describe the nodepool to see max surge and max unavailable is set correctly")
+				out, err = machinePoolService.DescribeAndReflectNodePool(clusterID, machinePool_Name)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(out.ManagementUpgrade[0]["Type"]).To(Equal("Replace"))
+				Expect(out.ManagementUpgrade[1]["Max surge"]).To(Equal("1"))
+				Expect(out.ManagementUpgrade[2]["Max unavailable"]).To(Equal("2"))
+
 				By("Get a nodepool to edit")
 				res, err := machinePoolService.ListAndReflectNodePools(clusterID)
 				Expect(err).ToNot(HaveOccurred())
@@ -1214,6 +1256,40 @@ var _ = Describe("Edit nodepool",
 								Equal(flags["max unavailable"]))
 					}
 				}
+
+				By("Edit a nodepool with just max surge set")
+				output, err = machinePoolService.EditMachinePool(
+					clusterID,
+					machinePoolName,
+					"--max-surge", "7")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(rosaClient.Parser.TextData.Input(output).Parse().Tip()).
+					To(ContainSubstring(
+						"Updated machine pool '%s' on hosted cluster '%s'",
+						machinePoolName,
+						clusterID))
+
+				By("Describe the nodepool to see max surge and max unavailable is set correctly")
+				out, err = machinePoolService.DescribeAndReflectNodePool(clusterID, machinePoolName)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(out.ManagementUpgrade[1]["Max surge"]).To(Equal("7"))
+
+				By("Edit a nodepool with just max unavailable set")
+				output, err = machinePoolService.EditMachinePool(
+					clusterID,
+					machinePoolName,
+					"--max-unavailable", "7")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(rosaClient.Parser.TextData.Input(output).Parse().Tip()).
+					To(ContainSubstring(
+						"Updated machine pool '%s' on hosted cluster '%s'",
+						machinePoolName,
+						clusterID))
+
+				By("Describe the nodepool to see max surge and max unavailable is set correctly")
+				out, err = machinePoolService.DescribeAndReflectNodePool(clusterID, machinePoolName)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(out.ManagementUpgrade[2]["Max unavailable"]).To(Equal("7"))
 			})
 
 		It("validation for create/edit HCP nodepool with maxunavailable/maxsurge - [id:74430]",


### PR DESCRIPTION
[OCM-8933](https://issues.redhat.com//browse/OCM-8933)
$ ginkgo --focus 74387 tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.14.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: ROSA CLI e2e tests suite - /home/aaraj/ocm-forked-code/rosa/tests/e2e
====================================================================================
Random Seed: 1721311915

Will run 1 of 139 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 139 Specs in 501.586 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 138 Skipped
PASS

Ginkgo ran 1 suite in 8m36.366307228s
Test Suite Passed
[aaraj@aaraj-thinkpadt14