### PR TITLE
OCM-10024 | ci: fix id:67275

### DIFF
--- a/tests/e2e/rosa_autoscaler_test.go
+++ b/tests/e2e/rosa_autoscaler_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Autoscaler", labels.Feature.Autoscaler, func() {
 						"--ignore-daemonsets-utilization",
 						"--max-node-provision-time", "10m",
 						"--balancing-ignored-labels", "aaa",
-						"--max-nodes-total", "1000",
+						"--max-nodes-total", "100",
 						"--min-cores", "0",
 						"--scale-down-delay-after-add", "10s",
 						"--max-cores", "100",
@@ -156,7 +156,7 @@ var _ = Describe("Autoscaler", labels.Feature.Autoscaler, func() {
 					Expect(autoscaler.ResourcesLimits.GPUs[1].Range.Max).To(Equal(5))
 					Expect(autoscaler.ResourcesLimits.GPUs[1].Range.Min).To(Equal(1))
 					Expect(autoscaler.ResourcesLimits.GPUs[1].Type).To(Equal("amd.com/gpu"))
-					Expect(autoscaler.ResourcesLimits.MaxNodesTotal).To(Equal(1000))
+					Expect(autoscaler.ResourcesLimits.MaxNodesTotal).To(Equal(100))
 					Expect(autoscaler.ScaleDown.DelayAfterAdd).To(Equal("10s"))
 					Expect(autoscaler.ScaleDown.DelayAfterDelete).To(Equal("10s"))
 					Expect(autoscaler.ScaleDown.DelayAfterFailure).To(Equal("10s"))


### PR DESCRIPTION
$ ginkgo --focus 67275 tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.14.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: ROSA CLI e2e tests suite - /home/aaraj/ocm-forked-code/rosa/tests/e2e
====================================================================================
Random Seed: 1722409075

Will run 1 of 160 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 160 Specs in 27.332 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 159 Skipped
PASS

Ginkgo ran 1 suite in 34.213252315s
Test Suite Passed
