### PR TITLE
OCM-9904 | test: automated cases id:72174

### DIFF
--- a/tests/e2e/test_rosacli_machine_pool.go
+++ b/tests/e2e/test_rosacli_machine_pool.go
@@ -255,6 +255,8 @@ var _ = Describe("Create machinepool",
 					"--permissions-boundary", permissionsBoundaryArn,
 					"-y")
 				Expect(err).To(BeNil())
+				defer ocmResourceService.DeleteAccountRole("--mode", "auto", "--prefix", accountRolePrefix, "-y")
+
 				accountRoleList, _, err := ocmResourceService.ListAccountRole()
 				Expect(err).To(BeNil())
 				classicInstallerRoleArn := accountRoleList.InstallerRole(accountRolePrefix, false).RoleArn
@@ -272,13 +274,6 @@ var _ = Describe("Create machinepool",
 					"--region", "xxx", "--role-arn", classicInstallerRoleArn)
 				Expect(err).To(HaveOccurred())
 				Expect(output.String()).Should(ContainSubstring("ERR: Unsupported region 'xxx', available regions"))
-
-				By("Delete the account-roles")
-				rosaClient.Runner.UnsetArgs()
-				_, err = ocmResourceService.DeleteAccountRole("--mode", "auto",
-					"--prefix", accountRolePrefix,
-					"-y")
-				Expect(err).To(BeNil())
 			})
 
 		It("can create spot machinepool - [id:43251]",

--- a/tests/e2e/test_rosacli_machine_pool.go
+++ b/tests/e2e/test_rosacli_machine_pool.go
@@ -267,10 +267,18 @@ var _ = Describe("Create machinepool",
 				}
 				Expect(availableMachineTypesIDs).To(ContainElements(typesList))
 
+				By("Try to list instance-types with invalid region")
 				availableMachineTypes, output, err := ocmResourceService.ListInstanceTypes(
 					"--region", "xxx", "--role-arn", classicInstallerRoleArn)
 				Expect(err).To(HaveOccurred())
 				Expect(output.String()).Should(ContainSubstring("ERR: Unsupported region 'xxx', available regions"))
+
+				By("Delete the account-roles")
+				rosaClient.Runner.UnsetArgs()
+				_, err = ocmResourceService.DeleteAccountRole("--mode", "auto",
+					"--prefix", accountRolePrefix,
+					"-y")
+				Expect(err).To(BeNil())
 			})
 
 		It("can create spot machinepool - [id:43251]",

--- a/tests/e2e/test_rosacli_machine_pool.go
+++ b/tests/e2e/test_rosacli_machine_pool.go
@@ -268,9 +268,9 @@ var _ = Describe("Create machinepool",
 				Expect(availableMachineTypesIDs).To(ContainElements(typesList))
 
 				availableMachineTypes, output, err := ocmResourceService.ListInstanceTypes(
-					"--region", region, "--role-arn", "xxx")
+					"--region", "xxx", "--role-arn", classicInstallerRoleArn)
 				Expect(err).To(HaveOccurred())
-				Expect(output.String()).Should(ContainSubstring("E: Unsupported region 'xxx', available regions"))
+				Expect(output.String()).Should(ContainSubstring("ERR: Unsupported region 'xxx', available regions"))
 			})
 
 		It("can create spot machinepool - [id:43251]",

--- a/tests/e2e/test_rosacli_machine_pool.go
+++ b/tests/e2e/test_rosacli_machine_pool.go
@@ -248,7 +248,7 @@ var _ = Describe("Create machinepool",
 			func() {
 				By("List the available instance-types with the region flag")
 				typesList := []string{"dl1.24xlarge", "g4ad.16xlarge", "c5.xlarge"}
-				region := "us-east-1"
+				region := "us-west-2"
 				accountRolePrefix := fmt.Sprintf("QEAuto-accr72174-%s", time.Now().UTC().Format("20060102"))
 				_, err := ocmResourceService.CreateAccountRole("--mode", "auto",
 					"--prefix", accountRolePrefix,
@@ -264,6 +264,15 @@ var _ = Describe("Create machinepool",
 					"--region", region, "--role-arn", classicInstallerRoleArn)
 				Expect(err).To(BeNil())
 				var availableMachineTypesIDs []string
+				for _, it := range availableMachineTypes.InstanceTypesList {
+					availableMachineTypesIDs = append(availableMachineTypesIDs, it.ID)
+				}
+				Expect(availableMachineTypesIDs).To(ContainElements(typesList))
+
+				By("List the available instance-types with the region flag and hosted-cp flag")
+				availableMachineTypes, _, err = ocmResourceService.ListInstanceTypes(
+					"--region", region, "--role-arn", classicInstallerRoleArn, "--hosted-cp")
+				Expect(err).To(BeNil())
 				for _, it := range availableMachineTypes.InstanceTypesList {
 					availableMachineTypesIDs = append(availableMachineTypesIDs, it.ID)
 				}

--- a/tests/utils/exec/rosacli/ocm_resource_service.go
+++ b/tests/utils/exec/rosacli/ocm_resource_service.go
@@ -204,7 +204,8 @@ func (ors *ocmResourceService) ReflectInstanceTypesList(result bytes.Buffer) (ur
 func (ors *ocmResourceService) ListInstanceTypes(flags ...string) (InstanceTypesList, bytes.Buffer, error) {
 	ors.client.Runner.cmdArgs = []string{}
 	listInstanceTypes := ors.client.Runner.
-		Cmd("list", "instance-types").CmdFlags(flags...)
+		Cmd("list", "instance-types").
+		CmdFlags(flags...)
 	output, err := listInstanceTypes.Run()
 	if err != nil {
 		return InstanceTypesList{}, output, err

--- a/tests/utils/exec/rosacli/ocm_resource_service.go
+++ b/tests/utils/exec/rosacli/ocm_resource_service.go
@@ -54,7 +54,7 @@ type OCMResourceService interface {
 	ReflectOCMRoleList(result bytes.Buffer) (orl OCMRoleList, err error)
 
 	ListOIDCConfig() (OIDCConfigList, bytes.Buffer, error)
-	ListInstanceTypes() (InstanceTypesList, bytes.Buffer, error)
+	ListInstanceTypes(flags ...string) (InstanceTypesList, bytes.Buffer, error)
 	DeleteOIDCConfig(flags ...string) (bytes.Buffer, error)
 	CreateOIDCConfig(flags ...string) (bytes.Buffer, error)
 	ReflectOIDCConfigList(result bytes.Buffer) (oidclist OIDCConfigList, err error)
@@ -201,10 +201,10 @@ func (ors *ocmResourceService) ReflectInstanceTypesList(result bytes.Buffer) (ur
 }
 
 // ListInstanceTypes implements OCMResourceService.
-func (ors *ocmResourceService) ListInstanceTypes() (InstanceTypesList, bytes.Buffer, error) {
+func (ors *ocmResourceService) ListInstanceTypes(flags ...string) (InstanceTypesList, bytes.Buffer, error) {
 	ors.client.Runner.cmdArgs = []string{}
 	listInstanceTypes := ors.client.Runner.
-		Cmd("list", "instance-types")
+		Cmd("list", "instance-types").CmdFlags(flags...)
 	output, err := listInstanceTypes.Run()
 	if err != nil {
 		return InstanceTypesList{}, output, err


### PR DESCRIPTION
```
jfrazier@jfrazier-mac  ~/workspace/rosa   jf_72174 ±  ginkgo run -focus 72174 tests/e2e
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.11.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: ROSA CLI e2e tests suite - /Users/jfrazier/workspace/rosa/tests/e2e
==================================================================================
Random Seed: 1721850145

Will run 1 of 152 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 152 Specs in 43.968 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 151 Skipped
PASS

Ginkgo ran 1 suite in 49.266472625s
Test Suite Passed
```