### PR TITLE
OCM-9967 | ci: fix id:59530,73492

### DIFF
--- a/tests/e2e/test_rosacli_node_pool.go
+++ b/tests/e2e/test_rosacli_node_pool.go
@@ -1009,9 +1009,12 @@ var _ = Describe("Edit nodepool",
 
 				By("Get OCM Env")
 				if ciConfig.Test.GlobalENV.OCM_LOGIN_ENV != "" {
-					if strings.Contains(ciConfig.Test.GlobalENV.OCM_LOGIN_ENV, "staging") {
+					OCM_LOGIN_ENV := ciConfig.Test.GlobalENV.OCM_LOGIN_ENV
+					if strings.Contains(OCM_LOGIN_ENV, "staging") ||
+						strings.Contains(OCM_LOGIN_ENV, "stage") {
 						OCMEnv = "staging"
-					} else if strings.Contains(ciConfig.Test.GlobalENV.OCM_LOGIN_ENV, "production") {
+					} else if strings.Contains(OCM_LOGIN_ENV, "production") ||
+						strings.Contains(OCM_LOGIN_ENV, "prod") {
 						OCMEnv = "production"
 					}
 				} else {


### PR DESCRIPTION
$ ginkgo --focus "(59530|73492)" tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.14.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: ROSA CLI e2e tests suite - /home/aaraj/ocm-forked-code/rosa/tests/e2e
====================================================================================
Random Seed: 1722319754

Will run 2 of 160 specs
SSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 2 of 160 Specs in 111.404 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 158 Skipped
PASS

Ginkgo ran 1 suite in 1m59.947714301s
Test Suite Passed
