### PR TITLE
OCM-10532: Update staging qaprodauth console url for details page

### DIFF
--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	StageURL      = "https://qaprodauth.console.redhat.com/openshift/details/s/"
+	StageURL      = "https://console.dev.redhat.com/openshift/details/s/"
 	ProductionURL = "https://console.redhat.com/openshift/details/s/"
 	StageEnv      = "https://api.stage.openshift.com"
 	ProductionEnv = "https://api.openshift.com"


### PR DESCRIPTION
It appears the previous staging envs Detail page url using "qaprodauth.console.redhat.com" is no longer valid?
This PR changes the details page url to use "console.dev.redhat.com" instead. 
https://issues.redhat.com/browse/OCM-10532