### PR TITLE
OCM-13330 | ci: fix additional principle issue for rosa classic clust…

### DIFF
--- a/tests/utils/handler/cluster_handler.go
+++ b/tests/utils/handler/cluster_handler.go
@@ -397,7 +397,7 @@ func (ch *clusterHandler) GenerateClusterCreateFlags() ([]string, error) {
 		if sharedVPCAdditionalPrincipalsForHostedCP != "" {
 			flags = append(flags, "--additional-allowed-principals",
 				fmt.Sprintf("%s,%s", sharedVPCAdditionalPrincipalsForHostedCP, additionalPrincipalRoleArn))
-		} else {
+		} else if additionalPrincipalRoleArn != "" {
 			flags = append(flags, "--additional-allowed-principals", additionalPrincipalRoleArn)
 		}
 


### PR DESCRIPTION
One new involved issue when creating cluster with profiles of rosa classic clusters in ci job is caused by the empty '--additional-allowed-principals' flag