### PR TITLE
OCM-7568 | feat: Clarify that 'billing-account' expects an account ID

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -721,7 +721,7 @@ func initFlags(cmd *cobra.Command) {
 		&args.billingAccount,
 		"billing-account",
 		"",
-		"Account used for billing subscriptions purchased via the AWS marketplace",
+		"Account ID used for billing subscriptions purchased via the AWS marketplace",
 	)
 
 	flags.BoolVar(


### PR DESCRIPTION
Clarify that when creating a cluster, the `billing-account` param expects an account ID and not an ARN or other identifier. 

Resolves [OCM-7568](https://issues.redhat.com//browse/OCM-7568).