### PR TITLE
OCM-6419 | feat: Move fetching thumbprint from ROSA to backend

### DIFF
--- a/pkg/ocm/oidc_config.go
+++ b/pkg/ocm/oidc_config.go
@@ -64,3 +64,11 @@ func (c *Client) DeleteOidcConfig(id string) error {
 	}
 	return nil
 }
+
+func (c *Client) FetchOidcThumbprint(oidcConfigInput *cmv1.OidcThumbprintInput) (*cmv1.OidcThumbprint, error) {
+	response, err := c.ocm.ClustersMgmt().V1().AWSInquiries().OidcThumbprint().Post().Body(oidcConfigInput).Send()
+	if err != nil {
+		return nil, handleErr(response.Error(), err)
+	}
+	return response.Body(), nil
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-6419

Replaces ROSA based fetching for thumbprint with backend (CS) API calls to circumvent inability to fetch thumbprints when users use a proxy