### PR TITLE
OCM-10452 | fix: Add cluster key back to oidcprovider create/cluster call

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -3263,8 +3263,10 @@ func run(cmd *cobra.Command, _ []string) {
 			}
 			if oidcConfig != nil {
 				oidcprovider.Cmd.Flags().Set(oidcprovider.OidcConfigIdFlag, oidcConfig.ID())
+			} else {
+				oidcprovider.Cmd.Flags().Set("cluster", clusterName)
 			}
-			oidcprovider.Cmd.Run(oidcprovider.Cmd, []string{"", mode, ""})
+			oidcprovider.Cmd.Run(oidcprovider.Cmd, []string{clusterName, mode, ""})
 		} else {
 			output := ""
 			if len(operatorRoles) == 0 {


### PR DESCRIPTION
Adds back cluster key passing to create/oidcprovider cmd in create/cluster to fix regression from removing it