### PR TITLE
OCM-12364 | feat: Add hcpsharedvpc flags + deprecation warnings to create/cluster

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -90,6 +90,11 @@ const (
 	duplicateIamRoleArnErrorMsg = "ROSA IAM roles must have unique ARNs " +
 		"and should not be shared with other IAM roles within the same cluster. " +
 		"Duplicated ARN: %s"
+
+	route53RoleArnFlag                       = "route53-role-arn"
+	vpcEndpointRoleArnFlag                   = "vpc-endpoint-role-arn"
+	hcpInternalCommunicationHostedZoneIdFlag = "hcp-internal-communication-hosted-zone-id"
+	ingressPrivateHostedZoneIdFlag           = "ingress-private-hosted-zone-id"
 )
 
 var args struct {
@@ -213,6 +218,20 @@ var args struct {
 	privateHostedZoneID string
 	sharedVPCRoleARN    string
 	baseDomain          string
+
+	// HCP Shared VPC
+	vpcEndpointRoleArn string
+	//
+	//route53RoleArn string
+	// Route53 Role Arn is the same thing as `sharedVpcRoleArn` for now- deprecation warning will be in place
+	// This is the same behavior as create/operatorroles
+	//
+	hcpInternalCommunicationHostedZoneId string
+	//
+	//ingressPrivateHostedZoneId string
+	// Ingress Private Hosted Zone ID is the same thing as `privateHostedZoneID` for now- deprecation warning
+	// will be in place
+	//
 
 	// Worker machine pool attributes
 	additionalComputeSecurityGroupIds []string
@@ -819,6 +838,46 @@ func initFlags(cmd *cobra.Command) {
 		"AWS IAM role ARN with a policy attached, granting permissions necessary to create and manage Route 53 DNS records "+
 			"in private Route 53 hosted zone associated with intended shared VPC.",
 	)
+
+	flags.StringVar(
+		&args.vpcEndpointRoleArn,
+		vpcEndpointRoleArnFlag,
+		"",
+		"AWS IAM Role ARN with policy attached, associated with the shared VPC."+
+			" Grants permissions necessary to communicate with and handle a Hosted Control Plane cross-account VPC.")
+
+	flags.StringVar(
+		&args.sharedVPCRoleARN,
+		route53RoleArnFlag,
+		"",
+		"AWS IAM Role Arn with policy attached, associated with shared VPC."+
+			" Grants permission necessary to handle route53 operations associated with a cross-account VPC. "+
+			"This flag deprecates '--shared-vpc-role-arn'.",
+	)
+
+	// Mark old sharedvpc role arn flag as deprecated for future transitioning of the flag name (both are usable for now)
+	flags.MarkDeprecated("shared-vpc-role-arn", fmt.Sprintf("'--shared-vpc-role-arn' will be replaced with "+
+		"'--%s' in future versions of ROSA.", route53RoleArnFlag))
+
+	flags.StringVar(
+		&args.hcpInternalCommunicationHostedZoneId,
+		hcpInternalCommunicationHostedZoneIdFlag,
+		"",
+		"The internal communication Route 53 hosted zone ID to be used for Hosted Control Plane cross-account "+
+			"VPC, e.g., 'Z05646003S02O1ENCDCSN'.",
+	)
+
+	flags.StringVar(
+		&args.privateHostedZoneID,
+		ingressPrivateHostedZoneIdFlag,
+		"",
+		"ID assigned by AWS to private Route 53 hosted zone associated with intended shared VPC, "+
+			"e.g., 'Z05646003S02O1ENCDCSN'.",
+	)
+
+	// Mark old private hosted zone id flag as deprecated for future transitioning of the flag (both are usable for now)
+	flags.MarkDeprecated("private-hosted-zone-id", fmt.Sprintf("'--private-hosted-zone-id' will be "+
+		"replaced with '--%s' in future versions of ROSA.", ingressPrivateHostedZoneIdFlag))
 
 	flags.StringVar(
 		&args.baseDomain,

--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -139,7 +139,7 @@ func init() {
 		vpcEndpointRoleArnFlag,
 		"",
 		"AWS IAM Role ARN with policy attached, associated with the shared VPC."+
-			" Grants permissions necessary to communicate with and handle a cross-account VPC.",
+			" Grants permissions necessary to communicate with and handle a Hosted Control Plane cross-account VPC.",
 	)
 
 	flags.StringVar(
@@ -151,8 +151,8 @@ func init() {
 			"This flag deprecates '--shared-vpc-role-arn'.",
 	)
 
-	flags.MarkDeprecated("shared-vpc-role-arn", fmt.Sprintf("'--shared-vpc-role-arn' will be replaced with %s "+
-		"in future versions of ROSA", hostedZoneRoleArnFlag))
+	flags.MarkDeprecated("shared-vpc-role-arn", fmt.Sprintf("'--shared-vpc-role-arn' will be replaced with "+
+		"'--%s' in future versions of ROSA.", hostedZoneRoleArnFlag))
 
 	interactive.AddModeFlag(Cmd)
 	confirm.AddFlag(flags)

--- a/cmd/rosa/structure_test/command_args/rosa/create/cluster/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/create/cluster/command_args.yml
@@ -92,6 +92,10 @@
 - name: default-ingress-namespace-ownership-policy
 - name: private-hosted-zone-id
 - name: shared-vpc-role-arn
+- name: route53-role-arn
+- name: vpc-endpoint-role-arn
+- name: hcp-internal-communication-hosted-zone-id
+- name: ingress-private-hosted-zone-id
 - name: base-domain
 - name: additional-compute-security-group-ids
 - name: additional-infra-security-group-ids


### PR DESCRIPTION
Functional MR in progress, this is to save time in review by getting the customer-facing flags and deprecations reviewed first