### PR TITLE
OCM-9705 | ci: Setup COMPUTE_MACHINE_TYPE global env

### DIFF
--- a/tests/ci/config/config.go
+++ b/tests/ci/config/config.go
@@ -51,6 +51,7 @@ type GlobalENVVariables struct {
 	ClusterWaitingTime    int    `env:"CLUSTER_TIMEOUT" default:"60"`
 	WaitSetupClusterReady bool   `env:"WAIT_SETUP_CLUSTER_READY" default:"true"`
 	SVPC_CREDENTIALS_FILE string `env:"SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE" default:""`
+	ComputeMachineType    string `env:"COMPUTE_MACHINE_TYPE" default:""`
 }
 
 func init() {
@@ -103,6 +104,7 @@ func init() {
 		ProvisionShard:        os.Getenv("PROVISION_SHARD"),
 		NamePrefix:            os.Getenv("NAME_PREFIX"),
 		SVPC_CREDENTIALS_FILE: os.Getenv("SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE"),
+		ComputeMachineType:    os.Getenv("COMPUTE_MACHINE_TYPE"),
 		ClusterWaitingTime:    waitingTime,
 		WaitSetupClusterReady: waitSetupClusterReady,
 	}

--- a/tests/e2e/test_rosacli_cluster_post.go
+++ b/tests/e2e/test_rosacli_cluster_post.go
@@ -275,7 +275,6 @@ var _ = Describe("Healthy check",
 		It("Rosa cluster with fips enabled can be created successfully - [id:46312]",
 			labels.Critical, labels.Runtime.Day1Post,
 			func() {
-				profile := profilehandler.LoadProfileYamlFileByENV()
 				output, err := clusterService.DescribeCluster(clusterID)
 				Expect(err).ToNot(HaveOccurred())
 				des, err := clusterService.ReflectClusterDescription(output)
@@ -306,6 +305,27 @@ var _ = Describe("Healthy check",
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ingress.Private).To(Equal(ingressPrivate))
 
+			})
+		It("cluster is multiarch - [id:75108]", labels.Runtime.Day1Post, labels.High,
+			func() {
+				By("Check cluster is multiarch")
+				jsonData, err := clusterService.GetJSONClusterDescription(clusterID)
+				Expect(err).To(BeNil())
+				isHosted, err := clusterService.IsHostedCPCluster(clusterID)
+				Expect(err).To(BeNil())
+				if isHosted {
+					Expect(jsonData.DigBool("multi_arch_enabled")).To(BeTrue())
+				} else {
+					Expect(jsonData.DigBool("multi_arch_enabled")).To(BeFalse())
+				}
+			})
+
+		It("with compute_machine_type will work - [id:75150]", labels.Runtime.Day1Post, labels.High,
+			func() {
+				By("Check compute machine type")
+				jsonData, err := clusterService.GetJSONClusterDescription(clusterID)
+				Expect(err).To(BeNil())
+				Expect(jsonData.DigString("nodes", "compute_machine_type", "id")).To(Equal(profile.ClusterConfig.InstanceType))
 			})
 	})
 

--- a/tests/utils/profilehandler/profile_handler.go
+++ b/tests/utils/profilehandler/profile_handler.go
@@ -68,6 +68,11 @@ func LoadProfileYamlFileByENV() *Profile {
 			config.Test.GlobalENV.NamePrefix)
 		profile.NamePrefix = config.Test.GlobalENV.NamePrefix
 	}
+	if config.Test.GlobalENV.ComputeMachineType != "" {
+		log.Logger.Infof("Got global env settings for INSTANCE_TYPE, overwritten the profile setting with value %s",
+			config.Test.GlobalENV.ComputeMachineType)
+		profile.ClusterConfig.InstanceType = config.Test.GlobalENV.ComputeMachineType
+	}
 
 	return profile
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-9705

```
Healthy check cluster is multiarch - [id:75108] [feature-cluster, day1-post, High]
/home/tradisso/projects/openshift/rosa/tests/e2e/test_rosacli_cluster_post.go:310
  STEP: Get the cluster @ 07/19/24 15:12:35.713
  STEP: Init the client @ 07/19/24 15:12:35.713
  time=2024-07-19T15:12:35+02:00 level=info msg=Loaded cluster profile configuration from original profile rosa-hcp-arm : {candidate rosa-hcp-arm  us-west-2 latest 0xc0010d1680 0xc001164410}
  time=2024-07-19T15:12:35+02:00 level=info msg=Loaded cluster profile configuration from original cluster rosa-hcp-arm : {  m6g.xlarge  managed   0 0 0 0 0 false false false false false true false false false false false false false true false false false true false false false false true false false }
  time=2024-07-19T15:12:35+02:00 level=info msg=Loaded cluster profile configuration from original account-roles rosa-hcp-arm : { }
  time=2024-07-19T15:12:35+02:00 level=info msg=Got global env settings for NAME_PREFIX, overwritten the profile setting with value tr
  STEP: Check cluster is multiarch @ 07/19/24 15:12:35.714
  time=2024-07-19T15:12:35+02:00 level=info msg=Running command: rosa describe cluster -c 2ck1ajmqdt6198o01ee4j9mkfgo3heuo --output json
  time=2024-07-19T15:12:38+02:00 level=info msg=Get Combining Stdout and Stderr is :
  {
[...]
    "multi_arch_enabled": true,
[...]
  }

  STEP: Clean the cluster @ 07/19/24 15:12:38.42
• [2.708 seconds]
------------------------------

Ran 1 of 147 Specs in 2.710 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 146 Skipped
PASS
```