### PR TITLE
OCM-13126 | fix: Make vpcendpointrolearn and hcp HZID prompts hcp only

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2384,11 +2384,14 @@ func run(cmd *cobra.Command, _ []string) {
 			// TODO: We can remove this and replace the above once we deprecate the old flags
 			ingressPrivateHostedZoneId = privateHostedZoneID
 
-			hcpInternalCommunicationHostedZoneId, err = getHcpInternalCommunicationHostedZoneId(cmd,
-				hcpInternalCommunicationHostedZoneId)
-			if err != nil {
-				r.Reporter.Errorf("%s", err)
-				os.Exit(1)
+			if isHostedCP {
+				hcpInternalCommunicationHostedZoneId, err = getHcpInternalCommunicationHostedZoneId(cmd,
+					hcpInternalCommunicationHostedZoneId)
+
+				if err != nil {
+					r.Reporter.Errorf("%s", err)
+					os.Exit(1)
+				}
 			}
 
 			sharedVPCRoleARN, err = getSharedVpcRoleArn(cmd, sharedVPCRoleARN)
@@ -2400,10 +2403,12 @@ func run(cmd *cobra.Command, _ []string) {
 			// TODO: We can remove this and replace the above once we deprecate the old flags
 			route53RoleArn = sharedVPCRoleARN
 
-			vpcEndpointRoleArn, err = getVpcEndpointRoleArn(cmd, vpcEndpointRoleArn)
-			if err != nil {
-				r.Reporter.Errorf("%s", err)
-				os.Exit(1)
+			if isHostedCP {
+				vpcEndpointRoleArn, err = getVpcEndpointRoleArn(cmd, vpcEndpointRoleArn)
+				if err != nil {
+					r.Reporter.Errorf("%s", err)
+					os.Exit(1)
+				}
 			}
 
 			baseDomain, err = getBaseDomain(r, cmd, baseDomain)


### PR DESCRIPTION
These 2 prompts were prompted when making a classic cluster, they are meant only for HCP