### PR TITLE
OCM-9917 | fix: Issue with interactive + replicas edit machinepool

### DIFF
--- a/cmd/edit/machinepool/cmd_test.go
+++ b/cmd/edit/machinepool/cmd_test.go
@@ -81,8 +81,8 @@ var _ = Describe("Edit Machinepool", func() {
 				cmd := NewEditMachinePoolCommand()
 				Expect(cmd.Flag("cluster").Value.Set(clusterId)).To(Succeed())
 				Expect(cmd.Flags().Set("labels", "test=test")).To(Succeed())
-				Expect(runner(context.Background(), t.RosaRuntime, cmd, []string{"--machinepool",
-					nodePoolId, "--min-replicas", "2", "--enable-autoscaling", "true", "-y"})).To(Succeed())
+				Expect(cmd.Flags().Set("replicas", "1")).To(Succeed())
+				Expect(runner(context.Background(), t.RosaRuntime, cmd, []string{})).To(Succeed())
 			})
 			It("Machinepool ID passed in without flag in random location", func() {
 				// First get
@@ -96,8 +96,11 @@ var _ = Describe("Edit Machinepool", func() {
 				cmd := NewEditMachinePoolCommand()
 				Expect(cmd.Flag("cluster").Value.Set(clusterId)).To(Succeed())
 				Expect(cmd.Flags().Set("labels", "test=test")).To(Succeed())
+				Expect(cmd.Flags().Set("min-replicas", "1")).To(Succeed())
+				Expect(cmd.Flags().Set("max-replicas", "1")).To(Succeed())
+				Expect(cmd.Flags().Set("enable-autoscaling", "true")).To(Succeed())
 				Expect(runner(context.Background(), t.RosaRuntime, cmd,
-					[]string{"--min-replicas", "2", nodePoolId, "--enable-autoscaling", "true", "-y"})).To(Succeed())
+					[]string{})).To(Succeed())
 			})
 		})
 

--- a/cmd/edit/machinepool/options.go
+++ b/cmd/edit/machinepool/options.go
@@ -73,6 +73,9 @@ func (m *EditMachinepoolOptions) Bind(args *EditMachinepoolUserOptions, argv []s
 		if m.args.minReplicas > m.args.maxReplicas {
 			return fmt.Errorf("Min replicas must be less than max replicas")
 		}
+		if m.args.replicas != 0 {
+			return fmt.Errorf("Autoscaling enabled on machine pool '%s'. can't set replicas", m.Machinepool())
+		}
 	}
 
 	return nil

--- a/pkg/machinepool/validation.go
+++ b/pkg/machinepool/validation.go
@@ -22,3 +22,33 @@ func validateCount[K any](kubeletConfigs []K) error {
 	}
 	return nil
 }
+
+func validateEditInput(poolType string, autoscaling bool, minReplicas int, maxReplicas int, replicas int,
+	isReplicasSet bool, isAutoscalingSet bool, isMinReplicasSet bool, isMaxReplicasSet bool, id string) error {
+
+	if autoscaling && minReplicas <= 0 && isMinReplicasSet {
+		return fmt.Errorf("Min replicas must be a positive number when autoscaling is set")
+	}
+
+	if autoscaling && maxReplicas <= 0 && isMaxReplicasSet {
+		return fmt.Errorf("Max replicas must be a positive number when autoscaling is set")
+	}
+
+	if !autoscaling && replicas <= 0 {
+		return fmt.Errorf("Replicas must be a positive number")
+	}
+
+	if autoscaling && isReplicasSet && isAutoscalingSet {
+		return fmt.Errorf("Autoscaling enabled on %s pool '%s'. can't set replicas", poolType, id)
+	}
+
+	if autoscaling && isAutoscalingSet && maxReplicas < minReplicas {
+		return fmt.Errorf("Max replicas must not be greater than min replicas when autoscaling is enabled")
+	}
+
+	if !autoscaling && (isMinReplicasSet || isMaxReplicasSet) {
+		return fmt.Errorf("Autoscaling disabled on %s pool '%s'. can't set min or max replicas", poolType, id)
+	}
+
+	return nil
+}

--- a/pkg/machinepool/validation_test.go
+++ b/pkg/machinepool/validation_test.go
@@ -65,4 +65,48 @@ var _ = Describe("MachinePool validation", func() {
 			Expect(err.Error()).To(Equal("Input for kubelet config flag is not valid"))
 		})
 	})
+	Context("Validate edit machinepool options", func() {
+		It("Fails with autoscaling + replicas set", func() {
+			Expect(validateEditInput("machine", true, 1,
+				2, 1, true, true, true,
+				true, "test")).ToNot(Succeed())
+		})
+		It("Fails with max, min, and replicas <= 0", func() {
+			Expect(validateEditInput("machine", true, 0,
+				1, 0, false, true, true,
+				true, "test")).ToNot(Succeed())
+			Expect(validateEditInput("machine", true, 1,
+				0, 0, false, true, true,
+				true, "test")).ToNot(Succeed())
+			Expect(validateEditInput("machine", false, 0,
+				0, 0, true, true, false,
+				false, "test")).ToNot(Succeed())
+		})
+		It("Fails with max < min replicas", func() {
+			Expect(validateEditInput("machine", true, 5,
+				4, 0, false, true, true,
+				true, "test")).ToNot(Succeed())
+		})
+		It("Fails when no autoscaling, but min/max are set", func() {
+			Expect(validateEditInput("machine", false, 1,
+				0, 1, true, false, true,
+				false, "test")).ToNot(Succeed())
+			Expect(validateEditInput("machine", false, 0,
+				1, 1, true, false, false,
+				true, "test")).ToNot(Succeed())
+			Expect(validateEditInput("machine", false, 1,
+				1, 1, true, false, true,
+				true, "test")).ToNot(Succeed())
+		})
+		It("Passes (autoscaling)", func() {
+			Expect(validateEditInput("machine", true, 1,
+				2, 0, false, true, true,
+				true, "test")).To(Succeed())
+		})
+		It("Passes (not autoscaling)", func() {
+			Expect(validateEditInput("machine", false, 0,
+				0, 2, true, false, false,
+				false, "test")).To(Succeed())
+		})
+	})
 })


### PR DESCRIPTION
Replicas must be  >= 0
Can't set replicas when autoscaling enabled
interactive min/max replicas fix