### PR TITLE
OCM-10512 | fix: Fixing OCM-10512 bug

### DIFF
--- a/tests/e2e/test_rosacli_machine_pool.go
+++ b/tests/e2e/test_rosacli_machine_pool.go
@@ -660,12 +660,20 @@ var _ = Describe("Create machinepool",
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Create temporary account-roles for instance type list")
-				accountRoles, err := ph.PrepareAccountRoles(rosaClient, "test-55979",
-					false,
-					clusterConfig.Version.RawID,
-					clusterConfig.Version.ChannelGroup,
-					"", "")
+				namePrefix := common.GenerateRandomName("test-55979", 2)
+				majorVersion := common.SplitMajorVersion(clusterConfig.Version.RawID)
+				_, err = rosaClient.OCMResource.CreateAccountRole("--mode", "auto",
+					"--prefix", namePrefix,
+					"--version", majorVersion,
+					"--channel-group", clusterConfig.Version.ChannelGroup,
+					"-y")
 				Expect(err).ToNot(HaveOccurred())
+
+				var accountRoles *rosacli.AccountRolesUnit
+				accRoleList, _, err := rosaClient.OCMResource.ListAccountRole()
+				Expect(err).ToNot(HaveOccurred())
+				accountRoles = accRoleList.DigAccountRoles(namePrefix, false)
+
 				defer rosaClient.OCMResource.DeleteAccountRole(
 					"--prefix", "test-55979",
 					"--mode", "auto",


### PR DESCRIPTION
original ticket: https://issues.redhat.com/browse/OCM-10512



```
oaharoni-mac:rosa oaharoni$ ginkgo run -focus 55979 tests/e2e
Running Suite: ROSA CLI e2e tests suite - /Users/oaharoni/rosa_workspace/rosa/tests/e2e
=======================================================================================
Random Seed: 1725472885

Will run 1 of 208 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSStime="2024-09-04 14:01:36" level=info msg="Trying to list subnets of the vpc"
time="2024-09-04 14:01:36" level=info msg="Got 6 subnets"
time="2024-09-04 14:01:36" level=info msg="subnet-08fcb10ff2e65f926\t10.0.1.0/24\tus-west-2a\t"
time="2024-09-04 14:01:36" level=info msg="subnet-0ee04f509e61abd18\t10.0.5.0/24\tus-west-2c\t"
time="2024-09-04 14:01:36" level=info msg="subnet-02cfdf4266c55a438\t10.0.3.0/24\tus-west-2b\t"
time="2024-09-04 14:01:36" level=info msg="subnet-0e7834353bbb8c9bd\t10.0.4.0/24\tus-west-2c\t"
time="2024-09-04 14:01:36" level=info msg="subnet-034e360a9bd68bf1c\t10.0.0.0/24\tus-west-2a\t"
time="2024-09-04 14:01:36" level=info msg="subnet-058862eee0d7ac2dc\t10.0.2.0/24\tus-west-2b\t"
time="2024-09-04 14:01:36" level=info msg="Got custom rt rtb-02eaf43e066cc6029 "
time="2024-09-04 14:01:36" level=info msg="Got custom rt rtb-045abee8c70032ec2 "
time="2024-09-04 14:01:36" level=info msg="Got custom rt rtb-0fe3b6e679e843770 "
time="2024-09-04 14:01:36" level=info msg="Got custom rt rtb-08050c0ec42069d47 "
time="2024-09-04 14:01:36" level=info msg="Got custom rt rtb-0066d4b7687fedbd1 "
time="2024-09-04 14:01:36" level=info msg="Got custom rt rtb-03f5c96084e9bbb4c "
time="2024-09-04 14:01:36" level=info msg="Got main association for rt rtb-0e16459095e395fd7"
time="2024-09-04 14:01:36" level=info msg="Going to prepare proper pair of subnets"
time="2024-09-04 14:01:36" level=info msg="Subnet subnet-08fcb10ff2e65f926 in zone: us-west-2a, region us-west-2"
time="2024-09-04 14:01:36" level=info msg="Subnet subnet-0ee04f509e61abd18 in zone: us-west-2c, region us-west-2"
time="2024-09-04 14:01:36" level=info msg="Subnet subnet-02cfdf4266c55a438 in zone: us-west-2b, region us-west-2"
time="2024-09-04 14:01:36" level=info msg="Subnet subnet-0e7834353bbb8c9bd in zone: us-west-2c, region us-west-2"
time="2024-09-04 14:01:36" level=info msg="Subnet subnet-034e360a9bd68bf1c in zone: us-west-2a, region us-west-2"
time="2024-09-04 14:01:36" level=info msg="Subnet subnet-058862eee0d7ac2dc in zone: us-west-2b, region us-west-2"
time="2024-09-04 14:01:36" level=info msg="Got no public subnet for current zone us-west-2-den-1a, going to create one"
time="2024-09-04 14:01:36" level=info msg="Created subnet subnet-095abd91a67f75749 for vpc vpc-0bb65b425a7ec41f2"
time="2024-09-04 14:01:37" level=info msg="Created subnet with ID subnet-095abd91a67f75749"
time="2024-09-04 14:01:37" level=info msg="Associate route table success rtbassoc-0386d7f07319f15c4"
time="2024-09-04 14:01:38" level=info msg="Create route success for route table: rtb-05131ea20f5ad97cd"
time="2024-09-04 14:01:38" level=info msg="Tag resource subnet-095abd91a67f75749 successfully"
time="2024-09-04 14:01:38" level=info msg="Got no proper private subnet for current zone us-west-2-den-1a, going to create one"
time="2024-09-04 14:01:39" level=info msg="Created subnet subnet-0f35bc0af3f1903d5 for vpc vpc-0bb65b425a7ec41f2"
time="2024-09-04 14:01:39" level=info msg="Created subnet with ID subnet-0f35bc0af3f1903d5"
time="2024-09-04 14:01:40" level=info msg="Associate route table success rtbassoc-0c4cd601a8e20c1a6"
time="2024-09-04 14:01:40" level=info msg="Found existing nat gateway: nat-0dca403e4f35fba39"
time="2024-09-04 14:01:40" level=info msg="Create route success for route table: rtb-0b1c2df59ad99e56c"
time="2024-09-04 14:01:41" level=info msg="Tag resource subnet-0f35bc0af3f1903d5 successfully"
time="2024-09-04 14:01:43" level=info msg="Tag resource subnet-0f35bc0af3f1903d5 successfully"
•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 208 Specs in 119.859 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 207 Skipped
PASS
```