### PR TITLE
OCM-11556 | fix: refactor multiple ca tests from getClusterRegistryConfig

### DIFF
--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -892,10 +893,17 @@ func getClusterRegistryConfig(cluster *cmv1.Cluster, allowlist *cmv1.RegistryAll
 			cluster.RegistryConfig().PlatformAllowlist().ID(), strings.Join(allowlist.Registries(), ","))
 	}
 	if cluster.RegistryConfig().AdditionalTrustedCa() != nil {
+		additionalTrustedCa := cluster.RegistryConfig().AdditionalTrustedCa()
 		output = fmt.Sprintf("%s"+
 			" - Additional Trusted CA:         \n", output,
 		)
-		for registry := range cluster.RegistryConfig().AdditionalTrustedCa() {
+		keys := make([]string, 0, len(additionalTrustedCa))
+		for k := range additionalTrustedCa {
+			keys = append(keys, k)
+		}
+
+		sort.Strings(keys)
+		for _, registry := range keys {
 			output = fmt.Sprintf("%s"+
 				"    - %s: REDACTED\n", output,
 				registry)

--- a/cmd/describe/cluster/cmd_test.go
+++ b/cmd/describe/cluster/cmd_test.go
@@ -140,6 +140,7 @@ var _ = Describe("getClusterRegistryConfig", func() {
 	It("Should return expected output", func() {
 		mockCa := make(map[string]string)
 		mockCa["registry.io"] = "-----BEGIN CERTIFICATE-----\nlalala\n-----END CERTIFICATE-----\n"
+		mockCa["registry.io2"] = "-----BEGIN CERTIFICATE-----\nlalala\n-----END CERTIFICATE-----\n"
 		mockCluster, err := cmv1.NewCluster().RegistryConfig(cmv1.NewClusterRegistryConfig().AdditionalTrustedCa(mockCa).
 			RegistrySources(cmv1.NewRegistrySources().
 				AllowedRegistries([]string{"allow1.com", "allow2.com"}...).
@@ -163,7 +164,8 @@ var _ = Describe("getClusterRegistryConfig", func() {
 			" - Platform Allowlist:      test-id\n" +
 			"    - Registries:           registry1.io,registry2.io\n" +
 			" - Additional Trusted CA:         \n" +
-			"    - registry.io: REDACTED\n"
+			"    - registry.io: REDACTED\n" +
+			"    - registry.io2: REDACTED\n"
 		Expect(output).To(Equal(expectedOutput))
 	})
 })


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-11556