### PR TITLE
OCM-10676 | fix: Assign cluster ID var in create/oidc_provider

### DIFF
--- a/cmd/create/oidcprovider/cmd.go
+++ b/cmd/create/oidcprovider/cmd.go
@@ -189,6 +189,9 @@ func run(cmd *cobra.Command, argv []string) {
 		if !confirm.Prompt(true, confirmPromptMessage) {
 			os.Exit(0)
 		}
+		if clusterId == "" {
+			clusterId = cmd.Flag("cluster").Value.String()
+		}
 		err = createProvider(r, oidcEndpointURL, clusterId)
 		if err != nil {
 			r.Reporter.Errorf("There was an error creating the OIDC provider: %s", err)


### PR DESCRIPTION
Assigns cluster ID flag to the right var to be used when creating an OIDC provider