### PR TITLE
OCM-13473 | ci: add external auth provider to make  console operator …

### DIFF
--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -51,8 +51,22 @@ var _ = Describe("Cluster preparation", labels.Feature.Cluster, func() {
 				clusterDetails, err := clusterService.ReflectClusterDescription(output)
 				Expect(err).To(BeNil())
 				if clusterDetails.ExternalAuthentication == "Enabled" {
+					By("Create a fake external auth provider to avoid failure of console operator")
+					value := []string{
+						"--name", helper.GenerateRandomName("provider", 2),
+						"--issuer-url", "https://login.microsoftonline.com/fa5d3dd8-b8ec-4407-a55c-ced639f1c8c5/v2.0",
+						"--issuer-audiences", "8a769b34-13c9-4f5b-9933-ec439700ec67",
+						"--claim-mapping-username-claim", "email",
+						"--claim-mapping-groups-claim", "groups",
+						"--console-client-id", "8a769b34-13c9-4f5b-9933-ec439700ec67",
+						"--console-client-secret", "vfq8Q~XpgXx9vsKF~XSW1bcSowfJP2JGraybYa7X",
+					}
+					_, err = client.ExternalAuthProvider.CreateExternalAuthProvider(clusterID, value...)
+					Expect(err).ToNot(HaveOccurred())
+
 					// it is not support to create htpasswd for cluster with xternal auth enabled
 					// create break-glass-credential to get kubeconfig
+					By("Create a break glass credential")
 					_, err := client.BreakGlassCredential.CreateBreakGlassCredential(clusterID)
 					Expect(err).To(BeNil())
 					breakGlassCredList, err := client.BreakGlassCredential.ListBreakGlassCredentialsAndReflect(clusterID)


### PR DESCRIPTION
Due to console operator can't be ready if it is not set external auth provider to external auth enabled cluster,it caused the OCP E2E step failed.
So add one step to add an  external auth provider to cluster. The secret is fake in the code
https://privatebin.corp.redhat.com/?26e345dff33b7bbb#36joopcFCAnc6iXXGTWghnL1CQRetxdVjNoSjag6Ebjd
