### PR TITLE
OCM-9503 | chore: bump version for 1.2.44

### DIFF
--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,7 +18,7 @@ limitations under the License.
 
 package info
 
-const Version = "1.2.44-RC1"
+const Version = "1.2.44"
 
 // Build contains the short Git SHA of the CLI at the point it was build. Set via `-ldflags` at build time
 var Build = "local"


### PR DESCRIPTION
*WHAT*

Bumps version for 1.2.44