### PR TITLE
OCM-11560 | fix: allow trailing comma for taints/labels

### DIFF
--- a/pkg/helper/machinepools/helpers.go
+++ b/pkg/helper/machinepools/helpers.go
@@ -43,8 +43,13 @@ func ParseLabels(labels string) (map[string]string, error) {
 	if labels == "" || labels == interactiveModeEmptyLabels {
 		return labelMap, nil
 	}
-
-	for _, label := range strings.Split(labels, ",") {
+	possibleLabels := strings.Split(labels, ",")
+	for i, label := range possibleLabels {
+		// If it is empty and it is the last one
+		// can be disregarded to still continue with the ones up to it
+		if label == "" && i == len(possibleLabels)-1 {
+			continue
+		}
 		if !strings.Contains(label, "=") {
 			return nil, fmt.Errorf("Expected key=value format for labels")
 		}
@@ -105,7 +110,13 @@ func ParseTaints(taints string) ([]*cmv1.TaintBuilder, error) {
 		return taintBuilders, nil
 	}
 	var errs []error
-	for _, taint := range strings.Split(taints, ",") {
+	possibleTaints := strings.Split(taints, ",")
+	for i, taint := range possibleTaints {
+		// If it is empty and it is the last one
+		// can be disregarded to still continue with the ones up to it
+		if taint == "" && i == len(possibleTaints)-1 {
+			continue
+		}
 		if !strings.Contains(taint, "=") || !strings.Contains(taint, ":") {
 			return nil, fmt.Errorf("Expected key=value:scheduleType format for taints. Got '%s'", taint)
 		}

--- a/pkg/helper/machinepools/helpers_test.go
+++ b/pkg/helper/machinepools/helpers_test.go
@@ -33,6 +33,9 @@ var _ = Describe("MachinePool", func() {
 			"2 well formed taints",
 			"node-role.kubernetes.io/infra=bar:NoSchedule,node-role.kubernetes.io/master=val:NoSchedule", "", 2),
 		Entry(
+			"Trailing ',' is parsed correctly",
+			"node-role.kubernetes.io/infra=bar:NoSchedule,node-role.kubernetes.io/master=val:NoSchedule,", "", 2),
+		Entry(
 			"Empty value taint bad format",
 			"node-role.kubernetes.io/infraNoSchedule",
 			"Expected key=value:scheduleType format", 0),
@@ -75,6 +78,9 @@ var _ = Describe("MachinePool", func() {
 		),
 		Entry("Multiple labels are parsed correctly",
 			"com.example.foo=bar,com.example.baz=bob", "", 2,
+		),
+		Entry("Trailing ',' is parsed correctly",
+			"com.example.foo=bar,com.example.baz=bob,", "", 2,
 		),
 		Entry("Labels with no value are parsed correctly",
 			"com.example.foo=,com.example.baz=bob", "", 2,


### PR DESCRIPTION
[OCM-11560](https://issues.redhat.com//browse/OCM-11560)