### PR TITLE
OCM-13193 | fix: Filter DNS domains when create/cluster if hosted CP

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2411,7 +2411,7 @@ func run(cmd *cobra.Command, _ []string) {
 				}
 			}
 
-			baseDomain, err = getBaseDomain(r, cmd, baseDomain)
+			baseDomain, err = getBaseDomain(r, cmd, baseDomain, isHostedCP)
 			if err != nil {
 				r.Reporter.Errorf("%s", err)
 				os.Exit(1)


### PR DESCRIPTION
When making a hosted control plane cluster, filter DNS domains in interactive mode and return only hostedCP dns domains (using the new `ClusterArch` field)