### PR TITLE
OCM-13188 | ci: fix the VPC deletion failure in teardown steps

### DIFF
--- a/tests/utils/handler/resources_handler_clean.go
+++ b/tests/utils/handler/resources_handler_clean.go
@@ -7,7 +7,6 @@ import (
 	"github.com/openshift-online/ocm-common/pkg/test/kms_key"
 	"github.com/openshift-online/ocm-common/pkg/test/vpc_client"
 
-	ciConfig "github.com/openshift/rosa/tests/ci/config"
 	"github.com/openshift/rosa/tests/utils/log"
 )
 
@@ -15,7 +14,7 @@ func (rh *resourcesHandler) DeleteVPCChain() error {
 	var err error
 	if rh.vpc == nil {
 		var awsclient *aws_client.AWSClient
-		awsSharedCredentialFile := ciConfig.Test.GlobalENV.SVPC_CREDENTIALS_FILE
+		awsSharedCredentialFile := rh.awsSharedCredentialsFile
 		if awsSharedCredentialFile == "" {
 			awsclient, err = aws_client.CreateAWSClient("", rh.resources.Region)
 		} else {


### PR DESCRIPTION
[OCM-13188](https://issues.redhat.com//browse/OCM-13188) | ci: fix the VPC deletion failure in teardown steps

logs on local is here: https://privatebin.corp.redhat.com/?f13ffaea3d7798a0#AMC5F1PK9RxjqUcanDcwwESpjjEvWxNkfvbe7cM6ySJf