### PR TITLE
OCM-10450 | fix: Pass in OIDC Config ID when creating oidcprovider from create/oidcconfig

### DIFF
--- a/cmd/create/oidcprovider/cmd.go
+++ b/cmd/create/oidcprovider/cmd.go
@@ -80,7 +80,7 @@ func run(cmd *cobra.Command, argv []string) {
 	// Allow the command to be called programmatically
 	isProgmaticallyCalled := false
 	shouldUseClusterKey := true
-	if len(argv) == 3 && !cmd.Flag("cluster").Changed {
+	if len(argv) >= 3 && !cmd.Flag("cluster").Changed {
 		ocm.SetClusterKey(argv[0])
 		interactive.SetModeKey(argv[1])
 


### PR DESCRIPTION
Fixes issue where oidc provider was not automatically created when creating an oidc config due to neither an oidc config id, nor a cluster id being passed in