### PR TITLE
OCM-7783 | feat: add rosa describe accessrequest command

### DIFF
--- a/cmd/create/decision/cmd.go
+++ b/cmd/create/decision/cmd.go
@@ -38,7 +38,6 @@ func NewCreateDecisionCommand() *cobra.Command {
 	options := NewDecisionOptions()
 	cmd := &cobra.Command{
 		Use:     use,
-		Aliases: []string{"access-request"},
 		Short:   short,
 		Long:    long,
 		Example: example,

--- a/cmd/describe/accessrequest/accessrequest_suite_test.go
+++ b/cmd/describe/accessrequest/accessrequest_suite_test.go
@@ -1,0 +1,13 @@
+package accessrequest
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDescribeAccessRequest(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Describe AccessRequest Suite")
+}

--- a/cmd/describe/accessrequest/cmd.go
+++ b/cmd/describe/accessrequest/cmd.go
@@ -1,0 +1,122 @@
+package accessrequest
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	v1 "github.com/openshift-online/ocm-sdk-go/accesstransparency/v1"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/output"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+const (
+	use     = "accessrequest"
+	short   = "Describe an access request"
+	long    = short
+	example = `  # Describe an access request wit id <access_request_id>
+  rosa describe accessrequest --id <access_request_id>
+  `
+)
+
+type Options struct {
+	id string
+}
+
+func NewOptions() *Options {
+	return &Options{}
+}
+
+func NewDescribeAccessRequestCommand() *cobra.Command {
+	options := NewOptions()
+	cmd := &cobra.Command{
+		Use:     use,
+		Aliases: []string{"access-request"},
+		Short:   short,
+		Long:    long,
+		Example: example,
+		Run:     rosa.DefaultRunner(rosa.RuntimeWithOCM(), DescribeAccessRequestRunner(options)),
+		Args:    cobra.NoArgs,
+	}
+	flags := cmd.Flags()
+	flags.StringVar(
+		&options.id,
+		"id",
+		"",
+		"ID of the access request. (required).",
+	)
+	cmd.MarkFlagRequired("id")
+	output.AddFlag(cmd)
+	return cmd
+}
+
+func DescribeAccessRequestRunner(options *Options) rosa.CommandRunner {
+	return func(_ context.Context, r *rosa.Runtime, _ *cobra.Command, _ []string) error {
+		accessRequest, exists, err := r.OCMClient.GetAccessRequest(options.id)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("The Access Request with id '%s' does not exist", options.id)
+		}
+
+		if output.HasFlag() {
+			return output.Print(accessRequest)
+		}
+		fmt.Print(printAccessRequest(accessRequest))
+		if accessRequest.Status().State() == v1.AccessRequestStatePending {
+			r.Reporter.Infof("Run the following command to approve or deny the access request:\n\n"+
+				"   rosa create decision --access-request %s --decision Approved\n"+
+				"   rosa create decision --access-request %s --decision Denied\n",
+				accessRequest.ID(), accessRequest.ID())
+		}
+		return nil
+	}
+}
+
+func printAccessRequest(accessRequest *v1.AccessRequest) string {
+	outputMsg := fmt.Sprintf("\n"+
+		"ID:                                %s\n"+
+		"Subscription ID:                   %s\n"+
+		"Cluster ID:                        %s\n"+
+		"Support Case ID:                   %s\n"+
+		"Requested By:                      %s\n"+
+		"Created At:                        %s\n"+
+		"Respond By:                        %s\n"+
+		"Request Duration:                  %s\n"+
+		"Justification:                     %s\n"+
+		"Status:                            %s\n",
+		accessRequest.ID(),
+		accessRequest.SubscriptionId(),
+		accessRequest.ClusterId(),
+		accessRequest.SupportCaseId(),
+		accessRequest.RequestedBy(),
+		accessRequest.CreatedAt().Format(time.UnixDate),
+		accessRequest.DeadlineAt().Format(time.UnixDate),
+		accessRequest.Duration(),
+		accessRequest.Justification(),
+		accessRequest.Status().State(),
+	)
+	if len(accessRequest.Decisions()) > 0 {
+		outputMsg = outputMsg + "Decisions:                           \n"
+		for i := len(accessRequest.Decisions()) - 1; i >= 0; i-- {
+			outputMsg = outputMsg + printDecision(accessRequest.Decisions()[i])
+		}
+	}
+	return outputMsg
+}
+
+func printDecision(decision *v1.Decision) string {
+	return fmt.Sprintf(
+		"  - Decision:                      %s\n"+
+			"    Decided By:                    %s\n"+
+			"    Created At:                    %s\n"+
+			"    Justification:                 %s\n",
+		decision.Decision(),
+		decision.DecidedBy(),
+		decision.CreatedAt().Format(time.UnixDate),
+		decision.Justification(),
+	)
+}

--- a/cmd/describe/accessrequest/cmd_test.go
+++ b/cmd/describe/accessrequest/cmd_test.go
@@ -1,0 +1,113 @@
+package accessrequest
+
+import (
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "github.com/openshift-online/ocm-sdk-go/accesstransparency/v1"
+	"github.com/openshift-online/ocm-sdk-go/testing"
+
+	"github.com/openshift/rosa/pkg/output"
+	. "github.com/openshift/rosa/pkg/test"
+)
+
+var _ = Describe("rosa describe accessrequest", func() {
+	Context("Create Command", func() {
+		It("Returns Command", func() {
+
+			cmd := NewDescribeAccessRequestCommand()
+			Expect(cmd).NotTo(BeNil())
+
+			Expect(cmd.Use).To(Equal(use))
+			Expect(cmd.Example).To(Equal(example))
+			Expect(cmd.Short).To(Equal(short))
+			Expect(cmd.Long).To(Equal(long))
+			Expect(cmd.Args).NotTo(BeNil())
+			Expect(cmd.Run).NotTo(BeNil())
+
+			flag := cmd.Flags().Lookup("id")
+			Expect(flag).NotTo(BeNil())
+		})
+	})
+
+	Context("Execute command", func() {
+		var (
+			t       *TestingRuntime
+			options *Options
+		)
+
+		BeforeEach(func() {
+			t = NewTestRuntime()
+			options = &Options{
+				id: "mock-id",
+			}
+			output.SetOutput("")
+		})
+
+		AfterEach(func() {
+			output.SetOutput("")
+		})
+
+		It("Returns an error if access request not found", func() {
+			t.ApiServer.AppendHandlers(
+				testing.RespondWithJSON(
+					http.StatusNotFound, ""))
+			runner := DescribeAccessRequestRunner(options)
+			err := runner(nil, t.RosaRuntime, nil, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("The Access Request with id 'mock-id' does not exist"))
+		})
+
+		It("Describe access request successfully", func() {
+			layout := "Jan 2, 2006 at 3:04pm (MST)"
+			mock_time, _ := time.Parse(layout, "Sep 28, 2024 at 8:35pm (PST)")
+			decision := v1.NewDecision().
+				Decision(v1.DecisionDecisionApproved).
+				DecidedBy("mock-decider").
+				CreatedAt(mock_time).
+				Justification("mock-decision-justification")
+			accessRequest, err := v1.NewAccessRequest().
+				ID("mock-id").
+				SubscriptionId("mock-subscription-id").
+				ClusterId("mock-cluster-id").
+				CreatedAt(mock_time).
+				DeadlineAt(mock_time).
+				Duration("8h").
+				RequestedBy("mock-requestor").
+				Justification("mock-justification").
+				SupportCaseId("mock-case-id").
+				Status(v1.NewAccessRequestStatus().State(v1.AccessRequestStateApproved)).
+				Decisions(decision).
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+			t.ApiServer.AppendHandlers(
+				testing.RespondWithJSON(
+					http.StatusOK, FormatResource(accessRequest)))
+			runner := DescribeAccessRequestRunner(options)
+			t.StdOutReader.Record()
+			err = runner(nil, t.RosaRuntime, nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+			stdOut, _ := t.StdOutReader.Read()
+			Expect(stdOut).To(Equal(`
+ID:                                mock-id
+Subscription ID:                   mock-subscription-id
+Cluster ID:                        mock-cluster-id
+Support Case ID:                   mock-case-id
+Requested By:                      mock-requestor
+Created At:                        Sat Sep 28 20:35:00 UTC 2024
+Respond By:                        Sat Sep 28 20:35:00 UTC 2024
+Request Duration:                  8h
+Justification:                     mock-justification
+Status:                            Approved
+Decisions:                           
+  - Decision:                      Approved
+    Decided By:                    mock-decider
+    Created At:                    Sat Sep 28 20:35:00 UTC 2024
+    Justification:                 mock-decision-justification
+`))
+		})
+
+	})
+})

--- a/cmd/describe/cmd.go
+++ b/cmd/describe/cmd.go
@@ -19,6 +19,7 @@ package describe
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/rosa/cmd/describe/accessrequest"
 	"github.com/openshift/rosa/cmd/describe/addon"
 	"github.com/openshift/rosa/cmd/describe/admin"
 	"github.com/openshift/rosa/cmd/describe/autoscaler"
@@ -46,12 +47,14 @@ func init() {
 	machinePoolCommand := machinepool.NewDescribeMachinePoolCommand()
 	ingressCommand := ingress.NewDescribeIngressCommand()
 	kubeletconfig := kubeletconfig.NewDescribeKubeletConfigCommand()
+	accessrequestCommand := accessrequest.NewDescribeAccessRequestCommand()
 	cmds := []*cobra.Command{
 		addon.Cmd, admin.Cmd, cluster.Cmd, service.Cmd,
 		installation.Cmd, upgrade.Cmd, tuningconfigs.Cmd,
 		machinePoolCommand, kubeletconfig,
 		autoscaler.NewDescribeAutoscalerCommand(), ingressCommand,
 		externalauthprovider.Cmd, breakglasscredential.Cmd,
+		accessrequestCommand,
 	}
 	for _, cmd := range cmds {
 		Cmd.AddCommand(cmd)
@@ -67,6 +70,7 @@ func init() {
 		admin.Cmd, breakglasscredential.Cmd,
 		externalauthprovider.Cmd, installation.Cmd,
 		kubeletconfig, upgrade.Cmd, ingressCommand,
+		accessrequestCommand,
 	}
 	arguments.MarkRegionDeprecated(Cmd, globallyAvailableCommands)
 }

--- a/cmd/rosa/structure_test/command_args/rosa/describe/accessrequest/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/describe/accessrequest/command_args.yml
@@ -1,0 +1,4 @@
+- name: id
+- name: output
+- name: profile
+- name: region

--- a/cmd/rosa/structure_test/command_structure.yml
+++ b/cmd/rosa/structure_test/command_structure.yml
@@ -53,6 +53,7 @@ children:
     - name: user-role
 - name: describe
   children:
+    - name: accessrequest
     - name: addon
     - name: admin
     - name: autoscaler

--- a/pkg/ocm/accessrequests.go
+++ b/pkg/ocm/accessrequests.go
@@ -1,6 +1,10 @@
 package ocm
 
-import v1 "github.com/openshift-online/ocm-sdk-go/accesstransparency/v1"
+import (
+	"net/http"
+
+	v1 "github.com/openshift-online/ocm-sdk-go/accesstransparency/v1"
+)
 
 func (c *Client) CreateDecision(accessRequest string, decision string, justification string) error {
 	decisionSpec, err := v1.NewDecision().
@@ -19,4 +23,16 @@ func (c *Client) CreateDecision(accessRequest string, decision string, justifica
 		return err
 	}
 	return nil
+}
+
+func (c *Client) GetAccessRequest(id string) (*v1.AccessRequest, bool, error) {
+	resp, err := c.ocm.AccessTransparency().V1().AccessRequests().
+		AccessRequest(id).Get().Send()
+	if resp.Status() == http.StatusNotFound {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	return resp.Body(), true, nil
 }

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -27,6 +27,7 @@ import (
 
 	"sigs.k8s.io/yaml"
 
+	arv1 "github.com/openshift-online/ocm-sdk-go/accesstransparency/v1"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	msv1 "github.com/openshift-online/ocm-sdk-go/servicemgmt/v1"
 
@@ -172,6 +173,10 @@ func Print(resource interface{}) error {
 					return err
 				}
 			}
+		}
+	case "*v1.AccessRequest":
+		if accessRequest, ok := resource.(*arv1.AccessRequest); ok {
+			arv1.MarshalAccessRequest(accessRequest, &b)
 		}
 	// default to catch non concrete types
 	default:

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -285,6 +285,10 @@ func FormatResource(resource interface{}) string {
 		if res, ok := resource.(*accessv1.Decision); ok {
 			err = accessv1.MarshalDecision(res, &outputJson)
 		}
+	case "*v1.AccessRequest":
+		if res, ok := resource.(*accessv1.AccessRequest); ok {
+			err = accessv1.MarshalAccessRequest(res, &outputJson)
+		}
 	default:
 		{
 			return "NOTIMPLEMENTED"


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-7783

samples:
```
bash-5.2$ ./rosa describe accessrequest --id 2msh3sGFmkhzAXf3j56faQvESMO

ID:                                2msh3sGFmkhzAXf3j56faQvESMO
Subscription ID:                   2msfSLdXe59mjR8VcMVl3KoCGU3
Cluster ID:                        2e5edtubdsalag01sg2mp9lnrt58fef7
Support Case ID:                   
Requested By:                      llan.openshift
Created At:                        Wed Oct  2 12:09:54 UTC 2024
Respond By:                        Sat Oct  5 12:09:54 UTC 2024
Request Duration:                  8h
Justification:                     test
Status:                            Denied
Decisions:                           
  - Decision:                      Denied
    Decided By:                    llan.openshift
    Created At:                    Wed Oct  2 12:10:48 UTC 2024
    Justification:                 test2
  - Decision:                      Approved
    Decided By:                    llan.openshift
    Created At:                    Wed Oct  2 12:10:25 UTC 2024
    Justification:                 test2
```