### PR TITLE
OCM-10676 | fix: Remove manual cluster ID flag update for create/oidcprovider

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -3263,8 +3263,6 @@ func run(cmd *cobra.Command, _ []string) {
 			}
 			if oidcConfig != nil {
 				oidcprovider.Cmd.Flags().Set(oidcprovider.OidcConfigIdFlag, oidcConfig.ID())
-			} else {
-				oidcprovider.Cmd.Flags().Set("cluster", clusterName)
 			}
 			oidcprovider.Cmd.Run(oidcprovider.Cmd, []string{clusterName, mode, ""})
 		} else {


### PR DESCRIPTION
Manually setting the cluster ID caused the command to not be 'programmatically called', removed 2 lines to fix this