### PR TITLE
OCM-10477 | test: fix id:75210

### DIFF
--- a/tests/e2e/test_rosacli_cluster_post.go
+++ b/tests/e2e/test_rosacli_cluster_post.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	nets "net/http"
+	"net/url"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -585,7 +586,10 @@ var _ = Describe("Post-Check testing for cluster deletion",
 				clusterDetail, err := profilehandler.ParserClusterDetail()
 				Expect(err).To(BeNil())
 				oidcEndpointUrlC = clusterDetail.OIDCEndpointURL
-				oidcEndpointUrlC, err = common.ExtractOIDCProviderFromOidcUrl(oidcEndpointUrlC)
+				parsedUrl, err := url.Parse(oidcEndpointUrlC)
+				Expect(err).To(BeNil())
+				oidcEndpointUrl := parsedUrl.String()
+				_, err = common.ExtractOIDCProviderFromOidcUrl(oidcEndpointUrl)
 				Expect(err).To(BeNil())
 
 				By("Check the cluster is deleted")


### PR DESCRIPTION
[ocm-10477](https://issues.redhat.com//browse/ocm-10477) 

$ ginkgo --focus 75210 tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.11.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: ROSA CLI e2e tests suite - /home/akanni/OCP-Repository/rosa/tests/e2e
====================================================================================
Random Seed: 1724047994

Will run 1 of 179 specs
SSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 179 Specs in 538.786 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 178 Skipped
PASS

Ginkgo ran 1 suite in 10m46.024667257s
Test Suite Passed
