### PR TITLE
OCM-11711 | fix: Adding a default template if no template is specified

### DIFF
--- a/cmd/create/network/cmd.go
+++ b/cmd/create/network/cmd.go
@@ -70,6 +70,7 @@ func NewNetworkCommand() *cobra.Command {
 func NetworkRunner(userOptions *opts.NetworkUserOptions) rosa.CommandRunner {
 	return func(ctx context.Context, r *rosa.Runtime, cmd *cobra.Command, argv []string) error {
 		var err error
+		templateCommand := "rosa-quickstart-default-vpc"
 		options := NewNetworkOptions()
 		options.args = userOptions
 
@@ -95,7 +96,6 @@ func NetworkRunner(userOptions *opts.NetworkUserOptions) rosa.CommandRunner {
 		}
 
 		// Extract the first non-`--param` argument to use as the template command
-		var templateCommand string
 		for _, arg := range argv {
 			if !strings.HasPrefix(arg, "--param") {
 				templateCommand = arg

--- a/pkg/options/network/create.go
+++ b/pkg/options/network/create.go
@@ -46,7 +46,7 @@ func BuildNetworkCommandWithOptions() (*cobra.Command, *NetworkUserOptions) {
 		Long:    long,
 		Aliases: []string{"networks"},
 		Example: example,
-		Args:    cobra.ExactArgs(1),
+		Args:    cobra.MaximumNArgs(1),
 		Hidden:  true,
 	}
 


### PR DESCRIPTION
Adding a default template if no template is specified in the `rosa create network` command
[OCM-11711](https://issues.redhat.com/browse/OCM-11711)