### PR TITLE
OCM-13048 | fix: Output formatting for deleting account roles

### DIFF
--- a/cmd/dlt/accountroles/cmd.go
+++ b/cmd/dlt/accountroles/cmd.go
@@ -238,9 +238,8 @@ func deleteAccountRoles(r *rosa.Runtime, cmd *cobra.Command, env string, prefix 
 				r.Reporter.Warnf("There was an error deleting the account roles or policies: %s", err)
 				continue
 			}
-
-			r.Reporter.Infof(fmt.Sprintf("Successfully deleted the %s account roles", roleTypeString))
 		}
+		r.Reporter.Infof(fmt.Sprintf("Successfully deleted the %saccount roles", roleTypeString))
 	case interactive.ModeManual:
 		r.OCMClient.LogEvent("ROSADeleteAccountRoleModeManual", nil)
 		policyMap, arbitraryPolicyMap, err := r.AWSClient.GetAccountRolePolicies(finalRoleList, prefix)


### PR DESCRIPTION
```
I: Deleting classic account roles
I: Deleting account role 'yw1209svpc1-Installer-Role'
I: Successfully deleted the classic  account roles
I: Deleting account role 'yw1209svpc1-ControlPlane-Role'
I: Successfully deleted the classic  account roles
I: Deleting account role 'yw1209svpc1-Worker-Role'
I: Successfully deleted the classic  account roles
I: Deleting account role 'yw1209svpc1-Support-Role'
I: Successfully deleted the classic  account roles
I: Deleting hosted CP account roles
I: Deleting account role 'yw1209svpc1-HCP-ROSA-Installer-Role'
I: Successfully deleted the hosted CP  account roles
I: Deleting account role 'yw1209svpc1-HCP-ROSA-Support-Role'
I: Successfully deleted the hosted CP  account roles
I: Deleting account role 'yw1209svpc1-HCP-ROSA-Worker-Role'
I: Successfully deleted the hosted CP  account roles
```

Before ^

After v

```
I: Deleting classic account roles
I: Deleting account role 'yw1209svpc1-Worker-Role'
I: Deleting account role 'yw1209svpc1-Support-Role'
I: Deleting account role 'yw1209svpc1-Installer-Role'
I: Deleting account role 'yw1209svpc1-ControlPlane-Role'
I: Successfully deleted the classic account roles
I: Deleting hosted CP account roles
I: Deleting account role 'yw1209svpc1-HCP-ROSA-Installer-Role'
I: Deleting account role 'yw1209svpc1-HCP-ROSA-Support-Role'
I: Deleting account role 'yw1209svpc1-HCP-ROSA-Worker-Role'
I: Successfully deleted the hosted CP account roles
```