### PR TITLE
OCM-13175 | fix: optional work role check for AmazonEC2ContainerRegistryReadOnly optional

### DIFF
--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -2175,13 +2175,15 @@ func (c *awsClient) GetOperatorRoleDefaultPolicy(roleName string) (string, error
 
 func (c *awsClient) validateManagedPolicy(policies map[string]*cmv1.AWSSTSPolicy, policyKey string,
 	roleName string) error {
+	// EC2 policy is now returned from CS for all orgs. It is optional since it's only required
+	// to create zero egress clusters
+	if policyKey == WorkerEC2RegistryKey {
+		c.logger.Infof("Ignored check for policy key '%s' (only required for zero egress enabled clusters)", policyKey)
+		return nil
+	}
+
 	managedPolicyARN, err := GetManagedPolicyARN(policies, policyKey)
 	if err != nil {
-		// EC2 policy is only available to orgs for zero-egress feature toggle enabled
-		if policyKey == WorkerEC2RegistryKey {
-			c.logger.Infof("Ignored check for policy key '%s' (zero egress feature toggle is not enabled)", policyKey)
-			return nil
-		}
 		return err
 	}
 

--- a/pkg/aws/policies_test.go
+++ b/pkg/aws/policies_test.go
@@ -845,6 +845,7 @@ var _ = Describe("validateManagedPolicy", func() {
 	DescribeTable("validate ECR policy", func(
 		policies map[string]*cmv1.AWSSTSPolicy, policyKey, roleName, expectedErr string,
 	) {
+		mockIamAPI.EXPECT().ListAttachedRolePolicies(gomock.Any(), gomock.Any()).Return(nil, nil).Times(0)
 		err := client.validateManagedPolicy(policies, policyKey, roleName)
 		if expectedErr == "" {
 			Expect(err).To(BeNil())
@@ -855,6 +856,11 @@ var _ = Describe("validateManagedPolicy", func() {
 	},
 		Entry("succeeds if ECR policy does not exist", map[string]*cmv1.AWSSTSPolicy{
 			"sts_hcp_instance_worker_permission_policy": workerPolicy},
+			"sts_hcp_ec2_registry_permission_policy", "worker", ""),
+		Entry("succeeds if ECR policy exist but skips check if policy is attached",
+			map[string]*cmv1.AWSSTSPolicy{
+				"sts_hcp_instance_worker_permission_policy": workerPolicy,
+				"sts_hcp_ec2_registry_permission_policy":    ec2ContainerPolicy},
 			"sts_hcp_ec2_registry_permission_policy", "worker", ""),
 		Entry("fails to find worker policy", map[string]*cmv1.AWSSTSPolicy{
 			"sts_hcp_ec2_registry_permission_policy": ec2ContainerPolicy},


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-13175