### PR TITLE
OCM-12119 | fix: Env var regression with create/network

### DIFF
--- a/cmd/create/network/cmd.go
+++ b/cmd/create/network/cmd.go
@@ -72,7 +72,8 @@ func NetworkRunner(userOptions *opts.NetworkUserOptions) rosa.CommandRunner {
 		var err error
 		templateCommand := "rosa-quickstart-default-vpc"
 		options := NewNetworkOptions()
-		options.args = userOptions
+		userOptions.CleanTemplateDir()
+		options.Bind(userOptions)
 
 		defer r.Cleanup()
 

--- a/cmd/create/network/options.go
+++ b/cmd/create/network/options.go
@@ -11,6 +11,10 @@ type Options struct {
 	args *opts.NetworkUserOptions
 }
 
+func (o *Options) Bind(userOptions *opts.NetworkUserOptions) {
+	o.args = userOptions
+}
+
 func NewNetworkUserOptions() *opts.NetworkUserOptions {
 	return &opts.NetworkUserOptions{
 		Params: []string{},

--- a/pkg/options/network/create_test.go
+++ b/pkg/options/network/create_test.go
@@ -1,10 +1,13 @@
 package network
 
 import (
+	"os"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/rosa/pkg/constants"
 	"github.com/openshift/rosa/pkg/reporter"
 )
 
@@ -29,6 +32,40 @@ var _ = Describe("BuildMachinePoolCreateCommandWithOptions", func() {
 			options := NewNetworkOptions()
 			Expect(options.reporter).To(BeAssignableToTypeOf(&reporter.Object{}))
 			Expect(options.args).To(BeAssignableToTypeOf(&NetworkUserOptions{}))
+		})
+	})
+
+	Context("NewNetworkUserOptions", func() {
+		It("should create default network options with env var", func() {
+			testDir := "test/1"
+			Expect(os.Setenv(constants.OcmTemplateDir, testDir)).ToNot(HaveOccurred())
+			options := NewNetworkUserOptions()
+			options.CleanTemplateDir()
+			Expect(options.TemplateDir).To(Equal(testDir))
+		})
+		It("should create default network options with env var which has trailing '/' and remove it", func() {
+			testDir := "/test/1/"
+			finalTestDir := "/test/1"
+			Expect(os.Setenv(constants.OcmTemplateDir, testDir)).ToNot(HaveOccurred())
+			options := NewNetworkUserOptions()
+			options.CleanTemplateDir()
+			Expect(options.TemplateDir).To(Equal(finalTestDir))
+		})
+		It("should create default network options with env var which has trailing '/' and remove it", func() {
+			testDir := "/"
+			finalTestDir := ""
+			Expect(os.Setenv(constants.OcmTemplateDir, testDir)).ToNot(HaveOccurred())
+			options := NewNetworkUserOptions()
+			options.CleanTemplateDir()
+			Expect(options.TemplateDir).To(Equal(finalTestDir))
+		})
+		It("should create default network options with empty dir and not fail", func() {
+			testDir := ""
+			finalTestDir := ""
+			Expect(os.Setenv(constants.OcmTemplateDir, testDir)).ToNot(HaveOccurred())
+			options := NewNetworkUserOptions()
+			options.CleanTemplateDir()
+			Expect(options.TemplateDir).To(Equal(finalTestDir))
 		})
 	})
 


### PR DESCRIPTION
Unable to use env var for template dir (if flag is not desired) before this MR. This MR checks 1) if the env var is set, 2) if the `template-dir` flag is used
If both are true, it uses the `template-dir` flag. If the `template-dir` flag is not set, it will use the env var instead (sanitizing """" to "")

Also fixes un-discovered bug where when using an extra `/` in env var or `template-dir` flag, the command would not remove and it would result in a template dirpath which looked like `path/to/dir//here/`