### PR TITLE
OCM-10856 | test: fix id:55883 fixes ci job "e2e-rosa-sts-upgrade-y-stream-prod-f3"

### DIFF
--- a/tests/e2e/test_rosacli_upgrade.go
+++ b/tests/e2e/test_rosacli_upgrade.go
@@ -53,6 +53,14 @@ var _ = Describe("Cluster Upgrade testing",
 		})
 
 		AfterEach(func() {
+			if profile.Version == con.YStreamPreviousVersion {
+				By("Delete cluster upgrade")
+				output, err := upgradeService.DeleteUpgrade("-c", clusterID, "-y")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(output.String()).To(ContainSubstring(
+					"Successfully canceled scheduled upgrade on cluster '%s'", clusterID))
+			}
+
 			By("Clean remaining resources")
 			err := rosaClient.CleanResources(clusterID)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
[OCM-10856](https://issues.redhat.com//browse/OCM-10856) | test: fix id:55883

$ echo $TEST_PROFILE
rosa-upgrade-y-stream

$ ginkgo run --label-filter day1 tests/e2e --timeout 2h
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.11.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: ROSA CLI e2e tests suite - /home/akanni/OCP-Repository/rosa/tests/e2e
====================================================================================
Random Seed: 1725340859

Will run 1 of 198 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 198 Specs in 2540.315 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 197 Skipped
PASS

Ginkgo ran 1 suite in 42m26.837645809s
Test Suite Passed

