### PR TITLE
OCM-9974 | fix: Change options validations to allow 0 min replicas as well

### DIFF
--- a/cmd/edit/machinepool/options.go
+++ b/cmd/edit/machinepool/options.go
@@ -64,11 +64,11 @@ func (m *EditMachinepoolOptions) Bind(args *EditMachinepoolUserOptions, argv []s
 	}
 
 	if m.args.autoscalingEnabled {
-		if m.args.minReplicas <= 0 {
-			return fmt.Errorf("Min replicas must be greater than zero when autoscaling is enabled")
+		if m.args.minReplicas < 0 {
+			return fmt.Errorf("Min replicas must be a number that is 0 or greater when autoscaling is enabled")
 		}
-		if m.args.maxReplicas <= 0 {
-			return fmt.Errorf("Max replicas must be greater than zero when autoscaling is enabled")
+		if m.args.maxReplicas < 0 {
+			return fmt.Errorf("Max replicas must be a number that is 0 or greater when autoscaling is enabled")
 		}
 		if m.args.minReplicas > m.args.maxReplicas {
 			return fmt.Errorf("Min replicas must be less than max replicas")

--- a/cmd/edit/machinepool/options_test.go
+++ b/cmd/edit/machinepool/options_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Test edit machinepool options", func() {
 			args.autoscalingEnabled = true
 			args.machinepool = "test"
 			err := options.Bind(args, []string{})
-			Expect(err).To(MatchError("Min replicas must be greater than zero when autoscaling is enabled"))
+			Expect(err).To(MatchError("Min replicas must be a number that is 0 or greater when autoscaling is enabled"))
 		})
 		It("Test max replicas negative value (fail)", func() {
 			args.maxReplicas = -1
@@ -65,7 +65,7 @@ var _ = Describe("Test edit machinepool options", func() {
 			args.autoscalingEnabled = true
 			args.machinepool = "test"
 			err := options.Bind(args, []string{})
-			Expect(err).To(MatchError("Max replicas must be greater than zero when autoscaling is enabled"))
+			Expect(err).To(MatchError("Max replicas must be a number that is 0 or greater when autoscaling is enabled"))
 		})
 		It("Test min replicas > max replicas (fail)", func() {
 			args.maxReplicas = 1


### PR DESCRIPTION
In the fix for [OCM-9974](https://issues.redhat.com//browse/OCM-9974), I had forgotten to also fix the options validations. This change is included here + updated tests