### PR TITLE
OCM-12302 | feat: Add `--hosted-cp` functionality to create/dns-domain

### DIFF
--- a/cmd/create/dnsdomains/cmd_test.go
+++ b/cmd/create/dnsdomains/cmd_test.go
@@ -1,0 +1,35 @@
+package dnsdomains
+
+import (
+	"go.uber.org/mock/gomock"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+)
+
+var _ = Describe("Create dns domain", func() {
+	var ctrl *gomock.Controller
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+	})
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Context("createDnsDomain", func() {
+		When("Creating DNS domain for API call", func() {
+			It("OK: should return dns domain with classic architecture", func() {
+				domain, err := createDnsDomain(false)
+				Expect(domain.ClusterArch()).To(Equal(cmv1.ClusterArchitectureClassic))
+				Expect(err).ToNot(HaveOccurred())
+			})
+			It("OK: should return dns domain with hcp architecture", func() {
+				domain, err := createDnsDomain(true)
+				Expect(domain.ClusterArch()).To(Equal(cmv1.ClusterArchitectureHcp))
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+	})
+})

--- a/cmd/create/dnsdomains/suite_test.go
+++ b/cmd/create/dnsdomains/suite_test.go
@@ -1,0 +1,13 @@
+package dnsdomains
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDnsDomain(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "DNS domain suite")
+}

--- a/cmd/rosa/structure_test/command_args/rosa/create/dns-domain/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/create/dns-domain/command_args.yml
@@ -1,3 +1,4 @@
 - name: profile
 - name: region
 - name: "yes"
+- name: hosted-cp

--- a/pkg/ocm/dns_domain.go
+++ b/pkg/ocm/dns_domain.go
@@ -43,11 +43,11 @@ func (c *Client) DeleteDNSDomain(id string) error {
 	return nil
 }
 
-func (c *Client) CreateDNSDomain() (*cmv1.DNSDomain, error) {
+func (c *Client) CreateDNSDomain(dnsDomain *cmv1.DNSDomain) (*cmv1.DNSDomain, error) {
 	response, err := c.ocm.ClustersMgmt().V1().
 		DNSDomains().
 		Add().
-		Body(&cmv1.DNSDomain{}).
+		Body(dnsDomain).
 		Send()
 	if err != nil {
 		return nil, handleErr(response.Error(), err)


### PR DESCRIPTION
Allows passing of `--hosted-cp` flag into `rosa create dns-domain` as well as actually creates DNS domain for either HCP or classic cluster architecture

Tested output here:

```
 hkepley@hkepley-mac  ~/Documents/programming/rosa   ocm-12302 ±  ./rosa create dns-domain --hosted-cp
I: DNS domain ‘ziaa.i3.devshift.org’ has been created.
I: To view all DNS domains, run 'rosa list dns-domains
 hkepley@hkepley-mac  ~/Documents/programming/rosa   ocm-12302 ±  ./rosa create dns-domain           
I: DNS domain ‘kmiz.i1.devshift.org’ has been created.
I: To view all DNS domains, run 'rosa list dns-domains
```


```
./rosa create dns-domain
I: DNS domain ‘1r3d.i1.devshift.org’ has been created.
I: To view all DNS domains, run 'rosa list dns-domains
```

```
./rosa list dns-domains
ID                    CLUSTER ID  RESERVED TIME         USER DEFINED
1r3d.i1.devshift.org              0001-01-01T00:00:00Z  Yes
2to6.i1.devshift.org              0001-01-01T00:00:00Z  Yes
4ocd.i1.devshift.org              0001-01-01T00:00:00Z  Yes
a3hc.i3.devshift.org              2024-10-11T13:47:39Z  Yes
aojp.i1.devshift.org              2023-09-07T15:49:07Z  Yes
cz25.i1.devshift.org              0001-01-01T00:00:00Z  Yes
djcm.i3.devshift.org              2024-10-05T03:36:55Z  Yes
e17z.i1.devshift.org              0001-01-01T00:00:00Z  Yes
etk0.i1.devshift.org              2023-09-08T22:41:55Z  Yes
fc0j.i1.devshift.org              0001-01-01T00:00:00Z  Yes
flum.i1.devshift.org              0001-01-01T00:00:00Z  Yes
hwrf.i1.devshift.org              2023-11-13T16:30:44Z  Yes
kksm.i1.devshift.org              2023-09-07T16:52:04Z  Yes
kmiz.i1.devshift.org              0001-01-01T00:00:00Z  Yes
kmvp.i1.devshift.org              0001-01-01T00:00:00Z  Yes
l4lv.i1.devshift.org              0001-01-01T00:00:00Z  Yes
nes7.i1.devshift.org              0001-01-01T00:00:00Z  Yes
ntjc.i1.devshift.org              0001-01-01T00:00:00Z  Yes
p59z.i1.devshift.org              0001-01-01T00:00:00Z  Yes
pcm8.i1.devshift.org              0001-01-01T00:00:00Z  Yes
rsqe.i1.devshift.org              2023-09-08T22:02:31Z  Yes
ryly.i1.devshift.org              0001-01-01T00:00:00Z  Yes
ubr8.i1.devshift.org              2023-09-07T02:13:39Z  Yes
ziaa.i3.devshift.org              0001-01-01T00:00:00Z  Yes
ztb9.i1.devshift.org              0001-01-01T00:00:00Z  Yes
zvdq.i1.devshift.org              0001-01-01T00:00:00Z  Yes
```