### PR TITLE
OCM-7551 | feat: add role console url in the output for policy attach

### DIFF
--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -41,6 +41,7 @@ import (
 const (
 	awsManagedPolicyRegexPattern = `^arn:aws:iam::aws:policy/.*$`
 	awsManagedPolicyUrlPrefix    = "https://docs.aws.amazon.com/aws-managed-policy/latest/reference/"
+	roleUrlPrefix                = "https://console.aws.amazon.com/iam/home?#/roles/"
 )
 
 var (
@@ -216,7 +217,7 @@ func (c *awsClient) EnsureRole(reporter *reporter.Object, name string, policy st
 		if err != nil {
 			return roleArn, err
 		}
-		reporter.Infof("Attached trust policy to role '%s': %s", name, policy)
+		reporter.Infof("Attached trust policy to role '%s(%s)': %s", name, roleUrlPrefix+name, policy)
 
 		_, err = c.iamClient.TagRole(context.Background(), &iam.TagRoleInput{
 			RoleName: aws.String(name),
@@ -272,7 +273,7 @@ func (c *awsClient) createRole(reporter *reporter.Object, name string, policy st
 		}
 		return "", err
 	}
-	reporter.Infof("Attached trust policy to role '%s': %s", name, policy)
+	reporter.Infof("Attached trust policy to role '%s(%s)': %s", name, roleUrlPrefix+name, policy)
 	return aws.ToString(output.Role.Arn), nil
 }
 
@@ -469,7 +470,7 @@ func (c *awsClient) AttachRolePolicy(reporter *reporter.Object, roleName string,
 		policyName := policyARNArr[len(policyARNArr)-1]
 		policyARN = fmt.Sprintf("%s(%s)", policyName, awsManagedPolicyUrlPrefix+policyName)
 	}
-	reporter.Infof("Attached policy '%s' to role '%s'\n", policyARN, roleName)
+	reporter.Infof("Attached policy '%s' to role '%s(%s)'\n", policyARN, roleName, roleUrlPrefix+roleName)
 	return nil
 }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-7551
https://issues.redhat.com/browse/OCM-7552

sample output when create account-roles
```I: Creating classic account roles using 'arn:aws:iam::765374464689:user/llan@redhat.com'
I: Attached trust policy to role 'testrole-Installer-Role(https://console.aws.amazon.com/iam/home?#/roles/testrole-Installer-Role)': {"Version": "2012-10-17", "Statement": [{"Action": ["sts:AssumeRole"], "Effect": "Allow", "Principal": {"AWS": ["arn:aws:iam::644306948063:role/RH-Managed-OpenShift-Installer"]}}]}
I: Created role 'testrole-Installer-Role' with ARN 'arn:aws:iam::765374464689:role/testrole-Installer-Role'
I: Attached policy 'arn:aws:iam::765374464689:policy/testrole-Installer-Role-Policy' to role 'testrole-Installer-Role(https://console.aws.amazon.com/iam/home?#/roles/testrole-Installer-Role)'

I: Attached trust policy to role 'testrole-ControlPlane-Role(https://console.aws.amazon.com/iam/home?#/roles/testrole-ControlPlane-Role)': {"Version": "2012-10-17", "Statement": [{"Action": ["sts:AssumeRole"], "Effect": "Allow", "Principal": {"Service": ["ec2.amazonaws.com"]}}]}
I: Created role 'testrole-ControlPlane-Role' with ARN 'arn:aws:iam::765374464689:role/testrole-ControlPlane-Role'
I: Attached policy 'arn:aws:iam::765374464689:policy/testrole-ControlPlane-Role-Policy' to role 'testrole-ControlPlane-Role(https://console.aws.amazon.com/iam/home?#/roles/testrole-ControlPlane-Role)'

I: Attached trust policy to role 'testrole-Worker-Role(https://console.aws.amazon.com/iam/home?#/roles/testrole-Worker-Role)': {"Version": "2012-10-17", "Statement": [{"Action": ["sts:AssumeRole"], "Effect": "Allow", "Principal": {"Service": ["ec2.amazonaws.com"]}}]}
I: Created role 'testrole-Worker-Role' with ARN 'arn:aws:iam::765374464689:role/testrole-Worker-Role'
I: Attached policy 'arn:aws:iam::765374464689:policy/testrole-Worker-Role-Policy' to role 'testrole-Worker-Role(https://console.aws.amazon.com/iam/home?#/roles/testrole-Worker-Role)'

I: Attached trust policy to role 'testrole-Support-Role(https://console.aws.amazon.com/iam/home?#/roles/testrole-Support-Role)': {"Version": "2012-10-17", "Statement": [{"Action": ["sts:AssumeRole"], "Effect": "Allow", "Principal": {"AWS": ["arn:aws:iam::644306948063:role/RH-Technical-Support-12541229"]}}]}
I: Created role 'testrole-Support-Role' with ARN 'arn:aws:iam::765374464689:role/testrole-Support-Role'
I: Attached policy 'arn:aws:iam::765374464689:policy/testrole-Support-Role-Policy' to role 'testrole-Support-Role(https://console.aws.amazon.com/iam/home?#/roles/testrole-Support-Role)'

I: Creating hosted CP account roles using 'arn:aws:iam::765374464689:user/llan@redhat.com'
I: Attached trust policy to role 'testrole-HCP-ROSA-Installer-Role(https://console.aws.amazon.com/iam/home?#/roles/testrole-HCP-ROSA-Installer-Role)': {"Version": "2012-10-17", "Statement": [{"Action": ["sts:AssumeRole"], "Effect": "Allow", "Principal": {"AWS": ["arn:aws:iam::644306948063:role/RH-Managed-OpenShift-Installer"]}}]}
I: Created role 'testrole-HCP-ROSA-Installer-Role' with ARN 'arn:aws:iam::765374464689:role/testrole-HCP-ROSA-Installer-Role'
I: Attached policy 'ROSAInstallerPolicy(https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAInstallerPolicy)' to role 'testrole-HCP-ROSA-Installer-Role(https://console.aws.amazon.com/iam/home?#/roles/testrole-HCP-ROSA-Installer-Role)'

I: Attached trust policy to role 'testrole-HCP-ROSA-Support-Role(https://console.aws.amazon.com/iam/home?#/roles/testrole-HCP-ROSA-Support-Role)': {"Version": "2012-10-17", "Statement": [{"Action": ["sts:AssumeRole"], "Effect": "Allow", "Principal": {"AWS": ["arn:aws:iam::644306948063:role/RH-Technical-Support-12541229"]}}]}
I: Created role 'testrole-HCP-ROSA-Support-Role' with ARN 'arn:aws:iam::765374464689:role/testrole-HCP-ROSA-Support-Role'
I: Attached policy 'ROSASRESupportPolicy(https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSASRESupportPolicy)' to role 'testrole-HCP-ROSA-Support-Role(https://console.aws.amazon.com/iam/home?#/roles/testrole-HCP-ROSA-Support-Role)'

I: Attached trust policy to role 'testrole-HCP-ROSA-Worker-Role(https://console.aws.amazon.com/iam/home?#/roles/testrole-HCP-ROSA-Worker-Role)': {"Version": "2012-10-17", "Statement": [{"Action": ["sts:AssumeRole"], "Effect": "Allow", "Principal": {"Service": ["ec2.amazonaws.com"]}}]}
I: Created role 'testrole-HCP-ROSA-Worker-Role' with ARN 'arn:aws:iam::765374464689:role/testrole-HCP-ROSA-Worker-Role'
I: Attached policy 'ROSAWorkerInstancePolicy(https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAWorkerInstancePolicy)' to role 'testrole-HCP-ROSA-Worker-Role(https://console.aws.amazon.com/iam/home?#/roles/testrole-HCP-ROSA-Worker-Role)'
```