### PR TITLE
OCM-13495 | test: fix ids: 57410,57444,75445,75603,75534

### DIFF
--- a/tests/e2e/test_rosacli_cluster_post.go
+++ b/tests/e2e/test_rosacli_cluster_post.go
@@ -930,7 +930,19 @@ var _ = Describe("Post-Check testing for cluster creation",
 					By("Check policy is aws managed policy")
 					attachedPolicies, err := awsClient.ListAttachedRolePolicies(operatorRoleName)
 					Expect(err).To(BeNil())
-					Expect(*attachedPolicies[0].PolicyArn).To(ContainSubstring("arn:aws:iam::aws"), operatorRoleName)
+
+					if len(attachedPolicies) > 1 {
+						managedPolicyFound := false
+						for _, policy := range attachedPolicies {
+							if strings.Contains(*policy.PolicyArn, "arn:aws:iam::aws") {
+								managedPolicyFound = true
+								break
+							}
+						}
+						Expect(managedPolicyFound).To(BeTrue())
+					} else {
+						Expect(*attachedPolicies[0].PolicyArn).To(ContainSubstring("arn:aws:iam::aws"), operatorRoleName)
+					}
 				}
 			})
 	})

--- a/tests/e2e/test_rosacli_upgrade.go
+++ b/tests/e2e/test_rosacli_upgrade.go
@@ -60,11 +60,16 @@ var _ = Describe("Cluster Upgrade testing",
 
 		AfterEach(func() {
 			if profile.Version == constants.YStreamPreviousVersion {
-				By("Delete cluster upgrade")
-				output, err := upgradeService.DeleteUpgrade("-c", clusterID, "-y")
+				By("Delete cluster upgrade if there is some scheduled upgrade existed")
+				output, err := upgradeService.DescribeUpgrade(clusterID)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(output.String()).To(ContainSubstring(
-					"Successfully canceled scheduled upgrade on cluster '%s'", clusterID))
+				if !strings.Contains(output.String(), "No scheduled upgrades for cluster") {
+					output, err = upgradeService.DeleteUpgrade("-c", clusterID, "-y")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(output.String()).To(ContainSubstring(
+						"Successfully canceled scheduled upgrade on cluster '%s'", clusterID))
+				}
+
 			}
 
 			By("Clean remaining resources")


### PR DESCRIPTION
- 57444: It met error when 'delete upgrade' if there is no schedule upgrade policy. Fixed in the AfterEach step for this condition
- 75445: It met error when 'delete upgrade' if there is no schedule upgrade policy. Fixed in the AfterEach step for this condition
- 57410: for shared-vpc hcp cluster, two attached operation roles has attached shared policies along with the managed policies, Fixed with condition for shared-vpc hcp cluster
- 75603: add waiting time for the trust relationship
- 75534: Adjust the wait time to avoid the timeout error

The jobs met above failures recently:

- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-rosa-master-e2e-rosa-hcp-upgrade-y-stream-f3/1880792836664725504
- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-rosa-master-e2e-rosa-hcp-shared-vpc-critical-high-f3/1880767768479928320
- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-rosa-master-e2e-rosa-day1-supplemental-f3/1880755842270105600

logs with the fixes: https://privatebin.corp.redhat.com/?c22faa5ebd11005e#9Av8EhS2KAJHBK3bcrPUzXHUR6uJQ4jFSuJmbn9ExNze