### PR TITLE
OCM-10908 | fix: Do not exit when unable to save refresh token

### DIFF
--- a/pkg/ocm/client.go
+++ b/pkg/ocm/client.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ocm
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -169,7 +170,8 @@ func (b *ClientBuilder) Build() (result *Client, err error) {
 	// Persist tokens in the configuration file, the SDK may have refreshed them
 	err = config.PersistTokens(b.cfg, accessToken, refreshToken)
 	if err != nil {
-		return nil, fmt.Errorf("error creating connection. Can't persist tokens to config: %s", err)
+		b.logger.Warn(context.TODO(),
+			fmt.Sprintf("error creating connection. Can't persist tokens to config: %v", err))
 	}
 
 	return &Client{
@@ -201,7 +203,8 @@ func (c *Client) KeepTokensAlive() error {
 
 	err = config.PersistTokens(nil, accessToken, refreshToken)
 	if err != nil {
-		return fmt.Errorf("Can't persist tokens to config: %v", err)
+		c.ocm.Logger().Warn(context.TODO(),
+			fmt.Sprintf("error creating connection. Can't persist tokens to config: %v", err))
 	}
 
 	return nil


### PR DESCRIPTION
Issue stems from: https://github.com/openshift/rosa/pull/2340

The associated ticket ([OCM-10908](https://issues.redhat.com//browse/OCM-10908)) has context in a slack thread link about the issue

Pretty much, when running ROSACLI on a container, the files created (At least for Kubernetes) are read-only

This means that, when saving the refresh token (a new feature) to the OCM config file, ROSA would error out and exit. This means about every time credentials/tokens are checked, ROSA will exit abruptly in the middle of a task for those using ROSA in a containerized environment.

This 'fix' skips the exit which comes from this recently introduced function, and rather warns the user that the refresh token was not saved to the config file. This way the user may continue using ROSACLI.

The refresh token needs to be saved specifically for Govcloud/FedRAMP environments. In those environments, you would be logged out every 15 minutes on the dot, and would have to get a new token and log back in. The MR which fixed this (linked at the top of this description) introduces saving the refresh token to the config file. This way, every time you run a command, ROSA will refresh your tokens using that refresh token. This is not needed for non-govcloud environments, so I think it's safe to warn the user about this, and continue trucking along.