### PR TITLE
OCM-12351 | feat: --hosted-cp functionality for `rosa list dns-domains`

### DIFF
--- a/cmd/list/dnsdomains/cmd_test.go
+++ b/cmd/list/dnsdomains/cmd_test.go
@@ -1,0 +1,91 @@
+package dnsdomains
+
+import (
+	"go.uber.org/mock/gomock"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
+	"github.com/openshift/rosa/tests/utils/constants"
+)
+
+var _ = Describe("List dns domains", func() {
+	var ctrl *gomock.Controller
+
+	var domains = make([]*v1.DNSDomain, 0)
+
+	var hostedCpDomainIds = []string{"1234.i3.devshift.org", "4321.i3.devshift.org"}
+	var domainIds = []string{"1234.i1.devshift.org", hostedCpDomainIds[0], hostedCpDomainIds[1],
+		"4321.i1.devshift.org"}
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		b := v1.DNSDomainBuilder{}
+		domain1, err := b.ID(domainIds[0]).Build()
+		Expect(err).NotTo(HaveOccurred())
+		domains = append(domains, domain1)
+		domain2, err := b.ID(domainIds[1]).Build()
+		Expect(err).NotTo(HaveOccurred())
+		domains = append(domains, domain2)
+		domain3, err := b.ID(domainIds[2]).Build()
+		Expect(err).NotTo(HaveOccurred())
+		domains = append(domains, domain3)
+		domain4, err := b.ID(domainIds[3]).Build()
+		Expect(err).NotTo(HaveOccurred())
+		domains = append(domains, domain4)
+	})
+	AfterEach(func() {
+		ctrl.Finish()
+		domains = make([]*v1.DNSDomain, 0)
+	})
+
+	Context("List DNS domains", func() {
+		When("filterByBaseDomain", func() {
+			It("OK: should return all DNS domains", func() {
+				domains = filterByBaseDomain(domains, constants.ClassicDnsBaseDomain)
+				Expect(domains).To(HaveLen(4))
+				for i, domain := range domains {
+					Expect(domain.ID()).To(Equal(domainIds[i]))
+				}
+			})
+			It("OK: should return only hosted-cp DNS domains", func() {
+				domains = filterByBaseDomain(domains, constants.HostedCpDnsBaseDomain)
+				Expect(domains).To(HaveLen(2))
+				for i, domain := range domains {
+					Expect(domain.ID()).To(Equal(hostedCpDomainIds[i]))
+				}
+			})
+		})
+		When("returnBaseDomain", func() {
+			It("OK: should return correct DNS base domain when not hosted-cp", func() {
+				isHostedCp := false
+				baseDomain := returnBaseDomain(isHostedCp)
+				Expect(baseDomain).To(Equal(constants.ClassicDnsBaseDomain))
+			})
+			It("OK: should return correct DNS base domain when hosted-cp", func() {
+				isHostedCp := true
+				baseDomain := returnBaseDomain(isHostedCp)
+				Expect(baseDomain).To(Equal(constants.HostedCpDnsBaseDomain))
+			})
+		})
+		When("Combining returnBaseDomain and filterByBaseDomain", func() {
+			It("OK: should return all DNS domains", func() {
+				isHostedCp := false
+				domains = filterByBaseDomain(domains, returnBaseDomain(isHostedCp))
+				Expect(domains).To(HaveLen(4))
+				for i, domain := range domains {
+					Expect(domain.ID()).To(Equal(domainIds[i]))
+				}
+			})
+			It("OK: should return only hosted-cp DNS domains", func() {
+				isHostedCp := true
+				domains = filterByBaseDomain(domains, returnBaseDomain(isHostedCp))
+				Expect(domains).To(HaveLen(2))
+				for i, domain := range domains {
+					Expect(domain.ID()).To(Equal(hostedCpDomainIds[i]))
+				}
+			})
+		})
+	})
+})

--- a/cmd/list/dnsdomains/suite_test.go
+++ b/cmd/list/dnsdomains/suite_test.go
@@ -1,0 +1,13 @@
+package dnsdomains
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDnsDomain(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "DNS domain suite")
+}

--- a/cmd/rosa/structure_test/command_args/rosa/list/dns-domain/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/list/dns-domain/command_args.yml
@@ -2,3 +2,4 @@
 - name: output
 - name: profile
 - name: region
+- name: hosted-cp

--- a/tests/utils/constants/cluster.go
+++ b/tests/utils/constants/cluster.go
@@ -42,7 +42,9 @@ const (
 
 // cluster topology
 const (
-	HostedCP = "Hosted CP"
+	HostedCP              = "Hosted CP"
+	HostedCpDnsBaseDomain = "i3.devshift.org"
+	ClassicDnsBaseDomain  = "i1.devshift.org"
 )
 
 // cluster upgrade status


### PR DESCRIPTION
Manual testing output below (unit tests included)


```
 hkepley@hkepley-mac  ~/Documents/programming/rosa   ocm-12351 ±  ./rosa list dns-domains
ID                    CLUSTER ID  RESERVED TIME         USER DEFINED
1r3d.i1.devshift.org              0001-01-01T00:00:00Z  Yes
2to6.i1.devshift.org              0001-01-01T00:00:00Z  Yes
4ocd.i1.devshift.org              0001-01-01T00:00:00Z  Yes
a3hc.i3.devshift.org              2024-10-11T13:47:39Z  Yes
aojp.i1.devshift.org              2023-09-07T15:49:07Z  Yes
cz25.i1.devshift.org              0001-01-01T00:00:00Z  Yes
djcm.i3.devshift.org              2024-10-05T03:36:55Z  Yes
e17z.i1.devshift.org              0001-01-01T00:00:00Z  Yes
etk0.i1.devshift.org              2023-09-08T22:41:55Z  Yes
fc0j.i1.devshift.org              0001-01-01T00:00:00Z  Yes
flum.i1.devshift.org              0001-01-01T00:00:00Z  Yes
hwrf.i1.devshift.org              2023-11-13T16:30:44Z  Yes
kksm.i1.devshift.org              2023-09-07T16:52:04Z  Yes
kmiz.i1.devshift.org              0001-01-01T00:00:00Z  Yes
kmvp.i1.devshift.org              0001-01-01T00:00:00Z  Yes
l4lv.i1.devshift.org              0001-01-01T00:00:00Z  Yes
nes7.i1.devshift.org              0001-01-01T00:00:00Z  Yes
ntjc.i1.devshift.org              0001-01-01T00:00:00Z  Yes
p59z.i1.devshift.org              0001-01-01T00:00:00Z  Yes
pcm8.i1.devshift.org              0001-01-01T00:00:00Z  Yes
rsqe.i1.devshift.org              2023-09-08T22:02:31Z  Yes
ryly.i1.devshift.org              0001-01-01T00:00:00Z  Yes
ubr8.i1.devshift.org              2023-09-07T02:13:39Z  Yes
ziaa.i3.devshift.org              0001-01-01T00:00:00Z  Yes
ztb9.i1.devshift.org              0001-01-01T00:00:00Z  Yes
zvdq.i1.devshift.org              0001-01-01T00:00:00Z  Yes
 hkepley@hkepley-mac  ~/Documents/programming/rosa   ocm-12351 ±  ./rosa list dns-domains --hosted-cp
ID                    CLUSTER ID  RESERVED TIME         USER DEFINED
a3hc.i3.devshift.org              2024-10-11T13:47:39Z  Yes
djcm.i3.devshift.org              2024-10-05T03:36:55Z  Yes
ziaa.i3.devshift.org              0001-01-01T00:00:00Z  Yes
```

This MR allows users to type `--hosted-cp` to grab only `XXX.i3.devshift.org` dns-domains, `i3.devshift.org` is the base domain from ACM shards, rather than hive shards

Normal usage of this command (without `--hosted-cp` will print all dns-domains including ones meant for HCP