### PR TITLE
OCM-12689 | fix: Creation of operator roles for classic fixes

### DIFF
--- a/cmd/create/operatorroles/validation.go
+++ b/cmd/create/operatorroles/validation.go
@@ -25,6 +25,8 @@ func validateSharedVpcInputs(hostedCp bool, vpcEndpointRoleArn string,
 				hostedZoneRoleArnFlag,
 			)
 		}
+	} else {
+		return false, nil
 	}
 
 	return hostedCp && vpcEndpointRoleArn != "" && route53RoleArn != "", nil


### PR DESCRIPTION
Fixes logic which would return `true` when using classic and roles for sharedvpc