### PR TITLE
OCM-11484 | fix: registry config allowed for import flag should not enable interactive mode

### DIFF
--- a/cmd/edit/cluster/cmd.go
+++ b/cmd/edit/cluster/cmd.go
@@ -202,7 +202,8 @@ func run(cmd *cobra.Command, _ []string) {
 			"additional-trust-bundle-file", "additional-allowed-principals", "audit-log-arn",
 			"registry-config-allowed-registries", "registry-config-blocked-registries",
 			"registry-config-insecure-registries", "allowed-registries-for-import",
-			"registry-config-platform-allowlist", "registry-config-additional-trusted-ca", "billing-account"} {
+			"registry-config-platform-allowlist", "registry-config-additional-trusted-ca", "billing-account",
+			"registry-config-allowed-registries-for-import"} {
 			if cmd.Flags().Changed(flag) {
 				changedFlags = true
 				break


### PR DESCRIPTION
Specifying `--registry-config-allowed-registries-for-import` flag when editing a cluster should not enable interactive mode.

https://issues.redhat.com/browse/OCM-11484