### PR TITLE
OCM-11202 | chore : add output to release script for errata jira list

### DIFF
--- a/hack/release-list-jiras.sh
+++ b/hack/release-list-jiras.sh
@@ -35,6 +35,10 @@ done <<< "$commit_output"
 # Create a comma-separated list of Jira tickets
 jira_list=$(IFS=, ; echo "${jira_tickets[*]}")
 
+# Create a space-separated list of capitalized Jira tickets
+errata_list=$(IFS=' ' ; echo "${jira_tickets[@]^^}")
+echo -e "List of JIRA's to be used in Errata \n$errata_list"
+
 # Create the JQL query for the list of Jira tickets
 jql="project = \"Openshift Cluster Manager\" AND issue in ($jira_list) AND labels not in (no-qe) AND (fixVersion is EMPTY OR fixVersion = $current_release)"
 


### PR DESCRIPTION
**WHAT**

As we require a list of JIRAs for Errata, this adds the output to the release list script 

**Validation**
```
./hack/release-list-jiras.sh 1.2.45 1.2.44
List of JIRA's to be used in Errata 
OCM-7552  OCM-6419  OCM-10341  OCM-3704  OCM-9503  OCM-10333  OCM-7551  OCM-10412  OCM-10221  OCM-9284  OCM-10455  OCM-10299  OCM-10459  OCM-10455  OCM-10438  OCM-10485  OCM-10506  OCM-10299  OCM-10507  OCM-9805  OCM-10511  OCM-7551  OCM-10532  OCM-10479  OCM-10538  OCM-10450  OCM-5445  OCM-10543  OCM-10477  OCM-10545  OCM-10606  OCM-10460  OCM-10452  OCM-9804  OCM-10616  OCM-10631  OCM-10633  OCM-10636  OCM-10406  OCM-10452  OCM-10676  OCM-10467  OCM-10711  OCM-9784  OCM-7184  OCM-7186  OCM-10489  OCM-10756  OCM-10754  OCM-10530  OCM-10712  OCM-10779  OCM-10676  OCM-9876  OCM-9773  OCM-10812  OCM-10852  OCM-10854  OCM-10837  OCM-10712  OCM-9299  OCM-10638  OCM-10815  OCM-10866  OCM-10856  OCM-10897  OCM-10903  OCM-10777  OCM-10868  OCM-10897  OCM-10897  OCM-10512  OCM-9804  OCM-9882  OCM-10943  OCM-9804  OCM-8760  OCM-10628  OCM-10990  OCM-10998  OCM-10952  OCM-10939  OCM-10939  OCM-7568  OCM-11028  OCM-10690  OCM-9774  OCM-11019  OCM-10674  OCM-11027  OCM-10374  OCM-11019  OCM-11054  OCM-11096  OCM-11097  OCM-11026  OCM-11019  OCM-11113  OCM-11135  OCM-11158  OCM-10679  OCM-11156  OCM-11201 

```

JIRA - https://issues.redhat.com/browse/OCM-11202