### PR TITLE
OCM-10455 | feat: Add a configuration for a custom user agent

### DIFF
--- a/cmd/create/service/cmd.go
+++ b/cmd/create/service/cmd.go
@@ -172,7 +172,7 @@ func run(cmd *cobra.Command, argv []string) {
 	args.AwsAccountID = r.Creator.AccountID
 	args.Properties = map[string]string{
 		ocmConsts.CreatorArn:  r.Creator.ARN,
-		properties.CLIVersion: info.Version,
+		properties.CLIVersion: info.DefaultVersion,
 	}
 
 	if args.FakeCluster {

--- a/cmd/rosa/main.go
+++ b/cmd/rosa/main.go
@@ -131,7 +131,7 @@ func versionCheck(cmd *cobra.Command, _ []string) {
 		rprtr.Debugf("You might be running on an outdated version. Make sure you are using the current version of ROSA.")
 		return
 	}
-	latestVersionFromMirror, isLatest, err := rosaVersion.IsLatest(info.Version)
+	latestVersionFromMirror, isLatest, err := rosaVersion.IsLatest(info.DefaultVersion)
 	if err != nil {
 		rprtr.Debugf("There was a problem retrieving the latest version of ROSA: %v", err)
 		rprtr.Debugf("You might be running on an outdated version. Make sure you are using the current version of ROSA.")
@@ -139,7 +139,7 @@ func versionCheck(cmd *cobra.Command, _ []string) {
 	}
 	if !isLatest {
 		rprtr.Warnf("The current version (%s) is not up to date with latest released version (%s).",
-			info.Version,
+			info.DefaultVersion,
 			latestVersionFromMirror.Original(),
 		)
 		rprtr.Warnf("It is recommended that you update to the latest version.")

--- a/cmd/verify/rosa/cmd.go
+++ b/cmd/verify/rosa/cmd.go
@@ -87,7 +87,7 @@ type VerifyRosaOptions struct {
 }
 
 func (o *VerifyRosaOptions) Verify() error {
-	latestVersion, isLatest, err := o.rosaVersion.IsLatest(info.Version)
+	latestVersion, isLatest, err := o.rosaVersion.IsLatest(info.DefaultVersion)
 	if err != nil {
 		return fmt.Errorf("there was a problem verifying if version is latest: %v", err)
 	}

--- a/cmd/version/cmd_test.go
+++ b/cmd/version/cmd_test.go
@@ -145,7 +145,7 @@ var _ = Describe("RosaVersionOptions", func() {
 			stdout, _ = io.ReadAll(rout)
 
 			// Verify the outputs
-			Expect(string(stdout)).To(ContainSubstring(info.Version))
+			Expect(string(stdout)).To(ContainSubstring(info.DefaultVersion))
 
 			if opts.args.verbose {
 				expectedVerboseInfo := fmt.Sprintf("Information and download locations:\n\t%s\n\t%s\n",

--- a/cmd/version/options.go
+++ b/cmd/version/options.go
@@ -39,7 +39,7 @@ func NewRosaVersionOptions() (*RosaVersionOptions, error) {
 }
 
 func (o *RosaVersionOptions) Version() error {
-	o.reporter.Infof("%s", info.Version)
+	o.reporter.Infof("%s", info.DefaultVersion)
 
 	if o.args.verbose {
 		o.reporter.Infof("Information and download locations:\n\t%s\n\t%s\n",

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -330,7 +330,7 @@ func (b *ClientBuilder) BuildSessionWithOptionsCredentials(value *AccessKey,
 		config.WithClientLogMode(logLevel),
 		config.WithAPIOptions([]func(stack *middleware.Stack) error{
 			smithyhttp.AddHeaderValue("User-Agent",
-				strings.Join([]string{"ROSACLI", info.Version}, ";")),
+				strings.Join([]string{"ROSACLI", info.DefaultVersion}, ";")),
 		}),
 		config.WithRetryer(func() aws.Retryer {
 			retryer := retry.AddWithMaxAttempts(retry.NewStandard(), numMaxRetries)
@@ -358,7 +358,7 @@ func (b *ClientBuilder) BuildSessionWithOptions(logLevel aws.ClientLogMode) (aws
 		config.WithClientLogMode(logLevel),
 		config.WithAPIOptions([]func(stack *middleware.Stack) error{
 			smithyhttp.AddHeaderValue("User-Agent",
-				strings.Join([]string{"ROSACLI", info.Version}, ";")),
+				strings.Join([]string{"ROSACLI", info.DefaultVersion}, ";")),
 		}),
 		config.WithRetryer(func() aws.Retryer {
 			retryer := retry.AddWithMaxAttempts(retry.NewStandard(), numMaxRetries)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -54,6 +54,7 @@ type Config struct {
 	Scopes       []string `json:"scopes,omitempty" doc:"OpenID scope."`
 	TokenURL     string   `json:"token_url,omitempty" doc:"OpenID token URL."`
 	URL          string   `json:"url,omitempty" doc:"URL of the API gateway."`
+	UserAgent    string   `json:"user_agent,omitempty" doc:"OCM clients UserAgent. Default value is used if not set."`
 	FedRAMP      bool     `json:"fedramp,omitempty" doc:"Indicates FedRAMP."`
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -54,7 +54,8 @@ type Config struct {
 	Scopes       []string `json:"scopes,omitempty" doc:"OpenID scope."`
 	TokenURL     string   `json:"token_url,omitempty" doc:"OpenID token URL."`
 	URL          string   `json:"url,omitempty" doc:"URL of the API gateway."`
-	UserAgent    string   `json:"user_agent,omitempty" doc:"OCM clients UserAgent. Default value is used if not set."`
+	UserAgent    string   `json:"user_agent,omitempty" doc:"OCM client UserAgent. Default value is used if not set."`
+	Version      string   `json:"version,omitempty" doc:"OCM client version. Default value is used if not set."`
 	FedRAMP      bool     `json:"fedramp,omitempty" doc:"Indicates FedRAMP."`
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -53,7 +53,8 @@ var _ = Describe("Config", Ordered, func() {
 		"scopes":        "OpenID scope.",
 		"token_url":     "OpenID token URL.",
 		"url":           "URL of the API gateway.",
-		"user_agent":    "OCM clients UserAgent. Default value is used if not set.",
+		"user_agent":    "OCM client UserAgent. Default value is used if not set.",
+		"version":       "OCM client version. Default value is used if not set.",
 		"fedramp":       "Indicates FedRAMP.",
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -53,6 +53,7 @@ var _ = Describe("Config", Ordered, func() {
 		"scopes":        "OpenID scope.",
 		"token_url":     "OpenID token URL.",
 		"url":           "URL of the API gateway.",
+		"user_agent":    "OCM clients UserAgent. Default value is used if not set.",
 		"fedramp":       "Indicates FedRAMP.",
 	}
 

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,7 +18,7 @@ limitations under the License.
 
 package info
 
-const Version = "1.2.45"
+const DefaultVersion = "1.2.45"
 
 // Build contains the short Git SHA of the CLI at the point it was build. Set via `-ldflags` at build time
 var Build = "local"

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -23,4 +23,4 @@ const Version = "1.2.45"
 // Build contains the short Git SHA of the CLI at the point it was build. Set via `-ldflags` at build time
 var Build = "local"
 
-const UserAgent = "ROSACLI"
+const DefaultUserAgent = "ROSACLI"

--- a/pkg/ocm/client.go
+++ b/pkg/ocm/client.go
@@ -120,10 +120,14 @@ func (b *ClientBuilder) Build() (result *Client, err error) {
 	builder.Logger(logger)
 
 	userAgent := info.DefaultUserAgent
+	version := info.DefaultVersion
 	if b.cfg.UserAgent != "" {
 		userAgent = b.cfg.UserAgent
 	}
-	builder.Agent(userAgent + "/" + info.Version + " " + sdk.DefaultAgent)
+	if b.cfg.Version != "" {
+		version = b.cfg.Version
+	}
+	builder.Agent(userAgent + "/" + version + " " + sdk.DefaultAgent)
 	if b.cfg.TokenURL != "" {
 		builder.TokenURL(b.cfg.TokenURL)
 	}

--- a/pkg/ocm/client.go
+++ b/pkg/ocm/client.go
@@ -118,7 +118,12 @@ func (b *ClientBuilder) Build() (result *Client, err error) {
 	// values in the configuration, so that default values won't be overridden:
 	builder := sdk.NewConnectionBuilder()
 	builder.Logger(logger)
-	builder.Agent(info.UserAgent + "/" + info.Version + " " + sdk.DefaultAgent)
+
+	userAgent := info.DefaultUserAgent
+	if b.cfg.UserAgent != "" {
+		userAgent = b.cfg.UserAgent
+	}
+	builder.Agent(userAgent + "/" + info.Version + " " + sdk.DefaultAgent)
 	if b.cfg.TokenURL != "" {
 		builder.TokenURL(b.cfg.TokenURL)
 	}

--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -755,7 +755,7 @@ func (c *Client) createClusterSpec(config Spec) (*cmv1.Cluster, error) {
 	}
 
 	clusterProperties[ocmConsts.CreatorArn] = config.AWSCreator.ARN
-	clusterProperties[properties.CLIVersion] = info.Version
+	clusterProperties[properties.CLIVersion] = info.DefaultVersion
 
 	// Create the cluster:
 	clusterBuilder := cmv1.NewCluster().

--- a/tests/e2e/test_rosacli_version.go
+++ b/tests/e2e/test_rosacli_version.go
@@ -42,7 +42,7 @@ var _ = Describe("Get CLI version",
 				stdout = rosaClient.Parser.TextData.Input(buf).Parse().Output()
 				By("Check the version output")
 				Expect(stdout).NotTo(ContainSubstring("Not logged in"))
-				Expect(stdout).To(ContainSubstring(info.Version))
+				Expect(stdout).To(ContainSubstring(info.DefaultVersion))
 
 				By("Get the client version output")
 				buf, err = rosaClient.Runner.Cmd("version", "--client").Run()
@@ -50,7 +50,7 @@ var _ = Describe("Get CLI version",
 				stdout = rosaClient.Parser.TextData.Input(buf).Parse().Output()
 				By("Check the client version output")
 				Expect(stdout).NotTo(ContainSubstring("Not logged in"))
-				Expect(stdout).To(ContainSubstring(info.Version))
+				Expect(stdout).To(ContainSubstring(info.DefaultVersion))
 			},
 		)
 	})


### PR DESCRIPTION
This is needed by arbitrary services which use the client package to communicate with ocm / rosa.