### PR TITLE
OCM-9917 | fix: Bug related to editing min/max replicas (machinepools)

### DIFF
--- a/cmd/edit/machinepool/cmd_test.go
+++ b/cmd/edit/machinepool/cmd_test.go
@@ -41,7 +41,6 @@ var _ = Describe("Edit Machinepool", func() {
 			c.State(cmv1.ClusterStateReady)
 			c.Hypershift(cmv1.NewHypershift().Enabled(false))
 		})
-		classicClusterReady := test.FormatClusterList([]*cmv1.Cluster{mockClassicClusterReady})
 
 		version := cmv1.NewVersion().ID("4.12.24").RawID("openshift-4.12.24")
 		awsNodePool := cmv1.NewAWSNodePool().InstanceType("m5.xlarge")
@@ -69,9 +68,8 @@ var _ = Describe("Edit Machinepool", func() {
 			t.SetCluster("", nil)
 		})
 
-		Describe("Machinepools", func() {
+		Describe("Machinepools", Ordered, func() {
 			It("Able to edit machinepool with no issues", func() {
-				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, classicClusterReady))
 				// First get
 				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, mpResponse))
 				// Edit
@@ -87,7 +85,6 @@ var _ = Describe("Edit Machinepool", func() {
 					nodePoolId, "--min-replicas", "2", "--enable-autoscaling", "true", "-y"})).To(Succeed())
 			})
 			It("Machinepool ID passed in without flag in random location", func() {
-				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, classicClusterReady))
 				// First get
 				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, mpResponse))
 				// Edit
@@ -135,6 +132,8 @@ var _ = Describe("Edit Machinepool", func() {
 				args := NewEditMachinepoolUserOptions()
 				args.machinepool = nodePoolId
 				args.autoscalingEnabled = true
+				args.maxReplicas = 10
+				args.minReplicas = 2
 				runner := EditMachinePoolRunner(args)
 				cmd := NewEditMachinePoolCommand()
 				Expect(cmd.Flag("cluster").Value.Set(clusterId)).To(Succeed())

--- a/cmd/edit/machinepool/options.go
+++ b/cmd/edit/machinepool/options.go
@@ -53,13 +53,25 @@ func (m *EditMachinepoolOptions) Bind(args *EditMachinepoolUserOptions, argv []s
 	}
 
 	if m.args.machinepool == "" {
-		return fmt.Errorf("you need to specify a machine pool name")
+		return fmt.Errorf("You need to specify a machine pool name")
 	}
 
 	if m.args.labels != "" {
 		_, err := mpHelpers.ParseLabels(args.labels)
 		if err != nil {
 			return err
+		}
+	}
+
+	if m.args.autoscalingEnabled {
+		if m.args.minReplicas <= 0 {
+			return fmt.Errorf("Min replicas must be greater than zero when autoscaling is enabled")
+		}
+		if m.args.maxReplicas <= 0 {
+			return fmt.Errorf("Max replicas must be greater than zero when autoscaling is enabled")
+		}
+		if m.args.minReplicas > m.args.maxReplicas {
+			return fmt.Errorf("Min replicas must be less than max replicas")
 		}
 	}
 

--- a/cmd/edit/machinepool/options_test.go
+++ b/cmd/edit/machinepool/options_test.go
@@ -15,6 +15,9 @@ var _ = Describe("Test edit machinepool options", func() {
 	})
 	Context("Edit Machinepool Options", func() {
 		var options EditMachinepoolOptions
+		BeforeEach(func() {
+			args = NewEditMachinepoolUserOptions()
+		})
 		It("Create args from options using Bind (also tests MachinePool func)", func() {
 			// Set value then bind
 			testMachinepool := "test"
@@ -25,7 +28,7 @@ var _ = Describe("Test edit machinepool options", func() {
 		It("Fail to bind args due to empty machinepool name", func() {
 			args.machinepool = ""
 			err := options.Bind(args, []string{})
-			Expect(err).To(MatchError("you need to specify a machine pool name"))
+			Expect(err).To(MatchError("You need to specify a machine pool name"))
 		})
 		It("Test Bind with argv instead of normal args (single arg, no flag for machinepool)", func() {
 			argv := []string{"test-id"}
@@ -47,6 +50,30 @@ var _ = Describe("Test edit machinepool options", func() {
 			args.machinepool = testMachinepool
 			err := options.Bind(args, []string{})
 			Expect(err).To(MatchError("Expected key=value format for labels"))
+		})
+		It("Test min replicas negative value (fail)", func() {
+			args.minReplicas = -1
+			args.maxReplicas = 1
+			args.autoscalingEnabled = true
+			args.machinepool = "test"
+			err := options.Bind(args, []string{})
+			Expect(err).To(MatchError("Min replicas must be greater than zero when autoscaling is enabled"))
+		})
+		It("Test max replicas negative value (fail)", func() {
+			args.maxReplicas = -1
+			args.minReplicas = 1
+			args.autoscalingEnabled = true
+			args.machinepool = "test"
+			err := options.Bind(args, []string{})
+			Expect(err).To(MatchError("Max replicas must be greater than zero when autoscaling is enabled"))
+		})
+		It("Test min replicas > max replicas (fail)", func() {
+			args.maxReplicas = 1
+			args.minReplicas = 5
+			args.autoscalingEnabled = true
+			args.machinepool = "test"
+			err := options.Bind(args, []string{})
+			Expect(err).To(MatchError("Min replicas must be less than max replicas"))
 		})
 	})
 })


### PR DESCRIPTION
Min/Max replicas were not validated properly, moved it to the options binding to allow for 0 command execution if input is invalid

Added test cases for each issue