### PR TITLE
OCM-10690 | test: updated id:34102

### DIFF
--- a/tests/e2e/test_rosacli_cluster.go
+++ b/tests/e2e/test_rosacli_cluster.go
@@ -82,6 +82,13 @@ var _ = Describe("Edit cluster",
 				rosaClient.Runner.UnsetFormat()
 				jsonData := rosaClient.Parser.JsonData.Input(jsonOutput).Parse()
 
+				By("Get OCM Environment")
+				rosaClient.Runner.JsonFormat()
+				userInfo, err := rosaClient.OCMResource.UserInfo()
+				Expect(err).To(BeNil())
+				rosaClient.Runner.UnsetFormat()
+				ocmApi := userInfo.OCMApi
+
 				By("Compare the text result with the json result")
 				Expect(CD.ID).To(Equal(jsonData.DigString("id")))
 				Expect(CD.ExternalID).To(Equal(jsonData.DigString("external_id")))
@@ -94,7 +101,13 @@ var _ = Describe("Edit cluster",
 
 				Expect(CD.State).To(Equal(jsonData.DigString("status", "state")))
 				Expect(CD.Created).NotTo(BeEmpty())
-				Expect(CD.DetailsPage).NotTo(BeEmpty())
+
+				By("Get details page console url")
+				consoleURL := common.GetConsoleUrlBasedOnEnv(ocmApi)
+				subscriptionID := jsonData.DigString("subscription", "id")
+				if consoleURL != "" {
+					Expect(CD.DetailsPage).To(Equal(consoleURL + subscriptionID))
+				}
 
 				if jsonData.DigBool("aws", "private_link") {
 					Expect(CD.Private).To(Equal("Yes"))

--- a/tests/utils/common/constants/general.go
+++ b/tests/utils/common/constants/general.go
@@ -18,3 +18,10 @@ var JumpAccounts = map[string]string{
 	"production": "710019948333",
 	"staging":    "644306948063",
 }
+
+const (
+	StageURL      = "https://console.dev.redhat.com/openshift/details/s/"
+	ProductionURL = "https://console.redhat.com/openshift/details/s/"
+	StageEnv      = "https://api.stage.openshift.com"
+	ProductionEnv = "https://api.openshift.com"
+)

--- a/tests/utils/common/helper.go
+++ b/tests/utils/common/helper.go
@@ -4,6 +4,8 @@ import (
 	"crypto/rand"
 	"math/big"
 	"os"
+
+	"github.com/openshift/rosa/tests/utils/common/constants"
 )
 
 func ReadENVWithDefaultValue(envName string, fallback string) string {
@@ -19,4 +21,15 @@ func RandomInt(max int) int {
 		panic(err)
 	}
 	return int(val.Int64())
+}
+
+func GetConsoleUrlBasedOnEnv(ocmApi string) string {
+	switch ocmApi {
+	case constants.StageEnv:
+		return constants.StageURL
+	case constants.ProductionEnv:
+		return constants.ProductionURL
+	default:
+		return ""
+	}
 }


### PR DESCRIPTION
$ ginkgo --focus 34102 tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.14.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: ROSA CLI e2e tests suite - /home/aaraj/ocm-forked-code/rosa/tests/e2e
====================================================================================
Random Seed: 1725947577

Will run 1 of 213 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSS

Ran 1 of 213 Specs in 16.431 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 212 Skipped
PASS

Ginkgo ran 1 suite in 18.196512616s
Test Suite Passed
