### PR TITLE
OCM-9724 | fix: Elevate QE approvers to main ROSA approvers to reduce TOIL and enable QE team

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -16,6 +16,10 @@ approvers:
 - pvasant
 - robpblake
 - davidleerh
+- xueli181114
+- radtriste
+- yasun1
+- yuwang-RH
 emeritus_approvers:
 - igoihman
 - jharrington22


### PR DESCRIPTION
This PR elevates the list of `approvers` from `/tests/OWNERS` to approvers on ROSA itself to alleviate the TOIL on ROSA squad and enable the QE team to self-service.