### PR TITLE
OCM-10331 | ci: fix id:72174,75527

### DIFF
--- a/tests/e2e/test_rosacli_cluster_post.go
+++ b/tests/e2e/test_rosacli_cluster_post.go
@@ -477,7 +477,7 @@ var _ = Describe("Healthy check",
 				if isAutoscale {
 					Expect(jsonData.DigString("nodes", "autoscale_compute")).ToNot(BeNil())
 				} else {
-					Expect(jsonData.DigString("nodes", "autoscale_compute")).To(BeNil())
+					Expect(jsonData.DigString("nodes", "autoscale_compute")).To(BeEmpty())
 				}
 			})
 

--- a/tests/e2e/test_rosacli_machine_pool.go
+++ b/tests/e2e/test_rosacli_machine_pool.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -26,13 +25,12 @@ var _ = Describe("Create machinepool",
 	func() {
 		defer GinkgoRecover()
 		var (
-			clusterID              string
-			rosaClient             *rosacli.Client
-			machinePoolService     rosacli.MachinePoolService
-			ocmResourceService     rosacli.OCMResourceService
-			clusterConfig          *config.ClusterConfig
-			profile                *ph.Profile
-			permissionsBoundaryArn string = "arn:aws:iam::aws:policy/AdministratorAccess"
+			clusterID          string
+			rosaClient         *rosacli.Client
+			machinePoolService rosacli.MachinePoolService
+			ocmResourceService rosacli.OCMResourceService
+			clusterConfig      *config.ClusterConfig
+			profile            *ph.Profile
 		)
 
 		BeforeEach(func() {
@@ -241,48 +239,6 @@ var _ = Describe("Create machinepool",
 					}
 					Expect(availableMachineTypesIDs).To(ContainElements(newlyAddedTypes))
 				}
-			})
-
-		It("List instance-types with region flag - [id:72174]",
-			labels.Low, labels.Runtime.OCMResources,
-			func() {
-				By("List the available instance-types with the region flag")
-				typesList := []string{"dl1.24xlarge", "g4ad.16xlarge", "c5.xlarge"}
-				region := "us-west-2"
-				accountRolePrefix := fmt.Sprintf("QEAuto-accr72174-%s", time.Now().UTC().Format("20060102"))
-				_, err := ocmResourceService.CreateAccountRole("--mode", "auto",
-					"--prefix", accountRolePrefix,
-					"--permissions-boundary", permissionsBoundaryArn,
-					"-y")
-				Expect(err).To(BeNil())
-				defer ocmResourceService.DeleteAccountRole("--mode", "auto", "--prefix", accountRolePrefix, "-y")
-
-				accountRoleList, _, err := ocmResourceService.ListAccountRole()
-				Expect(err).To(BeNil())
-				classicInstallerRoleArn := accountRoleList.InstallerRole(accountRolePrefix, false).RoleArn
-				availableMachineTypes, _, err := ocmResourceService.ListInstanceTypes(
-					"--region", region, "--role-arn", classicInstallerRoleArn)
-				Expect(err).To(BeNil())
-				var availableMachineTypesIDs []string
-				for _, it := range availableMachineTypes.InstanceTypesList {
-					availableMachineTypesIDs = append(availableMachineTypesIDs, it.ID)
-				}
-				Expect(availableMachineTypesIDs).To(ContainElements(typesList))
-
-				By("List the available instance-types with the region flag and hosted-cp flag")
-				availableMachineTypes, _, err = ocmResourceService.ListInstanceTypes(
-					"--region", region, "--role-arn", classicInstallerRoleArn, "--hosted-cp")
-				Expect(err).To(BeNil())
-				for _, it := range availableMachineTypes.InstanceTypesList {
-					availableMachineTypesIDs = append(availableMachineTypesIDs, it.ID)
-				}
-				Expect(availableMachineTypesIDs).To(ContainElements(typesList))
-
-				By("Try to list instance-types with invalid region")
-				availableMachineTypes, output, err := ocmResourceService.ListInstanceTypes(
-					"--region", "xxx", "--role-arn", classicInstallerRoleArn)
-				Expect(err).To(HaveOccurred())
-				Expect(output.String()).Should(ContainSubstring("ERR: Unsupported region 'xxx', available regions"))
 			})
 
 		It("can create spot machinepool - [id:43251]",

--- a/tests/e2e/test_rosacli_region.go
+++ b/tests/e2e/test_rosacli_region.go
@@ -1,6 +1,9 @@
 package e2e
 
 import (
+	"fmt"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -14,8 +17,9 @@ var _ = Describe("Region",
 		defer GinkgoRecover()
 
 		var (
-			rosaClient         *rosacli.Client
-			ocmResourceService rosacli.OCMResourceService
+			rosaClient             *rosacli.Client
+			ocmResourceService     rosacli.OCMResourceService
+			permissionsBoundaryArn string = "arn:aws:iam::aws:policy/AdministratorAccess"
 		)
 
 		BeforeEach(func() {
@@ -42,5 +46,47 @@ var _ = Describe("Region",
 				for _, r := range usersTabH {
 					Expect(r.MultiAZSupported).To(Equal("true"))
 				}
+			})
+
+		It("List instance-types with region flag - [id:72174]",
+			labels.Low, labels.Runtime.OCMResources,
+			func() {
+				By("List the available instance-types with the region flag")
+				typesList := []string{"dl1.24xlarge", "g4ad.16xlarge", "c5.xlarge"}
+				region := "us-west-2"
+				accountRolePrefix := fmt.Sprintf("QEAuto-accr72174-%s", time.Now().UTC().Format("20060102"))
+				_, err := ocmResourceService.CreateAccountRole("--mode", "auto",
+					"--prefix", accountRolePrefix,
+					"--permissions-boundary", permissionsBoundaryArn,
+					"-y")
+				Expect(err).To(BeNil())
+				defer ocmResourceService.DeleteAccountRole("--mode", "auto", "--prefix", accountRolePrefix, "-y")
+
+				accountRoleList, _, err := ocmResourceService.ListAccountRole()
+				Expect(err).To(BeNil())
+				classicInstallerRoleArn := accountRoleList.InstallerRole(accountRolePrefix, false).RoleArn
+				availableMachineTypes, _, err := ocmResourceService.ListInstanceTypes(
+					"--region", region, "--role-arn", classicInstallerRoleArn)
+				Expect(err).To(BeNil())
+				var availableMachineTypesIDs []string
+				for _, it := range availableMachineTypes.InstanceTypesList {
+					availableMachineTypesIDs = append(availableMachineTypesIDs, it.ID)
+				}
+				Expect(availableMachineTypesIDs).To(ContainElements(typesList))
+
+				By("List the available instance-types with the region flag and hosted-cp flag")
+				availableMachineTypes, _, err = ocmResourceService.ListInstanceTypes(
+					"--region", region, "--role-arn", classicInstallerRoleArn, "--hosted-cp")
+				Expect(err).To(BeNil())
+				for _, it := range availableMachineTypes.InstanceTypesList {
+					availableMachineTypesIDs = append(availableMachineTypesIDs, it.ID)
+				}
+				Expect(availableMachineTypesIDs).To(ContainElements(typesList))
+
+				By("Try to list instance-types with invalid region")
+				availableMachineTypes, output, err := ocmResourceService.ListInstanceTypes(
+					"--region", "xxx", "--role-arn", classicInstallerRoleArn)
+				Expect(err).To(HaveOccurred())
+				Expect(output.String()).Should(ContainSubstring("ERR: Unsupported region 'xxx', available regions"))
 			})
 	})


### PR DESCRIPTION
`$ ginkgo --focus "(75527|72174)" tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.14.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: ROSA CLI e2e tests suite - /home/aaraj/ocm-forked-code/rosa/tests/e2e
====================================================================================
Random Seed: 1723438779

Will run 2 of 179 specs
SSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 2 of 179 Specs in 177.123 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 177 Skipped
PASS

Ginkgo ran 1 suite in 3m5.296155891s
Test Suite Passed
`