### PR TITLE
OCM-13044 | fix: Replace deprecated flags when building cluster cmd

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -4036,8 +4036,8 @@ func buildCommand(spec ocm.Spec, operatorRolesPrefix string,
 	}
 	if spec.PrivateHostedZoneID != "" {
 		// TODO: Change flag names here when we deprecate the old flags
-		command += fmt.Sprintf(" --private-hosted-zone-id %s", spec.PrivateHostedZoneID)
-		command += fmt.Sprintf(" --shared-vpc-role-arn %s", spec.SharedVPCRoleArn)
+		command += fmt.Sprintf(" --%s %s", ingressPrivateHostedZoneIdFlag, spec.PrivateHostedZoneID)
+		command += fmt.Sprintf(" --%s %s", route53RoleArnFlag, spec.SharedVPCRoleArn)
 		command += fmt.Sprintf(" --base-domain %s", spec.BaseDomain)
 	}
 	if spec.InternalCommunicationHostedZoneId != "" {


### PR DESCRIPTION
Without this MR, the output when running the generated cluster command to recreate the same cluster always printed deprecation warnings:

```
Flag --private-hosted-zone-id has been deprecated, '--private-hosted-zone-id' will be replaced with '--ingress-private-hosted-zone-id' in future versions of ROSA.
Flag --shared-vpc-role-arn has been deprecated, '--shared-vpc-role-arn' will be replaced with '--route53-role-arn' in future versions of ROSA.
```