### PR TITLE
OCM-13982 | fix: Spelling of flag in external auth provider

### DIFF
--- a/pkg/externalauthprovider/flags.go
+++ b/pkg/externalauthprovider/flags.go
@@ -145,7 +145,7 @@ func AddExternalAuthProvidersFlags(cmd *cobra.Command, prefix string) *ExternalA
 		&args.claimMappingUsernameClaim,
 		claimMappingUsernameClaimFlag,
 		"",
-		"The name of the claim that should be used to construct usernmaes for the cluster identity.",
+		"The name of the claim that should be used to construct usernames for the cluster identity.",
 	)
 
 	cmd.Flags().StringSliceVar(


### PR DESCRIPTION
Correction of `usernames` in external auth provider flag