### PR TITLE
OCM-10303 | feat: unhide no-cni flag at cluster creation

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -737,7 +737,6 @@ func initFlags(cmd *cobra.Command) {
 		false,
 		"Disable CNI creation to let users bring their own CNI.",
 	)
-	flags.MarkHidden("no-cni")
 
 	flags.StringVar(
 		&args.clusterAdminUser,


### PR DESCRIPTION
Unhide the flag as the feature is ready for release

Related: [OCM-10303](https://issues.redhat.com//browse/OCM-10303)