### PR TITLE
OCM-9935 | test: fix ids: 60688,73731 to use cluster service to confirm if the cluster is HCP

### DIFF
--- a/tests/e2e/test_rosacli_cluster.go
+++ b/tests/e2e/test_rosacli_cluster.go
@@ -1756,7 +1756,6 @@ var _ = Describe("Reusing opeartor prefix and oidc config to create clsuter", la
 		oidcConfigToClean        string
 		ocmResourceService       rosacli.OCMResourceService
 		originalMajorMinorVerson string
-		clusterConfig            *config.ClusterConfig
 		clusterService           rosacli.ClusterService
 		awsClient                *aws_client.AWSClient
 		operatorPolicyArn        string
@@ -1770,7 +1769,6 @@ var _ = Describe("Reusing opeartor prefix and oidc config to create clsuter", la
 		ocmResourceService = rosaClient.OCMResource
 		clusterService = rosaClient.Cluster
 		profile = profilehandler.LoadProfileYamlFileByENV()
-		clusterConfig, err = config.ParseClusterProfile()
 		Expect(err).ToNot(HaveOccurred())
 
 		awsClient, err = aws_client.CreateAWSClient("", "")
@@ -1858,7 +1856,9 @@ var _ = Describe("Reusing opeartor prefix and oidc config to create clsuter", la
 			originalMajorMinorVerson = fmt.Sprintf("%d.%d", major, minor)
 			testingRoleVersion := fmt.Sprintf("%d.%d", major, minor-1)
 
-			if !clusterConfig.Hypershift {
+			isHosted, err := clusterService.IsHostedCPCluster(clusterID)
+			Expect(err).ToNot(HaveOccurred())
+			if !isHosted {
 				By("Update the all operator policies tags to low version")
 				_, roleName, err := common.ParseRoleARN(operatorRolesArns[1])
 				Expect(err).To(BeNil())

--- a/tests/e2e/test_rosacli_upgrade.go
+++ b/tests/e2e/test_rosacli_upgrade.go
@@ -29,8 +29,6 @@ var _ = Describe("Cluster Upgrade testing",
 			arbitraryPoliciesToClean []string
 			awsClient                *aws_client.AWSClient
 			profile                  *profilehandler.Profile
-			clusterConfig            *config.ClusterConfig
-			err                      error
 		)
 
 		BeforeEach(func() {
@@ -42,9 +40,6 @@ var _ = Describe("Cluster Upgrade testing",
 			rosaClient = rosacli.NewClient()
 			arbitraryPolicyService = rosaClient.Policy
 			clusterService = rosaClient.Cluster
-
-			clusterConfig, err = config.ParseClusterProfile()
-			Expect(err).ToNot(HaveOccurred())
 
 			By("Load the profile")
 			profile = profilehandler.LoadProfileYamlFileByENV()
@@ -214,7 +209,9 @@ var _ = Describe("Cluster Upgrade testing",
 				Expect(err).To(BeNil())
 				Expect(len(policy.Tags)).To(Equal(0))
 			}
-			if !clusterConfig.Hypershift {
+			isHosted, err := clusterService.IsHostedCPCluster(clusterID)
+			Expect(err).ToNot(HaveOccurred())
+			if !isHosted {
 				By("Update the all operator policies tags to low version")
 				tagName := "rosa_openshift_version"
 				clusterMajorVersion := common.SplitMajorVersion(clusterVersion)


### PR DESCRIPTION
60688,73731 to use cluster service to confirm if the cluster is HCP