### PR TITLE
OCM-12257 | fix: Fixing tags and network not appearing in help

### DIFF
--- a/cmd/create/network/cmd.go
+++ b/cmd/create/network/cmd.go
@@ -54,6 +54,7 @@ func NewNetworkCommand() *cobra.Command {
 				for paramName := range parameters {
 					fmt.Printf("  %s\n", paramName)
 				}
+				fmt.Printf("  %s\n", "Tags")
 			}
 			return nil
 		})

--- a/pkg/options/network/create.go
+++ b/pkg/options/network/create.go
@@ -77,7 +77,7 @@ func BuildNetworkCommandWithOptions() (*cobra.Command, *NetworkUserOptions) {
 		Aliases: []string{"networks"},
 		Example: example,
 		Args:    cobra.MaximumNArgs(1),
-		Hidden:  true,
+		Hidden:  false,
 	}
 
 	flags := cmd.Flags()


### PR DESCRIPTION
[OCM-12257](https://issues.redhat.com/browse/OCM-12257)