### PR TITLE
OCM-10990 | test: fix id:67057

### DIFF
--- a/tests/e2e/test_rosacli_machine_pool.go
+++ b/tests/e2e/test_rosacli_machine_pool.go
@@ -733,7 +733,7 @@ var _ = Describe("Create machinepool",
 						"-y",
 					)
 					Expect(err).To(HaveOccurred())
-					Expect(output.String()).Should(ContainSubstring("min-replicas must be a non-negative integer"))
+					Expect(output.String()).Should(ContainSubstring("Replicas must be a non-negative integer"))
 
 					By("Create with invalid labels will fail")
 					output, err = rosaClient.MachinePool.CreateMachinePool(clusterID, mpName,


### PR DESCRIPTION
[OCM-10990](https://issues.redhat.com//browse/OCM-10990) | test: fix id:67057

$ ginkgo --focus 67057 tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.11.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: ROSA CLI e2e tests suite - /home/akanni/OCP-Repository/rosa/tests/e2e
====================================================================================
Random Seed: 1725867185

Will run 1 of 209 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 209 Specs in 53.780 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 208 Skipped
PASS

Ginkgo ran 1 suite in 57.460551062s
Test Suite Passed
