### PR TITLE
OCM-9617 | feat: adding extra validation to fix panic introduced with httpTokens

### DIFF
--- a/pkg/machinepool/machinepool.go
+++ b/pkg/machinepool/machinepool.go
@@ -955,11 +955,9 @@ func (m *machinePool) AddNodePool(cmd *cobra.Command, clusterKey string, cluster
 			return fmt.Errorf("Expected a valid http tokens value : %v", err)
 		}
 	}
+
 	if err = ocm.ValidateHttpTokensValue(httpTokens); err != nil {
 		return fmt.Errorf("Expected a valid http tokens value : %v", err)
-	}
-	if err := ocm.ValidateHttpTokensVersion(ocm.GetVersionMinor(version), httpTokens); err != nil {
-		return fmt.Errorf(err.Error())
 	}
 
 	npBuilder.AWSNodePool(createAwsNodePoolBuilder(instanceType, securityGroupIds, httpTokens, awsTags))


### PR DESCRIPTION
[OCM-9617](https://issues.redhat.com//browse/OCM-9617) Adding version validation before validating httpToken to avoid panic when version is empty