### PR TITLE
OCM-9508 | chore: bump version info to 1.2.46

### DIFF
--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,7 +18,7 @@ limitations under the License.
 
 package info
 
-const DefaultVersion = "1.2.45"
+const DefaultVersion = "1.2.46"
 
 // Build contains the short Git SHA of the CLI at the point it was build. Set via `-ldflags` at build time
 var Build = "local"


### PR DESCRIPTION
**WHAT**

Bumps version to 1.2.46 on master. Release branch is created for 1.2.45

**Validation**
```
╭─ ~/Work/ocm/rosa  on OCM-9508 *7 ························································································································································································································································· ✔  at 11:00:39 
╰─ make clean rosa
rm -rf \
        ./cover.out \
        rosa \
        rosa-darwin-amd64 \
        rosa-darwin-arm64 \
        rosa-linux-amd64 \
        rosa-linux-arm64 \
        rosa-windows-amd64.exe \
        *.sha256 \
        
go build -ldflags="-X github.com/openshift/rosa/pkg/info.Build=19b332e4" ./cmd/rosa
╭─ ~/Work/ocm/rosa  on OCM-9508 *7 ·············································································································································································································································· ✔  took 19s  at 11:01:01 
╰─ ./rosa version
I: 1.2.46
I: Your ROSA CLI is up to date.
```