### PR TITLE
OCM-11943 | chore: bump version to 1.2.47-RC1

### DIFF
--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,7 +18,7 @@ limitations under the License.
 
 package info
 
-const DefaultVersion = "1.2.46"
+const DefaultVersion = "1.2.47-RC1"
 
 // Build contains the short Git SHA of the CLI at the point it was build. Set via `-ldflags` at build time
 var Build = "local"


### PR DESCRIPTION
Bumps version to cut release branch