### PR TITLE
OCM-10017 | fix: revert adding EC2 policy to worker role

### DIFF
--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -961,9 +961,6 @@ func GetAccountRolePolicyKeys(roleType string) []string {
 // GetAccountRolePolicyKeys returns the policy key for fetching the managed policy ARN
 func GetHcpAccountRolePolicyKeys(roleType string) []string {
 	policyKeys := []string{fmt.Sprintf("sts_hcp_%s_permission_policy", roleType)}
-	if roleType == HCPWorkerRole {
-		policyKeys = append(policyKeys, WorkerEC2RegistryKey)
-	}
 
 	return policyKeys
 }

--- a/pkg/aws/helpers_test.go
+++ b/pkg/aws/helpers_test.go
@@ -251,9 +251,8 @@ var _ = Describe("GetHcpAccountRolePolicyKeys", func() {
 	When("role_type contains instance_worker", func() {
 		It("should return correct policy keys", func() {
 			policyKeys := GetHcpAccountRolePolicyKeys("instance_worker")
-			Expect(len(policyKeys)).To(Equal(2))
+			Expect(len(policyKeys)).To(Equal(1))
 			Expect(policyKeys[0]).To(Equal("sts_hcp_instance_worker_permission_policy"))
-			Expect(policyKeys[1]).To(Equal("sts_hcp_ec2_registry_permission_policy"))
 		})
 	})
 	When("role_type contains installer", func() {


### PR DESCRIPTION
Breaks creation of account-roles for orgs that do not have the zero-egress feature enabled.