### PR TITLE
OCM-10754 | fix: validate int32 for user input in autoscaler attributes

### DIFF
--- a/pkg/clusterautoscaler/flags.go
+++ b/pkg/clusterautoscaler/flags.go
@@ -338,14 +338,14 @@ func GetAutoscalerOptions(
 			Default:  result.LogVerbosity,
 			Required: false,
 			Validators: []interactive.Validator{
-				ocm.NonNegativeIntValidator,
+				ocm.NonNegativeInt32Validator,
 			},
 		})
 		if err != nil {
 			return nil, err
 		}
 	}
-	if err := ocm.NonNegativeIntValidator(result.LogVerbosity); err != nil {
+	if err := ocm.NonNegativeInt32Validator(result.LogVerbosity); err != nil {
 		return nil, fmt.Errorf("Error validating log-verbosity: %s", err)
 	}
 
@@ -408,14 +408,14 @@ func GetAutoscalerOptions(
 			Required: false,
 			Default:  result.MaxPodGracePeriod,
 			Validators: []interactive.Validator{
-				ocm.NonNegativeIntValidator,
+				ocm.NonNegativeInt32Validator,
 			},
 		})
 		if err != nil {
 			return nil, err
 		}
 	}
-	if err := ocm.NonNegativeIntValidator(result.MaxPodGracePeriod); err != nil {
+	if err := ocm.NonNegativeInt32Validator(result.MaxPodGracePeriod); err != nil {
 		return nil, fmt.Errorf("Error validating max-pod-grace-period: %s", err)
 	}
 
@@ -426,7 +426,7 @@ func GetAutoscalerOptions(
 			Required: false,
 			Default:  result.PodPriorityThreshold,
 			Validators: []interactive.Validator{
-				ocm.IntValidator,
+				ocm.Int32Validator,
 			},
 		})
 		if err != nil {
@@ -441,14 +441,14 @@ func GetAutoscalerOptions(
 			Required: false,
 			Default:  result.ResourceLimits.MaxNodesTotal,
 			Validators: []interactive.Validator{
-				ocm.NonNegativeIntValidator,
+				ocm.NonNegativeInt32Validator,
 			},
 		})
 		if err != nil {
 			return nil, err
 		}
 	}
-	if err := ocm.NonNegativeIntValidator(result.ResourceLimits.MaxNodesTotal); err != nil {
+	if err := ocm.NonNegativeInt32Validator(result.ResourceLimits.MaxNodesTotal); err != nil {
 		return nil, fmt.Errorf("Error validating max-nodes-total: %s", err)
 	}
 
@@ -459,14 +459,14 @@ func GetAutoscalerOptions(
 			Required: false,
 			Default:  result.ResourceLimits.Cores.Min,
 			Validators: []interactive.Validator{
-				ocm.NonNegativeIntValidator,
+				ocm.NonNegativeInt32Validator,
 			},
 		})
 		if err != nil {
 			return nil, err
 		}
 	}
-	if err = ocm.NonNegativeIntValidator(result.ResourceLimits.Cores.Min); err != nil {
+	if err = ocm.NonNegativeInt32Validator(result.ResourceLimits.Cores.Min); err != nil {
 		return nil, fmt.Errorf("Error validating min-cores: %s", err)
 	}
 
@@ -477,7 +477,7 @@ func GetAutoscalerOptions(
 			Required: false,
 			Default:  result.ResourceLimits.Cores.Max,
 			Validators: []interactive.Validator{
-				ocm.NonNegativeIntValidator,
+				ocm.NonNegativeInt32Validator,
 				getValidMaxRangeValidator(result.ResourceLimits.Cores.Min),
 			},
 		})
@@ -485,7 +485,7 @@ func GetAutoscalerOptions(
 			return nil, err
 		}
 	}
-	if err := ocm.NonNegativeIntValidator(result.ResourceLimits.Cores.Max); err != nil {
+	if err := ocm.NonNegativeInt32Validator(result.ResourceLimits.Cores.Max); err != nil {
 		return nil, fmt.Errorf("Error validating max-cores: %s", err)
 	}
 
@@ -500,14 +500,14 @@ func GetAutoscalerOptions(
 			Required: false,
 			Default:  result.ResourceLimits.Memory.Min,
 			Validators: []interactive.Validator{
-				ocm.NonNegativeIntValidator,
+				ocm.NonNegativeInt32Validator,
 			},
 		})
 		if err != nil {
 			return nil, err
 		}
 	}
-	if err := ocm.NonNegativeIntValidator(result.ResourceLimits.Memory.Min); err != nil {
+	if err := ocm.NonNegativeInt32Validator(result.ResourceLimits.Memory.Min); err != nil {
 		return nil, fmt.Errorf("Error validating min-memory: %s", err)
 	}
 
@@ -518,7 +518,7 @@ func GetAutoscalerOptions(
 			Required: false,
 			Default:  result.ResourceLimits.Memory.Max,
 			Validators: []interactive.Validator{
-				ocm.NonNegativeIntValidator,
+				ocm.NonNegativeInt32Validator,
 				getValidMaxRangeValidator(result.ResourceLimits.Memory.Min),
 			},
 		})
@@ -526,7 +526,7 @@ func GetAutoscalerOptions(
 			return nil, err
 		}
 	}
-	if err := ocm.NonNegativeIntValidator(result.ResourceLimits.Memory.Max); err != nil {
+	if err := ocm.NonNegativeInt32Validator(result.ResourceLimits.Memory.Max); err != nil {
 		return nil, fmt.Errorf("Error validating max-memory: %s", err)
 	}
 
@@ -542,7 +542,7 @@ func GetAutoscalerOptions(
 			Default:  0,
 			Required: false,
 			Validators: []interactive.Validator{
-				ocm.NonNegativeIntValidator,
+				ocm.NonNegativeInt32Validator,
 			},
 		})
 
@@ -566,7 +566,7 @@ func GetAutoscalerOptions(
 				Help: "An integer stating the minimum number of GPUs of the given type to deploy in the cluster. " +
 					"Must always be smaller than or equal to the maximal value.",
 				Validators: []interactive.Validator{
-					ocm.NonNegativeIntValidator,
+					ocm.NonNegativeInt32Validator,
 				},
 			})
 
@@ -579,7 +579,7 @@ func GetAutoscalerOptions(
 				Help: "An integer stating the maximum number of GPUs of the given type to deploy in the cluster. " +
 					"Must always be smaller than or equal to the maximal value.",
 				Validators: []interactive.Validator{
-					ocm.NonNegativeIntValidator,
+					ocm.NonNegativeInt32Validator,
 					getValidMaxRangeValidator(gpuLimitMin),
 				},
 			})

--- a/pkg/ocm/validators.go
+++ b/pkg/ocm/validators.go
@@ -8,21 +8,24 @@ import (
 	commonUtils "github.com/openshift-online/ocm-common/pkg/utils"
 )
 
-func IntValidator(val interface{}) error {
+func Int32Validator(val interface{}) error {
 	if val == "" { // if a value is not passed it should not throw an error (optional value)
 		return nil
 	}
-	_, err := strconv.Atoi(fmt.Sprintf("%v", val))
-	return err
+	_, err := strconv.ParseInt(fmt.Sprintf("%v", val), 10, 32)
+	if err != nil {
+		return fmt.Errorf("Should provide an integer number between -2147483648 to 2147483647.")
+	}
+	return nil
 }
 
-func NonNegativeIntValidator(val interface{}) error {
+func NonNegativeInt32Validator(val interface{}) error {
 	if val == "" { // if a value is not passed it should not throw an error (optional value)
 		return nil
 	}
-	number, err := strconv.Atoi(fmt.Sprintf("%v", val))
+	number, err := strconv.ParseInt(fmt.Sprintf("%v", val), 10, 32)
 	if err != nil {
-		return fmt.Errorf("Failed parsing '%v' to an integer number.", val)
+		return fmt.Errorf("Should provide an integer number between 0 to 2147483647.")
 	}
 
 	if number < 0 {

--- a/pkg/ocm/validators_test.go
+++ b/pkg/ocm/validators_test.go
@@ -8,41 +8,49 @@ import (
 var _ = Describe("Input Validators", Ordered, func() {
 	Context("int validator", func() {
 		It("succeeds if got an empty string", func() {
-			Expect(IntValidator("")).To(BeNil())
+			Expect(Int32Validator("")).To(BeNil())
 		})
 
 		It("raises an error if it fails to parse the input into an integer", func() {
-			Expect(IntValidator("something")).ToNot(BeNil())
+			Expect(Int32Validator("something")).ToNot(BeNil())
 		})
 
 		It("raises an error if it got a float", func() {
-			Expect(IntValidator("1.0")).ToNot(BeNil())
+			Expect(Int32Validator("1.0")).ToNot(BeNil())
+		})
+
+		It("raises an error if it got an integer out of range", func() {
+			Expect(Int32Validator("1152000000000")).ToNot(BeNil())
 		})
 
 		It("successfully parses an input that contains an integer", func() {
-			Expect(IntValidator("1")).To(BeNil())
+			Expect(Int32Validator("1")).To(BeNil())
 		})
 	})
 
 	Context("non-negative int validator", func() {
 		It("succeeds if got an empty string", func() {
-			Expect(NonNegativeIntValidator("")).To(BeNil())
+			Expect(NonNegativeInt32Validator("")).To(BeNil())
 		})
 
 		It("raises an error if it fails to parse the input into an integer", func() {
-			Expect(NonNegativeIntValidator("something")).ToNot(BeNil())
+			Expect(NonNegativeInt32Validator("something")).ToNot(BeNil())
 		})
 
 		It("raises an error if it got a float", func() {
-			Expect(NonNegativeIntValidator("1.0")).ToNot(BeNil())
+			Expect(NonNegativeInt32Validator("1.0")).ToNot(BeNil())
+		})
+
+		It("raises an error if it got an integer out of range", func() {
+			Expect(NonNegativeInt32Validator("1152000000000")).ToNot(BeNil())
 		})
 
 		It("raises an error if it got a negative number", func() {
-			Expect(NonNegativeIntValidator("-1")).ToNot(BeNil())
+			Expect(NonNegativeInt32Validator("-1")).ToNot(BeNil())
 		})
 
 		It("successfully parses an input that contains an integer", func() {
-			Expect(NonNegativeIntValidator("1")).To(BeNil())
+			Expect(NonNegativeInt32Validator("1")).To(BeNil())
 		})
 	})
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-10754