### PR TITLE
OCM-10679 | fix: use default user agent

### DIFF
--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -330,7 +330,7 @@ func (b *ClientBuilder) BuildSessionWithOptionsCredentials(value *AccessKey,
 		config.WithClientLogMode(logLevel),
 		config.WithAPIOptions([]func(stack *middleware.Stack) error{
 			smithyhttp.AddHeaderValue("User-Agent",
-				strings.Join([]string{"ROSACLI", info.DefaultVersion}, ";")),
+				strings.Join([]string{info.DefaultUserAgent, info.DefaultVersion}, ";")),
 		}),
 		config.WithRetryer(func() aws.Retryer {
 			retryer := retry.AddWithMaxAttempts(retry.NewStandard(), numMaxRetries)
@@ -358,7 +358,7 @@ func (b *ClientBuilder) BuildSessionWithOptions(logLevel aws.ClientLogMode) (aws
 		config.WithClientLogMode(logLevel),
 		config.WithAPIOptions([]func(stack *middleware.Stack) error{
 			smithyhttp.AddHeaderValue("User-Agent",
-				strings.Join([]string{"ROSACLI", info.DefaultVersion}, ";")),
+				strings.Join([]string{info.DefaultUserAgent, info.DefaultVersion}, ";")),
 		}),
 		config.WithRetryer(func() aws.Retryer {
 			retryer := retry.AddWithMaxAttempts(retry.NewStandard(), numMaxRetries)


### PR DESCRIPTION
After #2356 there were a few places where the default user agent was hardcoded and needed to be fixed