### PR TITLE
OCM-7551 | feat: output content of trust policy attached to a role

### DIFF
--- a/cmd/create/accountroles/creators.go
+++ b/cmd/create/accountroles/creators.go
@@ -88,7 +88,7 @@ func (mp *managedPoliciesCreator) createRoles(r *rosa.Runtime, input *accountRol
 		r.Reporter.Debugf("Creating role '%s'", accRoleName)
 		tagsList := mp.getRoleTags(file, input)
 		r.Reporter.Debugf("start to EnsureRole")
-		roleARN, err := r.AWSClient.EnsureRole(accRoleName, assumeRolePolicy, input.permissionsBoundary,
+		roleARN, err := r.AWSClient.EnsureRole(r.Reporter, accRoleName, assumeRolePolicy, input.permissionsBoundary,
 			input.defaultPolicyVersion, tagsList, input.path, true)
 		if err != nil {
 			return err
@@ -268,7 +268,7 @@ func (db *doubleRolesCreator) getAccountRolesMap() map[string]aws.AccountRole {
 func createRoleUnmanagedPolicy(r *rosa.Runtime, input *accountRolesCreationInput, accRoleName string,
 	assumeRolePolicy string, tagsList map[string]string, filename string) error {
 	r.Reporter.Debugf("Creating role '%s'", accRoleName)
-	roleARN, err := r.AWSClient.EnsureRole(accRoleName, assumeRolePolicy, input.permissionsBoundary,
+	roleARN, err := r.AWSClient.EnsureRole(r.Reporter, accRoleName, assumeRolePolicy, input.permissionsBoundary,
 		input.defaultPolicyVersion, tagsList, input.path, false)
 	if err != nil {
 		return err
@@ -315,7 +315,7 @@ func (hcp *hcpManagedPoliciesCreator) createRoles(r *rosa.Runtime, input *accoun
 
 		r.Reporter.Debugf("Creating role '%s'", accRoleName)
 		tagsList := hcp.getRoleTags(file, input)
-		roleARN, err := r.AWSClient.EnsureRole(accRoleName, assumeRolePolicy, input.permissionsBoundary,
+		roleARN, err := r.AWSClient.EnsureRole(r.Reporter, accRoleName, assumeRolePolicy, input.permissionsBoundary,
 			input.defaultPolicyVersion, tagsList, input.path, true)
 		if err != nil {
 			return err

--- a/cmd/create/ocmrole/cmd.go
+++ b/cmd/create/ocmrole/cmd.go
@@ -482,7 +482,7 @@ func createRoles(r *rosa.Runtime, prefix string, roleName string, rolePath strin
 	if !exists {
 		r.Reporter.Debugf("Creating role '%s'", roleName)
 
-		roleARN, err = r.AWSClient.EnsureRole(roleName, policy, permissionsBoundary,
+		roleARN, err = r.AWSClient.EnsureRole(r.Reporter, roleName, policy, permissionsBoundary,
 			"", iamTags, rolePath, false)
 		if err != nil {
 			return "", err

--- a/cmd/create/operatorroles/by_clusterkey.go
+++ b/cmd/create/operatorroles/by_clusterkey.go
@@ -253,7 +253,7 @@ func createRoles(
 			tagsList[tags.HypershiftPolicies] = helper.True
 		}
 
-		roleARN, err := r.AWSClient.EnsureRole(roleName, policy, permissionsBoundary, accountRoleVersion,
+		roleARN, err := r.AWSClient.EnsureRole(r.Reporter, roleName, policy, permissionsBoundary, accountRoleVersion,
 			tagsList, path, managedPolicies)
 		if err != nil {
 			return err

--- a/cmd/create/operatorroles/by_prefix.go
+++ b/cmd/create/operatorroles/by_prefix.go
@@ -372,7 +372,7 @@ func createRolesByPrefix(r *rosa.Runtime, prefix string, permissionsBoundary str
 			tagsList[tags.HypershiftPolicies] = helper.True
 		}
 
-		roleARN, err := r.AWSClient.EnsureRole(roleName, policy, permissionsBoundary, defaultPolicyVersion,
+		roleARN, err := r.AWSClient.EnsureRole(r.Reporter, roleName, policy, permissionsBoundary, defaultPolicyVersion,
 			tagsList, path, managedPolicies)
 		if err != nil {
 			return err

--- a/cmd/create/userrole/cmd.go
+++ b/cmd/create/userrole/cmd.go
@@ -297,7 +297,7 @@ func createRoles(r *rosa.Runtime,
 		return roleARN, nil
 	}
 	r.Reporter.Debugf("Creating role '%s'", roleName)
-	roleARN, err = r.AWSClient.EnsureRole(roleName, policy, permissionsBoundary,
+	roleARN, err = r.AWSClient.EnsureRole(r.Reporter, roleName, policy, permissionsBoundary,
 		"", map[string]string{
 			tags.RolePrefix:    prefix,
 			tags.RoleType:      aws.OCMUserRole,

--- a/cmd/install/addon/cmd.go
+++ b/cmd/install/addon/cmd.go
@@ -314,7 +314,7 @@ func createAddonRole(r *rosa.Runtime, roleName string, cr *cmv1.CredentialReques
 
 	r.Reporter.Debugf("Creating role '%s'", roleName)
 
-	roleARN, err := r.AWSClient.EnsureRole(roleName, assumePolicy, "", "",
+	roleARN, err := r.AWSClient.EnsureRole(r.Reporter, roleName, assumePolicy, "", "",
 		map[string]string{
 			tags.ClusterID:    cluster.ID(),
 			"addon_namespace": cr.Namespace(),

--- a/cmd/upgrade/roles/cmd.go
+++ b/cmd/upgrade/roles/cmd.go
@@ -1089,7 +1089,7 @@ func upgradeMissingOperatorRole(
 			return err
 		}
 		r.Reporter.Debugf("Creating role '%s'", roleName)
-		roleARN, err := r.AWSClient.EnsureRole(roleName, policy, "", "",
+		roleARN, err := r.AWSClient.EnsureRole(r.Reporter, roleName, policy, "", "",
 			map[string]string{
 				tags.ClusterID:         cluster.ID(),
 				tags.OperatorNamespace: operator.Namespace(),

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -119,7 +119,7 @@ type Client interface {
 	ValidateQuota() (bool, error)
 	TagUserRegion(username string, region string) error
 	GetClusterRegionTagForUser(username string) (string, error)
-	EnsureRole(name string, policy string, permissionsBoundary string,
+	EnsureRole(reporter *reporter.Object, name string, policy string, permissionsBoundary string,
 		version string, tagList map[string]string, path string, managedPolicies bool) (string, error)
 	ValidateRoleNameAvailable(name string) (err error)
 	PutRolePolicy(roleName string, policyName string, policy string) error

--- a/pkg/aws/client_mock.go
+++ b/pkg/aws/client_mock.go
@@ -377,18 +377,18 @@ func (mr *MockClientMockRecorder) EnsurePolicy(policyArn, document, version, tag
 }
 
 // EnsureRole mocks base method.
-func (m *MockClient) EnsureRole(name, policy, permissionsBoundary, version string, tagList map[string]string, path string, managedPolicies bool) (string, error) {
+func (m *MockClient) EnsureRole(reporter *reporter.Object, name, policy, permissionsBoundary, version string, tagList map[string]string, path string, managedPolicies bool) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureRole", name, policy, permissionsBoundary, version, tagList, path, managedPolicies)
+	ret := m.ctrl.Call(m, "EnsureRole", reporter, name, policy, permissionsBoundary, version, tagList, path, managedPolicies)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // EnsureRole indicates an expected call of EnsureRole.
-func (mr *MockClientMockRecorder) EnsureRole(name, policy, permissionsBoundary, version, tagList, path, managedPolicies any) *gomock.Call {
+func (mr *MockClientMockRecorder) EnsureRole(reporter, name, policy, permissionsBoundary, version, tagList, path, managedPolicies any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureRole", reflect.TypeOf((*MockClient)(nil).EnsureRole), name, policy, permissionsBoundary, version, tagList, path, managedPolicies)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureRole", reflect.TypeOf((*MockClient)(nil).EnsureRole), reporter, name, policy, permissionsBoundary, version, tagList, path, managedPolicies)
 }
 
 // FetchPublicSubnetMap mocks base method.

--- a/pkg/helper/roles/helpers.go
+++ b/pkg/helper/roles/helpers.go
@@ -266,7 +266,7 @@ func upgradeMissingOperatorRole(missingRoles map[string]*cmv1.STSOperator, clust
 			tagsList[awsCommonValidations.ManagedPolicies] = "true"
 		}
 		r.Reporter.Debugf("Creating role '%s'", roleName)
-		roleARN, err := r.AWSClient.EnsureRole(roleName, policy, "", "",
+		roleARN, err := r.AWSClient.EnsureRole(r.Reporter, roleName, policy, "", "",
 			tagsList, unifiedPath, false)
 		if err != nil {
 			return err


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-7551

sample output when creating account-roles
```
I: Creating classic account roles using 'arn:aws:iam::765374464689:user/llan@redhat.com'
I: Attached trust policy to role 'test-Support-Role': {"Version": "2012-10-17", "Statement": [{"Action": ["sts:AssumeRole"], "Effect": "Allow", "Principal": {"AWS": ["arn:aws:iam::644306948063:role/RH-Technical-Support-12541229"]}}]}
I: Created role 'test-Support-Role' with ARN 'arn:aws:iam::765374464689:role/test-Support-Role'
I: Attached policy 'arn:aws:iam::765374464689:policy/test-Support-Role-Policy' to role 'test-Support-Role'

I: Attached trust policy to role 'test-Installer-Role': {"Version": "2012-10-17", "Statement": [{"Action": ["sts:AssumeRole"], "Effect": "Allow", "Principal": {"AWS": ["arn:aws:iam::644306948063:role/RH-Managed-OpenShift-Installer"]}}]}
I: Created role 'test-Installer-Role' with ARN 'arn:aws:iam::765374464689:role/test-Installer-Role'
I: Attached policy 'arn:aws:iam::765374464689:policy/test-Installer-Role-Policy' to role 'test-Installer-Role'

I: Attached trust policy to role 'test-ControlPlane-Role': {"Version": "2012-10-17", "Statement": [{"Action": ["sts:AssumeRole"], "Effect": "Allow", "Principal": {"Service": ["ec2.amazonaws.com"]}}]}
I: Created role 'test-ControlPlane-Role' with ARN 'arn:aws:iam::765374464689:role/test-ControlPlane-Role'
I: Attached policy 'arn:aws:iam::765374464689:policy/test-ControlPlane-Role-Policy' to role 'test-ControlPlane-Role'

I: Attached trust policy to role 'test-Worker-Role': {"Version": "2012-10-17", "Statement": [{"Action": ["sts:AssumeRole"], "Effect": "Allow", "Principal": {"Service": ["ec2.amazonaws.com"]}}]}
I: Created role 'test-Worker-Role' with ARN 'arn:aws:iam::765374464689:role/test-Worker-Role'
I: Attached policy 'arn:aws:iam::765374464689:policy/test-Worker-Role-Policy' to role 'test-Worker-Role'
```

sample output when creating account-roles that already existed
```
I: Creating classic account roles using 'arn:aws:iam::765374464689:user/llan@redhat.com'
I: Created role 'test-Support-Role' with ARN 'arn:aws:iam::765374464689:role/test-Support-Role'
I: Attached policy 'arn:aws:iam::765374464689:policy/test-Support-Role-Policy' to role 'test-Support-Role'

I: Created role 'test-Installer-Role' with ARN 'arn:aws:iam::765374464689:role/test-Installer-Role'
I: Attached policy 'arn:aws:iam::765374464689:policy/test-Installer-Role-Policy' to role 'test-Installer-Role'

I: Created role 'test-ControlPlane-Role' with ARN 'arn:aws:iam::765374464689:role/test-ControlPlane-Role'
I: Attached policy 'arn:aws:iam::765374464689:policy/test-ControlPlane-Role-Policy' to role 'test-ControlPlane-Role'

I: Created role 'test-Worker-Role' with ARN 'arn:aws:iam::765374464689:role/test-Worker-Role'
I: Attached policy 'arn:aws:iam::765374464689:policy/test-Worker-Role-Policy' to role 'test-Worker-Role'
```

sample output when creating account-roles that already existed, but the trust policy attached to support role already updated manually, so it will be updated again during the account-roles creation command
```
I: Creating classic account roles using 'arn:aws:iam::765374464689:user/llan@redhat.com'
I: Attached trust policy to role 'test-Support-Role': {"Version": "2012-10-17", "Statement": [{"Action": ["sts:AssumeRole"], "Effect": "Allow", "Principal": {"AWS": ["arn:aws:iam::644306948063:role/RH-Technical-Support-12541229"]}}]}
I: Created role 'test-Support-Role' with ARN 'arn:aws:iam::765374464689:role/test-Support-Role'
I: Attached policy 'arn:aws:iam::765374464689:policy/test-Support-Role-Policy' to role 'test-Support-Role'

I: Created role 'test-Installer-Role' with ARN 'arn:aws:iam::765374464689:role/test-Installer-Role'
I: Attached policy 'arn:aws:iam::765374464689:policy/test-Installer-Role-Policy' to role 'test-Installer-Role'

I: Created role 'test-ControlPlane-Role' with ARN 'arn:aws:iam::765374464689:role/test-ControlPlane-Role'
I: Attached policy 'arn:aws:iam::765374464689:policy/test-ControlPlane-Role-Policy' to role 'test-ControlPlane-Role'

I: Created role 'test-Worker-Role' with ARN 'arn:aws:iam::765374464689:role/test-Worker-Role'
I: Attached policy 'arn:aws:iam::765374464689:policy/test-Worker-Role-Policy' to role 'test-Worker-Role'
```

@ciaranRoche Please help to check the above samples. 
Are the output messages what we want for this story?
Also, the attached permission policy and role created message will always be there, but for the trust policy, current implementation only include it in output when user really added/updated the trust policy. Should we keep this behavior, or make it as same as the permission policy/role?