### PR TITLE
OCM-9967 | ci: fix id:73731,75150,73492

### DIFF
--- a/tests/ci/config/config.go
+++ b/tests/ci/config/config.go
@@ -52,6 +52,7 @@ type GlobalENVVariables struct {
 	WaitSetupClusterReady bool   `env:"WAIT_SETUP_CLUSTER_READY" default:"true"`
 	SVPC_CREDENTIALS_FILE string `env:"SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE" default:""`
 	ComputeMachineType    string `env:"COMPUTE_MACHINE_TYPE" default:""`
+	OCM_LOGIN_ENV         string `env:"OCM_LOGIN_ENV" default:""`
 }
 
 func init() {

--- a/tests/e2e/test_rosacli_cluster_post.go
+++ b/tests/e2e/test_rosacli_cluster_post.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openshift-online/ocm-common/pkg/aws/aws_client"
 
+	ciConfig "github.com/openshift/rosa/tests/ci/config"
 	"github.com/openshift/rosa/tests/ci/labels"
 	"github.com/openshift/rosa/tests/utils/common"
 	"github.com/openshift/rosa/tests/utils/common/constants"
@@ -369,7 +370,10 @@ var _ = Describe("Healthy check",
 				By("Check compute machine type")
 				jsonData, err := clusterService.GetJSONClusterDescription(clusterID)
 				Expect(err).To(BeNil())
-				if profile.ClusterConfig.InstanceType == "" {
+				if ciConfig.Test.GlobalENV.ComputeMachineType != "" {
+					Expect(jsonData.DigString("nodes", "compute_machine_type", "id")).To(
+						Equal(ciConfig.Test.GlobalENV.ComputeMachineType))
+				} else if profile.ClusterConfig.InstanceType == "" {
 					Expect(jsonData.DigString("nodes", "compute_machine_type", "id")).To(Equal(constants.DefaultInstanceType))
 				} else {
 					Expect(jsonData.DigString("nodes", "compute_machine_type", "id")).To(Equal(profile.ClusterConfig.InstanceType))

--- a/tests/e2e/test_rosacli_node_pool.go
+++ b/tests/e2e/test_rosacli_node_pool.go
@@ -16,6 +16,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	ciConfig "github.com/openshift/rosa/tests/ci/config"
 	"github.com/openshift/rosa/tests/ci/labels"
 	"github.com/openshift/rosa/tests/utils/common"
 	"github.com/openshift/rosa/tests/utils/common/constants"
@@ -1004,8 +1005,18 @@ var _ = Describe("Edit nodepool",
 				rosaClient.Runner.UnsetFormat()
 				organizationID := userInfo.OCMOrganizationID
 
+				var OCMEnv string
+
 				By("Get OCM Env")
-				OCMEnv := common.ReadENVWithDefaultValue("OCM_LOGIN_ENV", "staging")
+				if ciConfig.Test.GlobalENV.OCM_LOGIN_ENV != "" {
+					if strings.Contains(ciConfig.Test.GlobalENV.OCM_LOGIN_ENV, "staging") {
+						OCMEnv = "staging"
+					} else if strings.Contains(ciConfig.Test.GlobalENV.OCM_LOGIN_ENV, "production") {
+						OCMEnv = "production"
+					}
+				} else {
+					OCMEnv = common.ReadENVWithDefaultValue("OCM_LOGIN_ENV", "staging")
+				}
 
 				By("Get the cluster informations")
 				rosaClient.Runner.JsonFormat()

--- a/tests/e2e/test_rosacli_upgrade.go
+++ b/tests/e2e/test_rosacli_upgrade.go
@@ -247,12 +247,21 @@ var _ = Describe("Cluster Upgrade testing",
 			// without arbitrary policies attach share this profile.
 			// It needs to add step to wait the cluster upgrade done
 			// and to check the `rosa describe/list upgrade` in both of these two case.
-			output, err = clusterService.Upgrade(
-				"-c", clusterID,
-				"--version", upgradingVersion,
-				"--mode", "auto",
-				"-y",
-			)
+			if !isHosted {
+				output, err = clusterService.Upgrade(
+					"-c", clusterID,
+					"--version", upgradingVersion,
+					"--mode", "auto",
+					"-y",
+				)
+			} else {
+				output, err = clusterService.Upgrade(
+					"-c", clusterID,
+					"--version", upgradingVersion,
+					"--mode", "auto", "--hosted-cp",
+					"-y",
+				)
+			}
 			Expect(err).To(BeNil())
 			Expect(output.String()).To(ContainSubstring("are already up-to-date"))
 			Expect(output.String()).To(ContainSubstring("are compatible with upgrade"))


### PR DESCRIPTION
$ ginkgo --focus "(73492|75150)" tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.14.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: ROSA CLI e2e tests suite - /home/aaraj/ocm-forked-code/rosa/tests/e2e
====================================================================================
Random Seed: 1722247272

Will run 2 of 160 specs
SSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 2 of 160 Specs in 80.391 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 158 Skipped
PASS

Ginkgo ran 1 suite in 1m28.00699366s
Test Suite Passed
