### PR TITLE
OCM-10511 | fix: missing operator roles when filtering due to extended naming cutting the postfix

### DIFF
--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -647,7 +647,7 @@ func isAccountRoleVersionCompatible(tagsList []iamtypes.Tag, roleType string,
 }
 
 func (c *awsClient) ListRoles() ([]iamtypes.Role, error) {
-	roles := []iamtypes.Role{}
+	var roles []iamtypes.Role
 	paginator := iam.NewListRolesPaginator(c.iamClient, &iam.ListRolesInput{})
 	for paginator.HasMorePages() {
 		output, err := paginator.NextPage(context.TODO())
@@ -1011,6 +1011,18 @@ func (c *awsClient) ListOperatorRoles(targetVersion string,
 	return operatorMap, nil
 }
 
+func (c *awsClient) ValidateIfRosaOperatorRole(role iamtypes.Role,
+	credRequest map[string]*cmv1.STSOperator) (bool, error) {
+	listRoleTags, err := c.iamClient.ListRoleTags(context.Background(), &iam.ListRoleTagsInput{
+		RoleName: role.RoleName,
+	})
+	if err != nil {
+		return false, err
+	}
+	role.Tags = listRoleTags.Tags
+	return checkIfROSAOperatorRole(role, credRequest), nil
+}
+
 // Check if it is one of the ROSA account roles
 func checkIfAccountRole(roleName *string) bool {
 	for _, prefix := range AccountRoles {
@@ -1022,9 +1034,16 @@ func checkIfAccountRole(roleName *string) bool {
 }
 
 // Check if it is one of the ROSA account roles
-func checkIfROSAOperatorRole(roleName *string, credRequest map[string]*cmv1.STSOperator) bool {
+func checkIfROSAOperatorRole(role iamtypes.Role, credRequest map[string]*cmv1.STSOperator) bool {
 	for _, operatorRole := range credRequest {
-		if strings.Contains(aws.ToString(roleName), operatorRole.Namespace()) {
+		for _, tag := range role.Tags {
+			if aws.ToString(tag.Key) == "operator_namespace" {
+				if strings.Contains(aws.ToString(tag.Value), operatorRole.Namespace()) {
+					return true
+				}
+			}
+		}
+		if strings.Contains(aws.ToString(role.RoleName), operatorRole.Namespace()) {
 			return true
 		}
 	}
@@ -1358,15 +1377,20 @@ func (c *awsClient) detachOperatorRolePolicies(role *string) error {
 
 func (c *awsClient) GetOperatorRolesFromAccountByClusterID(clusterID string,
 	credRequest map[string]*cmv1.STSOperator) ([]string, error) {
-	roleList := []string{}
+	var roleList []string
 	roles, err := c.ListRoles()
 	if err != nil {
 		return roleList, err
 	}
 	for _, role := range roles {
-		if !checkIfROSAOperatorRole(role.RoleName, credRequest) {
+		isValidOperatorRole, err := c.ValidateIfRosaOperatorRole(role, credRequest)
+		if err != nil {
+			return roleList, err
+		}
+		if !isValidOperatorRole {
 			continue
 		}
+
 		listRoleTagsOutput, err := c.iamClient.ListRoleTags(context.Background(),
 			&iam.ListRoleTagsInput{
 				RoleName: role.RoleName,
@@ -1393,19 +1417,24 @@ func (c *awsClient) GetOperatorRolesFromAccountByClusterID(clusterID string,
 
 func (c *awsClient) GetOperatorRolesFromAccountByPrefix(prefix string,
 	credRequest map[string]*cmv1.STSOperator) ([]string, error) {
-	roleList := []string{}
+	var roleList []string
 	roles, err := c.ListRoles()
 	if err != nil {
 		return roleList, err
 	}
 	prefixOperatorRoleRE := regexp.MustCompile(("(?i)" + fmt.Sprintf("(%s)-(openshift|kube-system)", prefix)))
 	for _, role := range roles {
-		if !checkIfROSAOperatorRole(role.RoleName, credRequest) {
+		if !prefixOperatorRoleRE.MatchString(*role.RoleName) {
 			continue
 		}
-		if prefixOperatorRoleRE.MatchString(*role.RoleName) {
-			roleList = append(roleList, aws.ToString(role.RoleName))
+		isValidOperatorRole, err := c.ValidateIfRosaOperatorRole(role, credRequest)
+		if err != nil {
+			return roleList, err
 		}
+		if !isValidOperatorRole {
+			continue
+		}
+		roleList = append(roleList, aws.ToString(role.RoleName))
 	}
 	return roleList, nil
 }


### PR DESCRIPTION
*WHAT*
Roles with a large prefix and large operator-namespace lead to the role name being trimed to AWS conventions. This results in a regression in our filtering where we expect the role name to contain the operator-namespace. 

This change fetches the role tags and uses the tags to verify the operator namespace. The old check on the naming convention still remains if the operator-namespace tag is not found. 

*Verification* 

```
─ ~/Work/ocm/rosa  on OCM-10511 ···································································· ✔  took 24s  default eu-west-1    at 13:19:38 
╰─ aws iam list-roles --query "Roles[?starts_with(RoleName, 'rosacli-ci-y7tigturtqczcjrvyodmm')].RoleName"  | jq

[
  "rosacli-ci-y7tigturtqczcjrvyodmm-openshift-cloud-credential-oper",
  "rosacli-ci-y7tigturtqczcjrvyodmm-openshift-cloud-network-config-",
  "rosacli-ci-y7tigturtqczcjrvyodmm-openshift-cluster-csi-drivers-e",
  "rosacli-ci-y7tigturtqczcjrvyodmm-openshift-image-registry-instal",
  "rosacli-ci-y7tigturtqczcjrvyodmm-openshift-ingress-operator-clou",
  "rosacli-ci-y7tigturtqczcjrvyodmm-openshift-machine-api-aws-cloud"
]
╭─ ~/Work/ocm/rosa  on OCM-10511 ······································································································ ✔  at 13:19:43 
╰─ rosa delete operator-roles --prefix rosacli-ci-y7tigturtqczcjrvyodmm --mode auto -y
I: Fetching operator roles for the prefix: rosacli-ci-y7tigturtqczcjrvyodmm
I: Deleting operator role 'rosacli-ci-y7tigturtqczcjrvyodmm-openshift-cloud-credential-oper'
I: Deleting operator role 'rosacli-ci-y7tigturtqczcjrvyodmm-openshift-cloud-network-config-'
I: Deleting operator role 'rosacli-ci-y7tigturtqczcjrvyodmm-openshift-cluster-csi-drivers-e'
I: Deleting operator role 'rosacli-ci-y7tigturtqczcjrvyodmm-openshift-image-registry-instal'
I: Deleting operator role 'rosacli-ci-y7tigturtqczcjrvyodmm-openshift-ingress-operator-clou'
I: Deleting operator role 'rosacli-ci-y7tigturtqczcjrvyodmm-openshift-machine-api-aws-cloud'
I: Successfully deleted the operator roles
╭─ ~/Work/ocm/rosa  on OCM-10511 ···································································· ✔  took 15s  default eu-west-1    at 13:20:04 
╰─ aws iam list-roles --query "Roles[?starts_with(RoleName, 'rosacli-ci-y7tigturtqczcjrvyodmm')].RoleName"  | jq

[]

```