### PR TITLE
OCM-12693 | fix: Fix failing when using hcp sharedvpc flags without hostedcp flag

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -421,8 +421,8 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	if !createHostedCP {
-		rosa.HostedClusterOnlyFlag(r, cmd, route53RoleArnFlag)
 		rosa.HostedClusterOnlyFlag(r, cmd, vpcEndpointRoleArnFlag)
+		rosa.HostedClusterOnlyFlag(r, cmd, route53RoleArnFlag)
 	}
 
 	rolesCreator, createRoles := initCreator(r, managedPolicies, createClassic, createHostedCP,


### PR DESCRIPTION
Fixes small bug where the error for running create/accountroles with hcp shared vpc flags but not `--hosted-cp` would fail too late (should fail immediately)