### PR TITLE
OCM-10175 | test: fix id:67057

### DIFF
--- a/tests/e2e/test_rosacli_machine_pool.go
+++ b/tests/e2e/test_rosacli_machine_pool.go
@@ -798,7 +798,7 @@ var _ = Describe("Create machinepool",
 					)
 					Expect(err).To(HaveOccurred())
 					Expect(output.String()).Should(
-						ContainSubstring("Unrecognized taint effect 'Invalid'," +
+						ContainSubstring("Invalid taint effect 'Invalid'," +
 							" only the following effects are supported: 'NoExecute', 'NoSchedule', 'PreferNoSchedule'"))
 
 				})


### PR DESCRIPTION
[OCM-10175](https://issues.redhat.com//browse/OCM-10175) 
$ ginkgo --focus 67057 tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.11.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: ROSA CLI e2e tests suite - /home/akanni/OCP-Repository/rosa/tests/e2e
====================================================================================
Random Seed: 1722922393

Will run 1 of 168 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 168 Specs in 38.040 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 167 Skipped
PASS

Ginkgo ran 1 suite in 41.525803996s
Test Suite Passed
