### PR TITLE
OCM-11364 | fix: Regression, HCP nodepool creation validation used for classic

### DIFF
--- a/pkg/machinepool/helper.go
+++ b/pkg/machinepool/helper.go
@@ -205,14 +205,18 @@ func maxReplicaValidator(minReplicas int, multiAZMachinePool bool) interactive.V
 	}
 }
 
-func minReplicaValidator(multiAZMachinePool bool, autoscaling bool) interactive.Validator {
+func minReplicaValidator(multiAZMachinePool bool, autoscaling bool, isHypershift bool) interactive.Validator {
 	return func(val interface{}) error {
 		minReplicas, err := strconv.Atoi(fmt.Sprintf("%v", val))
 		if err != nil {
 			return err
 		}
-		if autoscaling && minReplicas < 1 {
+		if autoscaling && minReplicas < 1 && isHypershift {
 			return fmt.Errorf("min-replicas must be greater than zero")
+		}
+		if autoscaling && minReplicas < 0 && !isHypershift {
+			return fmt.Errorf("min-replicas must be a number that is 0 or greater when autoscaling is" +
+				" enabled")
 		}
 		if !autoscaling && minReplicas < 0 {
 			return fmt.Errorf("Replicas must be a non-negative integer")

--- a/pkg/machinepool/helper_test.go
+++ b/pkg/machinepool/helper_test.go
@@ -3,7 +3,7 @@ package machinepool
 import (
 	"fmt"
 
-	gomock "go.uber.org/mock/gomock"
+	"go.uber.org/mock/gomock"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -417,7 +417,7 @@ var _ = Describe("getSecurityGroupsOption", func() {
 var _ = Describe("Machine pool min/max replicas validation", func() {
 	DescribeTable("Machine pool min replicas validation",
 		func(minReplicas int, autoscaling bool, multiAZ bool, hasError bool) {
-			err := minReplicaValidator(multiAZ, autoscaling)(minReplicas)
+			err := minReplicaValidator(multiAZ, autoscaling, false)(minReplicas)
 			if hasError {
 				Expect(err).To(HaveOccurred())
 			} else {
@@ -440,7 +440,7 @@ var _ = Describe("Machine pool min/max replicas validation", func() {
 			0,
 			true,
 			false,
-			true,
+			false,
 		),
 		Entry("One replicas - autoscaling",
 			1,

--- a/pkg/machinepool/machinepool_test.go
+++ b/pkg/machinepool/machinepool_test.go
@@ -6,10 +6,10 @@ import (
 	"io"
 	"net/http"
 	"os"
-	reflect "reflect"
+	"reflect"
 	"time"
 
-	gomock "go.uber.org/mock/gomock"
+	"go.uber.org/mock/gomock"
 
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	. "github.com/onsi/ginkgo/v2"
@@ -515,7 +515,7 @@ var _ = Describe("Utility Functions", func() {
 		var validator interactive.Validator
 
 		BeforeEach(func() {
-			validator = minReplicaValidator(true, false) // or false for non-multiAZ
+			validator = minReplicaValidator(true, false, false) // or false for non-multiAZ
 		})
 
 		When("input is non-integer", func() {
@@ -1532,7 +1532,7 @@ var _ = Describe("ManageReplicas", func() {
 			args.AutoscalingEnabled = true
 			cmd.Flags().Int32("replicas", 1, "Replicas of the machine pool")
 			cmd.Flags().Set("replicas", "1")
-			_, _, _, autoscaling, err := manageReplicas(cmd, args, multiAZMachinePool)
+			_, _, _, autoscaling, err := manageReplicas(cmd, args, multiAZMachinePool, false)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("Replicas can't be set when autoscaling is enabled"))
 			Expect(autoscaling).To(BeTrue())
@@ -1545,7 +1545,7 @@ var _ = Describe("ManageReplicas", func() {
 			cmd.Flags().Set("max-replicas", "6")
 			args.MinReplicas = 3
 			args.MaxReplicas = 6
-			_, _, _, _, err := manageReplicas(cmd, args, multiAZMachinePool)
+			_, _, _, _, err := manageReplicas(cmd, args, multiAZMachinePool, false)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
@@ -1559,7 +1559,7 @@ var _ = Describe("ManageReplicas", func() {
 			cmd.Flags().Set("max-replicas", "3")
 			args.MinReplicas = 1
 			args.MaxReplicas = 3
-			_, _, _, autoscaling, err := manageReplicas(cmd, args, multiAZMachinePool)
+			_, _, _, autoscaling, err := manageReplicas(cmd, args, multiAZMachinePool, false)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("Autoscaling must be enabled in order to set min and max replicas"))
 			Expect(autoscaling).To(BeFalse())
@@ -1568,7 +1568,7 @@ var _ = Describe("ManageReplicas", func() {
 			args.AutoscalingEnabled = false
 			cmd.Flags().Int32("replicas", 1, "Replicas of the machine pool")
 			cmd.Flags().Set("replicas", "1")
-			_, _, _, autoscaling, err := manageReplicas(cmd, args, multiAZMachinePool)
+			_, _, _, autoscaling, err := manageReplicas(cmd, args, multiAZMachinePool, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(autoscaling).To(BeFalse())
 		})
@@ -1594,7 +1594,7 @@ var _ = Describe("Utility Functions", func() {
 		var validator interactive.Validator
 
 		BeforeEach(func() {
-			validator = minReplicaValidator(true, false) // or false for non-multiAZ
+			validator = minReplicaValidator(true, false, false) // or false for non-multiAZ
 		})
 
 		It("should return error for non-integer input", func() {


### PR DESCRIPTION
Fix for issue customer faced after 1.2.45 released

Logic which checked # of min replicas for newly created machinepools was applied to both HCP and classic- though there is a difference between what is supported (when autoscaling is enabled)

for HCP, >0 min replicas
for classic, >=0 min replicas

This fix adds different logic paths in the validation + fixes unit tests