### PR TITLE
OCM-13423 | test: fix ids:56786,73754,38775 and shared-vpc hcp preparation

### DIFF
--- a/tests/ci/data/profiles/rosa-hcp.yaml
+++ b/tests/ci/data/profiles/rosa-hcp.yaml
@@ -188,7 +188,7 @@ profiles:
     volume_size: 75
     disable_uwm: true
     autoscaler_enabled: false
-    additional_sg_number: 3
+    additional_sg_number: 0
     registries_config: true
     allowed_registries: true
   account-role:

--- a/tests/e2e/hcp_machine_pool_test.go
+++ b/tests/e2e/hcp_machine_pool_test.go
@@ -477,8 +477,7 @@ var _ = Describe("HCP Machine Pool", labels.Feature.Machinepool, func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).
 				Should(
-					ContainSubstring("Replicas+Autoscaling.Min: The total number of compute nodes for a single cluster"))
-			Expect(err.Error()).Should(ContainSubstring("exceeds the maximum allowed"))
+					ContainSubstring("should provide an integer number less than or equal to"))
 
 			By("with invalid name")
 			_, err = machinePoolService.CreateMachinePool(clusterID, "anything%^#@", "--replicas", "2")
@@ -506,7 +505,7 @@ var _ = Describe("HCP Machine Pool", labels.Feature.Machinepool, func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).
 				Should(
-					ContainSubstring("Invalid autoscaling range: 6 - 3. 'min_replica' must be less than or equal to 'max_replica'"))
+					ContainSubstring("max-replicas must be greater or equal to min-replicas"))
 
 			By("with min-replicas and max-replicas but without enable-autoscaling")
 			_, err = machinePoolService.CreateMachinePool(
@@ -527,8 +526,7 @@ var _ = Describe("HCP Machine Pool", labels.Feature.Machinepool, func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).
 				Should(
-					ContainSubstring("Replicas+Autoscaling.Max: The total number of compute nodes for a single cluster"))
-			Expect(err.Error()).Should(ContainSubstring("exceeds the maximum allowed"))
+					ContainSubstring("should provide an integer number less than or equal to"))
 
 			By("with wrong instance-type")
 			_, err = machinePoolService.CreateMachinePool(clusterID, "anything", "--replicas", "2", "--instance-type", "wrong")

--- a/tests/e2e/test_rosacli_kubelet_config.go
+++ b/tests/e2e/test_rosacli_kubelet_config.go
@@ -359,7 +359,7 @@ var _ = Describe("Kubeletconfig on HCP cluster",
 				Expect(err).To(HaveOccurred())
 				Expect(out.String()).
 					Should(ContainSubstring(
-						"The name must be a lowercase RFC 1123 subdomain."))
+						"The name must be a lowercase RFC 1123 subdomain"))
 
 				By("Create kubeletconfig with invalid pod pids limit value like 123456789")
 				out, err = kubeletService.CreateKubeletConfig(clusterID,

--- a/tests/e2e/test_rosacli_machine_pool.go
+++ b/tests/e2e/test_rosacli_machine_pool.go
@@ -820,7 +820,7 @@ var _ = Describe("Create machinepool",
 						"--max-replicas", "3",
 						"--enable-autoscaling")
 					Expect(err).To(HaveOccurred())
-					Expect(output.String()).Should(ContainSubstring("'min_replicas' must be less than or equal to 'max_replicas'"))
+					Expect(output.String()).Should(ContainSubstring("max-replicas must be greater or equal to min-replicas"))
 
 					By("Set min-replicas and max-replicas without set --enable-autoscaling")
 					output, err = rosaClient.MachinePool.CreateMachinePool(


### PR DESCRIPTION
- fix failed cases :56786,73754,38775, they are failed as the error message has changed.
- Fix the failure that prepare shared-vpc hcp cluster with proxy configuration. Before the steps creates proxy then create shared-resource that make the failure.
- Disable the additional security group in the share-vpc-hcp profile

The security group needs to added in the share resources, will support that in coming PR.

Logs for creating cluster with updated shared-vpc hcp profile:https://privatebin.corp.redhat.com/?0dbf0ae15e9c7425#AJRiRKJLvacApgoncsNsC14Ph7DcruWrq9SR2XVgqAYS

logs for the fixed cases: https://privatebin.corp.redhat.com/?126de46da8d8bc81#6rDZs8ePVgonsefsc3BnpdxAxNj46LPHsGHYJP6cyPZq