### PR TITLE
OCM-12379 | fix: Duplicate commands when manual create/accountroles

### DIFF
--- a/cmd/create/accountroles/creators.go
+++ b/cmd/create/accountroles/creators.go
@@ -354,6 +354,8 @@ func (hcp *hcpManagedPoliciesCreator) printCommands(r *rosa.Runtime, input *acco
 
 		createRole := buildCreateRoleCommand(accRoleName, file, iamTags, input)
 
+		commands = append(commands, createRole)
+
 		policyKeys := aws.GetHcpAccountRolePolicyKeys(file)
 		for _, policyKey := range policyKeys {
 			policyARN, err := aws.GetManagedPolicyARN(input.policies, policyKey)
@@ -368,7 +370,7 @@ func (hcp *hcpManagedPoliciesCreator) printCommands(r *rosa.Runtime, input *acco
 			}
 
 			attachRolePolicy := buildAttachRolePolicyCommand(accRoleName, policyARN)
-			commands = append(commands, createRole, attachRolePolicy)
+			commands = append(commands, attachRolePolicy)
 		}
 	}
 


### PR DESCRIPTION
Creating account roles with `mode=manual` resulted in multiple commands to create worker role when the worker role had >1 policy. This fixes that by only printing the role creation command once before the policy loop.