### PR TITLE
OCM-12118 | fix: Ask for oidc config ID for register/oidcconfig

### DIFF
--- a/cmd/register/oidcconfig/cmd.go
+++ b/cmd/register/oidcconfig/cmd.go
@@ -218,6 +218,13 @@ func run(cmd *cobra.Command, _ []string) {
 		output := fmt.Sprintf(InformOperatorRolesOutput, oidcConfig.ID())
 		r.Reporter.Infof(output)
 	}
+
+	err = oidcprovider.Cmd.Flags().Set(OidcConfigIdFlag, oidcConfig.ID())
+	if err != nil {
+		r.Reporter.Errorf("Unable to set %s flag: %s", OidcConfigIdFlag, err)
+		os.Exit(1)
+	}
+
 	arguments.DisableRegionDeprecationWarning = true // disable region deprecation warning
 	oidcprovider.Cmd.Run(oidcprovider.Cmd, []string{"", mode, args.issuerUrl})
 	arguments.DisableRegionDeprecationWarning = false // enable region deprecation again

--- a/pkg/constants/oidc_config.go
+++ b/pkg/constants/oidc_config.go
@@ -4,6 +4,7 @@ const (
 	InstallerRoleArnFlag = "role-arn"
 	IssuerUrlFlag        = "issuer-url"
 	SecretArnFlag        = "secret-arn"
+	OidcConfigIdFlag     = "oidc-config-id"
 
 	SecretsManagerService = "secretsmanager"
 


### PR DESCRIPTION
Regression occurred with using `rosa register oidcconfig` due to the new thumbprint fetching using OIDC config ID or Cluster ID. This change forces the use of an OIDC config ID and gives a warning if somehow it is not supplied (error is bubbled up later from the OIDC thumbprint fetch)