### PR TITLE
OCM-12347 | ci: fix id:60688

### DIFF
--- a/tests/e2e/test_rosacli_cluster.go
+++ b/tests/e2e/test_rosacli_cluster.go
@@ -3249,14 +3249,17 @@ var _ = Describe("Reusing opeartor prefix and oidc config to create clsuter", la
 		}
 
 		By("Delete resources for testing")
-		output, err := ocmResourceService.DeleteOIDCConfig(
-			"--oidc-config-id", oidcConfigToClean,
-			"--mode", "auto",
-			"-y",
-		)
-		Expect(err).To(BeNil())
-		textData := rosaClient.Parser.TextData.Input(output).Parse().Tip()
-		Expect(textData).To(ContainSubstring("Successfully deleted the OIDC provider"))
+		if oidcConfigToClean != "" {
+			output, err := ocmResourceService.DeleteOIDCConfig(
+				"--oidc-config-id", oidcConfigToClean,
+				"--region", profile.Region,
+				"--mode", "auto",
+				"-y",
+			)
+			Expect(err).To(BeNil())
+			textData := rosaClient.Parser.TextData.Input(output).Parse().Tip()
+			Expect(textData).To(ContainSubstring("Successfully deleted the OIDC provider"))
+		}
 
 	})
 

--- a/tests/utils/profilehandler/profile_handler.go
+++ b/tests/utils/profilehandler/profile_handler.go
@@ -3,6 +3,7 @@ package profilehandler
 import (
 	"errors"
 	"fmt"
+	"path"
 	"strings"
 	"time"
 
@@ -736,7 +737,7 @@ func GenerateClusterCreateFlags(profile *Profile, client *rosacli.Client) ([]str
 		registryConfigCa := map[string]string{
 			"test.io": caContent,
 		}
-		caFile := fmt.Sprintf("%s-%s", config.Test.OutputDir, "registryConfig")
+		caFile := path.Join(config.Test.OutputDir, "registryConfig")
 		_, err = helper.CreateFileWithContent(caFile, registryConfigCa)
 		if err != nil {
 			return flags, err


### PR DESCRIPTION
fixed case id: 60688

- It cannot use the registryConfig file which is not in the shared directory.
- In afterEach step, it needs to specify the region to delete the oidc-config

Logs on local is https://privatebin.corp.redhat.com/?244971df16e30548#4s1rWZkXX38swr2GGsoKneLQpe4etutfbtryRwzJxYmE