### PR TITLE
OCM-13124 | fix: Make route53 role arn usable for classic oproles

### DIFF
--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -181,7 +181,6 @@ func run(cmd *cobra.Command, argv []string) {
 	var isHcpSharedVpc bool
 	var err error
 	if !args.hostedCp {
-		rosa.HostedClusterOnlyFlag(r, cmd, hostedZoneRoleArnFlag)
 		rosa.HostedClusterOnlyFlag(r, cmd, vpcEndpointRoleArnFlag)
 	} else {
 		isHcpSharedVpc, err = roles.ValidateSharedVpcInputs(args.vpcEndpointRoleArn, args.sharedVpcRoleArn,

--- a/pkg/rosa/helpers.go
+++ b/pkg/rosa/helpers.go
@@ -12,7 +12,8 @@ func HostedClusterOnlyFlag(r *Runtime, cmd *cobra.Command, flagName string) {
 	if cmd.Flag(hostedCpFlagName) == nil || (cmd.Flag(hostedCpFlagName) != nil && !cmd.Flag(hostedCpFlagName).Changed) {
 		isFlagSet := cmd.Flags().Changed(flagName)
 		if isFlagSet {
-			r.Reporter.Errorf("Setting the `%s` flag is only supported for hosted clusters", flagName)
+			r.Reporter.Errorf("Setting the `%s` flag is only supported for Hosted Control Plane clusters",
+				flagName)
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
the route53 role arn was mistakenly put as HCP only for `create/operatorroles` - removed this validation