### PR TITLE
OCM-11446 | feat: Add "rosa cli" to !latest error main.go

### DIFF
--- a/cmd/rosa/main.go
+++ b/cmd/rosa/main.go
@@ -138,7 +138,7 @@ func versionCheck(cmd *cobra.Command, _ []string) {
 		return
 	}
 	if !isLatest {
-		rprtr.Warnf("The current version (%s) is not up to date with latest released version (%s).",
+		rprtr.Warnf("The current version (%s) is not up to date with latest rosa cli released version (%s).",
 			info.DefaultVersion,
 			latestVersionFromMirror.Original(),
 		)


### PR DESCRIPTION
If my zshrc has following
```bash
if [ $(command -v rosa) ]; then
  source <(rosa completion zsh)
  compdef _rosa rosa
fi
```

On startup of zsh shell I can observe following, which is not helpful.
```
Last login: Tue Sep 24 11:17:26 on ttys011
WARN: The current version (1.2.44) is not up to date with latest released version (1.2.45).                                                                     
WARN: It is recommended that you update to the latest version.
```