### PR TITLE
OCM-13513 | test: fix ids: 64620,43070,57408,77140

### DIFF
--- a/tests/utils/helper/file.go
+++ b/tests/utils/helper/file.go
@@ -2,6 +2,7 @@ package helper
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -31,15 +32,16 @@ func GetCurrentWorkingDir() (string, error) {
 }
 
 func CreateTemplateDirForNetworkResources(templateName string, fileContent string) (string, error) {
-	err := os.Mkdir(templateName, 0744)
+	// err := os.Mkdir(templateName, 0744)
+	dirpath, err := os.MkdirTemp("", fmt.Sprintf("%s-*", templateName))
 	if err != nil {
 		return "", err
 	}
-	exPath, err := GetCurrentWorkingDir()
+	// exPath, err := GetCurrentWorkingDir()
 	if err != nil {
 		return "", err
 	}
-	dirpath := filepath.Join(exPath + "/" + templateName)
+	// dirpath := filepath.Join(exPath + "/" + templateName)
 	outputPath := filepath.Join(dirpath, "cloudformation.yaml")
 
 	f, err := os.Create(outputPath)

--- a/tests/utils/helper/oidc.go
+++ b/tests/utils/helper/oidc.go
@@ -71,6 +71,9 @@ func ExtractCommandsFromOIDCRegister(bf bytes.Buffer) []string {
 		command = spaceRegex.ReplaceAllString(command, " ")
 		// remove '' in the value
 		command = strings.ReplaceAll(command, "'", "")
+		if strings.Contains(command, " INFO") {
+			command = strings.Split(command, " INFO")[0]
+		}
 		newCommands = append(newCommands, command)
 
 	}


### PR DESCRIPTION
- 64620: Fix some expected message
- 43070: Fix the parameter parse for unmanaged oidc config
- 57408: commented out the auto mode test as the aws account in the managed policies is the dev aws account which will lead failure.Move this back when the managed policies are supported officailly for classic account-roles
- 77140: The filesystem on PROWCI is read-only, that makes the file creattion failed. And also fix some design change

The job where found above failed cases is https://redhat-internal.slack.com/archives/C0519LZH1RA/p1737403094419139

logs: https://privatebin.corp.redhat.com/?319d99f0bec95506#B7Fmms8Gp1wNgdx2fTbaoxZvp6zAeFQKdMSix9drC4Rf