### PR TITLE
OCM-67348 | test: fix id:67348

### DIFF
--- a/tests/e2e/rosa_autoscaler_test.go
+++ b/tests/e2e/rosa_autoscaler_test.go
@@ -360,11 +360,9 @@ var _ = Describe("Autoscaler", labels.Feature.Autoscaler, func() {
 						Expect(err).To(HaveOccurred())
 						textData = rosaClient.Parser.TextData.Input(resp).Parse().Tip()
 						Expect(textData).
-							To(
-								ContainSubstring(
-									"ERR: Failed to delete autoscaler configuration for "+
-										"cluster '%s': Autoscaler for cluster ID '%s' is not found",
-									clusterID, clusterID))
+							To(ContainSubstring("ERR: Failed to delete autoscaler configuration for cluster '%s", clusterID))
+						Expect(textData).
+							To(ContainSubstring("Autoscaler for cluster ID '%s' is not found", clusterID))
 
 						By("Create autoscaler without setting cluster id")
 						resp, err = rosaClient.AutoScaler.CreateAutoScaler("")


### PR DESCRIPTION
ocm-67348

$ ginkgo --focus 67348 tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.11.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: ROSA CLI e2e tests suite - /home/akanni/OCP-Repository/rosa/tests/e2e
====================================================================================
Random Seed: 1727940781

Will run 2 of 234 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 234 Specs in 52.600 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 233 Skipped
PASS

Ginkgo ran 1 suite in 57.13508319s
Test Suite Passed
