### PR TITLE
OCM-12036 | test: automated ids:38827,38829,35894,55701

### DIFF
--- a/tests/utils/exec/rosacli/upgrade_service.go
+++ b/tests/utils/exec/rosacli/upgrade_service.go
@@ -11,7 +11,7 @@ import (
 type UpgradeService interface {
 	ResourcesCleaner
 
-	ListUpgrades(clusterID string, flags ...string) (bytes.Buffer, error)
+	ListUpgrades(flags ...string) (bytes.Buffer, error)
 	DescribeUpgrade(clusterID string, flags ...string) (bytes.Buffer, error)
 	DescribeUpgradeAndReflect(clusterID string) (*UpgradeDescription, error)
 	DeleteUpgrade(flags ...string) (bytes.Buffer, error)
@@ -43,11 +43,10 @@ type UpgradeDescription struct {
 	EnableMinorVersionUpgrades string `yaml:"Enable minor version upgrades,omitempty"`
 }
 
-func (u *upgradeService) ListUpgrades(clusterID string, flags ...string) (bytes.Buffer, error) {
-	combflags := append([]string{"--cluster", clusterID}, flags...)
+func (u *upgradeService) ListUpgrades(flags ...string) (bytes.Buffer, error) {
 	describe := u.client.Runner.
 		Cmd("list", "upgrade").
-		CmdFlags(combflags...)
+		CmdFlags(flags...)
 	return describe.Run()
 }
 


### PR DESCRIPTION
Running Suite: ROSA CLI e2e tests suite - /home/zhewang/go/src/rosa/tests/e2e
=============================================================================
Random Seed: 1729838995

Will run 1 of 242 specs
------------------------------

Sts cluster creation supplemental testing rosacli makes STS cluster by default - [id:55701] [feature-cluster, Medium, day1-supplemental]
/home/zhewang/go/src/rosa/tests/e2e/test_rosacli_cluster.go:3783
  STEP: Init the client @ 10/25/24 14:49:55.172
  STEP: Get AWS account id @ 10/25/24 14:49:55.172
  STEP: Prepare custom profile @ 10/25/24 14:49:55.172
  STEP: Check the help message of 'rosa describe upgrade -h' @ 10/25/24 14:49:55.173
  time=2024-10-25T14:49:55+08:00 level=info msg=Running command: rosa create cluster -c ocp55701 --help
……
STEP: Delete account-roles @ 10/25/24 15:08:05.064
  time=2024-10-25T15:08:05+08:00 level=info msg=Running command: rosa delete account-roles --prefix rosacli-ci --mode auto -y
  time=2024-10-25T15:08:14+08:00 level=info msg=Get Combining Stdout and Stderr is :
  WARN: There are no classic account roles to be deleted
  WARN: There are no hosted CP account roles to be deleted
• [1098.979 seconds]
------------------------------
Ran 1 of 242 Specs in 1098.996 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 241 Skipped


Running Suite: ROSA CLI e2e tests suite - /home/zhewang/go/src/rosa/tests/e2e
=============================================================================
Random Seed: 1729840482

Will run 1 of 242 specs
------------------------------

Post-Check testing for cluster clusters with the --disable-scp-checks flag  Create MOA clusters with the --disable-scp-check flag - [id:35894] [feature-cluster, Medium, day1-post]
/home/zhewang/go/src/rosa/tests/e2e/test_rosacli_cluster_post.go:962
  STEP: Get the cluster @ 10/25/24 15:14:42.086
  STEP: Init the client @ 10/25/24 15:14:42.086
……
STEP: Clean remaining resources @ 10/25/24 15:14:53.508
• [11.422 seconds]
------------------------------
Ran 1 of 242 Specs in 11.435 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 241 Skipped


Running Suite: ROSA CLI e2e tests suite - /home/zhewang/go/src/rosa/tests/e2e
=============================================================================
Random Seed: 1729842824

Will run 1 of 242 specs
------------------------------

Create cluster upgrade policy validation Validation for creating upgrade policy via ROSA cli will work - [id:38829] [feature-cluster, Medium, day2]
/home/zhewang/go/src/rosa/tests/e2e/test_rosacli_upgrade.go:1202
  STEP: Get the cluster @ 10/25/24 15:53:44.914
  STEP: Init the client @ 10/25/24 15:53:44.914
  STEP: Load the profile @ 10/25/24 15:53:44.914
……
  STEP: Clean the cluster @ 10/25/24 15:55:24.91
• [103.035 seconds]
------------------------------
Ran 1 of 242 Specs in 103.049 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 241 Skipped


Running Suite: ROSA CLI e2e tests suite - /home/zhewang/go/src/rosa/tests/e2e
=============================================================================
Random Seed: 1729844408

Will run 1 of 242 specs
------------------------------

Describe/List rosa upgrade List upgrades of cluster via ROSA cli will succeed - [id:38827] [feature-cluster, Medium, day2]
/home/zhewang/go/src/rosa/tests/e2e/test_rosacli_upgrade.go:805
  STEP: Get the cluster @ 10/25/24 16:20:08.325
  STEP: Init the client @ 10/25/24 16:20:08.325
  STEP: Load the profile @ 10/25/24 16:20:08.325
……
STEP: Clean remaining resources @ 10/25/24 16:25:28.491
• [320.166 seconds]
------------------------------
Ran 1 of 242 Specs in 320.179 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 241 Skipped
