### PR TITLE
OCM-10636 | chore: update goreleaser config to ignore merge commits

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -41,3 +41,7 @@ changelog:
       order: 1
     - title: Others
       order: 999
+  filters:
+    exclude:
+      - '^Merge pull request #'
+      - '^Merge branch '


### PR DESCRIPTION
**WHAT**

Excludes merge commits from change log

JIRA - https://issues.redhat.com/browse/OCM-10636