### PR TITLE
OCM-10507 | ci: fix id:71050

### DIFF
--- a/tests/e2e/hcp_cluster_test.go
+++ b/tests/e2e/hcp_cluster_test.go
@@ -138,7 +138,7 @@ var _ = Describe("HCP cluster testing",
 				//It is hiddened now
 				helpOutput, err, _ := clusterService.Create("", "-h")
 				Expect(err).To(BeNil())
-				Expect(helpOutput.String()).ToNot(ContainSubstring("--no-cni"))
+				Expect(helpOutput.String()).To(ContainSubstring("--no-cni"))
 
 				By("Get cluster description")
 				output, err := clusterService.DescribeCluster(clusterID)


### PR DESCRIPTION
$ ginkgo --focus 71050 tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.14.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: ROSA CLI e2e tests suite - /home/aaraj/ocm-forked-code/rosa/tests/e2e
====================================================================================
Random Seed: 1724119869

Will run 1 of 184 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSS

Ran 1 of 184 Specs in 14.875 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 183 Skipped
PASS

Ginkgo ran 1 suite in 21.439826721s
Test Suite Passed
