### PR TITLE
OCM-11019 | fix: Fix issue with classic clusters without --oidc-config-id flag

### DIFF
--- a/cmd/create/oidcprovider/cmd.go
+++ b/cmd/create/oidcprovider/cmd.go
@@ -230,7 +230,7 @@ func run(cmd *cobra.Command, argv []string) {
 
 func createProvider(r *rosa.Runtime, oidcEndpointUrl string, clusterId string, isProgrammaticallyCalled bool) error {
 	inputBuilder := cmv1.NewOidcThumbprintInput()
-	if isProgrammaticallyCalled || clusterId == "" {
+	if (isProgrammaticallyCalled || clusterId == "") && args.oidcConfigId != "" {
 		inputBuilder.OidcConfigId(args.oidcConfigId)
 	} else {
 		inputBuilder.ClusterId(clusterId)


### PR DESCRIPTION
Missing empty check allowed no inputs to be passed into the thumbprint fetch in one situation only

Manually verified every situation surrounding this