### PR TITLE
OCM-11156 | test: fix id:60275

### DIFF
--- a/tests/e2e/test_rosacli_cluster.go
+++ b/tests/e2e/test_rosacli_cluster.go
@@ -307,8 +307,7 @@ var _ = Describe("Edit cluster",
 
 				if isSTS && !isHostedCP {
 					Expect(editErr).ToNot(BeNil())
-					Expect(textData).Should(ContainSubstring("Failed to update cluster: Cannot update listening " +
-						"mode of cluster's API on an AWS STS cluster"))
+					Expect(textData).Should(ContainSubstring("Failed to update cluster"))
 
 					Expect(CD.Private).To(Equal("Yes"))
 				} else {


### PR DESCRIPTION
[OCM-11156](https://issues.redhat.com/browse/OCM-11156) | [CI] Debug and fix: id 60275




$ ginkgo --focus 60275 tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.11.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: ROSA CLI e2e tests suite - /home/akanni/OCP-Repository/rosa/tests/e2e
====================================================================================
Random Seed: 1726493453

Will run 1 of 223 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 223 Specs in 38.179 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 222 Skipped
PASS

Ginkgo ran 1 suite in 42.000779049s
Test Suite Passed
