### PR TITLE
OCM-9865 | test: fix id:75150

### DIFF
--- a/tests/e2e/test_rosacli_cluster_post.go
+++ b/tests/e2e/test_rosacli_cluster_post.go
@@ -325,7 +325,11 @@ var _ = Describe("Healthy check",
 				By("Check compute machine type")
 				jsonData, err := clusterService.GetJSONClusterDescription(clusterID)
 				Expect(err).To(BeNil())
-				Expect(jsonData.DigString("nodes", "compute_machine_type", "id")).To(Equal(profile.ClusterConfig.InstanceType))
+				if profile.ClusterConfig.InstanceType == "" {
+					Expect(jsonData.DigString("nodes", "compute_machine_type", "id")).To(Equal(constants.DefaultInstanceType))
+				} else {
+					Expect(jsonData.DigString("nodes", "compute_machine_type", "id")).To(Equal(profile.ClusterConfig.InstanceType))
+				}
 			})
 	})
 

--- a/tests/utils/common/constants/cluster.go
+++ b/tests/utils/common/constants/cluster.go
@@ -51,3 +51,8 @@ var (
 	VersionRawPattern        = regexp.MustCompile(`[0-9]+\.[0-9]+\.[0-9]+-?[0-9a-z\.-]*`)
 	VersionFlexyPattern      = regexp.MustCompile(`[zy]{1}-[1-3]{1}`)
 )
+
+// instance type
+const (
+	DefaultInstanceType = "m5.xlarge"
+)


### PR DESCRIPTION
$ ginkgo --focus 75150 tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.14.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: ROSA CLI e2e tests suite - /home/aaraj/ocm-forked-code/rosa/tests/e2e
====================================================================================
Random Seed: 1721809038

Will run 1 of 155 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 155 Specs in 4.741 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 154 Skipped
PASS

Ginkgo ran 1 suite in 11.834865049s
Test Suite Passed