### PR TITLE
OCM-9515 | chore: adjust goreleaser to use openshift/rosa

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,6 +29,9 @@ archives:
 release:
   prerelease: auto
   mode: append
+  github:
+    owner: openshift
+    name: rosa
 
 changelog:
   sort: asc


### PR DESCRIPTION
Allows to run goreleaser from fork