### PR TITLE
OCM-10143 | test: fix ids:60688,59530,74761

### DIFF
--- a/tests/e2e/test_rosacli_cluster_post.go
+++ b/tests/e2e/test_rosacli_cluster_post.go
@@ -584,6 +584,11 @@ var _ = Describe("Post-Check testing for cluster creation",
 				profile := profilehandler.LoadProfileYamlFileByENV()
 				Expect(err).ToNot(HaveOccurred())
 
+				By("Check if it is using oidc config")
+				if profile.ClusterConfig.OIDCConfig == "" {
+					Skip("Skip this case as it is only for byo oidc cluster")
+				}
+
 				By("Retrieve oidc config from cluster config")
 				clusterID = config.GetClusterID()
 				oidcConfigC = clusterConfig.Aws.Sts.OidcConfigID

--- a/tests/e2e/test_rosacli_operator_roles.go
+++ b/tests/e2e/test_rosacli_operator_roles.go
@@ -30,6 +30,8 @@ var _ = Describe("Edit operator roles", labels.Feature.OperatorRoles, func() {
 		rosaClient             *rosacli.Client
 		ocmResourceService     rosacli.OCMResourceService
 		permissionsBoundaryArn string = "arn:aws:iam::aws:policy/AdministratorAccess"
+		clusterConfig          *config.ClusterConfig
+		err                    error
 	)
 	BeforeEach(func() {
 		By("Init the client")
@@ -50,6 +52,10 @@ var _ = Describe("Edit operator roles", labels.Feature.OperatorRoles, func() {
 
 			By("Get the default dir")
 			defaultDir = rosaClient.Runner.GetDir()
+
+			By("Get cluster config")
+			clusterConfig, err = config.ParseClusterProfile()
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		AfterEach(func() {
@@ -105,6 +111,7 @@ var _ = Describe("Edit operator roles", labels.Feature.OperatorRoles, func() {
 				output, err = ocmResourceService.DeleteOIDCConfig(
 					"--oidc-config-id", oidcConfigID,
 					"--mode", "auto",
+					"--region", clusterConfig.Region,
 					"-y",
 				)
 				Expect(err).To(HaveOccurred())
@@ -114,6 +121,7 @@ var _ = Describe("Edit operator roles", labels.Feature.OperatorRoles, func() {
 				output, err = ocmResourceService.DeleteOIDCConfig(
 					"--oidc-config-id", oidcConfigID,
 					"--mode", "manual",
+					"--region", clusterConfig.Region,
 					"-y",
 				)
 				Expect(err).To(HaveOccurred())


### PR DESCRIPTION
60688: the cluster version was not syncronized to ‘rosa describe cluster’ output, will enhance it to get the cluster version from the cluster config;
And it should skip to recover the role for HCP in AfterEach;
And change the domain-prefix in the dry-run command
59530: It should skip on NON-STS and NON-BYO-OIDC jobs, will fix later
74761: It failed as the region is not the aws default configured one, will fix by add region on `rosa delete oidc-config`

the log is here https://privatebin.corp.redhat.com/?45d42710aee1b787#A8cfxNR8vRxSUNneP4y7onD8vWM1sSvHbqTfpaxxrwXV