### PR TITLE
OCM-11199 | test: fix id:38775

### DIFF
--- a/tests/e2e/test_rosacli_machine_pool.go
+++ b/tests/e2e/test_rosacli_machine_pool.go
@@ -787,7 +787,7 @@ var _ = Describe("Create machinepool",
 						clusterID, mpName,
 						"--replicas", "-1")
 					Expect(err).To(HaveOccurred())
-					Expect(output.String()).Should(ContainSubstring("min-replicas must be a non-negative integer"))
+					Expect(output.String()).Should(ContainSubstring("Replicas must be a non-negative integer"))
 
 					By("Create machine pool with invalid name")
 					output, err = rosaClient.MachinePool.CreateMachinePool(clusterID, "%^#@")
@@ -814,14 +814,14 @@ var _ = Describe("Create machinepool",
 					Expect(err).To(HaveOccurred())
 					Expect(output.String()).Should(ContainSubstring("Replicas can't be set when autoscaling is enabled"))
 
-					By("Set min-replicas large than max-replicas")
+					By("Set min-replicas larger than max-replicas")
 					output, err = rosaClient.MachinePool.CreateMachinePool(
 						clusterID, mpName,
 						"--min-replicas", "6",
 						"--max-replicas", "3",
 						"--enable-autoscaling")
 					Expect(err).To(HaveOccurred())
-					Expect(output.String()).Should(ContainSubstring("max-replicas must be greater or equal to min-replicas"))
+					Expect(output.String()).Should(ContainSubstring("'min_replicas' must be less than or equal to 'max_replicas'"))
 
 					By("Set min-replicas and max-replicas without set --enable-autoscaling")
 					output, err = rosaClient.MachinePool.CreateMachinePool(


### PR DESCRIPTION
[OCM-11199](https://issues.redhat.com//browse/OCM-11199)

$ ginkgo --focus 38775 tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.11.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: ROSA CLI e2e tests suite - /home/akanni/OCP-Repository/rosa/tests/e2e
====================================================================================
Random Seed: 1727095207

Will run 1 of 226 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 0 of 226 Specs in 12.008 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 225 Skipped
PASS

Ginkgo ran 1 suite in 16.215173339s
Test Suite Passed
