### PR TITLE
OCM-10298 | ci: fix id:73391,65160

### DIFF
--- a/tests/e2e/test_rosacli_idp.go
+++ b/tests/e2e/test_rosacli_idp.go
@@ -778,8 +778,6 @@ var _ = Describe("Edit IDP",
 						Expect(err).To(BeNil())
 						textData = rosaClient.Parser.TextData.Input(output).Parse().Tip()
 						Expect(textData).Should(ContainSubstring("Identity Provider '%s' has been created", idpNames[1]))
-						Expect(textData).Should(ContainSubstring("To log in to the console, open"))
-						Expect(textData).Should(ContainSubstring("and click on '%s'", idpNames[1]))
 
 						By("List IDPs")
 						idpTab, _, err := idpService.ListIDP(clusterID)
@@ -825,8 +823,6 @@ var _ = Describe("Edit IDP",
 						Expect(err).To(BeNil())
 						textData := rosaClient.Parser.TextData.Input(output).Parse().Tip()
 						Expect(textData).Should(ContainSubstring("Identity Provider '%s' has been created", idpNames[0]))
-						Expect(textData).Should(ContainSubstring("To log in to the console, open"))
-						Expect(textData).Should(ContainSubstring("and click on '%s'", idpNames[0]))
 
 						By("Create htpasswd idp with --users flag")
 						output, err = idpService.CreateIDP(clusterID, idpNames[1],

--- a/tests/e2e/test_rosacli_node_pool.go
+++ b/tests/e2e/test_rosacli_node_pool.go
@@ -947,7 +947,7 @@ var _ = Describe("Edit nodepool",
 				Expect(err).To(HaveOccurred())
 				Expect(rosaClient.Parser.TextData.Input(output).Parse().Tip()).
 					To(ContainSubstring(
-						"The number of machine pool replicas needs to be a non-negative integer"))
+						"ERR: Failed to get autoscaling or replicas: 'Replicas must be a non-negative number'"))
 
 				By("Try to edit the machinepool with --min-replicas flag when autoscaling is disabled for the machinepool.")
 				output, err = machinePoolService.EditMachinePool(clusterID, machinepoolName, "--min-replicas", "2")
@@ -986,7 +986,8 @@ var _ = Describe("Edit nodepool",
 				Expect(err).To(HaveOccurred())
 				Expect(rosaClient.Parser.TextData.Input(output).Parse().Tip()).
 					To(ContainSubstring(
-						"The number of machine pool min-replicas needs to be greater than zero"))
+						"ERR: Failed to get autoscaling or replicas: " +
+							"'Min replicas must be a non-negative number when autoscaling is set'"))
 
 				By("Try to edit machinepool with --replicas flag when the autoscaling is enabled for the machinepool.")
 				output, err = machinePoolService.EditMachinePool(clusterID, machinepoolName, "--replicas", "3")


### PR DESCRIPTION
`$ ginkgo --focus "(73391|65160)" tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.14.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: ROSA CLI e2e tests suite - /home/aaraj/ocm-forked-code/rosa/tests/e2e
====================================================================================
Random Seed: 1723184195

Will run 3 of 170 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS••SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 3 of 170 Specs in 167.390 seconds
SUCCESS! -- 3 Passed | 0 Failed | 0 Pending | 167 Skipped
PASS

Ginkgo ran 1 suite in 2m55.978107722s
Test Suite Passed
`