### PR TITLE
OCM-9817 | test: automate id:75210 delete byo oidc config cluster via rosacli

### DIFF
--- a/tests/utils/common/oidc.go
+++ b/tests/utils/common/oidc.go
@@ -3,6 +3,7 @@ package common
 import (
 	"bytes"
 	"fmt"
+	"net/url"
 	"regexp"
 	"strings"
 
@@ -104,4 +105,19 @@ func ParseSecretArnFromOutput(output string) string {
 func ParseIssuerURLFromCommand(command string) string {
 	re := regexp.MustCompile(`https://[^\s]+`)
 	return re.FindString(command)
+}
+
+// Extract oidc provider from the 'OIDC Endpoint URL' field of `rosa describe cluster`
+func ExtractOIDCProviderFromOidcUrl(urlString string) (string, error) {
+	parsedURL, err := url.Parse(urlString)
+	if err != nil {
+		return "", err
+	}
+	host := parsedURL.Host
+	path := strings.TrimPrefix(parsedURL.Path, "/")
+	fmt.Printf("The past host and path is %s and %s\n", host, path)
+	oidcProvider := fmt.Sprintf("%s/%s", host, path)
+	oidcProvider = strings.Split(oidcProvider, " ")[0]
+
+	return oidcProvider, nil
 }

--- a/tests/utils/profilehandler/interface.go
+++ b/tests/utils/profilehandler/interface.go
@@ -77,12 +77,13 @@ type UserData struct {
 
 // ClusterDetail will record basic cluster info to support other team's testing
 type ClusterDetail struct {
-	APIURL      string `json:"api_url,omitempty"`
-	ClusterID   string `json:"cluster_id,omitempty"`
-	ClusterName string `json:"cluster_name,omitempty"`
-	ClusterType string `json:"cluster_type,omitempty"`
-	ConsoleURL  string `json:"console_url,omitempty"`
-	InfraID     string `json:"infra_id,omitempty"`
+	APIURL          string `json:"api_url,omitempty"`
+	ClusterID       string `json:"cluster_id,omitempty"`
+	ClusterName     string `json:"cluster_name,omitempty"`
+	ClusterType     string `json:"cluster_type,omitempty"`
+	ConsoleURL      string `json:"console_url,omitempty"`
+	InfraID         string `json:"infra_id,omitempty"`
+	OIDCEndpointURL string `json:"oidc_endpoint_url,omitempty"`
 }
 
 type ProxyDetail struct {

--- a/tests/utils/profilehandler/profile_handler.go
+++ b/tests/utils/profilehandler/profile_handler.go
@@ -805,6 +805,7 @@ func CreateClusterByProfileWithoutWaiting(
 	clusterDetail.ClusterID = description.ID
 	clusterDetail.ClusterName = description.Name
 	clusterDetail.ClusterType = "rosa"
+	clusterDetail.OIDCEndpointURL = description.OIDCEndpointURL
 
 	// Need to do the post step when cluster has no oidcconfig enabled
 	if profile.ClusterConfig.OIDCConfig == "" && profile.ClusterConfig.STS {


### PR DESCRIPTION
Automate [OCM-9817](https://issues.redhat.com//browse/OCM-9817) | test: automate id:75210 delete byo oidc config via rosacli
Add OIDC Endpoint URL in the cluster_detail json file to be used by case
log : https://privatebin.corp.redhat.com/?0f1091b94db14286#GGEnV2oZ7wqiTsapzXYr8YFKi7MDrZh7yKAye6SwpFdP