### PR TITLE
OCM-7184 | fix: Fixing regression problems for OCM-9620,OCM-9655,OCM-9654,OCM-9625

### DIFF
--- a/cmd/create/machinepool/cmd.go
+++ b/cmd/create/machinepool/cmd.go
@@ -278,8 +278,12 @@ func run(cmd *cobra.Command, _ []string) {
 
 	service := machinepool.NewMachinePoolService()
 	if cluster.Hypershift().Enabled() {
-		service.AddNodePool(cmd, clusterKey, cluster, r, &args)
+		err = service.AddNodePool(cmd, clusterKey, cluster, r, &args)
 	} else {
-		service.AddMachinePool(cmd, clusterKey, cluster, r, &args)
+		err = service.AddMachinePool(cmd, clusterKey, cluster, r, &args)
+	}
+	if err != nil {
+		r.Reporter.Errorf("%s", err)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Fixes: 
- https://issues.redhat.com/browse/OCM-9655
- https://issues.redhat.com/browse/OCM-9620
- https://issues.redhat.com/browse/OCM-9654
- https://issues.redhat.com/browse/OCM-9625

Fixing regression changes