### PR TITLE
OCM-12806 | feat: Delete operator roles auto mode (and changes to account roles)

### DIFF
--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -145,7 +145,7 @@ type Client interface {
 	ListOidcProviders(targetClusterId string, config *cmv1.OidcConfig) ([]OidcProviderOutput, error)
 	GetRoleByARN(roleARN string) (iamtypes.Role, error)
 	GetRoleByName(roleName string) (iamtypes.Role, error)
-	DeleteOperatorRole(roles string, managedPolicies bool) error
+	DeleteOperatorRole(roles string, managedPolicies bool, deleteHcpSharedVpcPolicies bool) (map[string]bool, error)
 	GetOperatorRolesFromAccountByClusterID(
 		clusterID string,
 		credRequests map[string]*cmv1.STSOperator,
@@ -156,11 +156,12 @@ type Client interface {
 	GetAccountRoleForCurrentEnv(env string, roleName string) (Role, error)
 	GetAccountRoleForCurrentEnvWithPrefix(env string, rolePrefix string,
 		accountRolesMap map[string]AccountRole) ([]Role, error)
-	DeleteAccountRole(roleName string, prefix string, managedPolicies bool) error
+	DeleteAccountRole(roleName string, prefix string, managedPolicies bool, deleteHcpSharedVpcPolicies bool) error
 	DeleteOCMRole(roleARN string, managedPolicies bool) error
 	DeleteUserRole(roleName string) error
 	GetAccountRolePolicies(roles []string, prefix string) (map[string][]PolicyDetail, map[string][]PolicyDetail, error)
 	GetAttachedPolicy(role *string) ([]PolicyDetail, error)
+	GetPolicyDetailsFromRole(role *string) ([]*iam.GetPolicyOutput, error)
 	HasPermissionsBoundary(roleName string) (bool, error)
 	GetOpenIDConnectProviderByClusterIdTag(clusterID string) (string, error)
 	GetOpenIDConnectProviderByOidcEndpointUrl(oidcEndpointUrl string) (string, error)

--- a/pkg/aws/client_mock.go
+++ b/pkg/aws/client_mock.go
@@ -178,17 +178,17 @@ func (mr *MockClientMockRecorder) CreateSecretInSecretsManager(name, secret any)
 }
 
 // DeleteAccountRole mocks base method.
-func (m *MockClient) DeleteAccountRole(roleName, prefix string, managedPolicies bool) error {
+func (m *MockClient) DeleteAccountRole(roleName, prefix string, managedPolicies, deleteHcpSharedVpcPolicies bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteAccountRole", roleName, prefix, managedPolicies)
+	ret := m.ctrl.Call(m, "DeleteAccountRole", roleName, prefix, managedPolicies, deleteHcpSharedVpcPolicies)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteAccountRole indicates an expected call of DeleteAccountRole.
-func (mr *MockClientMockRecorder) DeleteAccountRole(roleName, prefix, managedPolicies any) *gomock.Call {
+func (mr *MockClientMockRecorder) DeleteAccountRole(roleName, prefix, managedPolicies, deleteHcpSharedVpcPolicies any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAccountRole", reflect.TypeOf((*MockClient)(nil).DeleteAccountRole), roleName, prefix, managedPolicies)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAccountRole", reflect.TypeOf((*MockClient)(nil).DeleteAccountRole), roleName, prefix, managedPolicies, deleteHcpSharedVpcPolicies)
 }
 
 // DeleteInlineRolePolicies mocks base method.
@@ -234,17 +234,18 @@ func (mr *MockClientMockRecorder) DeleteOpenIDConnectProvider(providerURL any) *
 }
 
 // DeleteOperatorRole mocks base method.
-func (m *MockClient) DeleteOperatorRole(roles string, managedPolicies bool) error {
+func (m *MockClient) DeleteOperatorRole(roles string, managedPolicies, deleteHcpSharedVpcPolicies bool) (map[string]bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteOperatorRole", roles, managedPolicies)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "DeleteOperatorRole", roles, managedPolicies, deleteHcpSharedVpcPolicies)
+	ret0, _ := ret[0].(map[string]bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // DeleteOperatorRole indicates an expected call of DeleteOperatorRole.
-func (mr *MockClientMockRecorder) DeleteOperatorRole(roles, managedPolicies any) *gomock.Call {
+func (mr *MockClientMockRecorder) DeleteOperatorRole(roles, managedPolicies, deleteHcpSharedVpcPolicies any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOperatorRole", reflect.TypeOf((*MockClient)(nil).DeleteOperatorRole), roles, managedPolicies)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOperatorRole", reflect.TypeOf((*MockClient)(nil).DeleteOperatorRole), roles, managedPolicies, deleteHcpSharedVpcPolicies)
 }
 
 // DeleteOsdCcsAdminUser mocks base method.
@@ -856,6 +857,21 @@ func (m *MockClient) GetOperatorRolesFromAccountByPrefix(prefix string, credRequ
 func (mr *MockClientMockRecorder) GetOperatorRolesFromAccountByPrefix(prefix, credRequest any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOperatorRolesFromAccountByPrefix", reflect.TypeOf((*MockClient)(nil).GetOperatorRolesFromAccountByPrefix), prefix, credRequest)
+}
+
+// GetPolicyDetailsFromRole mocks base method.
+func (m *MockClient) GetPolicyDetailsFromRole(role *string) ([]*iam.GetPolicyOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPolicyDetailsFromRole", role)
+	ret0, _ := ret[0].([]*iam.GetPolicyOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPolicyDetailsFromRole indicates an expected call of GetPolicyDetailsFromRole.
+func (mr *MockClientMockRecorder) GetPolicyDetailsFromRole(role any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPolicyDetailsFromRole", reflect.TypeOf((*MockClient)(nil).GetPolicyDetailsFromRole), role)
 }
 
 // GetRegion mocks base method.

--- a/pkg/aws/policies_test.go
+++ b/pkg/aws/policies_test.go
@@ -531,6 +531,15 @@ var _ = Describe("Cluster Roles/Policies", func() {
 		Expect(policies).To(HaveLen(1))
 		Expect(policies[0]).To(Equal(operatorRolePolicyArn))
 	})
+	It("Test GetPolicyDetailsFromRole", func() {
+		mockIamAPI.EXPECT().ListAttachedRolePolicies(gomock.Any(), &iam.ListAttachedRolePoliciesInput{
+			RoleName: aws.String(accountRole),
+		}).Return(accountRoleAttachedPolicies, nil).Times(1)
+		mockIamAPI.EXPECT().GetPolicy(gomock.Any(), gomock.Any()).Times(2)
+		output, err := client.GetPolicyDetailsFromRole(&accountRole)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(output).To(HaveLen(2))
+	})
 	It("Test DeleteAccountRole", func() {
 		mockIamAPI.EXPECT().ListRolePolicies(gomock.Any(), gomock.Any()).Return(&iam.ListRolePoliciesOutput{}, nil)
 		mockIamAPI.EXPECT().ListAttachedRolePolicies(gomock.Any(), &iam.ListAttachedRolePoliciesInput{
@@ -567,7 +576,7 @@ var _ = Describe("Cluster Roles/Policies", func() {
 		mockIamAPI.EXPECT().DeletePolicy(gomock.Any(), &iam.DeletePolicyInput{
 			PolicyArn: aws.String(accountRolePolicyArn),
 		}).Return(&iam.DeletePolicyOutput{}, nil)
-		err := client.DeleteAccountRole(accountRole, rolePrefix, false)
+		err := client.DeleteAccountRole(accountRole, rolePrefix, false, false)
 		Expect(err).NotTo(HaveOccurred())
 	})
 	It("Test DeleteOperatorRole", func() {
@@ -602,7 +611,7 @@ var _ = Describe("Cluster Roles/Policies", func() {
 				AttachmentCount: &attachCount,
 			},
 		}, nil)
-		err := client.DeleteOperatorRole(operatorRole, false)
+		_, err := client.DeleteOperatorRole(operatorRole, false, false)
 		Expect(err).NotTo(HaveOccurred())
 	})
 })


### PR DESCRIPTION
There is a map which we return from the function which merges with maps from the last call (deleteOperatorRole is called once per role so we must merge these, and only print out warnings that we could not delete the policies ONCE PER POLICY). The issue is that, without this, you will get prints 1) if they are deleted in the end and 2) multiple times for the route53 policy

With these changes, it only prints the warning when it is unable to delete the policy one time. One role may be unable to delete a policy (controlplane) if the other still has the role attached (ingress). We cannot do this before or after function calls because it is designed to ask the user per every oprole if they want to delete the role.

There is an extra change to account roles which makes sure you are using hcpsharedvpc roles before asking if you want to attempt deleting the hcpsharedvpc roles. This way it doesn't ask if you are using non-sharedvpc hcp account or op roles

In the end, this results in good UX, where the user is asked once if they want to delete these policies, and will tell you **once** if the policy was deleted, or unable to be deleted due to attachments to other resources