### PR TITLE
OCM-9183 | test: Get kubeconfig from env

### DIFF
--- a/tests/ci/config/config.go
+++ b/tests/ci/config/config.go
@@ -34,14 +34,15 @@ type TestConfig struct {
 	ConsoleUrlFile  string
 	InfraIDFile     string
 	// End of temporary
-	ClusterDetailFile             string
-	ClusterInstallLogArtifactFile string
-	ClusterAdminFile              string
-	TestFocusFile                 string
-	TestLabelFilterFile           string
-	ProxySSHPemFile               string
-	ProxyCABundleFile             string
-	GlobalENV                     *GlobalENVVariables
+	ClusterDetailFile               string
+	ClusterInstallLogArtifactFile   string
+	ClusterAdminFile                string
+	ClusterIDPAdminUsernamePassword string
+	TestFocusFile                   string
+	TestLabelFilterFile             string
+	ProxySSHPemFile                 string
+	ProxyCABundleFile               string
+	GlobalENV                       *GlobalENVVariables
 }
 type GlobalENVVariables struct {
 	ChannelGroup          string `env:"CHANNEL_GROUP" default:""`
@@ -90,6 +91,7 @@ func init() {
 	Test.ClusterDetailFile = path.Join(Test.OutputDir, "cluster-detail.json")
 	Test.ClusterInstallLogArtifactFile = path.Join(Test.ArtifactDir, ".install.log")
 	Test.ClusterAdminFile = path.Join(Test.ArtifactDir, ".admin")
+	Test.ClusterIDPAdminUsernamePassword = path.Join(Test.ArtifactDir, ".idp-admin-username-password")
 	Test.TestFocusFile = path.Join(Test.RootDir, "tests", "ci", "data", "commit-focus")
 	Test.TestLabelFilterFile = path.Join(Test.RootDir, "tests", "ci", "data", "label-filter")
 	Test.ProxySSHPemFile = "ocm-test-proxy"

--- a/tests/e2e/dummy_test.go
+++ b/tests/e2e/dummy_test.go
@@ -9,6 +9,7 @@ import (
 
 	ciConfig "github.com/openshift/rosa/tests/ci/config"
 	"github.com/openshift/rosa/tests/utils/config"
+	"github.com/openshift/rosa/tests/utils/exec/occli"
 	"github.com/openshift/rosa/tests/utils/exec/rosacli"
 	"github.com/openshift/rosa/tests/utils/helper"
 	. "github.com/openshift/rosa/tests/utils/log"
@@ -104,6 +105,18 @@ var _ = Describe("ROSA CLI Test", func() {
 			Logger.Info("--password antyhingoutofordinary endofpassword")
 			Logger.Info("beginning --client-id thisisclient end")
 			Expect(false).To(BeTrue())
+		})
+	})
+})
+
+var _ = Describe("OC CLI Test", func() {
+	Describe("Test created kubeconfig", func() {
+		It("Test", func() {
+			ocClient, err := occli.NewOCClient()
+			Expect(err).ShouldNot(HaveOccurred())
+			stdout, err := ocClient.Run("oc project dedicated-admin", 3)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(stdout).To(ContainSubstring("Now using project \"dedicated-admin\""))
 		})
 	})
 })

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -75,12 +75,27 @@ var _ = Describe("Cluster preparation", labels.Feature.Cluster, func() {
 						}
 					}
 					By("Deploy cilium configures")
-					ocClient := occli.NewOCClient(kubeconfigFile)
+					ocClient, err := occli.NewOCClient(kubeconfigFile)
+					Expect(err).ToNot(HaveOccurred())
 					err = utilConfig.DeployCilium(ocClient, podCIDR, hostPrefix, testDir, kubeconfigFile)
 					Expect(err).ToNot(HaveOccurred())
 					log.Logger.Infof("Deploy cilium for HCP cluster: %s successfully ", cluster.ID)
 				} else {
-					utilConfig.GetKubeconfigDummyFunc()
+					By("Create IDP to get kubeconfig")
+					idpType := "htpasswd"
+					idpName := "myhtpasswdKubeconf"
+					name, password := profilehandler.PrepareAdminUser()
+					usersValue := name + ":" + password
+					_, err := client.IDP.CreateIDP(clusterID, idpName,
+						"--type", idpType,
+						"--users", usersValue,
+						"-y")
+					Expect(err).ToNot(HaveOccurred())
+
+					_, err = client.User.GrantUser(clusterID, "dedicated-admins", name)
+					Expect(err).ToNot(HaveOccurred())
+
+					helper.CreateFileWithContent(config.Test.ClusterIDPAdminUsernamePassword, usersValue)
 				}
 			}
 		})

--- a/tests/utils/config/support.go
+++ b/tests/utils/config/support.go
@@ -72,8 +72,3 @@ func DeployCilium(ocClient *occli.Client, podCIDR string, hostPrefix string, out
 
 	return err
 }
-
-func GetKubeconfigDummyFunc() {
-	// TODO: create IDP to get kubeconfig
-	// Refer to OCM-9183
-}


### PR DESCRIPTION
Function GetKubeconfigDummyFunc(), in file tests/utils/config/support.go, is being blocked by import error `Import cycle not allowed` because of import of module `github.com/openshift/rosa/tests/utils/exec/rosacli`.