### PR TITLE
OCM-9984 | fix: Change replica (min, max, and normal) minimum to 0

### DIFF
--- a/pkg/machinepool/validation.go
+++ b/pkg/machinepool/validation.go
@@ -26,16 +26,16 @@ func validateCount[K any](kubeletConfigs []K) error {
 func validateEditInput(poolType string, autoscaling bool, minReplicas int, maxReplicas int, replicas int,
 	isReplicasSet bool, isAutoscalingSet bool, isMinReplicasSet bool, isMaxReplicasSet bool, id string) error {
 
-	if autoscaling && minReplicas <= 0 && isMinReplicasSet {
-		return fmt.Errorf("Min replicas must be a positive number when autoscaling is set")
+	if autoscaling && minReplicas < 0 && isMinReplicasSet {
+		return fmt.Errorf("Min replicas must be a non-negative number when autoscaling is set")
 	}
 
-	if autoscaling && maxReplicas <= 0 && isMaxReplicasSet {
-		return fmt.Errorf("Max replicas must be a positive number when autoscaling is set")
+	if autoscaling && maxReplicas < 0 && isMaxReplicasSet {
+		return fmt.Errorf("Max replicas must be a non-negative number when autoscaling is set")
 	}
 
-	if !autoscaling && replicas <= 0 {
-		return fmt.Errorf("Replicas must be a positive number")
+	if !autoscaling && replicas < 0 {
+		return fmt.Errorf("Replicas must be a non-negative number")
 	}
 
 	if autoscaling && isReplicasSet && isAutoscalingSet {

--- a/pkg/machinepool/validation_test.go
+++ b/pkg/machinepool/validation_test.go
@@ -71,15 +71,15 @@ var _ = Describe("MachinePool validation", func() {
 				2, 1, true, true, true,
 				true, "test")).ToNot(Succeed())
 		})
-		It("Fails with max, min, and replicas <= 0", func() {
-			Expect(validateEditInput("machine", true, 0,
+		It("Fails with max, min, and replicas < 0", func() {
+			Expect(validateEditInput("machine", true, -1,
 				1, 0, false, true, true,
 				true, "test")).ToNot(Succeed())
 			Expect(validateEditInput("machine", true, 1,
-				0, 0, false, true, true,
+				-1, 0, false, true, true,
 				true, "test")).ToNot(Succeed())
 			Expect(validateEditInput("machine", false, 0,
-				0, 0, true, true, false,
+				0, -1, true, true, false,
 				false, "test")).ToNot(Succeed())
 		})
 		It("Fails with max < min replicas", func() {


### PR DESCRIPTION
* Changed the minimum for max/min/non-autoscaling replicas to `0`, rather than `-1`, when editing machinepools
* Updated validation unit tests to use `-1` instead of `0`