### PR TITLE
OCM-12363 | feat: HCP sharedVPC functionality to create/operatoroles

### DIFF
--- a/cmd/create/operatorroles/by_prefix.go
+++ b/cmd/create/operatorroles/by_prefix.go
@@ -78,7 +78,7 @@ func handleOperatorRolesPrefixOptions(r *rosa.Runtime, cmd *cobra.Command) {
 func handleOperatorRoleCreationByPrefix(r *rosa.Runtime, env string,
 	permissionsBoundary string, mode string,
 	policies map[string]*cmv1.AWSSTSPolicy,
-	defaultPolicyVersion string) error {
+	defaultPolicyVersion string, isSharedVpc bool) error {
 	oidcConfig, err := r.OCMClient.GetOidcConfig(args.oidcConfigId)
 	if err != nil {
 		r.Reporter.Errorf("There was a problem retrieving OIDC Config '%s': %v", args.oidcConfigId, err)
@@ -88,7 +88,8 @@ func handleOperatorRoleCreationByPrefix(r *rosa.Runtime, env string,
 	operatorRolesPrefix := args.prefix
 	oidcEndpointUrl := oidcConfig.IssuerUrl()
 	installerRoleArn := args.installerRoleArn
-	sharedVpcRoleArn := args.sharedVpcRoleArn
+	sharedVpcRoleArn := args.vpcEndpointRoleArn
+	sharedVpcEndpointRoleArn := args.sharedVpcRoleArn
 
 	validateArgumentsOperatorRolesCreationByPrefix(r, operatorRolesPrefix, oidcEndpointUrl, installerRoleArn)
 
@@ -123,11 +124,6 @@ func handleOperatorRoleCreationByPrefix(r *rosa.Runtime, env string,
 	managedPolicies, err := r.AWSClient.HasManagedPolicies(installerRoleArn)
 	if err != nil {
 		r.Reporter.Errorf("Failed to determine if cluster has managed policies: %v", err)
-		os.Exit(1)
-	}
-	if managedPolicies && sharedVpcRoleArn != "" {
-		r.Reporter.Errorf("Installer role '%s' has managed policies, the 'shared-vpc-role-arn' flag is not "+
-			"supported for managed policies", installerRoleArn)
 		os.Exit(1)
 	}
 	awsCreator, err := r.AWSClient.GetCreator()
@@ -180,7 +176,8 @@ func handleOperatorRoleCreationByPrefix(r *rosa.Runtime, env string,
 			defaultPolicyVersion, policies,
 			credRequests, managedPolicies,
 			path, operatorIAMRoleList,
-			oidcEndpointUrl, hostedCPPolicies, sharedVpcRoleArn)
+			oidcEndpointUrl, hostedCPPolicies, sharedVpcRoleArn, sharedVpcEndpointRoleArn,
+			isSharedVpc)
 		if err != nil {
 			r.Reporter.Errorf("There was an error creating the operator roles: %s", err)
 			isThrottle := "false"
@@ -293,8 +290,8 @@ func createRolesByPrefix(r *rosa.Runtime, prefix string, permissionsBoundary str
 	policies map[string]*cmv1.AWSSTSPolicy, credRequests map[string]*cmv1.STSOperator,
 	managedPolicies bool, path string,
 	operatorIAMRoleList []*cmv1.OperatorIAMRole,
-	oidcEndpointUrl string, hostedCPPolicies bool, sharedVpcRoleArn string) error {
-	isSharedVpc := sharedVpcRoleArn != ""
+	oidcEndpointUrl string, hostedCPPolicies bool, sharedVpcRoleArn string, sharedVpcEndpointRoleArn string,
+	isSharedVpc bool) error {
 
 	for credrequest, operator := range credRequests {
 		roleArn := aws.FindOperatorRoleBySTSOperator(operatorIAMRoleList, operator)
@@ -312,6 +309,21 @@ func createRolesByPrefix(r *rosa.Runtime, prefix string, permissionsBoundary str
 			policyArn, err = aws.GetManagedPolicyARN(policies, filename)
 			if err != nil {
 				return err
+			}
+			if isSharedVpc {
+				if credrequest == aws.IngressOperatorCloudCredentialsRoleType {
+					policyArn, err = attachHcpSharedVpcPolicy(r, sharedVpcRoleArn, roleName, operator,
+						path, defaultPolicyVersion)
+					if err != nil {
+						return err
+					}
+				} else if credrequest == aws.ControlPlaneCloudCredentialsRoleType {
+					policyArn, err = attachHcpSharedVpcPolicy(r, sharedVpcEndpointRoleArn, roleName,
+						operator, path, defaultPolicyVersion)
+					if err != nil {
+						return err
+					}
+				}
 			}
 		} else {
 			policyArn = aws.GetOperatorPolicyARN(r.Creator.Partition, r.Creator.AccountID, prefix, operator.Namespace(),
@@ -502,4 +514,23 @@ func buildCommandsFromPrefix(r *rosa.Runtime, env string,
 		commands = append(commands, createRole, attachRolePolicy)
 	}
 	return awscb.JoinCommands(commands), nil
+}
+
+func attachHcpSharedVpcPolicy(r *rosa.Runtime, roleArn string, roleName string,
+	operator *cmv1.STSOperator, path string, defaultPolicyVersion string) (string, error) {
+	policyDetails := "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": {\n    \"Effect\": \"Allow\",\n    " +
+		"\"Action\": \"sts:AssumeRole\",\n    \"Resource\": \"%{shared_vpc_role_arn}\"\n  }\n}\n"
+	policyDetails = aws.InterpolatePolicyDocument(r.Creator.Partition, policyDetails, map[string]string{
+		"shared_vpc_role_arn": roleArn,
+	})
+	policy := aws.GetOperatorPolicyARN(r.Creator.Partition, r.Creator.AccountID,
+		"rosa-assume-role-"+roleName, operator.Namespace(), operator.Name(), path)
+
+	var err error
+	policyArn, err := r.AWSClient.EnsurePolicy(policy, policyDetails, defaultPolicyVersion,
+		map[string]string{tags.RedHatManaged: helper.True}, path)
+	if err != nil {
+		return policyArn, err
+	}
+	return policyArn, nil
 }

--- a/cmd/create/operatorroles/suite_test.go
+++ b/cmd/create/operatorroles/suite_test.go
@@ -1,0 +1,13 @@
+package operatorroles
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDnsDomain(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Operator role suite")
+}

--- a/cmd/create/operatorroles/validation.go
+++ b/cmd/create/operatorroles/validation.go
@@ -1,0 +1,32 @@
+package operatorroles
+
+import errors "github.com/zgalor/weberr"
+
+func validateSharedVpcInputs(hostedCp bool, vpcEndpointRoleArn string,
+	route53RoleArn string) (bool, error) {
+
+	if !hostedCp {
+		if vpcEndpointRoleArn != "" {
+			return false, errors.UserErrorf("Can only use '%s' flag for Hosted Control Plane operator roles",
+				vpcEndpointRoleArnFlag)
+		}
+	} else {
+		if vpcEndpointRoleArn != "" && route53RoleArn == "" {
+			return false, errors.UserErrorf(
+				"Must supply '%s' flag when using the '%s' flag",
+				hostedZoneRoleArnFlag,
+				vpcEndpointRoleArnFlag,
+			)
+		}
+
+		if route53RoleArn != "" && vpcEndpointRoleArn == "" {
+			return false, errors.UserErrorf(
+				"Must supply '%s' flag when using the '%s' flag",
+				vpcEndpointRoleArnFlag,
+				hostedZoneRoleArnFlag,
+			)
+		}
+	}
+
+	return hostedCp && vpcEndpointRoleArn != "" && route53RoleArn != "", nil
+}

--- a/cmd/create/operatorroles/validation_test.go
+++ b/cmd/create/operatorroles/validation_test.go
@@ -1,0 +1,76 @@
+package operatorroles
+
+import (
+	"go.uber.org/mock/gomock"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Create dns domain", func() {
+	var ctrl *gomock.Controller
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+	})
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Context("validateSharedVpcInputs", func() {
+		When("Validate flags properly for shared VPC for HCP op roles", func() {
+			It("OK: Should pass with no error, for classic (return false)", func() {
+				usingSharedVpc, err := validateSharedVpcInputs(false, "", "")
+				Expect(usingSharedVpc).To(BeFalse())
+				Expect(err).ToNot(HaveOccurred())
+			})
+			It("OK: Should pass with no error, for HCP (return false)", func() {
+				usingSharedVpc, err := validateSharedVpcInputs(true, "", "")
+				Expect(usingSharedVpc).To(BeFalse())
+				Expect(err).ToNot(HaveOccurred())
+			})
+			It("KO: Should error when using classic and the first flag (return false)", func() {
+				usingSharedVpc, err := validateSharedVpcInputs(false, "123", "")
+				Expect(usingSharedVpc).To(BeFalse())
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Can only use '%s' flag for Hosted Control Plane operator "+
+					"roles", vpcEndpointRoleArnFlag,
+				))
+			})
+			It("KO: Should error when using classic and the vpc endpoint flag (return false)", func() {
+				usingSharedVpc, err := validateSharedVpcInputs(false, "123", "")
+				Expect(usingSharedVpc).To(BeFalse())
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Can only use '%s' flag for Hosted Control Plane operator "+
+					"roles", vpcEndpointRoleArnFlag,
+				))
+			})
+			It("KO: Should error when using classic and both flags (return false)", func() {
+				usingSharedVpc, err := validateSharedVpcInputs(false, "123", "123")
+				Expect(usingSharedVpc).To(BeFalse())
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Can only use '%s' flag for Hosted Control Plane operator "+
+					"roles", vpcEndpointRoleArnFlag,
+				))
+			})
+			It("KO: Should error when using HCP and the first flag but not the second (return false)", func() {
+				usingSharedVpc, err := validateSharedVpcInputs(true, "123", "")
+				Expect(usingSharedVpc).To(BeFalse())
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Must supply '%s' flag when using the '%s' flag",
+					hostedZoneRoleArnFlag,
+					vpcEndpointRoleArnFlag,
+				))
+			})
+			It("KO: Should error when using HCP and the second flag but not the first (return false)", func() {
+				usingSharedVpc, err := validateSharedVpcInputs(true, "", "123")
+				Expect(usingSharedVpc).To(BeFalse())
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Must supply '%s' flag when using the '%s' flag",
+					vpcEndpointRoleArnFlag,
+					hostedZoneRoleArnFlag,
+				))
+			})
+		})
+	})
+})

--- a/cmd/rosa/structure_test/command_args/rosa/create/operator-roles/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/create/operator-roles/command_args.yml
@@ -12,3 +12,5 @@
 - name: role-arn
 - name: shared-vpc-role-arn
 - name: "yes"
+- name: vpc-endpoint-role-arn
+- name: route53-role-arn

--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -127,6 +127,7 @@ const (
 	HCPSuffixPattern = "HCP-ROSA"
 
 	IngressOperatorCloudCredentialsRoleType = "ingress_operator_cloud_credentials"
+	ControlPlaneCloudCredentialsRoleType    = "control_plane_operator_credentials"
 
 	TrueString = "true"
 )


### PR DESCRIPTION
* rosa create operator-roles [–oidc-config-id xxx] [-c xxx] –cross-account-hosted-zone-role-arn xxx –cross-account-vpc-endpoint-service-role-arn xxx
* The new parameter in bold is necessary to indicate the change to include permissions to assume role for both the control plane and ingress operator roles

The flag names above in the requirements were renamed to `route53-role-arn` and `vpc-endpoint-role-arn`

`vpc-endpoint-role-arn` deprecates `shared-vpc-role-arn` which is used currently for classic. This flag is still usable, but will print a deprecation warning when used instead of `route53-role-arn`

Output of commands surrounding operator roles:

**VALIDATION**:

```
> rosa create operator-roles --prefix hktest --route53-role-arn a
? Role creation mode:  [Use arrows to move, type to filter, ? for more help]
> auto
  manual

> rosa create operator-roles --prefix hktest --shared-vpc-role-arn a
Flag --shared-vpc-role-arn has been deprecated, '--shared-vpc-role-arn' will be replaced with route53-role-arn in future versions of ROSA
? Role creation mode:  [Use arrows to move, type to filter, ? for more help]
> auto
  manual

> rosa create operator-roles --prefix hktest --route53-role-arn a --vpc-endpoint-role-arn b
E: Invalid configuration: Can only use 'vpc-endpoint-role-arn' flag for Hosted Control Plane operator roles

> rosa create operator-roles --prefix hktest --route53-role-arn a --hosted-cp              
E: Invalid configuration: Must supply 'vpc-endpoint-role-arn' flag when using the 'route53-role-arn' flag

> rosa create operator-roles --prefix hktest --vpc-endpoint-role-arn b --hosted-cp
E: Invalid configuration: Must supply 'route53-role-arn' flag when using the 'vpc-endpoint-role-arn' flag

> rosa create operator-roles --prefix hktest --route53-role-arn a --vpc-endpoint-role-arn b --hosted-cp
? Role creation mode:  [Use arrows to move, type to filter, ? for more help]
> auto
  manual

> rosa create operator-roles --prefix hktest --shared-vpc-role-arn a --vpc-endpoint-role-arn b --hosted-cp
Flag --shared-vpc-role-arn has been deprecated, '--shared-vpc-role-arn' will be replaced with route53-role-arn in future versions of ROSA
? Role creation mode:  [Use arrows to move, type to filter, ? for more help]
> auto
  manual
```

**CREATION**:

```
> rosa create operatorroles --region us-west-2 --prefix hktest --hosted-cp --route53-role-arn arn:aws:iam::XXX:role/oadler-shared-vpc --vpc-endpoint-role-arn arn:aws:iam:: XXX:role/vpc-endpoint-service --profile shared-vpc
W: Region flag will be removed from this command in future versions
? Role creation mode: auto
? Operator roles prefix: hktest
? OIDC Configuration ID (default = 'XXX | https://XXX/XXX'): XXX | https://XXX.devshift.org/XXX
? Create hosted control plane operator roles: Yes
W: More than one Installer role found
? Installer role ARN (default = 'arn:aws:iam:: XXX:role/hk-HCP-ROSA-Installer-Role'): arn:aws:iam:: XXX:role/hk-HCP-ROSA-Installer-Role
? Permissions boundary ARN (optional): 
I: Reusable OIDC Configuration detected. Validating trusted relationships to operator roles: 
I: Creating roles using 'arn:aws:iam:: XXX:user/hkepley'
I: Attached trust policy to role 'hktest-kube-system-kube-controller-manager(https://console.aws.amazon.com/iam/home?#/roles/hktest-kube-system-kube-controller-manager)': {"Version": "2012-10-17", "Statement": [{"Action": ["sts:AssumeRoleWithWebIdentity"], "Effect": "Allow", "Condition": {"StringEquals": {"XXX.devshift.org/XXX:sub": ["system:serviceaccount:kube-system:kube-controller-manager"]}}, "Principal": {"Federated": "arn:aws:iam:: XXX:oidc-provider/XXX.devshift.org/XXX"}}]}
I: Created role 'hktest-kube-system-kube-controller-manager' with ARN 'arn:aws:iam:: XXX:role/hktest-kube-system-kube-controller-manager'
I: Attached policy 'ROSAKubeControllerPolicy(https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAKubeControllerPolicy)' to role 'hktest-kube-system-kube-controller-manager(https://console.aws.amazon.com/iam/home?#/roles/hktest-kube-system-kube-controller-manager)'

I: Attached trust policy to role 'hktest-kube-system-capa-controller-manager(https://console.aws.amazon.com/iam/home?#/roles/hktest-kube-system-capa-controller-manager)': {"Version": "2012-10-17", "Statement": [{"Action": ["sts:AssumeRoleWithWebIdentity"], "Effect": "Allow", "Condition": {"StringEquals": {"XXX.devshift.org/XXX:sub": ["system:serviceaccount:kube-system:capa-controller-manager"]}}, "Principal": {"Federated": "arn:aws:iam:: XXX:oidc-provider/XXX.devshift.org/XXX"}}]}
I: Created role 'hktest-kube-system-capa-controller-manager' with ARN 'arn:aws:iam:: XXX:role/hktest-kube-system-capa-controller-manager'
I: Attached policy 'ROSANodePoolManagementPolicy(https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSANodePoolManagementPolicy)' to role 'hktest-kube-system-capa-controller-manager(https://console.aws.amazon.com/iam/home?#/roles/hktest-kube-system-capa-controller-manager)'

I: Attached trust policy to role 'hktest-kube-system-control-plane-operator(https://console.aws.amazon.com/iam/home?#/roles/hktest-kube-system-control-plane-operator)': {"Version": "2012-10-17", "Statement": [{"Action": ["sts:AssumeRoleWithWebIdentity"], "Effect": "Allow", "Condition": {"StringEquals": {"XXX.devshift.org/XXX:sub": ["system:serviceaccount:kube-system:control-plane-operator"]}}, "Principal": {"Federated": "arn:aws:iam:: XXX:oidc-provider/XXX.devshift.org/XXX"}}]}
I: Created role 'hktest-kube-system-control-plane-operator' with ARN 'arn:aws:iam:: XXX:role/hktest-kube-system-control-plane-operator'
I: Attached policy 'arn:aws:iam:: XXX:policy/rosa-assume-role-hktest-kube-system-control-plane-operator-kube-' to role 'hktest-kube-system-control-plane-operator(https://console.aws.amazon.com/iam/home?#/roles/hktest-kube-system-control-plane-operator)'

I: Attached trust policy to role 'hktest-kube-system-kms-provider(https://console.aws.amazon.com/iam/home?#/roles/hktest-kube-system-kms-provider)': {"Version": "2012-10-17", "Statement": [{"Action": ["sts:AssumeRoleWithWebIdentity"], "Effect": "Allow", "Condition": {"StringEquals": {"XXX.devshift.org/XXX:sub": ["system:serviceaccount:kube-system:kms-provider"]}}, "Principal": {"Federated": "arn:aws:iam:: XXX:oidc-provider/XXX.devshift.org/XXX"}}]}
I: Created role 'hktest-kube-system-kms-provider' with ARN 'arn:aws:iam:: XXX:role/hktest-kube-system-kms-provider'
I: Attached policy 'ROSAKMSProviderPolicy(https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAKMSProviderPolicy)' to role 'hktest-kube-system-kms-provider(https://console.aws.amazon.com/iam/home?#/roles/hktest-kube-system-kms-provider)'

I: Attached trust policy to role 'hktest-openshift-image-registry-installer-cloud-credentials(https://console.aws.amazon.com/iam/home?#/roles/hktest-openshift-image-registry-installer-cloud-credentials)': {"Version": "2012-10-17", "Statement": [{"Action": ["sts:AssumeRoleWithWebIdentity"], "Effect": "Allow", "Condition": {"StringEquals": {"XXX.devshift.org/XXX:sub": ["system:serviceaccount:openshift-image-registry:cluster-image-registry-operator" , "system:serviceaccount:openshift-image-registry:registry"]}}, "Principal": {"Federated": "arn:aws:iam:: XXX:oidc-provider/XXX.devshift.org/XXX"}}]}
I: Created role 'hktest-openshift-image-registry-installer-cloud-credentials' with ARN 'arn:aws:iam:: XXX:role/hktest-openshift-image-registry-installer-cloud-credentials'
I: Attached policy 'ROSAImageRegistryOperatorPolicy(https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAImageRegistryOperatorPolicy)' to role 'hktest-openshift-image-registry-installer-cloud-credentials(https://console.aws.amazon.com/iam/home?#/roles/hktest-openshift-image-registry-installer-cloud-credentials)'

I: Attached trust policy to role 'hktest-openshift-ingress-operator-cloud-credentials(https://console.aws.amazon.com/iam/home?#/roles/hktest-openshift-ingress-operator-cloud-credentials)': {"Version": "2012-10-17", "Statement": [{"Action": ["sts:AssumeRoleWithWebIdentity"], "Effect": "Allow", "Condition": {"StringEquals": {"XXX.devshift.org/XXX:sub": ["system:serviceaccount:openshift-ingress-operator:ingress-operator"]}}, "Principal": {"Federated": "arn:aws:iam:: XXX:oidc-provider/XXX.devshift.org/XXX"}}]}
I: Created role 'hktest-openshift-ingress-operator-cloud-credentials' with ARN 'arn:aws:iam:: XXX:role/hktest-openshift-ingress-operator-cloud-credentials'
I: Attached policy 'arn:aws:iam:: XXX:policy/rosa-assume-role-hktest-openshift-ingress-operator-cloud-credent' to role 'hktest-openshift-ingress-operator-cloud-credentials(https://console.aws.amazon.com/iam/home?#/roles/hktest-openshift-ingress-operator-cloud-credentials)'

I: Attached trust policy to role 'hktest-openshift-cluster-csi-drivers-ebs-cloud-credentials(https://console.aws.amazon.com/iam/home?#/roles/hktest-openshift-cluster-csi-drivers-ebs-cloud-credentials)': {"Version": "2012-10-17", "Statement": [{"Action": ["sts:AssumeRoleWithWebIdentity"], "Effect": "Allow", "Condition": {"StringEquals": {"XXX.devshift.org/XXX:sub": ["system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-operator" , "system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-controller-sa"]}}, "Principal": {"Federated": "arn:aws:iam:: XXX:oidc-provider/XXX.devshift.org/XXX"}}]}
I: Created role 'hktest-openshift-cluster-csi-drivers-ebs-cloud-credentials' with ARN 'arn:aws:iam:: XXX:role/hktest-openshift-cluster-csi-drivers-ebs-cloud-credentials'
I: Attached policy 'ROSAAmazonEBSCSIDriverOperatorPolicy(https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAAmazonEBSCSIDriverOperatorPolicy)' to role 'hktest-openshift-cluster-csi-drivers-ebs-cloud-credentials(https://console.aws.amazon.com/iam/home?#/roles/hktest-openshift-cluster-csi-drivers-ebs-cloud-credentials)'

I: Attached trust policy to role 'hktest-openshift-cloud-network-config-controller-cloud-credentia(https://console.aws.amazon.com/iam/home?#/roles/hktest-openshift-cloud-network-config-controller-cloud-credentia)': {"Version": "2012-10-17", "Statement": [{"Action": ["sts:AssumeRoleWithWebIdentity"], "Effect": "Allow", "Condition": {"StringEquals": {"XXX.devshift.org/XXX:sub": ["system:serviceaccount:openshift-cloud-network-config-controller:cloud-network-config-controller"]}}, "Principal": {"Federated": "arn:aws:iam:: XXX:oidc-provider/XXX.devshift.org/XXX"}}]}
I: Created role 'hktest-openshift-cloud-network-config-controller-cloud-credentia' with ARN 'arn:aws:iam:: XXX:role/hktest-openshift-cloud-network-config-controller-cloud-credentia'
I: Attached policy 'ROSACloudNetworkConfigOperatorPolicy(https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSACloudNetworkConfigOperatorPolicy)' to role 'hktest-openshift-cloud-network-config-controller-cloud-credentia(https://console.aws.amazon.com/iam/home?#/roles/hktest-openshift-cloud-network-config-controller-cloud-credentia)'

I: To create a cluster with these roles, run the following command:
	rosa create cluster --sts --oidc-config-id XXX --operator-roles-prefix hktest --hosted-cp
```

**DELETION**:

```
> rosa delete operator-roles --prefix hktest -y --profile shared-vpc 
? Operator roles deletion mode: auto
I: Fetching operator roles for the prefix: hktest
I: Deleting operator role 'hktest-kube-system-capa-controller-manager'
I: Deleting operator role 'hktest-kube-system-control-plane-operator'
I: Deleting operator role 'hktest-kube-system-kms-provider'
I: Deleting operator role 'hktest-kube-system-kube-controller-manager'
I: Deleting operator role 'hktest-openshift-cloud-network-config-controller-cloud-credentia'
I: Deleting operator role 'hktest-openshift-cluster-csi-drivers-ebs-cloud-credentials'
I: Deleting operator role 'hktest-openshift-image-registry-installer-cloud-credentials'
I: Deleting operator role 'hktest-openshift-ingress-operator-cloud-credentials'
I: Successfully deleted the operator roles
```