### PR TITLE
OCM-12364 | feat: create/cluster support for HCP shared VPC

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -3294,6 +3294,12 @@ func run(cmd *cobra.Command, _ []string) {
 		clusterConfig.SharedVPCRoleArn = sharedVPCRoleARN
 		clusterConfig.BaseDomain = baseDomain
 	}
+	if isHcpSharedVpc {
+		clusterConfig.PrivateHostedZoneID = privateHostedZoneID
+		clusterConfig.SharedVPCRoleArn = sharedVPCRoleARN
+		clusterConfig.InternalCommunicationHostedZoneId = hcpInternalCommunicationHostedZoneId
+		clusterConfig.VpcEndpointRoleArn = vpcEndpointRoleArn
+	}
 	if clusterAutoscaler != nil {
 		autoscalerConfig, err := clusterautoscaler.CreateAutoscalerConfig(clusterAutoscaler)
 		if err != nil {

--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -166,6 +166,10 @@ type Spec struct {
 	SharedVPCRoleArn    string
 	BaseDomain          string
 
+	// HCP Shared VPC
+	VpcEndpointRoleArn                string
+	InternalCommunicationHostedZoneId string
+
 	// Worker Machine Pool attributes
 	AdditionalComputeSecurityGroupIds []string
 
@@ -1011,6 +1015,13 @@ func (c *Client) createClusterSpec(config Spec) (*cmv1.Cluster, error) {
 	if config.PrivateHostedZoneID != "" {
 		awsBuilder = awsBuilder.PrivateHostedZoneID(config.PrivateHostedZoneID)
 		awsBuilder = awsBuilder.PrivateHostedZoneRoleARN(config.SharedVPCRoleArn)
+	}
+	// hcp shared vpc
+	if config.VpcEndpointRoleArn != "" {
+		awsBuilder = awsBuilder.PrivateHostedZoneID(config.PrivateHostedZoneID)
+		awsBuilder = awsBuilder.PrivateHostedZoneRoleARN(config.SharedVPCRoleArn)
+		awsBuilder = awsBuilder.VpcEndpointRoleArn(config.VpcEndpointRoleArn)
+		awsBuilder = awsBuilder.HcpInternalCommunicationHostedZoneId(config.InternalCommunicationHostedZoneId)
 	}
 	if config.BaseDomain != "" {
 		clusterBuilder = clusterBuilder.DNS(v1.NewDNS().BaseDomain(config.BaseDomain))


### PR DESCRIPTION
Initial support for `create/cluster` for HCP shared VPC clusters

Next MR will include manual + interactive mode changes (better UX than just passing in flags), this MR purely opens up support