### PR TITLE
OCM-10011 | test: automated cases id:73538

### DIFF
--- a/tests/e2e/test_rosacli_ingress.go
+++ b/tests/e2e/test_rosacli_ingress.go
@@ -145,6 +145,22 @@ var _ = Describe("Edit default ingress",
 						"ERR: Updating route selectors is not supported for Hosted Control Plane clusters"))
 			})
 
+		It("can describe ingress of a cluster - [id:73538]",
+			labels.Low, labels.Runtime.Day2,
+			func() {
+				By("Retrieve cluster and get default ingress id")
+				output, err := ingressService.ListIngress(clusterID)
+				Expect(err).ToNot(HaveOccurred())
+				ingressList, err := ingressService.ReflectIngressList(output)
+				Expect(err).ToNot(HaveOccurred())
+
+				defaultID := ingressList.Ingresses[0]
+				_, err = rosaClient.Ingress.DescribeIngressAndReflect(clusterID, defaultID.ID)
+				Expect(err).ToNot(HaveOccurred())
+				in := ingressList.Ingress(defaultID.ID)
+				Expect(in.ID).To(Equal(defaultID.ID))
+			})
+
 		It("change load balancer type - [id:64767]",
 			labels.Critical,
 			labels.Runtime.Day2,


### PR DESCRIPTION
`jfrazier@jfrazier-mac  ~/workspace/rosa   jf_73538 ±  ginkgo run -focus 73538 tests/e2e
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.11.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: ROSA CLI e2e tests suite - /Users/jfrazier/workspace/rosa/tests/e2e
==================================================================================
Random Seed: 1722359243

Will run 1 of 161 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 161 Specs in 3.907 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 160 Skipped
PASS

Ginkgo ran 1 suite in 9.184167625s
Test Suite Passed`