### PR TITLE
OCM-12866 | fix: Do not create sharedvpc policies when answer is No

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -440,6 +440,11 @@ func run(cmd *cobra.Command, argv []string) {
 			r.Reporter.Errorf("Expected a valid value: %s", err)
 			os.Exit(1)
 		}
+
+		if !isHcpSharedVpc {
+			args.vpcEndpointRoleArn = ""
+			args.route53RoleArn = ""
+		}
 	}
 
 	if interactive.Enabled() && isHcpSharedVpc && !r.Creator.IsGovcloud {

--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -303,6 +303,11 @@ func run(cmd *cobra.Command, argv []string) {
 			r.Reporter.Errorf("Expected a valid value: %s", err)
 			os.Exit(1)
 		}
+
+		if !isHcpSharedVpc {
+			args.sharedVpcRoleArn = ""
+			args.vpcEndpointRoleArn = ""
+		}
 	}
 
 	if interactive.Enabled() && isHcpSharedVpc && !r.Creator.IsGovcloud {


### PR DESCRIPTION
HCP shared VPC policies still are created and attached when the answer to whether or not to create them is `No` when the flags are supplied. It doesn't matter if the flags are supplied, they should not be created in this situation