### PR TITLE
OCM-10030 | fix: Remove empty string checks for http/https proxy

### DIFF
--- a/cmd/edit/cluster/cmd.go
+++ b/cmd/edit/cluster/cmd.go
@@ -390,10 +390,7 @@ func run(cmd *cobra.Command, _ []string) {
 			os.Exit(1)
 		}
 
-		if len(httpProxyValue) == 0 {
-			//user skipped the prompt by pressing 'enter'
-			httpProxy = nil
-		} else if httpProxyValue == input.DoubleQuotesToRemove {
+		if def != httpProxyValue && httpProxyValue == input.DoubleQuotesToRemove {
 			//user entered double quotes ("") to remove the existing value
 			httpProxy = new(string)
 			*httpProxy = ""
@@ -431,10 +428,7 @@ func run(cmd *cobra.Command, _ []string) {
 			r.Reporter.Errorf("Expected a valid https proxy: %s", err)
 			os.Exit(1)
 		}
-		if len(httpsProxyValue) == 0 {
-			//user skipped the prompt by pressing 'enter'
-			httpsProxy = nil
-		} else if httpsProxyValue == input.DoubleQuotesToRemove {
+		if def != httpsProxyValue && httpsProxyValue == input.DoubleQuotesToRemove {
 			//user entered double quotes ("") to remove the existing value
 			httpsProxy = new(string)
 			*httpsProxy = ""


### PR DESCRIPTION
This is an interesting issue, which stems from editing a cluster's `https-proxy`/`http-proxy`/`no-proxy`

It says for the user to enter `""`  by itself if they want to 'delete' one of these values. If you do this in interactive, nothing happens

Removed a validator specific to `http-proxy` and `https-proxy` - which fixed the issue

The result is the expected results in `edit cluster`'s interactive mode.

Output:

```
./rosa edit cluster -c hk --https-proxy http://10.0.0.210:8080 --profile vpc-cluster -i
I: Interactive mode enabled.
Any optional fields can be ignored and will not be updated.
? Private cluster, check this command's help for possible impacts: No
? Disable Workload monitoring: No
? To remove any existing cluster-wide proxy value or an existing additional-trust-bundle value, enter a set of double quotes ("")
? HTTP proxy (optional): " "
E: Invalid http-proxy value '" "'
 ✘ hkepley@hkepley-mac  ~/Documents/programming/rosa   master ±  ./rosa edit cluster -c hk --https-proxy http://10.0.0.210:8080 --profile vpc-cluster -i
I: Interactive mode enabled.
Any optional fields can be ignored and will not be updated.
? Private cluster, check this command's help for possible impacts: No
? Disable Workload monitoring: No
? To remove any existing cluster-wide proxy value or an existing additional-trust-bundle value, enter a set of double quotes ("")
? HTTP proxy (optional): ""
? HTTPS proxy: ""
? No proxy (optional): ""
? Update additional trust bundle: No
? Update additional allowed principals: No
? Enable cluster deletion protection: No
I: Updated cluster 'hk'
```

The second run removes the `https-proxy` value. When describing the cluster after, it is no longer there.'
The first run was testing `" "` (a space in the quotes)