### PR TITLE
OCM-12435 | fix: Updated info message for when no template is specified

### DIFF
--- a/cmd/create/network/cmd.go
+++ b/cmd/create/network/cmd.go
@@ -101,7 +101,7 @@ func NetworkRunner(userOptions *opts.NetworkUserOptions) rosa.CommandRunner {
 			parsedParams["Region"] = r.AWSClient.GetRegion()
 		}
 
-		extractTemplateCommand(argv, options.args,
+		extractTemplateCommand(r, argv, options.args,
 			&templateCommand, &templateFile)
 
 		service := helper.NewNetworkService()
@@ -135,9 +135,13 @@ func NetworkRunner(userOptions *opts.NetworkUserOptions) rosa.CommandRunner {
 	}
 }
 
-func extractTemplateCommand(argv []string, options *opts.NetworkUserOptions,
+func extractTemplateCommand(r *rosa.Runtime, argv []string, options *opts.NetworkUserOptions,
 	templateCommand *string, templateFile *string) {
 	if len(argv) == 0 {
+		r.Reporter.Infof("No template name provided in the command. "+
+			"Defaulting to %s. Please note that a corresponding directory with this name"+
+			" must exist under the specified path <`--template-dir`> or the templates directory"+
+			" for the command to work correctly. ", *templateCommand)
 		*templateCommand = defaultTemplate
 		*templateFile = CloudFormationTemplateFile
 	}

--- a/cmd/create/network/cmd_test.go
+++ b/cmd/create/network/cmd_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openshift/rosa/pkg/network"
 	opts "github.com/openshift/rosa/pkg/options/network"
+	"github.com/openshift/rosa/pkg/rosa"
 )
 
 var _ = Describe("Network", func() {
@@ -92,12 +93,13 @@ var _ = Describe("Validation functions", func() {
 	Context("extractTemplateCommand", func() {
 		It("should use default template when no arguments are provided", func() {
 			argv := []string{}
+			r := rosa.NewRuntime()
 			templateCommand := "rosa-quickstart-default-vpc"
 			templateFile := ""
 			options := &opts.NetworkUserOptions{}
 			options.TemplateDir = "cmd/create/network/templates"
 
-			extractTemplateCommand(argv, options, &templateCommand, &templateFile)
+			extractTemplateCommand(r, argv, options, &templateCommand, &templateFile)
 
 			Expect(templateCommand).To(Equal("rosa-quickstart-default-vpc"))
 			Expect(templateFile).To(Equal(CloudFormationTemplateFile))
@@ -105,12 +107,13 @@ var _ = Describe("Validation functions", func() {
 
 		It("should extract the first non-`--param` argument as the template command", func() {
 			argv := []string{"my-template", "--param", "key=value"}
+			r := rosa.NewRuntime()
 			templateCommand := ""
 			templateFile := ""
 			options := &opts.NetworkUserOptions{}
 			options.TemplateDir = "cmd/create/network/templates"
 
-			extractTemplateCommand(argv, options, &templateCommand, &templateFile)
+			extractTemplateCommand(r, argv, options, &templateCommand, &templateFile)
 
 			Expect(templateCommand).To(Equal("my-template"))
 			Expect(templateFile).To(Equal("cmd/create/network/templates/my-template/cloudformation.yaml"))
@@ -118,12 +121,13 @@ var _ = Describe("Validation functions", func() {
 
 		It("should use the default template when the extracted template command is 'rosa-quickstart-default-vpc'", func() {
 			argv := []string{"rosa-quickstart-default-vpc"}
+			r := rosa.NewRuntime()
 			templateCommand := ""
 			templateFile := ""
 			options := &opts.NetworkUserOptions{}
 			options.TemplateDir = "cmd/create/network/templates"
 
-			extractTemplateCommand(argv, options, &templateCommand, &templateFile)
+			extractTemplateCommand(r, argv, options, &templateCommand, &templateFile)
 
 			Expect(templateCommand).To(Equal("rosa-quickstart-default-vpc"))
 			Expect(templateFile).To(Equal(CloudFormationTemplateFile))


### PR DESCRIPTION
[OCM-12435](https://issues.redhat.com/browse/OCM-12435)