### PR TITLE
OCM-11113 | feat: bump ocm-common to lower np min disk size to 75

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/nathan-fiscaletti/consolesize-go v0.0.0-20210105204122-a87d9f614b9d
 	github.com/onsi/ginkgo/v2 v2.17.1
 	github.com/onsi/gomega v1.30.0
-	github.com/openshift-online/ocm-common v0.0.10
+	github.com/openshift-online/ocm-common v0.0.11
 	github.com/openshift-online/ocm-sdk-go v0.1.440
 	github.com/pkg/errors v0.9.1
 	github.com/robfig/cron/v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -273,8 +273,8 @@ github.com/onsi/ginkgo/v2 v2.17.1 h1:V++EzdbhI4ZV4ev0UTIj0PzhzOcReJFyJaLjtSF55M8
 github.com/onsi/ginkgo/v2 v2.17.1/go.mod h1:llBI3WDLL9Z6taip6f33H76YcWtJv+7R3HigUjbIBOs=
 github.com/onsi/gomega v1.30.0 h1:hvMK7xYz4D3HapigLTeGdId/NcfQx1VHMJc60ew99+8=
 github.com/onsi/gomega v1.30.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
-github.com/openshift-online/ocm-common v0.0.10 h1:J3QtAOK/ZQlHTPB4uQfshO45vjYdJ9099PLM0HoOUR0=
-github.com/openshift-online/ocm-common v0.0.10/go.mod h1:6MWje2NFNJ3IWpGs7BYj6DWagWXHyp8EnmYY7XFTtI4=
+github.com/openshift-online/ocm-common v0.0.11 h1:DOj7fB59q0vAUFxSEQpLPp2AkReCCFq3r3NMaoZU20I=
+github.com/openshift-online/ocm-common v0.0.11/go.mod h1:6MWje2NFNJ3IWpGs7BYj6DWagWXHyp8EnmYY7XFTtI4=
 github.com/openshift-online/ocm-sdk-go v0.1.440 h1:qHVF8iZ0V3DPPuZq2LF7pwQKVsm0W0QxVDoXxDS7oyw=
 github.com/openshift-online/ocm-sdk-go v0.1.440/go.mod h1:CiAu2jwl3ITKOxkeV0Qnhzv4gs35AmpIzVABQLtcI2Y=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/vendor/github.com/openshift-online/ocm-common/pkg/machinepool/validations/disk_size.go
+++ b/vendor/github.com/openshift-online/ocm-common/pkg/machinepool/validations/disk_size.go
@@ -18,7 +18,7 @@ const (
 	// 16 TiB - limit as of 4.14
 	machinePoolRootVolumeSizeMaxAsOf414 = 16384
 	// constants for node pool root size validation
-	nodePoolRootAWSVolumeSizeMin = 128
+	nodePoolRootAWSVolumeSizeMin = 75
 	nodePoolRootAWSVolumeSizeMax = 16384
 )
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -413,7 +413,7 @@ github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
-# github.com/openshift-online/ocm-common v0.0.10
+# github.com/openshift-online/ocm-common v0.0.11
 ## explicit; go 1.21
 github.com/openshift-online/ocm-common/pkg/aws/aws_client
 github.com/openshift-online/ocm-common/pkg/aws/consts


### PR DESCRIPTION
bumps ocm-common version to include https://github.com/openshift-online/ocm-common/commit/8a39738ecf9dc231357f1302e1a8f7f202a64fec