### PR TITLE
OCM-11578 | fix: skip validation of container registry policy for create cluster

### DIFF
--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -2068,6 +2068,11 @@ func (c *awsClient) validateManagedPolicy(policies map[string]*cmv1.AWSSTSPolicy
 	roleName string) error {
 	managedPolicyARN, err := GetManagedPolicyARN(policies, policyKey)
 	if err != nil {
+		// EC2 policy is only available to orgs for zero-egress feature toggle enabled
+		if policyKey == WorkerEC2RegistryKey {
+			c.logger.Infof("Ignored check for policy key '%s' (zero egress feature toggle is not enabled)", policyKey)
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
Simiar to https://issues.redhat.com/browse/OCM-12012 where we skip validations for the EC2 container registry policy when creating account-roles. We also need to skip it in the cluster create validation.