### PR TITLE
OCM-8933 | test: automate id:75114,75227 hcp cluster/machinepool creation supports imdsv2

### DIFF
--- a/tests/e2e/test_rosacli_cluster_post.go
+++ b/tests/e2e/test_rosacli_cluster_post.go
@@ -253,6 +253,47 @@ var _ = Describe("Healthy check",
 				Expect(out.AdditionalPrincipals).To(ContainSubstring(clusterConfig.AdditionalPrincipals))
 			})
 
+		It("rosa hcp cluster creation support imdsv2 - [id:75114]",
+			labels.Critical, labels.Runtime.Day1Post,
+			func() {
+				By("Check the cluster is hosted cp cluster")
+				isHostedCPCluster, err := clusterService.IsHostedCPCluster(clusterID)
+				Expect(err).ToNot(HaveOccurred())
+
+				if !isHostedCPCluster {
+					SkipNotHosted()
+				}
+
+				By("Check the help message of 'rosa create cluster -h'")
+				res, err := clusterService.CreateDryRun(clusterID, "-h")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.String()).To(ContainSubstring("--ec2-metadata-http-tokens"))
+
+				By("Get the ec2_metadata_http_tokens value from cluster level spec attribute")
+				output, err := clusterService.GetJSONClusterDescription(clusterID)
+				Expect(err).ToNot(HaveOccurred())
+				clusterIMDSv2Value := output.DigString("aws", "ec2_metadata_http_tokens")
+
+				By("Check the cluster description value to match cluster profile configuration")
+				if profile.ClusterConfig.Ec2MetadataHttpTokens == "" {
+					Expect(clusterIMDSv2Value).To(Equal(constants.DefaultEc2MetadataHttpTokens))
+				} else {
+					Expect(clusterIMDSv2Value).To(Equal(profile.ClusterConfig.Ec2MetadataHttpTokens))
+				}
+
+				By("Check the default workers machinepool value to match cluster level spec attribute")
+				npList, err := machinePoolService.ListAndReflectNodePools(clusterID)
+				Expect(err).ToNot(HaveOccurred())
+				for _, np := range npList.NodePools {
+					Expect(np.ID).ToNot(BeNil())
+					if strings.HasPrefix(np.ID, constants.DefaultHostedWorkerPool) {
+						npDesc, err := machinePoolService.DescribeAndReflectNodePool(clusterID, np.ID)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(npDesc.EC2MetadataHttpTokens).To(Equal(clusterIMDSv2Value))
+					}
+				}
+			})
+
 		It("etcd encryption works on cluster creation - [id:42188]",
 			labels.Critical, labels.Runtime.Day1Post,
 			func() {

--- a/tests/utils/common/constants/general.go
+++ b/tests/utils/common/constants/general.go
@@ -4,3 +4,10 @@ const (
 	Yes = "Yes"
 	No  = "No"
 )
+
+// Ec2MetadataHttpTokens for hcp cluster
+const (
+	DefaultEc2MetadataHttpTokens  = "optional"
+	RequiredEc2MetadataHttpTokens = "required"
+	OptionalEc2MetadataHttpTokens = "optional"
+)

--- a/tests/utils/config/support.go
+++ b/tests/utils/config/support.go
@@ -35,8 +35,7 @@ func DeployCilium(ocClient *occli.Client, podCIDR string, hostPrefix string, out
 	url := "https://raw.githubusercontent.com/isovalent/olm-for-cilium/main/manifests"
 	for _, n := range yamlFileNames {
 		stdout, err := ocClient.Run(
-			fmt.Sprintf("oc apply -f %s/cilium.v%s/%s --kubeconfig %s", url, ciliumVersion,
-				n, kubeconfigFile))
+			fmt.Sprintf("oc apply -f %s/cilium.v%s/%s", url, ciliumVersion, n))
 		time.Sleep(3 * time.Second)
 
 		if err != nil {

--- a/tests/utils/exec/rosacli/machinepool_service.go
+++ b/tests/utils/exec/rosacli/machinepool_service.go
@@ -65,7 +65,7 @@ type MachinePoolList struct {
 	MachinePools []*MachinePool `json:"MachinePools,omitempty"`
 }
 
-// Struct for the 'rosa list machinepool' output for non-hosted-cp clusters
+// Struct for the 'rosa describe machinepool' output for non-hosted-cp clusters
 type MachinePoolDescription struct {
 	AvailablityZones string `yaml:"Availability zones,omitempty"`
 	AutoScaling      string `yaml:"Autoscaling,omitempty"`
@@ -106,7 +106,7 @@ type NodePoolDescription struct {
 	ID                         string              `yaml:"ID,omitempty"`
 	ClusterID                  string              `yaml:"Cluster ID,omitempty"`
 	AutoScaling                string              `yaml:"Autoscaling,omitempty"`
-	DesiredReplicas            string              `yaml:"Desired replicas,omitempty"`
+	DesiredReplicas            interface{}         `yaml:"Desired replicas,omitempty"`
 	CurrentReplicas            string              `yaml:"Current replicas,omitempty"`
 	InstanceType               string              `yaml:"Instance type,omitempty"`
 	KubeletConfigs             string              `yaml:"Kubelet configs,omitempty"`
@@ -116,6 +116,7 @@ type NodePoolDescription struct {
 	AvalaiblityZones           string              `yaml:"Availability zone,omitempty"`
 	Subnet                     string              `yaml:"Subnet,omitempty"`
 	Version                    string              `yaml:"Version,omitempty"`
+	EC2MetadataHttpTokens      string              `yaml:"EC2 Metadata Http Tokens,omitempty"`
 	AutoRepair                 string              `yaml:"Autorepair,omitempty"`
 	TuningConfigs              string              `yaml:"Tuning configs,omitempty"`
 	ManagementUpgrade          []map[string]string `yaml:"Management upgrade,omitempty"`


### PR DESCRIPTION
`$ ginkgo --focus "(75114|75227|56782)" tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.14.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: ROSA CLI e2e tests suite - /home/aaraj/ocm-forked-code/rosa/tests/e2e
====================================================================================
Random Seed: 1721910023

Will run 3 of 158 specs
SSS•SSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 3 of 158 Specs in 200.688 seconds
SUCCESS! -- 3 Passed | 0 Failed | 0 Pending | 155 Skipped
PASS

Ginkgo ran 1 suite in 3m22.871641525s
Test Suite Passed
`