### PR TITLE
OCM-10756 | fix: add missing aliases for describe/delete autoscaler commands

### DIFF
--- a/cmd/describe/autoscaler/cmd.go
+++ b/cmd/describe/autoscaler/cmd.go
@@ -20,9 +20,12 @@ const (
 rosa describe autoscaler --cluster foo`
 )
 
+var aliases = []string{"cluster-autoscaler"}
+
 func NewDescribeAutoscalerCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     use,
+		Aliases: aliases,
 		Short:   short,
 		Long:    long,
 		Example: example,

--- a/cmd/dlt/autoscaler/cmd.go
+++ b/cmd/dlt/autoscaler/cmd.go
@@ -35,9 +35,12 @@ const (
   rosa delete autoscaler --cluster=mycluster`
 )
 
+var aliases = []string{"cluster-autoscaler"}
+
 func NewDeleteAutoscalerCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     use,
+		Aliases: aliases,
 		Short:   short,
 		Long:    long,
 		Example: example,


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-10756