### PR TITLE
OCM-10263 | ci: fix id:57094

### DIFF
--- a/tests/e2e/test_rosacli_upgrade.go
+++ b/tests/e2e/test_rosacli_upgrade.go
@@ -356,7 +356,7 @@ var _ = Describe("Describe/List rosa upgrade",
 		})
 
 		It("to list/describe rosa upgrade via ROSA CLI - [id:57094]",
-			labels.High, labels.Runtime.Day2,
+			labels.High, labels.Runtime.Day2, labels.Runtime.Upgrade,
 			func() {
 				By("Check the help message of 'rosa describe upgrade -h'")
 				output, err := upgradeService.DescribeUpgrade(clusterID, "-h")
@@ -436,7 +436,7 @@ var _ = Describe("Describe/List rosa upgrade",
 					By("Check list upgrade")
 					out, err := upgradeService.ListUpgrades(clusterID)
 					Expect(err).To(BeNil())
-					Expect(out.String()).To(ContainSubstring("%s  scheduled for %s %s UTC", upgradingVersion,
+					Expect(out.String()).To(ContainSubstring("%s   recommended - scheduled for %s %s UTC", upgradingVersion,
 						scheduledDate, scheduledTime))
 
 					By("Check describe upgrade")


### PR DESCRIPTION
`$ ginkgo --focus 57094 tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.14.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: ROSA CLI e2e tests suite - /home/aaraj/ocm-forked-code/rosa/tests/e2e
====================================================================================
Random Seed: 1723102580

Will run 1 of 168 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 168 Specs in 167.446 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 167 Skipped
PASS

Ginkgo ran 1 suite in 3m3.617026034s
Test Suite Passed
`