### PR TITLE
OCM-11241 | fix: update description for 36293

### DIFF
--- a/tests/e2e/test_rosacli_machine_pool.go
+++ b/tests/e2e/test_rosacli_machine_pool.go
@@ -64,7 +64,7 @@ var _ = Describe("Create machinepool",
 
 		})
 
-		It("can create/list/delete machinepool - [id:36293]",
+		It("can create/list machinepool - [id:36293]",
 			labels.Critical,
 			labels.Runtime.Day2,
 			func() {


### PR DESCRIPTION
For test 36293, the description said that it was doing a delete, but from looking at the code, no delete was happening, so I updated the description to only mention that it was only creating and listing the machine pools.