### PR TITLE
OCM-11868 | feat: Adding --template-dir flag & TEMPLATE_DIR env var

### DIFF
--- a/cmd/create/network/cmd.go
+++ b/cmd/create/network/cmd.go
@@ -25,7 +25,7 @@ func NewNetworkCommand() *cobra.Command {
 	interactive.AddModeFlag(cmd)
 
 	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
-		templateDir := "cmd/create/network/templates"
+		templateDir := options.TemplateDir
 		err := filepath.WalkDir(templateDir, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return err
@@ -99,11 +99,16 @@ func NetworkRunner(userOptions *opts.NetworkUserOptions) rosa.CommandRunner {
 		for _, arg := range argv {
 			if !strings.HasPrefix(arg, "--param") {
 				templateCommand = arg
+				if templateCommand == "rosa-quickstart-default-vpc" {
+					r.Logger.Debugf("Template command not provided, using default template %s", templateCommand)
+				}
 				break
 			}
 		}
 
-		templateFile := helper.SelectTemplate(templateCommand)
+		templateDir := options.args.TemplateDir
+
+		templateFile := helper.SelectTemplate(templateDir, templateCommand)
 		if templateFile == "" {
 			return r.Reporter.Errorf("No suitable template found")
 		}

--- a/cmd/create/network/cmd_test.go
+++ b/cmd/create/network/cmd_test.go
@@ -82,7 +82,8 @@ var _ = Describe("Validation functions", func() {
 	Context("selectTemplate", func() {
 		It("input template to directory path", func() {
 			templateFile := "test-template.yaml"
-			templateSelected := network.SelectTemplate(templateFile)
+			templateDir := "cmd/create/network/templates"
+			templateSelected := network.SelectTemplate(templateDir, templateFile)
 			Expect(templateSelected).To(Equal("cmd/create/network/templates/test-template.yaml/cloudformation.yaml"))
 		})
 	})

--- a/cmd/login/cmd.go
+++ b/cmd/login/cmd.go
@@ -34,6 +34,7 @@ import (
 	"github.com/openshift/rosa/cmd/logout"
 	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/config"
+	"github.com/openshift/rosa/pkg/constants"
 	"github.com/openshift/rosa/pkg/fedramp"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/ocm"
@@ -268,9 +269,9 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command, argv []string) error {
 
 	// Verify environment variables:
 	if !haveReqs && !reAttempt && !fedramp.Enabled() {
-		token = os.Getenv("ROSA_TOKEN")
+		token = os.Getenv(constants.RosaToken)
 		if token == "" {
-			token = os.Getenv("OCM_TOKEN")
+			token = os.Getenv(constants.OcmToken)
 		}
 		haveReqs = token != ""
 	}

--- a/cmd/rosa/structure_test/command_args/rosa/create/network/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/create/network/command_args.yml
@@ -1,2 +1,3 @@
 - name: mode
 - name: param
+- name: template-dir

--- a/pkg/aws/region/flag.go
+++ b/pkg/aws/region/flag.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/spf13/pflag"
 
+	"github.com/openshift/rosa/pkg/constants"
 	"github.com/openshift/rosa/pkg/helper"
 )
 
@@ -41,7 +42,7 @@ func Region() string {
 	if helper.HandleEscapedEmptyString(region) != "" {
 		return region
 	}
-	awsRegion := os.Getenv("AWS_REGION")
+	awsRegion := os.Getenv(constants.AwsRegion)
 	if helper.HandleEscapedEmptyString(awsRegion) != "" {
 		return awsRegion
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,6 +34,7 @@ import (
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	"github.com/openshift-online/ocm-sdk-go/authentication/securestore"
 
+	"github.com/openshift/rosa/pkg/constants"
 	"github.com/openshift/rosa/pkg/debug"
 	"github.com/openshift/rosa/pkg/properties"
 )
@@ -224,7 +225,7 @@ func Remove() error {
 // use the XDG config directory.
 func Location() (path string, err error) {
 	// Use env variable
-	if ocmconfig := os.Getenv("OCM_CONFIG"); ocmconfig != "" {
+	if ocmconfig := os.Getenv(constants.OcmConfig); ocmconfig != "" {
 		return ocmconfig, nil
 	}
 

--- a/pkg/constants/config.go
+++ b/pkg/constants/config.go
@@ -1,3 +1,10 @@
 package constants
 
-const OcmConfig = "OCM_CONFIG"
+const (
+	RosaToken      = "ROSA_TOKEN"       // Token for ROSA authentication
+	OcmToken       = "OCM_TOKEN"        // Token for OCM authentication
+	AwsProfile     = "AWS_PROFILE"      // AWS CLI profile to use
+	AwsRegion      = "AWS_REGION"       // AWS region to use
+	OcmConfig      = "OCM_CONFIG"       // Path to OCM configuration file
+	OcmTemplateDir = "OCM_TEMPLATE_DIR" // Directory for OCM cloudformation templates
+)

--- a/pkg/network/helper.go
+++ b/pkg/network/helper.go
@@ -105,8 +105,8 @@ func ParseParams(params []string) (map[string]string, map[string]string, error) 
 }
 
 // SelectTemplate selects the appropriate template file based on the template name
-func SelectTemplate(command string) string {
-	return fmt.Sprintf("cmd/create/network/templates/%s/cloudformation.yaml", command)
+func SelectTemplate(templateDir, command string) string {
+	return fmt.Sprintf("%s/%s/cloudformation.yaml", templateDir, command)
 }
 
 func formatParams(params map[string]string) string {

--- a/pkg/network/helper_test.go
+++ b/pkg/network/helper_test.go
@@ -72,8 +72,9 @@ var _ = Describe("Helper Functions", func() {
 	Describe("SelectTemplate", func() {
 		It("should return the correct template file path", func() {
 			templateName := "test-template"
+			templateDir := "cmd/create/network/templates"
 			expectedTemplateFile := "cmd/create/network/templates/test-template/cloudformation.yaml"
-			Expect(SelectTemplate(templateName)).To(Equal(expectedTemplateFile))
+			Expect(SelectTemplate(templateDir, templateName)).To(Equal(expectedTemplateFile))
 		})
 	})
 

--- a/pkg/options/network/create_test.go
+++ b/pkg/options/network/create_test.go
@@ -1,4 +1,4 @@
-package Network
+package network
 
 import (
 	. "github.com/onsi/ginkgo/v2"

--- a/pkg/options/network/suite_test.go
+++ b/pkg/options/network/suite_test.go
@@ -1,4 +1,4 @@
-package Network
+package network
 
 import (
 	"testing"


### PR DESCRIPTION
Adding the TEMPLATE_DIR env variable along with the --template-dir flag to allow the user to point to the template directory path
[OCM-11868](https://issues.redhat.com/browse/OCM-11868)