### PR TITLE
OCM-12694 | fix: Pre-command validation for shared vpc flags

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -181,6 +181,21 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
+	if args.vpcEndpointRoleArn != "" {
+		err = aws.ARNValidator(args.vpcEndpointRoleArn)
+		if err != nil {
+			r.Reporter.Errorf("Expected a valid policy ARN for %s: %s", vpcEndpointRoleArnFlag, err)
+			os.Exit(1)
+		}
+	}
+	if args.route53RoleArn != "" {
+		err = aws.ARNValidator(args.route53RoleArn)
+		if err != nil {
+			r.Reporter.Errorf("Expected a valid policy ARN for %s: %s", route53RoleArnFlag, err)
+			os.Exit(1)
+		}
+	}
+
 	// If necessary, call `login` as part of `init`. We do this before
 	// other validations to get the prompt out of the way before performing
 	// longer checks.

--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -184,6 +184,21 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
+	if args.vpcEndpointRoleArn != "" {
+		err = aws.ARNValidator(args.vpcEndpointRoleArn)
+		if err != nil {
+			r.Reporter.Errorf("Expected a valid policy ARN for %s: %s", vpcEndpointRoleArnFlag, err)
+			os.Exit(1)
+		}
+	}
+	if args.sharedVpcRoleArn != "" {
+		err = aws.ARNValidator(args.sharedVpcRoleArn)
+		if err != nil {
+			r.Reporter.Errorf("Expected a valid policy ARN for %s: %s", hostedZoneRoleArnFlag, err)
+			os.Exit(1)
+		}
+	}
+
 	env, err := ocm.GetEnv()
 	if err != nil {
 		r.Reporter.Errorf("Failed to determine OCM environment: %v", err)


### PR DESCRIPTION
Adds validation for sharedvpc flags associated with HCP (account + op roles) before resources are created