### PR TITLE
OCM-10543 | test: fix ids: 75210,73731,57408,38770,74661,60688 some failures

### DIFF
--- a/tests/e2e/test_rosacli_operator_roles.go
+++ b/tests/e2e/test_rosacli_operator_roles.go
@@ -550,7 +550,7 @@ var _ = Describe("create operator-roles forcely testing",
 				By("Detach and Delete one operator-role policy,openshift-cluster-csi-drivers-ebs")
 				var deletingPolicyRoleName string
 				for roleName := range rolePolicyMap {
-					if strings.Contains(roleName, "openshift-cluster-csi-drivers-ebs") {
+					if strings.Contains(roleName, "openshift-cluster-csi-driver") {
 						deletingPolicyRoleName = roleName
 						break
 					}

--- a/tests/e2e/test_rosacli_upgrade.go
+++ b/tests/e2e/test_rosacli_upgrade.go
@@ -66,6 +66,14 @@ var _ = Describe("Cluster Upgrade testing",
 		})
 
 		It("to upgrade roles/operator-roles and cluster - [id:73731]", labels.Critical, labels.Runtime.Upgrade, func() {
+			By("Skip if the cluster is non-sts")
+			isHostedCP, err := clusterService.IsHostedCPCluster(clusterID)
+			Expect(err).To(BeNil())
+			IsSTS, err := clusterService.IsSTSCluster(clusterID)
+			Expect(err).To(BeNil())
+			if !(isHostedCP || IsSTS) {
+				Skip("Skip this case as it doesn't supports on not-sts clusters")
+			}
 			By("Check the cluster version and compare with the profile to decide if skip this case")
 			jsonData, err := clusterService.GetJSONClusterDescription(clusterID)
 			Expect(err).To(BeNil())
@@ -269,9 +277,13 @@ var _ = Describe("Cluster Upgrade testing",
 				)
 			}
 			Expect(err).To(BeNil())
-			Expect(output.String()).To(ContainSubstring("are already up-to-date"))
 			Expect(output.String()).To(ContainSubstring("are compatible with upgrade"))
 			Expect(output.String()).To(ContainSubstring("Upgrade successfully scheduled for cluster"))
+			if isHosted {
+				Expect(output.String()).To(ContainSubstring("have attached managed policies. An upgrade isn't needed"))
+			} else {
+				Expect(output.String()).To(ContainSubstring("are already up-to-date"))
+			}
 		})
 
 		It("to upgrade NON-STS rosa cluster across Y stream - [id:37499]", labels.Critical, labels.Runtime.Upgrade, func() {

--- a/tests/utils/common/oidc.go
+++ b/tests/utils/common/oidc.go
@@ -109,15 +109,17 @@ func ParseIssuerURLFromCommand(command string) string {
 
 // Extract oidc provider from the 'OIDC Endpoint URL' field of `rosa describe cluster`
 func ExtractOIDCProviderFromOidcUrl(urlString string) (string, error) {
+	var oidcProvider string
+	urlString = strings.TrimSpace(strings.Split(urlString, " ")[0])
 	parsedURL, err := url.Parse(urlString)
 	if err != nil {
 		return "", err
 	}
 	host := parsedURL.Host
 	path := strings.TrimPrefix(parsedURL.Path, "/")
-	fmt.Printf("The past host and path is %s and %s\n", host, path)
-	oidcProvider := fmt.Sprintf("%s/%s", host, path)
-	oidcProvider = strings.Split(oidcProvider, " ")[0]
-
+	oidcProvider = host
+	if path != "" {
+		oidcProvider = fmt.Sprintf("%s/%s", host, path)
+	}
 	return oidcProvider, nil
 }


### PR DESCRIPTION
[OCM-10543](https://issues.redhat.com//browse/OCM-10543) | test: fix ids: 75210,73731,57408,38770,74661,60688 some failures on rosacli ci

75210: update ExtractOIDCProviderFromOidcUrl to support the not-classic oidc config
73731: update expected output for hosted-cp cluster
57408: add one minute to wait time
38770: add condition for not autoscaling enabled cluster
74661: update the role matcher to adapt the long cluster prefix
60688: skip on share vpc clusters as the base domain cannot be reused