### PR TITLE
OCM-10506 | test: automated cases id:73638

### DIFF
--- a/tests/e2e/hcp_machine_pool_test.go
+++ b/tests/e2e/hcp_machine_pool_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"strconv"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -8,6 +9,7 @@ import (
 	"github.com/openshift-online/ocm-common/pkg/test/vpc_client"
 
 	"github.com/openshift/rosa/tests/ci/labels"
+	"github.com/openshift/rosa/tests/utils/common"
 	"github.com/openshift/rosa/tests/utils/exec/rosacli"
 	ph "github.com/openshift/rosa/tests/utils/profilehandler"
 )
@@ -15,12 +17,14 @@ import (
 var _ = Describe("Create Machine Pool", labels.Feature.Machinepool, func() {
 
 	var (
-		rosaClient *rosacli.Client
-		profile    *ph.Profile
+		rosaClient         *rosacli.Client
+		machinePoolService rosacli.MachinePoolService
+		profile            *ph.Profile
 	)
 	BeforeEach(func() {
 		Expect(clusterID).ToNot(BeEmpty(), "Cluster ID is empty, please export the env variable CLUSTER_ID")
 		rosaClient = rosacli.NewClient()
+		machinePoolService = rosaClient.MachinePool
 
 		By("Skip testing if the cluster is not a HCP cluster")
 		hostedCluster, err := rosaClient.Cluster.IsHostedCPCluster(clusterID)
@@ -75,5 +79,102 @@ var _ = Describe("Create Machine Pool", labels.Feature.Machinepool, func() {
 			mpDescription, err = rosaClient.MachinePool.DescribeAndReflectNodePool(clusterID, mpName)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(mpDescription.AdditionalSecurityGroupIDs).To(BeEmpty())
+		})
+
+	It("machinepool AWS preflight tag validation[id:73638]",
+		labels.Medium, labels.Runtime.Day2,
+		func() {
+
+			By("Check the help message of machinepool creation")
+			mpID := common.GenerateRandomName("mp-73638", 2)
+			out, err := machinePoolService.CreateMachinePool(clusterID, mpID, "-h")
+			Expect(err).ToNot(HaveOccurred(), out.String())
+			Expect(out.String()).Should(ContainSubstring("--tags strings"))
+
+			By("Create a machinepool with tags set")
+			tags := []string{
+				"test:testvalue",
+				"test2:testValue/openshift",
+			}
+			out, err = machinePoolService.CreateMachinePool(clusterID, mpID,
+				"--replicas", "3",
+				"--tags", strings.Join(tags, ","),
+			)
+			Expect(err).ToNot(HaveOccurred(), out.String())
+
+			By("Describe the machinepool")
+			description, err := machinePoolService.DescribeAndReflectMachinePool(clusterID, mpID)
+			Expect(err).ToNot(HaveOccurred(), out.String())
+
+			for _, tag := range tags {
+				Expect(description.Tags).Should(ContainSubstring(strings.Replace(tag, ":", "=", -1)))
+			}
+
+			By("Create machinepool with too many tags")
+			maxTags := 25
+			var tooManyTags []string
+			for i := 0; i < maxTags+1; i++ {
+				t := strconv.Itoa(i)
+				key := "foo" + t
+				kvp := key + ":testValue"
+				tooManyTags = append(tooManyTags, kvp)
+			}
+
+			out, err = machinePoolService.CreateMachinePool(clusterID, "invalid-73469",
+				"--replicas", "3",
+				"--tags", strings.Join(tooManyTags, ","),
+			)
+			Expect(err).To(HaveOccurred())
+			Expect(out.String()).Should(ContainSubstring("Invalid Node Pool AWS tags: Resource has too many AWS tags"))
+
+			By("Create machinepool with a tag too long")
+			maxKeyTagLength := 128
+			maxValueTagLength := 256
+
+			tooLongKeyTag := strings.Repeat("z", maxKeyTagLength+1)
+			tag := tooLongKeyTag + ":testValue"
+
+			out, err = machinePoolService.CreateMachinePool(clusterID, "invalid-73469",
+				"--replicas", "3",
+				"--tags", tag,
+			)
+			Expect(err).To(HaveOccurred())
+			Expect(out.String()).Should(ContainSubstring("ERR: expected a valid user tag key 'zzz"))
+
+			tooLongValueTag := strings.Repeat("z", maxValueTagLength+1)
+			tag = "testKey:" + tooLongValueTag
+
+			out, err = machinePoolService.CreateMachinePool(clusterID, "invalid-73469",
+				"--replicas", "3",
+				"--tags", tag,
+			)
+			Expect(err).To(HaveOccurred())
+			Expect(out.String()).Should(ContainSubstring("ERR: expected a valid user tag value 'zzz"))
+
+			By("Create machinepool using aws as a prefix")
+			tag = "aws:testKey:" + "testValue"
+			out, err = machinePoolService.CreateMachinePool(clusterID, "invalid-73469",
+				"--replicas", "3",
+				"--tags", tag,
+			)
+			Expect(err).To(HaveOccurred())
+			Expect(out.String()).Should(ContainSubstring("ERR: invalid tag format for tag '[aws testKey testValue]'"))
+
+			By("Create machinepool with an invalid tag")
+			tag = "#" + ":testValue"
+			out, err = machinePoolService.CreateMachinePool(clusterID, "invalid-73469",
+				"--replicas", "3",
+				"--tags", tag,
+			)
+			Expect(err).To(HaveOccurred())
+			Expect(out.String()).Should(ContainSubstring("ERR: expected a valid user tag key '#'"))
+
+			tag = "testKey:" + "#"
+			out, err = machinePoolService.CreateMachinePool(clusterID, "invalid-73469",
+				"--replicas", "3",
+				"--tags", tag,
+			)
+			Expect(err).To(HaveOccurred())
+			Expect(out.String()).Should(ContainSubstring("ERR: expected a valid user tag value '#'"))
 		})
 })


### PR DESCRIPTION
`jfrazier@jfrazier-mac  ~/workspace/rosa   jf_73638 ±  ginkgo run -focus 73638 tests/e2e
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.11.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: ROSA CLI e2e tests suite - /Users/jfrazier/workspace/rosa/tests/e2e
==================================================================================
Random Seed: 1724098611

Will run 1 of 171 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 171 Specs in 25.550 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 170 Skipped
PASS

Ginkgo ran 1 suite in 30.93282275s
Test Suite Passed`