### PR TITLE
OCM-10282 | fix: Add profile flag to very network command

### DIFF
--- a/cmd/rosa/structure_test/command_args/rosa/verify/network/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/verify/network/command_args.yml
@@ -7,3 +7,4 @@
 - name: subnet-ids
 - name: tags
 - name: watch
+- name: profile

--- a/cmd/verify/network/cmd.go
+++ b/cmd/verify/network/cmd.go
@@ -134,6 +134,8 @@ func initFlags(cmd *cobra.Command) {
 		false,
 		"Run network verifier with hosted control plane platform configuration",
 	)
+
+	arguments.AddProfileFlag(flags)
 }
 
 func run(cmd *cobra.Command, _ []string) {


### PR DESCRIPTION
Adds profile flag to `very network` command to use different AWS profiles