### PR TITLE
OCM-10020 | test: fix id:49137,53031

### DIFF
--- a/tests/e2e/test_rosacli_idp.go
+++ b/tests/e2e/test_rosacli_idp.go
@@ -18,9 +18,6 @@ import (
 func validateIDPOutput(textData string, clusterID string, idpName string) {
 	Expect(textData).Should(ContainSubstring("Configuring IDP for cluster '%s'", clusterID))
 	Expect(textData).Should(ContainSubstring("Identity Provider '%s' has been created", idpName))
-	Expect(textData).Should(ContainSubstring("To log in to the console, open"))
-	Expect(textData).Should(ContainSubstring("and click on '%s'", idpName))
-
 }
 
 var _ = Describe("Edit IDP",


### PR DESCRIPTION
[OCM-10020](https://issues.redhat.com//browse/OCM-10020) 

$ ginkgo --focus "(49137|53031)" tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.11.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: ROSA CLI e2e tests suite - /home/akanni/OCP-Repository/rosa/tests/e2e
====================================================================================
Random Seed: 1722405101

Will run 2 of 162 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS••SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 2 of 162 Specs in 65.782 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 160 Skipped
PASS

Ginkgo ran 1 suite in 1m9.344122317s
Test Suite Passed
