### PR TITLE
OCM-10195 | fix: cmd/version arguments not being passed

### DIFF
--- a/cmd/version/cmd.go
+++ b/cmd/version/cmd.go
@@ -58,7 +58,7 @@ func NewRosaVersionCommand() *cobra.Command {
 	return cmd
 }
 
-func RosaVersionRunner(userOptions RosaVersionUserOptions) rosa.CommandRunner {
+func RosaVersionRunner(userOptions *RosaVersionUserOptions) rosa.CommandRunner {
 	return func(_ context.Context, _ *rosa.Runtime, _ *cobra.Command, _ []string) error {
 		options, err := NewRosaVersionOptions()
 		if err != nil {

--- a/cmd/version/cmd_test.go
+++ b/cmd/version/cmd_test.go
@@ -46,7 +46,7 @@ var _ = Describe("RosaVersionOptions", func() {
 				verifyRosa: mockVerify,
 				reporter:   rpt,
 
-				args: RosaVersionUserOptions{
+				args: &RosaVersionUserOptions{
 					clientOnly: false,
 				},
 			}
@@ -87,7 +87,7 @@ var _ = Describe("RosaVersionOptions", func() {
 				verifyRosa: mockVerify,
 				reporter:   rpt,
 
-				args: RosaVersionUserOptions{
+				args: &RosaVersionUserOptions{
 					clientOnly: true,
 				},
 			}
@@ -114,7 +114,7 @@ var _ = Describe("RosaVersionOptions", func() {
 				verifyRosa: mockVerify,
 				reporter:   rpt,
 
-				args: RosaVersionUserOptions{
+				args: &RosaVersionUserOptions{
 					clientOnly: true,
 					verbose:    true,
 				},

--- a/cmd/version/options.go
+++ b/cmd/version/options.go
@@ -14,15 +14,15 @@ type RosaVersionUserOptions struct {
 	verbose    bool
 }
 
-func NewRosaVersionUserOptions() RosaVersionUserOptions {
-	return RosaVersionUserOptions{}
+func NewRosaVersionUserOptions() *RosaVersionUserOptions {
+	return &RosaVersionUserOptions{}
 }
 
 type RosaVersionOptions struct {
 	reporter   *reporter.Object
 	verifyRosa verify.VerifyRosa
 
-	args RosaVersionUserOptions
+	args *RosaVersionUserOptions
 }
 
 func NewRosaVersionOptions() (*RosaVersionOptions, error) {
@@ -55,7 +55,6 @@ func (o *RosaVersionOptions) Version() error {
 	return nil
 }
 
-func (o *RosaVersionOptions) BindAndValidate(options RosaVersionUserOptions) {
-	o.args.verbose = options.verbose
-	o.args.clientOnly = options.clientOnly
+func (o *RosaVersionOptions) BindAndValidate(options *RosaVersionUserOptions) {
+	o.args = options
 }

--- a/cmd/version/options_test.go
+++ b/cmd/version/options_test.go
@@ -24,16 +24,16 @@ var _ = Describe("RosaVersionOptions", func() {
 					verbose:    true,
 					clientOnly: true,
 				}
-				o.BindAndValidate(userOptions)
-				Expect(o.args).To(Equal(expectedArgs))
+				o.BindAndValidate(&userOptions)
+				Expect(o.args).To(Equal(&expectedArgs))
 			})
 		})
 
 		When("empty options are provided", func() {
 			It("should not change the default options", func() {
 				o = &RosaVersionOptions{}
-				o.BindAndValidate(RosaVersionUserOptions{})
-				Expect(o.args).To(Equal(RosaVersionUserOptions{}))
+				o.BindAndValidate(&RosaVersionUserOptions{})
+				Expect(o.args).To(Equal(&RosaVersionUserOptions{}))
 			})
 		})
 	})


### PR DESCRIPTION
The `--client` and `--verbose` arguments currently do nothing as they are always evaluated as `false`

When executing *rosa version* he *--client* and *--verbose* arguments do nothing as they are always evaluated as *false*

**Current**
```sh
# ./rosa version --verbose
I: 1.2.43
I: Your ROSA CLI is up to date.

# ./rosa version --client 
I: 1.2.43
I: Your ROSA CLI is up to date.
```


**Expected**
```sh
# ./rosa version --verbose
I: 1.2.43
I: Information and download locations:
	https://console.redhat.com/openshift/downloads#tool-rosa
	https://mirror.openshift.com/pub/openshift-v4/clients/rosa/latest/

I: Your ROSA CLI is up to date.

# ./rosa version --client 
I: 1.2.43
```


This PR fixes the issue