### PR TITLE
OCM-10711 | test: fix ids:73449, 74403

### DIFF
--- a/tests/e2e/test_rosacli_policy.go
+++ b/tests/e2e/test_rosacli_policy.go
@@ -29,6 +29,7 @@ var _ = Describe("Attach and Detach arbitrary policies",
 			awsClient                *aws_client.AWSClient
 			err                      error
 			profile                  *ph.Profile
+			roleUrlPrefix            = "https://console.aws.amazon.com/iam/home?#/roles/"
 		)
 
 		BeforeEach(func() {
@@ -99,7 +100,8 @@ var _ = Describe("Attach and Detach arbitrary policies",
 					out, err := arbitraryPolicyService.AttachPolicy(roleName, policyArns, "--mode", "auto")
 					Expect(err).To(BeNil())
 					for _, policyArn := range policyArns {
-						Expect(out.String()).To(ContainSubstring("Attached policy '%s' to role '%s'", policyArn, roleName))
+						Expect(out.String()).To(ContainSubstring("Attached policy '%s' to role '%s(%s)'",
+							policyArn, roleName, roleUrlPrefix+roleName))
 					}
 
 				}
@@ -116,7 +118,8 @@ var _ = Describe("Attach and Detach arbitrary policies",
 					out, err := arbitraryPolicyService.AttachPolicy(roleName, policyArns, "--mode", "auto")
 					Expect(err).To(BeNil())
 					for _, policyArn := range policyArns {
-						Expect(out.String()).To(ContainSubstring("Attached policy '%s' to role '%s'", policyArn, roleName))
+						Expect(out.String()).To(ContainSubstring("Attached policy '%s' to role '%s(%s)'",
+							policyArn, roleName, roleUrlPrefix+roleName))
 					}
 
 				}
@@ -209,7 +212,8 @@ var _ = Describe("Attach and Detach arbitrary policies",
 					out, err := arbitraryPolicyService.AttachPolicy(roleName, policyArns, "--mode", "auto")
 					Expect(err).To(BeNil())
 					for _, policyArn := range policyArns {
-						Expect(out.String()).To(ContainSubstring("Attached policy '%s' to role '%s'", policyArn, roleName))
+						Expect(out.String()).To(ContainSubstring("Attached policy '%s' to role '%s(%s)'",
+							policyArn, roleName, roleUrlPrefix+roleName))
 					}
 
 				}
@@ -218,7 +222,8 @@ var _ = Describe("Attach and Detach arbitrary policies",
 					out, err := arbitraryPolicyService.AttachPolicy(roleName, policyArns, "--mode", "auto")
 					Expect(err).To(BeNil())
 					for _, policyArn := range policyArns {
-						Expect(out.String()).To(ContainSubstring("Attached policy '%s' to role '%s'", policyArn, roleName))
+						Expect(out.String()).To(ContainSubstring("Attached policy '%s' to role '%s(%s)'",
+							policyArn, roleName, roleUrlPrefix+roleName))
 					}
 
 				}
@@ -681,6 +686,7 @@ var _ = Describe("Operator roles with attaching arbitrary policies",
 			err                      error
 			managedOIDCConfigID      string
 			ocmResourceService       rosacli.OCMResourceService
+			roleUrlPrefix            = "https://console.aws.amazon.com/iam/home?#/roles/"
 		)
 
 		BeforeEach(func() {
@@ -845,14 +851,16 @@ var _ = Describe("Operator roles with attaching arbitrary policies",
 				out, err := arbitraryPolicyService.AttachPolicy(roleName, policyArns, "--mode", "auto")
 				Expect(err).To(BeNil())
 				for _, policyArn := range policyArns {
-					Expect(out.String()).To(ContainSubstring("Attached policy '%s' to role '%s'", policyArn, roleName))
+					Expect(out.String()).To(ContainSubstring("Attached policy '%s' to role '%s(%s)'",
+						policyArn, roleName, roleUrlPrefix+roleName))
 				}
 			}
 			for roleName, policyArns := range operatorRolePoliciesMap2 {
 				out, err := arbitraryPolicyService.AttachPolicy(roleName, policyArns, "--mode", "auto")
 				Expect(err).To(BeNil())
 				for _, policyArn := range policyArns {
-					Expect(out.String()).To(ContainSubstring("Attached policy '%s' to role '%s'", policyArn, roleName))
+					Expect(out.String()).To(ContainSubstring("Attached policy '%s' to role '%s(%s)'",
+						policyArn, roleName, roleUrlPrefix+roleName))
 				}
 			}
 
@@ -867,7 +875,8 @@ var _ = Describe("Operator roles with attaching arbitrary policies",
 				out, err := arbitraryPolicyService.AttachPolicy(roleName, policyArns, "--mode", "auto")
 				Expect(err).To(BeNil())
 				for _, policyArn := range policyArns {
-					Expect(out.String()).To(ContainSubstring("Attached policy '%s' to role '%s'", policyArn, roleName))
+					Expect(out.String()).To(ContainSubstring("Attached policy '%s' to role '%s(%s)'",
+						policyArn, roleName, roleUrlPrefix+roleName))
 				}
 			}
 		})


### PR DESCRIPTION
[OCM-10711](https://issues.redhat.com//browse/OCM-10711)

$ ginkgo --focus "(73449|74403)" tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
Ginkgo CLI Version:
2.11.0
Mismatched package versions found:
2.17.1 used by e2e

Ginkgo will continue to attempt to run but you may see errors (including flag
parsing errors) and should either update your go.mod or your version of the
Ginkgo CLI to match.

To install the matching version of the CLI run
go install github.com/onsi/ginkgo/v2/ginkgo
from a path that contains a go.mod file. Alternatively you can use
go run github.com/onsi/ginkgo/v2/ginkgo
from a path that contains a go.mod file to invoke the matching version of the
Ginkgo CLI.

If you are attempting to test multiple packages that each have a different
version of the Ginkgo library with a single Ginkgo CLI that is currently
unsupported.

Running Suite: ROSA CLI e2e tests suite - /home/akanni/OCP-Repository/rosa/tests/e2e
Random Seed: 1724915049

Will run 2 of 184 specs
SSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 2 of 184 Specs in 280.120 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 182 Skipped
PASS

Ginkgo ran 1 suite in 4m43.753470903s
Test Suite Passed

