### PR TITLE
OCM-9296 | test: automate ids:41822,75256 Create/Delete STS cluster successfully via rosacli

### DIFF
--- a/tests/utils/profilehandler/interface.go
+++ b/tests/utils/profilehandler/interface.go
@@ -77,13 +77,14 @@ type UserData struct {
 
 // ClusterDetail will record basic cluster info to support other team's testing
 type ClusterDetail struct {
-	APIURL          string `json:"api_url,omitempty"`
-	ClusterID       string `json:"cluster_id,omitempty"`
-	ClusterName     string `json:"cluster_name,omitempty"`
-	ClusterType     string `json:"cluster_type,omitempty"`
-	ConsoleURL      string `json:"console_url,omitempty"`
-	InfraID         string `json:"infra_id,omitempty"`
-	OIDCEndpointURL string `json:"oidc_endpoint_url,omitempty"`
+	APIURL           string   `json:"api_url,omitempty"`
+	ClusterID        string   `json:"cluster_id,omitempty"`
+	ClusterName      string   `json:"cluster_name,omitempty"`
+	ClusterType      string   `json:"cluster_type,omitempty"`
+	ConsoleURL       string   `json:"console_url,omitempty"`
+	InfraID          string   `json:"infra_id,omitempty"`
+	OIDCEndpointURL  string   `json:"oidc_endpoint_url,omitempty"`
+	OperatorRoleArns []string `json:"operator_role_arn,omitempty"`
 }
 
 type ProxyDetail struct {

--- a/tests/utils/profilehandler/profile_handler.go
+++ b/tests/utils/profilehandler/profile_handler.go
@@ -806,6 +806,7 @@ func CreateClusterByProfileWithoutWaiting(
 	clusterDetail.ClusterName = description.Name
 	clusterDetail.ClusterType = "rosa"
 	clusterDetail.OIDCEndpointURL = description.OIDCEndpointURL
+	clusterDetail.OperatorRoleArns = description.OperatorIAMRoles
 
 	// Need to do the post step when cluster has no oidcconfig enabled
 	if profile.ClusterConfig.OIDCConfig == "" && profile.ClusterConfig.STS {


### PR DESCRIPTION
Add OperatorRoleArn info in cluster-detail file for testing.
Automate 41822,75256 Create/Delete STS cluster successfully via rosacli 