### PR TITLE
OCM-11407 | ci: fix nil value return for editNodepoolValidation

### DIFF
--- a/pkg/machinepool/machinepool.go
+++ b/pkg/machinepool/machinepool.go
@@ -1534,7 +1534,8 @@ func editNodePool(cmd *cobra.Command, nodePoolID string,
 		return fmt.Errorf("Failed to get autoscaling or replicas: '%s'", err)
 	}
 
-	if validateNodePoolEdit(cmd, autoscaling, replicas, minReplicas, maxReplicas) != nil {
+	err = validateNodePoolEdit(cmd, autoscaling, replicas, minReplicas, maxReplicas)
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Before this fix, no err message was shown
`$ rosa edit machinepool -c 2e0i256vrlvnjcc9rn63orr4fljal6gv test --min-replicas 0 --max-replicas 2 --enable-autoscaling`

After the fix
$ rosa edit machinepool -c 2e0i256vrlvnjcc9rn63orr4fljal6gv test --min-replicas 0 --max-replicas 2 --enable-autoscaling
E: min-replicas must be greater than zero.

Closes [OCM-11407](https://issues.redhat.com//browse/OCM-11407)