### PR TITLE
OCM-10374 | fix: Add Limited Support Reason Override support

### DIFF
--- a/pkg/ocm/limited_support.go
+++ b/pkg/ocm/limited_support.go
@@ -12,9 +12,11 @@ func (c *Client) GetLimitedSupportReasons(clusterID string) (
 		LimitedSupportReasons()
 	page := 1
 	size := 100
+	search := "override_enabled='f'"
 	for {
 		response, err := collection.List().
 			Page(page).
+			Parameter("search", search).
 			Size(size).
 			Send()
 		if err != nil {


### PR DESCRIPTION
Right now we have new override parameters in the LSR so we can keep the LSR visible to the SRE but it can be overriden when there is support exception. The cluster status shows only active LSR, without the override.

Depends on: https://github.com/openshift/rosa/pull/2350