### PR TITLE
OCM-12964 | feat: Allow use of flag for deleting hcpsharedvpc policies

### DIFF
--- a/cmd/dlt/accountroles/cmd.go
+++ b/cmd/dlt/accountroles/cmd.go
@@ -37,10 +37,15 @@ import (
 	"github.com/openshift/rosa/pkg/rosa"
 )
 
+const (
+	deleteHcpSharedVpcPoliciesFlagName = "delete-hcp-shared-vpc-policies"
+)
+
 var args struct {
-	prefix   string
-	hostedCP bool
-	classic  bool
+	prefix                     string
+	hostedCP                   bool
+	classic                    bool
+	deleteHcpSharedVpcPolicies bool
 }
 
 var Cmd = &cobra.Command{
@@ -77,6 +82,13 @@ func init() {
 		"classic",
 		false,
 		"Delete classic account roles",
+	)
+
+	flags.BoolVar(
+		&args.deleteHcpSharedVpcPolicies,
+		deleteHcpSharedVpcPoliciesFlagName,
+		false,
+		"Deletes the Hosted Control Plane shared vpc policies",
 	)
 
 	interactive.AddModeFlag(Cmd)
@@ -153,7 +165,7 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	if deleteClassic {
-		err = deleteAccountRoles(r, env, prefix, clusters, mode, false)
+		err = deleteAccountRoles(r, cmd, env, prefix, clusters, mode, false)
 		if err != nil {
 			r.Reporter.Errorf("%s", err)
 			os.Exit(1)
@@ -165,7 +177,7 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	if deleteHostedCP {
-		err = deleteAccountRoles(r, env, prefix, clusters, mode, true)
+		err = deleteAccountRoles(r, cmd, env, prefix, clusters, mode, true)
 		if err != nil {
 			r.Reporter.Errorf("%s", err)
 			os.Exit(1)
@@ -182,8 +194,8 @@ func setDeleteRoles(isClassicFlagSet bool, isHostedCPFlagSet bool) (bool, bool) 
 	return isClassicFlagSet, isHostedCPFlagSet
 }
 
-func deleteAccountRoles(r *rosa.Runtime, env string, prefix string, clusters []*cmv1.Cluster, mode string,
-	hostedCP bool) error {
+func deleteAccountRoles(r *rosa.Runtime, cmd *cobra.Command, env string, prefix string, clusters []*cmv1.Cluster,
+	mode string, hostedCP bool) error {
 	var accountRolesMap map[string]aws.AccountRole
 	var roleTypeString string
 	if hostedCP {
@@ -203,28 +215,32 @@ func deleteAccountRoles(r *rosa.Runtime, env string, prefix string, clusters []*
 		return nil
 	}
 
+	deleteHcpSharedVpcPolicies := args.deleteHcpSharedVpcPolicies
+
 	switch mode {
 	case interactive.ModeAuto:
 		r.Reporter.Infof(fmt.Sprintf("Deleting %saccount roles", roleTypeString))
 
 		r.OCMClient.LogEvent("ROSADeleteAccountRoleModeAuto", nil)
-		deleteHcpSharedVpcPolicies := false
-		if roles.CheckIfRolesAreHcpSharedVpc(r, finalRoleList) {
-			deleteHcpSharedVpcPolicies = confirm.Prompt(true, "Attempt to delete Hosted CP shared VPC"+
-				" policies?")
+		if roles.CheckIfRolesAreHcpSharedVpc(r, finalRoleList) &&
+			!cmd.Flag(deleteHcpSharedVpcPoliciesFlagName).Changed {
+			deleteHcpSharedVpcPolicies = confirm.Prompt(true, "Attempt to delete Hosted CP shared VPC policies?")
 		}
-		for _, role := range finalRoleList {
-			if !confirm.Prompt(true, "Delete the account role '%s'?", role) {
-				continue
+
+		if deleteHcpSharedVpcPolicies {
+			for _, role := range finalRoleList {
+				if !confirm.Prompt(true, "Delete the account role '%s'?", role) {
+					continue
+				}
+				r.Reporter.Infof("Deleting account role '%s'", role)
+				err := r.AWSClient.DeleteAccountRole(role, prefix, managedPolicies, deleteHcpSharedVpcPolicies)
+				if err != nil {
+					r.Reporter.Warnf("There was an error deleting the account roles or policies: %s", err)
+					continue
+				}
 			}
-			r.Reporter.Infof("Deleting account role '%s'", role)
-			err := r.AWSClient.DeleteAccountRole(role, prefix, managedPolicies, deleteHcpSharedVpcPolicies)
-			if err != nil {
-				r.Reporter.Warnf("There was an error deleting the account roles or policies: %s", err)
-				continue
-			}
+			r.Reporter.Infof(fmt.Sprintf("Successfully deleted the %s account roles", roleTypeString))
 		}
-		r.Reporter.Infof(fmt.Sprintf("Successfully deleted the %saccount roles", roleTypeString))
 	case interactive.ModeManual:
 		r.OCMClient.LogEvent("ROSADeleteAccountRoleModeManual", nil)
 		policyMap, arbitraryPolicyMap, err := r.AWSClient.GetAccountRolePolicies(finalRoleList, prefix)
@@ -234,8 +250,7 @@ func deleteAccountRoles(r *rosa.Runtime, env string, prefix string, clusters []*
 
 		// Get HCP shared vpc policy details if the user is deleting roles related to HCP shared vpc
 		policiesOutput := make([]*iam.GetPolicyOutput, 0)
-		if roles.CheckIfRolesAreHcpSharedVpc(r, finalRoleList) &&
-			confirm.Prompt(true, "Create commands to delete Hosted CP shared VPC policies?") {
+		if roles.CheckIfRolesAreHcpSharedVpc(r, finalRoleList) && deleteHcpSharedVpcPolicies {
 			for _, role := range finalRoleList {
 				policies, err := r.AWSClient.GetPolicyDetailsFromRole(awssdk.String(role))
 				policiesOutput = append(policiesOutput, policies...)

--- a/cmd/rosa/structure_test/command_args/rosa/delete/account-roles/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/delete/account-roles/command_args.yml
@@ -4,4 +4,5 @@
 - name: prefix
 - name: profile
 - name: region
+- name: delete-hcp-shared-vpc-policies
 - name: "yes"

--- a/cmd/rosa/structure_test/command_args/rosa/delete/operator-roles/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/delete/operator-roles/command_args.yml
@@ -3,4 +3,5 @@
 - name: prefix
 - name: profile
 - name: region
+- name: delete-hcp-shared-vpc-policies
 - name: "yes"


### PR DESCRIPTION
Allows use of script with manual mode, and skipping of prompt when using auto/interactive when deleting hcp shared vpc policies

