### PR TITLE
OCM-12438 | fix: changing default template dir in help message

### DIFF
--- a/pkg/options/network/create.go
+++ b/pkg/options/network/create.go
@@ -84,7 +84,7 @@ func BuildNetworkCommandWithOptions() (*cobra.Command, *NetworkUserOptions) {
 	flags.StringVar(
 		&options.TemplateDir,
 		"template-dir",
-		options.TemplateDir,
+		defaultTemplateDir,
 		"Use a specific template directory, overriding the OCM_TEMPLATE_DIR environment variable.",
 	)
 	flags.StringArrayVar(


### PR DESCRIPTION
[OCM-12438](https://issues.redhat.com/browse/OCM-12438)