### PR TITLE
OCM-11201 | fix : fix make target ensuring release builds and publishes to github

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,4 +144,4 @@ release:
 			exit 1; \
 		fi \
 	fi; \
-	$(GORELEASER) release --snapshot --clean
+	$(GORELEASER) release --clean


### PR DESCRIPTION
**WHAT**

At the moment release target creates a snapshot, this change removes the `--snapshot` param ensuring the the release is built and published to github

JIRA - https://issues.redhat.com/browse/OCM-11201