### PR TITLE
OCM-10300 | test: fix ids:57105,65798

### DIFF
--- a/tests/e2e/test_rosacli_ingress.go
+++ b/tests/e2e/test_rosacli_ingress.go
@@ -259,8 +259,9 @@ var _ = Describe("Edit default ingress",
 				defaultIngressInArrayForm := "[" + defaultIngressInArrayFormList[0] + ", " + defaultIngressInArrayFormList[1] + "]"
 				Expect(ingress.ExcludeNamespace).To(Equal(defaultIngressInArrayForm))
 				defaultIngressRouteSelectorList := strings.Split(ingressConfig.DefaultIngressRouteSelector, ",")
-				defaultIngressRouteSelector := defaultIngressRouteSelectorList[0] + ", " + defaultIngressRouteSelectorList[1]
-				Expect(ingress.RouteSelectors).To(Equal(defaultIngressRouteSelector))
+				defaultIngressRouteSelector_1 := defaultIngressRouteSelectorList[1] + ", " + defaultIngressRouteSelectorList[0]
+				defaultIngressRouteSelector_2 := defaultIngressRouteSelectorList[0] + ", " + defaultIngressRouteSelectorList[1]
+				Expect(ingress.RouteSelectors).To(Or(Equal(defaultIngressRouteSelector_1), Equal(defaultIngressRouteSelector_2)))
 				Expect(ingress.NamespaceOwnershipPolicy).To(Equal(ingressConfig.DefaultIngressNamespaceOwnershipPolicy))
 				Expect(ingress.WildcardPolicy).To(Equal(ingressConfig.DefaultIngressWildcardPolicy))
 			})

--- a/tests/e2e/test_rosacli_machine_pool.go
+++ b/tests/e2e/test_rosacli_machine_pool.go
@@ -1215,7 +1215,8 @@ var _ = Describe("Edit machinepool",
 				)
 				Expect(err).To(HaveOccurred())
 				Expect(output.String()).Should(
-					ContainSubstring("Taint at index 0 is incorrect: Unrecognized taint effect"))
+					ContainSubstring("Invalid taint effect 'InvalidEffect'," +
+						" only the following effects are supported: 'NoExecute', 'NoSchedule', 'PreferNoSchedule'"))
 
 				By("Remove other machinepools to make sure there is only workers left")
 				mpList, err := machinePoolService.ListAndReflectMachinePools(clusterID)


### PR DESCRIPTION
OCM-10300

$ ginkgo --focus "(57105|65798)" tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.11.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: ROSA CLI e2e tests suite - /home/akanni/OCP-Repository/rosa/tests/e2e
====================================================================================
Random Seed: 1723195585

Will run 2 of 172 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 2 of 172 Specs in 32.456 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 170 Skipped
PASS

Ginkgo ran 1 suite in 36.872945311s
Test Suite Passed
