### PR TITLE
OCM-12693 | fix: Only check for HCP only flags when not using `--mode auto`

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -420,7 +420,7 @@ func run(cmd *cobra.Command, argv []string) {
 		isHostedCPValueSet = true
 	}
 
-	if !createHostedCP {
+	if !createHostedCP && !cmd.Flag(interactive.Mode).Changed {
 		rosa.HostedClusterOnlyFlag(r, cmd, route53RoleArnFlag)
 		rosa.HostedClusterOnlyFlag(r, cmd, vpcEndpointRoleArnFlag)
 	} else {


### PR DESCRIPTION
`--mode auto` creates all account roles even without `-y` specified, so we must account for this when checking for HCP only flags for HCP sharedvpc