### PR TITLE
OCM-9882 | feat: print custom worker disk size in describe nodepool

### DIFF
--- a/pkg/machinepool/output.go
+++ b/pkg/machinepool/output.go
@@ -65,7 +65,7 @@ func machinePoolOutput(clusterId string, machinePool *cmv1.MachinePool) string {
 }
 
 func nodePoolOutput(clusterId string, nodePool *cmv1.NodePool) string {
-	return fmt.Sprintf(nodePoolOutputString,
+	output := fmt.Sprintf(nodePoolOutputString,
 		nodePool.ID(),
 		clusterId,
 		ocmOutput.PrintNodePoolAutoscaling(nodePool.Autoscaling()),
@@ -87,4 +87,13 @@ func nodePoolOutput(clusterId string, nodePool *cmv1.NodePool) string {
 		ocmOutput.PrintNodePoolManagementUpgrade(nodePool.ManagementUpgrade()),
 		ocmOutput.PrintNodePoolMessage(nodePool.Status()),
 	)
+
+	if nodePool.AWSNodePool() != nil && nodePool.AWSNodePool().RootVolume() != nil {
+		diskSize, ok := nodePool.AWSNodePool().RootVolume().GetSize()
+		if ok {
+			output += fmt.Sprintf("Disk size:                             %d\n", diskSize)
+		}
+	}
+
+	return output
 }

--- a/pkg/machinepool/output_test.go
+++ b/pkg/machinepool/output_test.go
@@ -141,5 +141,24 @@ var _ = Describe("Output", Ordered, func() {
 			result := nodePoolOutput("test-cluster", nodePool)
 			Expect(out).To(Equal(result))
 		})
+		It("nodepool output with custom disk size", func() {
+			awsNodePoolBuilder := cmv1.NewAWSNodePool().RootVolume(cmv1.NewAWSVolume().Size(256))
+			nodePoolBuilder := cmv1.NewNodePool().ID("test-mp").Replicas(4).AWSNodePool(awsNodePoolBuilder).
+				AvailabilityZone("test-az").Subnet("test-subnets").Version(cmv1.NewVersion().
+				ID("1")).AutoRepair(false).TuningConfigs("test-tc").
+				KubeletConfigs("test-kc").Labels(labels).Taints(taintsBuilder)
+			nodePool, err := nodePoolBuilder.Build()
+			Expect(err).ToNot(HaveOccurred())
+			labelsOutput := ocmOutput.PrintLabels(labels)
+			taintsOutput := ocmOutput.PrintTaints([]*cmv1.Taint{taint})
+
+			out := fmt.Sprintf(nodePoolOutputString,
+				"test-mp", "test-cluster", "No", "4", "", "", labelsOutput, "", taintsOutput, "test-az",
+				"test-subnets", "1", "optional", "No", "test-tc", "test-kc", "", "", "", "")
+			out += "Disk size:                             256\n"
+
+			result := nodePoolOutput("test-cluster", nodePool)
+			Expect(out).To(Equal(result))
+		})
 	})
 })


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-9882

adds disk size to describe machinepool output for node pools if the disk size is returned from the API
note: this includes a check that the disk size is actually set because the API work for this still needs to be enabled. In the future we will be able to remove this check.