### PR TITLE
OCM-11429 | ci: fix id:74225,73449,60278,74403

### DIFF
--- a/tests/e2e/hcp_machine_pool_test.go
+++ b/tests/e2e/hcp_machine_pool_test.go
@@ -323,7 +323,7 @@ var _ = Describe("HCP Machine Pool", labels.Feature.Machinepool, func() {
 		Entry("For arm64 cpu architecture [id:60278]", constants.M6gXLarge, constants.ARM),
 	)
 
-	DescribeTable("Scale up/down a machine pool with invalid replica", labels.Critical, labels.Runtime.Day2,
+	DescribeTable("Scale up/down a machine pool with invalid replica", labels.Medium, labels.Runtime.Day2,
 		func(instanceType string, updatedReplicas string, expectedErrMsg string) {
 			By("Create machinepool with instance " + instanceType)
 			mpName := helper.GenerateRandomName("mp-60278", 2)
@@ -399,7 +399,7 @@ var _ = Describe("HCP Machine Pool", labels.Feature.Machinepool, func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("should raise error message with the invalid parameters [id:60278]", labels.Critical, labels.Runtime.Day2, func() {
+		It("should raise error message with the invalid parameters [id:60278]", labels.Medium, labels.Runtime.Day2, func() {
 			instanceType := constants.M52XLarge
 			By("Create machinepool with" + " instance " + instanceType + " and enable autoscale")
 
@@ -423,7 +423,7 @@ var _ = Describe("HCP Machine Pool", labels.Feature.Machinepool, func() {
 				"--min-replicas", fmt.Sprintf("%v", zeroMinReplica),
 				"-y",
 			)
-			expectErrMsg := "The number of machine pool min-replicas needs to be a non-negative integer"
+			expectErrMsg := "ERR: min-replicas must be greater than zero."
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).Should(ContainSubstring(expectErrMsg))
 


### PR DESCRIPTION
`$ ginkgo --focus '(74225|73449)' tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.14.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: ROSA CLI e2e tests suite - /home/aaraj/ocm-forked-code/rosa/tests/e2e
====================================================================================
Random Seed: 1727258681

Will run 2 of 229 specs
SSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 2 of 229 Specs in 543.613 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 227 Skipped
PASS

Ginkgo ran 1 suite in 9m10.222613046s
Test Suite Passed
`