### PR TITLE
OCM-9994 | test: automated id:77159,77140

### DIFF
--- a/tests/ci/labels/features.go
+++ b/tests/ci/labels/features.go
@@ -28,6 +28,7 @@ type featureLabels struct {
 	Token                Labels
 	TuningConfigs        Labels
 	UserRole             Labels
+	NetworkResources     Labels
 	VerifyResources      Labels
 	Version              Labels
 	Upgrade              Labels

--- a/tests/e2e/test_rosacli_network_resources.go
+++ b/tests/e2e/test_rosacli_network_resources.go
@@ -1,0 +1,427 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openshift-online/ocm-common/pkg/aws/aws_client"
+
+	"github.com/openshift/rosa/tests/ci/labels"
+	"github.com/openshift/rosa/tests/utils/exec/rosacli"
+	"github.com/openshift/rosa/tests/utils/helper"
+)
+
+var _ = Describe("Network Resources",
+	labels.Feature.NetworkResources,
+	func() {
+		defer GinkgoRecover()
+
+		var (
+			rosaClient              *rosacli.Client
+			networkResourcesService rosacli.NetworkResourcesService
+			ocmResourceService      rosacli.OCMResourceService
+		)
+
+		BeforeEach(func() {
+			By("Init the client")
+			rosaClient = rosacli.NewClient()
+			networkResourcesService = rosaClient.NetworkResources
+			ocmResourceService = rosaClient.OCMResource
+		})
+
+		It("should be created successfully - [id:77140]",
+			labels.High, labels.Runtime.OCMResources,
+			func() {
+				By("Get region value")
+				region := "us-west-2"
+				if os.Getenv("REGION") != "" {
+					region = os.Getenv("REGION")
+				} else if os.Getenv("AWS_REGION") != "" {
+					region = os.Getenv("AWS_REGION")
+				}
+				By("Create aws client")
+				awsClient, err := aws_client.CreateAWSClient("", region)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Get the organization id")
+				accInfo, err := ocmResourceService.UserInfo()
+				Expect(err).ToNot(HaveOccurred())
+				awsAccountID := accInfo.AWSAccountID
+
+				By("Check the help message")
+				_, err = networkResourcesService.CreateNetworkResources(false, "--help")
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Create template dir for template file creating single vpc")
+				templateContent := helper.TemplateForSingleVPC()
+				templatePath, err := helper.CreateTemplateDirForNetworkResources("single-vpc", templateContent)
+				defer func() {
+					os.Remove(templatePath)
+					Eventually(func() (bool, error) {
+						_, err := os.Stat(templatePath)
+						if err != nil {
+							if os.IsNotExist(err) {
+								return true, nil
+							} else {
+								return false, err
+							}
+						} else {
+							return false, err
+						}
+					}, time.Minute*1, time.Second*5).Should(Equal(true))
+					os.Remove("single-vpc")
+					Eventually(func() (bool, error) {
+						_, err := os.Stat("single-vpc")
+						if err != nil {
+							if os.IsNotExist(err) {
+								return true, nil
+							} else {
+								return false, err
+							}
+						} else {
+							return false, err
+						}
+					}, time.Minute*1, time.Second*5).Should(Equal(true))
+				}()
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Get current working directory as template dir path")
+				templateDirPath, err := helper.GetCurrentWorkingDir()
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Create network resources without passing template name and parameter")
+				defaultName := fmt.Sprintf("rosa-network-stack-%s", awsAccountID)
+				output, err := networkResourcesService.CreateNetworkResources(false)
+				defer func() {
+					params := cloudformation.DeleteStackInput{
+						StackName: &defaultName,
+					}
+					_, err = awsClient.StackFormationClient.DeleteStack(context.TODO(), &params)
+					Expect(err).ToNot(HaveOccurred())
+				}()
+				Expect(err).ToNot(HaveOccurred())
+				resp := rosaClient.Parser.TextData.Input(output).Parse().Tip()
+				Expect(resp).To(And(
+					ContainSubstring("Name not provided, using default name %s", defaultName),
+					ContainSubstring("No template name provided in the command. Defaulting to rosa-quickstart-default-vpc"),
+					ContainSubstring("Region not provided, using default region %s", region)))
+
+				By("Create network resources by passing template name and all parameters")
+				stackName_1 := helper.GenerateRandomName("ocp-77140", 2)
+				paramNameFlag := fmt.Sprintf("--param=Name=%s", stackName_1)
+				paramRegionFlag := fmt.Sprintf("--param=Region=%s", region)
+				output, err = networkResourcesService.CreateNetworkResources(false, "single-vpc",
+					paramNameFlag,
+					paramRegionFlag,
+					"--template-dir", templateDirPath,
+					"--param=AvailabilityZoneCount=3",
+					"--param=Tags=Key1=Value1,Key2=Value2",
+					"--param=VpcCidr=10.0.0.0/20")
+				defer func() {
+					params := cloudformation.DeleteStackInput{
+						StackName: &stackName_1,
+					}
+					_, err = awsClient.StackFormationClient.DeleteStack(context.TODO(), &params)
+					Expect(err).ToNot(HaveOccurred())
+				}()
+				Expect(err).ToNot(HaveOccurred())
+				resp_tip := rosaClient.Parser.TextData.Input(output).Parse().Tip()
+				resp = rosaClient.Parser.TextData.Input(output).Parse().Output()
+				Expect(resp_tip).ToNot(
+					ContainSubstring(
+						"No template name provided in the command. Defaulting to rosa-quickstart-default-vpc"))
+				Expect(resp).To(
+					ContainSubstring("msg=\"Stack %s created\"", stackName_1))
+
+				By("Create network using manual mode")
+				stackName_2 := helper.GenerateRandomName("ocp-77140", 2)
+				manualModeOutput := fmt.Sprintf("aws cloudformation create-stack --stack-name %s "+
+					"--template-body file://%s"+
+					" --param ParameterKey=AvailabilityZoneCount,ParameterValue=3 "+
+					"ParameterKey=Name,ParameterValue=%s "+
+					"ParameterKey=Region,ParameterValue=%s  "+
+					"--tags Key=Key1,Value=Value1 Key=Key2,Value=Value2  --region %s",
+					stackName_2, templateContent, stackName_2, region, region)
+				paramNameFlag = fmt.Sprintf("--param=Name=%s", stackName_2)
+				output, err = networkResourcesService.CreateNetworkResources(false, "single-vpc",
+					paramNameFlag,
+					paramRegionFlag,
+					"--template-dir", templateDirPath,
+					"--param=AvailabilityZoneCount=3",
+					"--param=Tags=Key1=Value1,Key2=Value2",
+					"--mode", "manual")
+				defer func() {
+					params := cloudformation.DeleteStackInput{
+						StackName: &stackName_2,
+					}
+					_, err = awsClient.StackFormationClient.DeleteStack(context.TODO(), &params)
+					Expect(err).ToNot(HaveOccurred())
+				}()
+				Expect(err).ToNot(HaveOccurred())
+				resp = rosaClient.Parser.TextData.Input(output).Parse().Output()
+				Expect(resp).To(
+					ContainSubstring(manualModeOutput))
+
+				By("Try to create network by setting OCM_TEMPLATE_DIR env variable")
+				stackName_3 := helper.GenerateRandomName("ocp-77140", 2)
+				paramNameFlag = fmt.Sprintf("--param=Name=%s", stackName_3)
+				output, err = networkResourcesService.CreateNetworkResources(true, "single-vpc",
+					paramNameFlag,
+					paramRegionFlag)
+				defer func() {
+					params := cloudformation.DeleteStackInput{
+						StackName: &stackName_3,
+					}
+					_, err = awsClient.StackFormationClient.DeleteStack(context.TODO(), &params)
+					Expect(err).ToNot(HaveOccurred())
+					Eventually(func() string {
+						describeParam := cloudformation.DescribeStacksInput{
+							StackName: &stackName_3,
+						}
+						res, _ := awsClient.StackFormationClient.DescribeStacks(context.TODO(), &describeParam)
+						return string(res.Stacks[0].StackStatus)
+					}, time.Minute*2).Should(ContainSubstring("DELETE_IN_PROGRESS"))
+				}()
+				Expect(err).ToNot(HaveOccurred())
+				resp = rosaClient.Parser.TextData.Input(output).Parse().Output()
+				Expect(resp).To(
+					ContainSubstring("msg=\"Stack %s created\"", stackName_3))
+
+				By("Try to override 'OCM_TEMPLATE_DIR' env variable using --template-dir flag")
+				stackName_4 := helper.GenerateRandomName("ocp-77140", 2)
+				paramNameFlag = fmt.Sprintf("--param=Name=%s", stackName_4)
+				output, err = networkResourcesService.CreateNetworkResources(true, "single-vpc",
+					paramNameFlag,
+					paramRegionFlag,
+					"--template-dir", templateDirPath)
+				defer func() {
+					params := cloudformation.DeleteStackInput{
+						StackName: &stackName_4,
+					}
+					_, err = awsClient.StackFormationClient.DeleteStack(context.TODO(), &params)
+					Expect(err).ToNot(HaveOccurred())
+				}()
+				Expect(err).ToNot(HaveOccurred())
+				resp = rosaClient.Parser.TextData.Input(output).Parse().Output()
+				Expect(resp).To(
+					ContainSubstring("msg=\"Stack %s created\"", stackName_4))
+			})
+
+		It("should be validated successfully - [id:77159]",
+			labels.Medium, labels.Runtime.OCMResources,
+			func() {
+				By("Create aws client")
+				awsClient, err := aws_client.CreateAWSClient("", "us-west-2")
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Create template dir for template file missing Region Param")
+				templateContent := helper.TemplateWithoutRegionParam()
+				templatePath_1, err := helper.CreateTemplateDirForNetworkResources("without-region", templateContent)
+				defer func() {
+					os.Remove(templatePath_1)
+					Eventually(func() (bool, error) {
+						_, err := os.Stat(templatePath_1)
+						if err != nil {
+							if os.IsNotExist(err) {
+								return true, nil
+							} else {
+								return false, err
+							}
+						} else {
+							return false, err
+						}
+					}, time.Minute*1, time.Second*5).Should(Equal(true))
+					os.Remove("without-region")
+					Eventually(func() (bool, error) {
+						_, err := os.Stat("without-region")
+						if err != nil {
+							if os.IsNotExist(err) {
+								return true, nil
+							} else {
+								return false, err
+							}
+						} else {
+							return false, err
+						}
+					}, time.Minute*1, time.Second*5).Should(Equal(true))
+				}()
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Create template dir for template file missing Name Param")
+				templateContent = helper.TemplateWithoutNameParam()
+				templatePath_2, err := helper.CreateTemplateDirForNetworkResources("without-name", templateContent)
+				defer func() {
+					os.Remove(templatePath_2)
+					Eventually(func() (bool, error) {
+						_, err := os.Stat(templatePath_2)
+						if err != nil {
+							if os.IsNotExist(err) {
+								return true, nil
+							} else {
+								return false, err
+							}
+						} else {
+							return false, err
+						}
+					}, time.Minute*1, time.Second*5).Should(Equal(true))
+					os.Remove("without-name")
+					Eventually(func() (bool, error) {
+						_, err := os.Stat("without-name")
+						if err != nil {
+							if os.IsNotExist(err) {
+								return true, nil
+							} else {
+								return false, err
+							}
+						} else {
+							return false, err
+						}
+					}, time.Minute*1, time.Second*5).Should(Equal(true))
+				}()
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Create template dir for template file missing VpcCidr value")
+				templateContent = helper.TemplateWithoutCidrValueForVPC()
+				templatePath_3, err := helper.CreateTemplateDirForNetworkResources("without-vpccidr", templateContent)
+				defer func() {
+					os.Remove(templatePath_3)
+					Eventually(func() (bool, error) {
+						_, err := os.Stat(templatePath_3)
+						if err != nil {
+							if os.IsNotExist(err) {
+								return true, nil
+							} else {
+								return false, err
+							}
+						} else {
+							return false, err
+						}
+					}, time.Minute*1, time.Second*5).Should(Equal(true))
+					os.Remove("without-vpccidr")
+					Eventually(func() (bool, error) {
+						_, err := os.Stat("without-vpccidr")
+						if err != nil {
+							if os.IsNotExist(err) {
+								return true, nil
+							} else {
+								return false, err
+							}
+						} else {
+							return false, err
+						}
+					}, time.Minute*1, time.Second*5).Should(Equal(true))
+				}()
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Create template dir for template file creating single vpc")
+				templateContent = helper.TemplateForSingleVPC()
+				templatePath_4, err := helper.CreateTemplateDirForNetworkResources("single-vpc", templateContent)
+				defer func() {
+					os.Remove(templatePath_4)
+					Eventually(func() (bool, error) {
+						_, err := os.Stat(templatePath_4)
+						if err != nil {
+							if os.IsNotExist(err) {
+								return true, nil
+							} else {
+								return false, err
+							}
+						} else {
+							return false, err
+						}
+					}, time.Minute*1, time.Second*5).Should(Equal(true))
+					os.Remove("single-vpc")
+					Eventually(func() (bool, error) {
+						_, err := os.Stat("single-vpc")
+						if err != nil {
+							if os.IsNotExist(err) {
+								return true, nil
+							} else {
+								return false, err
+							}
+						} else {
+							return false, err
+						}
+					}, time.Minute*1, time.Second*5).Should(Equal(true))
+				}()
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Get current working directory as template dir path")
+				templateDirPath, err := helper.GetCurrentWorkingDir()
+				Expect(err).ToNot(HaveOccurred())
+
+				invalidTemplateDir := "/ss"
+				nonExistentTemplate := "non-existent"
+				invalidTemplateDirErrorMessage := fmt.Sprintf(
+					"ERR: failed to read template file: open %s/ss/cloudformation.yaml: no such file or directory",
+					invalidTemplateDir)
+				nonExistentTemplateErrorMessage := fmt.Sprintf(
+					"ERR: failed to read template file: open "+
+						"cmd/create/network/templates/%s/cloudformation.yaml: no such file or directory",
+					nonExistentTemplate)
+				rollBackInProgress := "ROLLBACK_IN_PROGRESS"
+				rollBackRequested := "Rollback requested by user"
+				withoutCidrErrorMessage := "Either CIDR Block or IPv4 IPAM Pool and IPv4 Netmask Length must be provided"
+				incorrectCidrErrorMessage := "Value (10.0.) for parameter cidrBlock is invalid"
+				incorrectStackNameErrorMessage := "Value '$#aaraj' at 'stackName' failed to satisfy constraint: " +
+					"Member must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*"
+
+				reqAndErrBody := map[string][]string{
+					"Error: flag needs an argument: --param": {"--param"},
+					"ERR: invalid parameter format":          {"--param="},
+					"Parameters: [Namwe] do not exist in the template": {"--param=Namwe=",
+						"--param=Name=invalid-param"},
+					invalidTemplateDirErrorMessage: {"ss",
+						"--template-dir", invalidTemplateDir, "--param=Name=invalid-dir"},
+					"Error: unknown flag: --invalid": {"--invalid"},
+					"ERR: duplicate tag key Key1": {"--param=Tags=Key1=Value1,Key1=Value2",
+						"--param=Name=duplicate-key"},
+					nonExistentTemplateErrorMessage: {nonExistentTemplate},
+					"Parameters: [Region] do not exist in the template": {"without-region",
+						"--template-dir", templateDirPath, "--param=Name=without-region"},
+					"Parameters: [Name] do not exist in the template": {"without-name",
+						"--template-dir", templateDirPath, "--param=Name=without-name"},
+					withoutCidrErrorMessage: {"without-vpccidr",
+						"--template-dir", templateDirPath, "--param=Name=withoutcidr", "--param=Region=us-west-2"},
+					"Parameter 'AvailabilityZoneCount' must be a number not greater than 3": {
+						"--param=AvailabilityZoneCount=10", "--param=Name=invalid-az"},
+					"Parameter 'AvailabilityZoneCount' must be a number not less than 1": {
+						"--param=AvailabilityZoneCount=0", "--param=Name=invalid-az"},
+					"request send failed, Post \"https://cloudformation.ind-west-2.amazonaws.com/\"": {
+						"--param=Region=ind-west-2", "--param=Name=invalid-region"},
+					incorrectStackNameErrorMessage: {"--param=Name=$#aaraj"},
+					incorrectCidrErrorMessage: {"single-vpc",
+						"--template-dir", templateDirPath,
+						"--param=VpcCidr=10.0.", "--param=Name=incorrectcidr", "--param=Region=us-west-2"},
+				}
+
+				By("Try to create network by setting invalid arguments and flags")
+				for key, value := range reqAndErrBody {
+					output, err := networkResourcesService.CreateNetworkResources(false, value...)
+					Expect(err).To(HaveOccurred())
+					resp := rosaClient.Parser.TextData.Input(output).Parse().Tip()
+					Expect(resp).To(ContainSubstring(key))
+					if key == withoutCidrErrorMessage || key == incorrectCidrErrorMessage {
+						Expect(resp).To(ContainSubstring(rollBackInProgress))
+						Expect(resp).To(ContainSubstring(rollBackRequested))
+						var name string
+						if key == withoutCidrErrorMessage {
+							name = "withoutcidr"
+						}
+						if key == incorrectCidrErrorMessage {
+							name = "incorrectcidr"
+						}
+						params := cloudformation.DeleteStackInput{
+							StackName: &name,
+						}
+						_, err := awsClient.StackFormationClient.DeleteStack(context.TODO(), &params)
+						Expect(err).ToNot(HaveOccurred())
+					}
+				}
+			})
+	})

--- a/tests/utils/exec/rosacli/cmd_client.go
+++ b/tests/utils/exec/rosacli/cmd_client.go
@@ -37,6 +37,7 @@ type Client struct {
 	MachinePool          MachinePoolService
 	MachinePoolUpgrade   MachinePoolUpgradeService
 	NetworkVerifier      NetworkVerifierService
+	NetworkResources     NetworkResourcesService
 	OCMResource          OCMResourceService
 	TuningConfig         TuningConfigService
 	User                 UserService
@@ -66,6 +67,7 @@ func NewClient() *Client {
 	client.MachinePool = NewMachinePoolService(client)
 	client.MachinePoolUpgrade = NewMachinePoolUpgradeService(client)
 	client.NetworkVerifier = NewNetworkVerifierService(client)
+	client.NetworkResources = NewNetworkResourceService(client)
 	client.OCMResource = NewOCMResourceService(client)
 	client.TuningConfig = NewTuningConfigService(client)
 	client.User = NewUserService(client)
@@ -90,6 +92,7 @@ func (c *Client) CleanResources(clusterID string) error {
 	errorList = append(errorList, c.MachinePool.CleanResources(clusterID)...)
 	errorList = append(errorList, c.Ingress.CleanResources(clusterID)...)
 	errorList = append(errorList, c.NetworkVerifier.CleanResources(clusterID)...)
+	errorList = append(errorList, c.NetworkResources.CleanResources(clusterID)...)
 	errorList = append(errorList, c.KubeletConfig.CleanResources(clusterID)...)
 	errorList = append(errorList, c.User.CleanResources(clusterID)...)
 	errorList = append(errorList, c.IDP.CleanResources(clusterID)...)

--- a/tests/utils/exec/rosacli/network_resource_service.go
+++ b/tests/utils/exec/rosacli/network_resource_service.go
@@ -1,0 +1,61 @@
+package rosacli
+
+import (
+	"bytes"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/openshift/rosa/tests/utils/helper"
+	. "github.com/openshift/rosa/tests/utils/log"
+)
+
+type NetworkResourcesService interface {
+	ResourcesCleaner
+	CreateNetworkResources(isEnvSet bool, flags ...string) (bytes.Buffer, error)
+}
+
+type networkResourcesService struct {
+	ResourcesService
+
+	nr map[string]string
+}
+
+func NewNetworkResourceService(client *Client) NetworkResourcesService {
+	return &networkResourcesService{
+		ResourcesService: ResourcesService{
+			client: client,
+		},
+		nr: make(map[string]string),
+	}
+}
+
+func (nr *networkResourcesService) CreateNetworkResources(isEnvSet bool,
+	flags ...string) (bytes.Buffer, error) {
+	if isEnvSet {
+		if slices.Contains(flags, "--template-dir") {
+			// This condition is applied for , even if we set 'OCM_TEMPLATE_DIR' env vraiable, it will be overrideen
+			// by --template-dir flag
+			cmd := fmt.Sprintf("export OCM_TEMPLATE_DIR=/ss/home/; rosa create network %s", strings.Join(flags, " "))
+			return nr.client.Runner.RunCMD([]string{"bash", "-c", cmd})
+		} else {
+			templateDirPath, err := helper.GetCurrentWorkingDir()
+			if err != nil {
+				return bytes.Buffer{}, err
+			}
+			cmd := fmt.Sprintf("export OCM_TEMPLATE_DIR=%s; rosa create network %s", templateDirPath, strings.Join(flags, " "))
+			return nr.client.Runner.RunCMD([]string{"bash", "-c", cmd})
+		}
+	} else {
+		createNetworkResources := nr.client.Runner.
+			Cmd("create", "network").
+			CmdFlags(flags...)
+
+		return createNetworkResources.Run()
+	}
+}
+
+func (nr *networkResourcesService) CleanResources(clusterID string) (errors []error) {
+	Logger.Debugf("Nothing to clean in NetworkResourcesService Service")
+	return
+}

--- a/tests/utils/exec/rosacli/ocm_resource_service.go
+++ b/tests/utils/exec/rosacli/ocm_resource_service.go
@@ -2,10 +2,11 @@ package rosacli
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
+
+	"gopkg.in/yaml.v2"
 
 	. "github.com/openshift/rosa/tests/utils/log"
 )
@@ -138,17 +139,17 @@ type OCMRoleList struct {
 	OCMRoleList []OCMRole `json:"OCMRoleList,omitempty"`
 }
 type AccountsInfo struct {
-	AWSArn                    string `json:"AWS ARN,omitempty"`
-	AWSAccountID              string `json:"AWS Account ID,omitempty"`
-	AWSDefaultRegion          string `json:"AWS Default Region,omitempty"`
-	OCMApi                    string `json:"OCM API,omitempty"`
-	OCMAccountEmail           string `json:"OCM Account Email,omitempty"`
-	OCMAccountID              string `json:"OCM Account ID,omitempty"`
-	OCMAccountName            string `json:"OCM Account Name,omitempty"`
-	OCMAccountUsername        string `json:"OCM Account Username,omitempty"`
-	OCMOrganizationExternalID string `json:"OCM Organization External ID,omitempty"`
-	OCMOrganizationID         string `json:"OCM Organization ID,omitempty"`
-	OCMOrganizationName       string `json:"OCM Organization Name,omitempty"`
+	AWSArn                    string `yaml:"AWS ARN,omitempty"`
+	AWSAccountID              string `yaml:"AWS Account ID,omitempty"`
+	AWSDefaultRegion          string `yaml:"AWS Default Region,omitempty"`
+	OCMApi                    string `yaml:"OCM API,omitempty"`
+	OCMAccountEmail           string `yaml:"OCM Account Email,omitempty"`
+	OCMAccountID              string `yaml:"OCM Account ID,omitempty"`
+	OCMAccountName            string `yaml:"OCM Account Name,omitempty"`
+	OCMAccountUsername        string `yaml:"OCM Account Username,omitempty"`
+	OCMOrganizationExternalID string `yaml:"OCM Organization External ID,omitempty"`
+	OCMOrganizationID         string `yaml:"OCM Organization ID,omitempty"`
+	OCMOrganizationName       string `yaml:"OCM Organization Name,omitempty"`
 }
 
 type AccountRole struct {
@@ -244,9 +245,9 @@ func (ors *ocmResourceService) ReflectRegionList(result bytes.Buffer) (regions [
 // Pasrse the result of 'rosa whoami' to the AccountsInfo struct
 func (ors *ocmResourceService) ReflectAccountsInfo(result bytes.Buffer) *AccountsInfo {
 	res := new(AccountsInfo)
-	theMap, _ := ors.client.Parser.TextData.Input(result).Parse().JsonToMap()
-	data, _ := json.Marshal(&theMap)
-	json.Unmarshal(data, res)
+	theMap, _ := ors.client.Parser.TextData.Input(result).Parse().YamlToMap()
+	data, _ := yaml.Marshal(&theMap)
+	yaml.Unmarshal(data, res)
 	return res
 }
 

--- a/tests/utils/helper/file.go
+++ b/tests/utils/helper/file.go
@@ -3,6 +3,7 @@ package helper
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 
 	. "github.com/openshift/rosa/tests/utils/log"
@@ -14,6 +15,34 @@ func CreateTempFileWithContent(fileContent string) (string, error) {
 
 func CreateTempFileWithPrefixAndContent(prefix string, fileContent string) (string, error) {
 	f, err := os.CreateTemp("", prefix+"-")
+	if err != nil {
+		return "", err
+	}
+	return CreateFileWithContent(f.Name(), fileContent)
+}
+
+func GetCurrentWorkingDir() (string, error) {
+	ex, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	exPath := filepath.Dir(ex)
+	return exPath, err
+}
+
+func CreateTemplateDirForNetworkResources(templateName string, fileContent string) (string, error) {
+	err := os.Mkdir(templateName, 0744)
+	if err != nil {
+		return "", err
+	}
+	exPath, err := GetCurrentWorkingDir()
+	if err != nil {
+		return "", err
+	}
+	dirpath := filepath.Join(exPath + "/" + templateName)
+	outputPath := filepath.Join(dirpath, "cloudformation.yaml")
+
+	f, err := os.Create(outputPath)
 	if err != nil {
 		return "", err
 	}

--- a/tests/utils/helper/network.go
+++ b/tests/utils/helper/network.go
@@ -1,0 +1,169 @@
+package helper
+
+func TemplateWithoutRegionParam() string {
+	templateContent := `AWSTemplateFormatVersion: '2010-09-09'
+Description: CloudFormation template to create a ROSA Quickstart default VPC.
+  This CloudFormation template may not work with rosa CLI versions later than 1.2.47. 
+  Please ensure that you are using the compatible CLI version before deploying this template.
+
+Parameters:
+  AvailabilityZoneCount:
+    Type: Number
+    Description: "Number of Availability Zones to use"
+    Default: 1
+    MinValue: 1
+    MaxValue: 3
+  Name:
+    Type: String
+    Description: "Name prefix for resources"
+  VpcCidr:
+    Type: String
+    Description: CIDR block for the VPC
+    Default: '10.0.0.0/16'
+Resources:
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: !Ref VpcCidr
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+        - Key: Name
+          Value: !Ref Name
+        - Key: 'rosa_managed_policies'
+          Value: 'true'
+        - Key: 'rosa_hcp_policies'
+          Value: 'true'
+        - Key: 'service'
+          Value: 'ROSA'
+`
+	return templateContent
+}
+
+func TemplateWithoutNameParam() string {
+	templateContent := `AWSTemplateFormatVersion: '2010-09-09'
+Description: CloudFormation template to create a ROSA Quickstart default VPC.
+  This CloudFormation template may not work with rosa CLI versions later than 1.2.47. 
+  Please ensure that you are using the compatible CLI version before deploying this template.
+
+Parameters:
+  AvailabilityZoneCount:
+    Type: Number
+    Description: "Number of Availability Zones to use"
+    Default: 1
+    MinValue: 1
+    MaxValue: 3
+  Region:
+    Type: String
+    Description: "AWS Region"
+    Default: "us-west-2"
+  VpcCidr:
+    Type: String
+    Description: CIDR block for the VPC
+    Default: '10.0.0.0/16'
+Resources:
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: !Ref VpcCidr
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+        - Key: Name
+          Value: !Ref Name
+        - Key: 'rosa_managed_policies'
+          Value: 'true'
+        - Key: 'rosa_hcp_policies'
+          Value: 'true'
+        - Key: 'service'
+          Value: 'ROSA'
+`
+	return templateContent
+}
+
+func TemplateWithoutCidrValueForVPC() string {
+	templateContent := `AWSTemplateFormatVersion: '2010-09-09'
+Description: CloudFormation template to create a ROSA Quickstart default VPC.
+  This CloudFormation template may not work with rosa CLI versions later than 1.2.47. 
+  Please ensure that you are using the compatible CLI version before deploying this template.
+
+Parameters:
+  AvailabilityZoneCount:
+    Type: Number
+    Description: "Number of Availability Zones to use"
+    Default: 1
+    MinValue: 1
+    MaxValue: 3
+  Region:
+    Type: String
+    Description: "AWS Region"
+    Default: "us-west-2"
+  Name:
+    Type: String
+    Description: "Name prefix for resources"
+  VpcCidr:
+    Type: String
+    Description: CIDR block for the VPC
+    Default: '10.0.0.0/16'
+Resources:
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+        - Key: Name
+          Value: !Ref Name
+        - Key: 'rosa_managed_policies'
+          Value: 'true'
+        - Key: 'rosa_hcp_policies'
+          Value: 'true'
+        - Key: 'service'
+          Value: 'ROSA'
+`
+	return templateContent
+}
+
+func TemplateForSingleVPC() string {
+	templateContent := `AWSTemplateFormatVersion: '2010-09-09'
+Description: CloudFormation template to create a ROSA Quickstart default VPC.
+  This CloudFormation template may not work with rosa CLI versions later than 1.2.47. 
+  Please ensure that you are using the compatible CLI version before deploying this template.
+
+Parameters:
+  AvailabilityZoneCount:
+    Type: Number
+    Description: "Number of Availability Zones to use"
+    Default: 1
+    MinValue: 1
+    MaxValue: 3
+  Region:
+    Type: String
+    Description: "AWS Region"
+    Default: "us-west-2"
+  Name:
+    Type: String
+    Description: "Name prefix for resources"
+  VpcCidr:
+    Type: String
+    Description: CIDR block for the VPC
+    Default: '10.0.0.0/16'
+Resources:
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: !Ref VpcCidr
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+        - Key: Name
+          Value: !Ref Name
+        - Key: 'rosa_managed_policies'
+          Value: 'true'
+        - Key: 'rosa_hcp_policies'
+          Value: 'true'
+        - Key: 'service'
+          Value: 'ROSA'
+`
+	return templateContent
+}


### PR DESCRIPTION
$ ginkgo --focus '(77140|77159)' tests/e2e/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.15.0
  Mismatched package versions found:
    2.17.1 used by e2e

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: ROSA CLI e2e tests suite - /home/aaraj/ocm-forked-code/rosa/tests/e2e
====================================================================================
Random Seed: 1731563234

Will run 2 of 255 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS••SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 2 of 255 Specs in 849.655 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 253 Skipped
PASS

Ginkgo ran 1 suite in 14m11.681977491s
Test Suite Passed
