### PR TITLE
OSDOCS-11559 | docs: Add example for enabling UWM day-2

### DIFF
--- a/cmd/edit/cluster/cmd.go
+++ b/cmd/edit/cluster/cmd.go
@@ -66,6 +66,9 @@ var Cmd = &cobra.Command{
 	Example: `  # Edit a cluster named "mycluster" to make it private
   rosa edit cluster -c mycluster --private
 
+  # Edit a cluster named "mycluster" to enable User Workload Monitoring
+  rosa edit cluster -c mycluster --disable-workload-monitoring=false
+
   # Edit all options interactively
   rosa edit cluster -c mycluster --interactive`,
 	Run:  run,


### PR DESCRIPTION
There was confusion around how to use this boolean flag and some users believed that it could only be disabled.

[OSDOCS-11559](https://issues.redhat.com//browse/OSDOCS-11559)