### PR TITLE
OCM-12922 | fix: Fixing manual-mode + log event output

### DIFF
--- a/cmd/create/network/cmd.go
+++ b/cmd/create/network/cmd.go
@@ -134,7 +134,6 @@ func NetworkRunner(userOptions *opts.NetworkUserOptions) rosa.CommandRunner {
 		if err != nil {
 			return err
 		}
-
 		service := helper.NewNetworkService()
 
 		mode, err := interactive.GetMode()
@@ -142,23 +141,24 @@ func NetworkRunner(userOptions *opts.NetworkUserOptions) rosa.CommandRunner {
 			return err
 		}
 
+		defaultTemplateUsed := templateCommand == defaultTemplate
 		switch mode {
 		case interactive.ModeManual:
-			r.Reporter.Infof(helper.ManualModeHelperMessage(parsedParams, templateFile, parsedTags))
+			r.Reporter.Infof(helper.ManualModeHelperMessage(parsedParams, parsedTags))
 			r.OCMClient.LogEvent("ROSANetworkStackManual",
 				map[string]string{
-					ocm.Account:      r.Creator.AccountID,
-					ocm.Organization: orgID,
-					"template":       templateFile,
+					ocm.Account:        r.Creator.AccountID,
+					ocm.Organization:   orgID,
+					"default-template": fmt.Sprintf("%t", defaultTemplateUsed),
 				},
 			)
 			return nil
 		default:
 			r.OCMClient.LogEvent("ROSANetworkStack",
 				map[string]string{
-					ocm.Account:      r.Creator.AccountID,
-					ocm.Organization: orgID,
-					"template":       templateFile,
+					ocm.Account:        r.Creator.AccountID,
+					ocm.Organization:   orgID,
+					"default-template": fmt.Sprintf("%t", defaultTemplateUsed),
 				},
 			)
 			return service.CreateStack(&templateFile, &templateBody, parsedParams, parsedTags)

--- a/pkg/network/helper.go
+++ b/pkg/network/helper.go
@@ -142,9 +142,9 @@ func deleteHelperMessage(logger *logrus.Logger, params map[string]string, err er
 		params["Name"], params["Region"])
 }
 
-func ManualModeHelperMessage(params map[string]string,
-	templateFile string, tags map[string]string) string {
+func ManualModeHelperMessage(params map[string]string, tags map[string]string) string {
 	return fmt.Sprintf("Run the following command to create the stack manually:\n"+
-		"aws cloudformation create-stack --stack-name %s --template-body file://%s --param %s --tags %s --region %s",
-		params["Name"], templateFile, formatParams(params), formatTags(tags), params["Region"])
+		"aws cloudformation create-stack --stack-name %s --template-body file://<template-file-path>"+
+		" --param %s --tags %s --region %s",
+		params["Name"], formatParams(params), formatTags(tags), params["Region"])
 }

--- a/pkg/network/helper_test.go
+++ b/pkg/network/helper_test.go
@@ -118,16 +118,15 @@ var _ = Describe("Helper Functions", func() {
 				"Name":   "test-stack",
 				"Region": "us-west-1",
 			}
-			templateFile := "test-template.yaml"
 			tags := map[string]string{
 				"TagKey1": "TagValue1",
 				"TagKey2": "TagValue2",
 			}
 			expectedMessage := "Run the following command to create the stack manually:\n" +
-				"aws cloudformation create-stack --stack-name test-stack --template-body file://test-template.yaml " +
+				"aws cloudformation create-stack --stack-name test-stack --template-body file://<template-file-path> " +
 				"--param ParameterKey=Name,ParameterValue=test-stack ParameterKey=Region,ParameterValue=us-west-1 " +
 				" --tags Key=TagKey1,Value=TagValue1 Key=TagKey2,Value=TagValue2  --region us-west-1"
-			Expect(ManualModeHelperMessage(params, templateFile, tags)).To(Equal(expectedMessage))
+			Expect(ManualModeHelperMessage(params, tags)).To(Equal(expectedMessage))
 		})
 	})
 

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -101,7 +101,7 @@ func (s *network) CreateStack(templateFile *string, templateBody *[]byte,
 	})
 	if err != nil {
 		deleteHelperMessage(logger, params, err)
-		helperMsg := ManualModeHelperMessage(params, template, tags)
+		helperMsg := ManualModeHelperMessage(params, tags)
 		logger.Infof(helperMsg)
 		return fmt.Errorf("failed to wait for stack creation, %v", err)
 	}


### PR DESCRIPTION
[OCM-12922](https://issues.redhat.com/browse/OCM-12922)
Fixing manual mode output to not output the whole cf file
Fixing log events to track if default was used through boolean