### PR TITLE
OCM-11054 | fix: add unit to disk size on describe nodepool

### DIFF
--- a/cmd/describe/machinepool/cmd_test.go
+++ b/cmd/describe/machinepool/cmd_test.go
@@ -32,6 +32,7 @@ Tags:
 Taints:                                
 Availability zone:                     us-east-1a
 Subnet:                                
+Disk Size:                             300 GiB
 Version:                               4.12.24
 EC2 Metadata Http Tokens:              optional
 Autorepair:                            No
@@ -57,6 +58,7 @@ Tags:
 Taints:                                
 Availability zone:                     us-east-1a
 Subnet:                                
+Disk Size:                             300 GiB
 Version:                               4.12.24
 EC2 Metadata Http Tokens:              optional
 Autorepair:                            No
@@ -83,6 +85,7 @@ Tags:                                  foo=bar
 Taints:                                
 Availability zone:                     us-east-1a
 Subnet:                                
+Disk Size:                             300 GiB
 Version:                               4.12.24
 EC2 Metadata Http Tokens:              optional
 Autorepair:                            No
@@ -102,6 +105,8 @@ Scheduled upgrade:                     scheduled 4.12.25 on 2023-08-07 15:22 UTC
 aws_node_pool:
   instance_type: m5.xlarge
   kind: AWSNodePool
+  root_volume:
+    size: 300
 id: nodepool85
 kind: NodePool
 management_upgrade:
@@ -426,7 +431,7 @@ var _ = Describe("Upgrade machine pool", func() {
 // formatNodePool simulates the output of APIs for a fake node pool
 func formatNodePool() string {
 	version := cmv1.NewVersion().ID("4.12.24").RawID("openshift-4.12.24")
-	awsNodePool := cmv1.NewAWSNodePool().InstanceType("m5.xlarge")
+	awsNodePool := cmv1.NewAWSNodePool().InstanceType("m5.xlarge").RootVolume(cmv1.NewAWSVolume().Size(300))
 	nodeDrain := cmv1.NewValue().Value(1).Unit("minute")
 	mgmtUpgrade := cmv1.NewNodePoolManagementUpgrade().Type("Replace").MaxSurge("1").MaxUnavailable("0")
 	np, err := cmv1.NewNodePool().ID(nodePoolName).Version(version).
@@ -439,7 +444,8 @@ func formatNodePool() string {
 // formatNodePool simulates the output of APIs for a fake node pool with AWS tags
 func formatNodePoolWithTags() string {
 	version := cmv1.NewVersion().ID("4.12.24").RawID("openshift-4.12.24")
-	awsNodePool := cmv1.NewAWSNodePool().InstanceType("m5.xlarge").Tags(map[string]string{"foo": "bar"})
+	awsNodePool := cmv1.NewAWSNodePool().InstanceType("m5.xlarge").Tags(map[string]string{"foo": "bar"}).
+		RootVolume(cmv1.NewAWSVolume().Size(300))
 	nodeDrain := cmv1.NewValue().Value(1).Unit("minute")
 	mgmtUpgrade := cmv1.NewNodePoolManagementUpgrade().Type("Replace").MaxSurge("1").MaxUnavailable("0")
 	np, err := cmv1.NewNodePool().ID(nodePoolName).Version(version).

--- a/pkg/machinepool/output.go
+++ b/pkg/machinepool/output.go
@@ -21,6 +21,7 @@ var nodePoolOutputString string = "\n" +
 	"Taints:                                %s\n" +
 	"Availability zone:                     %s\n" +
 	"Subnet:                                %s\n" +
+	"Disk Size:                             %s\n" +
 	"Version:                               %s\n" +
 	"EC2 Metadata Http Tokens:              %s\n" +
 	"Autorepair:                            %s\n" +
@@ -77,6 +78,7 @@ func nodePoolOutput(clusterId string, nodePool *cmv1.NodePool) string {
 		ocmOutput.PrintTaints(nodePool.Taints()),
 		nodePool.AvailabilityZone(),
 		nodePool.Subnet(),
+		ocmOutput.PrintNodePoolDiskSize(nodePool.AWSNodePool()),
 		ocmOutput.PrintNodePoolVersion(nodePool.Version()),
 		ocmOutput.PrintEC2MetadataHttpTokens(nodePool.AWSNodePool()),
 		ocmOutput.PrintNodePoolAutorepair(nodePool.AutoRepair()),
@@ -87,13 +89,6 @@ func nodePoolOutput(clusterId string, nodePool *cmv1.NodePool) string {
 		ocmOutput.PrintNodePoolManagementUpgrade(nodePool.ManagementUpgrade()),
 		ocmOutput.PrintNodePoolMessage(nodePool.Status()),
 	)
-
-	if nodePool.AWSNodePool() != nil && nodePool.AWSNodePool().RootVolume() != nil {
-		diskSize, ok := nodePool.AWSNodePool().RootVolume().GetSize()
-		if ok {
-			output += fmt.Sprintf("Disk size:                             %d\n", diskSize)
-		}
-	}
 
 	return output
 }

--- a/pkg/machinepool/output_test.go
+++ b/pkg/machinepool/output_test.go
@@ -101,9 +101,11 @@ var _ = Describe("Output", Ordered, func() {
 			Expect(out).To(Equal(result))
 		})
 		It("nodepool output with autoscaling", func() {
+			awsNodePoolBuilder := cmv1.NewAWSNodePool().RootVolume(cmv1.NewAWSVolume().Size(300))
 			npAutoscaling := cmv1.NewNodePoolAutoscaling().ID("test-as").MinReplica(2).MaxReplica(8)
 			mgmtUpgradeBuilder := cmv1.NewNodePoolManagementUpgrade().MaxSurge("1").MaxUnavailable("0")
 			nodePoolBuilder := *cmv1.NewNodePool().ID("test-mp").Autoscaling(npAutoscaling).Replicas(4).
+				AWSNodePool(awsNodePoolBuilder).
 				AvailabilityZone("test-az").Subnet("test-subnets").Version(cmv1.NewVersion().
 				ID("1")).AutoRepair(false).TuningConfigs("test-tc").
 				KubeletConfigs("test-kc").Labels(labels).Taints(taintsBuilder).
@@ -119,13 +121,15 @@ var _ = Describe("Output", Ordered, func() {
 
 			out := fmt.Sprintf(nodePoolOutputString,
 				"test-mp", "test-cluster", "Yes", replicasOutput, "", "", labelsOutput, "", taintsOutput, "test-az",
-				"test-subnets", "1", "optional", "No", "test-tc", "test-kc", "", "", managementUpgradeOutput, "")
+				"test-subnets", "300 GiB", "1", "optional", "No", "test-tc", "test-kc", "", "", managementUpgradeOutput, "")
 
 			result := nodePoolOutput("test-cluster", nodePool)
 			Expect(out).To(Equal(result))
 		})
 		It("nodepool output without autoscaling", func() {
+			awsNodePoolBuilder := cmv1.NewAWSNodePool().RootVolume(cmv1.NewAWSVolume().Size(300))
 			nodePoolBuilder := *cmv1.NewNodePool().ID("test-mp").Replicas(4).
+				AWSNodePool(awsNodePoolBuilder).
 				AvailabilityZone("test-az").Subnet("test-subnets").Version(cmv1.NewVersion().
 				ID("1")).AutoRepair(false).TuningConfigs("test-tc").
 				KubeletConfigs("test-kc").Labels(labels).Taints(taintsBuilder)
@@ -136,7 +140,7 @@ var _ = Describe("Output", Ordered, func() {
 
 			out := fmt.Sprintf(nodePoolOutputString,
 				"test-mp", "test-cluster", "No", "4", "", "", labelsOutput, "", taintsOutput, "test-az",
-				"test-subnets", "1", "optional", "No", "test-tc", "test-kc", "", "", "", "")
+				"test-subnets", "300 GiB", "1", "optional", "No", "test-tc", "test-kc", "", "", "", "")
 
 			result := nodePoolOutput("test-cluster", nodePool)
 			Expect(out).To(Equal(result))
@@ -154,8 +158,7 @@ var _ = Describe("Output", Ordered, func() {
 
 			out := fmt.Sprintf(nodePoolOutputString,
 				"test-mp", "test-cluster", "No", "4", "", "", labelsOutput, "", taintsOutput, "test-az",
-				"test-subnets", "1", "optional", "No", "test-tc", "test-kc", "", "", "", "")
-			out += "Disk size:                             256\n"
+				"test-subnets", "256 GiB", "1", "optional", "No", "test-tc", "test-kc", "", "", "", "")
 
 			result := nodePoolOutput("test-cluster", nodePool)
 			Expect(out).To(Equal(result))


### PR DESCRIPTION
for https://issues.redhat.com/browse/OCM-11054

- forgot to add the unit when displaying the node pool root disk size as part of the `rosa describe` command, this MR adds it
- also removes a check to verify the value is set before displaying - CS changes are merged and the value has a default in the DB so it will always be set, that check was just included initially because I added the ROSA changes before the CS changes