### PR TITLE
OCM-10266 | test: automate ids:75504,57410  Create/Delete cluster and…

### DIFF
--- a/tests/utils/common/constants/general.go
+++ b/tests/utils/common/constants/general.go
@@ -4,6 +4,7 @@ const (
 	Yes                    = "Yes"
 	No                     = "No"
 	YStreamPreviousVersion = "y-1"
+	TrueString             = "true"
 )
 
 // Ec2MetadataHttpTokens for hcp cluster


### PR DESCRIPTION
[OCM-10266](https://issues.redhat.com//browse/OCM-10266) | test: automate ids:75504,57410  Create/Delete cluster and operator-roles attaching managed policies

logs: https://privatebin.corp.redhat.com/?49ebaaa64d019a32#3CRB4Kv3RkVyFrqYfkhRgiayY2dyHhn8vF3TLge27nKg