### PR TITLE
OCM-13543 | test: fix 77159,77829,52419,54469,75534,64187,73814

### DIFF
--- a/tests/e2e/test_rosacli_account_roles.go
+++ b/tests/e2e/test_rosacli_account_roles.go
@@ -1010,6 +1010,14 @@ var _ = Describe("Create account roles", labels.Feature.AccountRoles, func() {
 	It("to create/Upgrade account-roles by setting version and channel-group via rosacli - [id:54469]",
 		labels.High, labels.Runtime.OCMResources,
 		func() {
+			var defaultDir string
+			By("Get the default dir")
+			defaultDir = rosaClient.Runner.GetDir()
+			defer func() {
+				By("Go back original by setting runner dir")
+				rosaClient.Runner.SetDir(defaultDir)
+			}()
+
 			By("Prepare y-1 version for testing")
 			versionService := rosaClient.Version
 			// get stable channel version
@@ -1293,6 +1301,7 @@ var _ = Describe("Create account roles for hosted-cp shared vpc", labels.Feature
 				"--path", path,
 				"--route53-role-arn", route53RoleArn,
 				"--vpc-endpoint-role-arn", invalidVpcEndpointRoleArn,
+				"--hosted-cp",
 				"-y")
 			Expect(err).NotTo(BeNil())
 			Expect(output.String()).To(ContainSubstring("Expected a valid policy ARN for vpc-endpoint-role-arn"))
@@ -1307,7 +1316,7 @@ var _ = Describe("Create account roles for hosted-cp shared vpc", labels.Feature
 				"-y")
 			Expect(err).NotTo(BeNil())
 			Expect(output.String()).To(ContainSubstring(
-				"Setting the `route53-role-arn` flag is only supported for hosted clusters"))
+				"Setting the `route53-role-arn` flag is only supported for Hosted Control Plane clusters"))
 
 			By("Validate two share vpc flags are not used together")
 			output, err = ocmResourceService.CreateAccountRole("--mode", "auto",

--- a/tests/e2e/test_rosacli_network_resources.go
+++ b/tests/e2e/test_rosacli_network_resources.go
@@ -210,6 +210,11 @@ var _ = Describe("Network Resources",
 				By("Create template dir for template file missing Region Param")
 				templateContent := helper.TemplateWithoutRegionParam()
 				templatePath_1, err := helper.CreateTemplateDirForNetworkResources("without-region", templateContent)
+
+				templateDir := filepath.Dir(templatePath_1)
+				tdpWithoutReion := filepath.Dir(templateDir)
+				tdnWithoutReion := filepath.Base(templateDir)
+				Expect(err).ToNot(HaveOccurred())
 				defer func() {
 					os.Remove(templatePath_1)
 					Eventually(func() (bool, error) {
@@ -243,6 +248,9 @@ var _ = Describe("Network Resources",
 				By("Create template dir for template file missing Name Param")
 				templateContent = helper.TemplateWithoutNameParam()
 				templatePath_2, err := helper.CreateTemplateDirForNetworkResources("without-name", templateContent)
+				templateDir = filepath.Dir(templatePath_2)
+				tdpWithoutName := filepath.Dir(templateDir)
+				tdnWithoutName := filepath.Base(templateDir)
 				defer func() {
 					os.Remove(templatePath_2)
 					Eventually(func() (bool, error) {
@@ -276,6 +284,9 @@ var _ = Describe("Network Resources",
 				By("Create template dir for template file missing VpcCidr value")
 				templateContent = helper.TemplateWithoutCidrValueForVPC()
 				templatePath_3, err := helper.CreateTemplateDirForNetworkResources("without-vpccidr", templateContent)
+				templateDir = filepath.Dir(templatePath_3)
+				tdpWithoutVPCCIDR := filepath.Dir(templateDir)
+				tdnWithoutVPCCIDR := filepath.Base(templateDir)
 				defer func() {
 					os.Remove(templatePath_3)
 					Eventually(func() (bool, error) {
@@ -309,6 +320,9 @@ var _ = Describe("Network Resources",
 				By("Create template dir for template file creating single vpc")
 				templateContent = helper.TemplateForSingleVPC()
 				templatePath_4, err := helper.CreateTemplateDirForNetworkResources("single-vpc", templateContent)
+				templateDir = filepath.Dir(templatePath_4)
+				tdpSingleVPC := filepath.Dir(templateDir)
+				tdnSingleVPC := filepath.Base(templateDir)
 				defer func() {
 					os.Remove(templatePath_4)
 					Eventually(func() (bool, error) {
@@ -340,18 +354,10 @@ var _ = Describe("Network Resources",
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Get current working directory as template dir path")
-				templateDirPath, err := helper.GetCurrentWorkingDir()
-				Expect(err).ToNot(HaveOccurred())
-
 				invalidTemplateDir := "/ss"
 				nonExistentTemplate := "non-existent"
-				invalidTemplateDirErrorMessage := fmt.Sprintf(
-					"ERR: failed to read template file: open %s/ss/cloudformation.yaml: no such file or directory",
-					invalidTemplateDir)
-				nonExistentTemplateErrorMessage := fmt.Sprintf(
-					"ERR: failed to read template file: open "+
-						"cmd/create/network/templates/%s/cloudformation.yaml: no such file or directory",
-					nonExistentTemplate)
+				invalidTemplateDirErrorMessage := "ERR: failed to read template file"
+				nonExistentTemplateErrorMessage := "ERR: failed to read template file"
 				rollBackInProgress := "ROLLBACK_IN_PROGRESS"
 				rollBackRequested := "Rollback requested by user"
 				withoutCidrErrorMessage := "Either CIDR Block or IPv4 IPAM Pool and IPv4 Netmask Length must be provided"
@@ -369,13 +375,16 @@ var _ = Describe("Network Resources",
 					"Error: unknown flag: --invalid": {"--invalid"},
 					"ERR: duplicate tag key Key1": {"--param=Tags=Key1=Value1,Key1=Value2",
 						"--param=Name=duplicate-key"},
-					nonExistentTemplateErrorMessage: {nonExistentTemplate},
-					"Parameters: [Region] do not exist in the template": {"without-region",
-						"--template-dir", templateDirPath, "--param=Name=without-region"},
-					"Parameters: [Name] do not exist in the template": {"without-name",
-						"--template-dir", templateDirPath, "--param=Name=without-name"},
-					withoutCidrErrorMessage: {"without-vpccidr",
-						"--template-dir", templateDirPath, "--param=Name=withoutcidr", "--param=Region=us-west-2"},
+					nonExistentTemplateErrorMessage: {nonExistentTemplate,
+						"--template-dir", invalidTemplateDir, "--param=Name=invalid-dir"},
+					"Parameters: [Region] do not exist in the template": {tdnWithoutReion,
+						"--template-dir", tdpWithoutReion, fmt.Sprintf("--param=Name=%s", tdnWithoutReion)},
+					"Parameters: [Name] do not exist in the template": {tdnWithoutName,
+						"--template-dir", tdpWithoutName, fmt.Sprintf("--param=Name=%s", tdnWithoutName)},
+					withoutCidrErrorMessage: {tdnWithoutVPCCIDR,
+						"--template-dir", tdpWithoutVPCCIDR, fmt.Sprintf(
+							"--param=Name=%s", tdnWithoutVPCCIDR), "--param=Region=us-west-2",
+					},
 					"Parameter 'AvailabilityZoneCount' must be a number not greater than 3": {
 						"--param=AvailabilityZoneCount=10", "--param=Name=invalid-az"},
 					"Parameter 'AvailabilityZoneCount' must be a number not less than 1": {
@@ -383,8 +392,8 @@ var _ = Describe("Network Resources",
 					"request send failed, Post \"https://cloudformation.ind-west-2.amazonaws.com/\"": {
 						"--param=Region=ind-west-2", "--param=Name=invalid-region"},
 					incorrectStackNameErrorMessage: {"--param=Name=$#aaraj"},
-					incorrectCidrErrorMessage: {"single-vpc",
-						"--template-dir", templateDirPath,
+					incorrectCidrErrorMessage: {tdnSingleVPC,
+						"--template-dir", tdpSingleVPC,
 						"--param=VpcCidr=10.0.", "--param=Name=incorrectcidr", "--param=Region=us-west-2"},
 				}
 

--- a/tests/e2e/test_rosacli_upgrade.go
+++ b/tests/e2e/test_rosacli_upgrade.go
@@ -284,21 +284,14 @@ var _ = Describe("Cluster Upgrade testing",
 			// without arbitrary policies attach share this profile.
 			// It needs to add step to wait the cluster upgrade done
 			// and to check the `rosa describe/list upgrade` in both of these two case.
-			if !isHosted {
-				output, err = upgradeService.Upgrade(
-					"-c", clusterID,
-					"--version", upgradingVersion,
-					"--mode", "auto",
-					"-y",
-				)
-			} else {
-				output, err = upgradeService.Upgrade(
-					"-c", clusterID,
-					"--version", upgradingVersion,
-					"--mode", "auto", "--control-plane",
-					"-y",
-				)
-			}
+
+			output, err = upgradeService.Upgrade(
+				"-c", clusterID,
+				"--version", upgradingVersion,
+				"--mode", "auto",
+				"-y",
+			)
+
 			Expect(err).To(BeNil())
 			Expect(output.String()).To(ContainSubstring("are compatible with upgrade"))
 			Expect(output.String()).To(ContainSubstring("Upgrade successfully scheduled for cluster"))
@@ -708,32 +701,19 @@ var _ = Describe("Describe/List rosa upgrade",
 
 					By("Upgrade cluster")
 					if profile.ClusterConfig.STS {
-						hostedCluster, err := clusterService.IsHostedCPCluster(clusterID)
 						Expect(err).ToNot(HaveOccurred())
-						if !hostedCluster {
-							output, errSTSUpgrade := upgradeService.Upgrade(
-								"-c", clusterID,
-								"--version", upgradingVersion,
-								"--schedule-date", scheduledDate,
-								"--schedule-time", scheduledTime,
-								"-m", "auto",
-								"-y",
-							)
-							Expect(errSTSUpgrade).To(BeNil())
-							Expect(output.String()).NotTo(ContainSubstring("There is already a scheduled upgrade"))
-						} else {
-							output, errHCPUpgrade := upgradeService.Upgrade(
-								"-c", clusterID,
-								"--version", upgradingVersion,
-								"--schedule-date", scheduledDate,
-								"--schedule-time", scheduledTime,
-								"-m", "auto",
-								"--control-plane",
-								"-y",
-							)
-							Expect(errHCPUpgrade).To(BeNil())
-							Expect(output.String()).NotTo(ContainSubstring("There is already a scheduled upgrade"))
-						}
+
+						output, errSTSUpgrade := upgradeService.Upgrade(
+							"-c", clusterID,
+							"--version", upgradingVersion,
+							"--schedule-date", scheduledDate,
+							"--schedule-time", scheduledTime,
+							"-m", "auto",
+							"-y",
+						)
+						Expect(errSTSUpgrade).To(BeNil())
+						Expect(output.String()).NotTo(ContainSubstring("There is already a scheduled upgrade"))
+
 					} else {
 						output, errUpgrade := upgradeService.Upgrade(
 							"-c", clusterID,
@@ -900,16 +880,8 @@ var _ = Describe("ROSA HCP cluster upgrade",
 		})
 
 		It("automatic upgrade for HCP cluster  - [id:64187]", labels.Critical, labels.Runtime.Upgrade, func() {
-			By("Check the help message for 'upgrade cluster'")
-			output, err := upgradeService.Upgrade(
-				"-c", clusterID,
-				"-h",
-			)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(output.String()).To(ContainSubstring("--control-plane"))
-
 			By("List the available ugrades for cluster")
-			output, err = upgradeService.ListUpgrades("-c", clusterID)
+			output, err := upgradeService.ListUpgrades("-c", clusterID)
 			Expect(err).To(BeNil())
 			Expect(output.String()).To(ContainSubstring("%s", zStreamVersion))
 			Expect(output.String()).To(ContainSubstring("%s", yStreamVersion))
@@ -925,7 +897,6 @@ var _ = Describe("ROSA HCP cluster upgrade",
 				"-c", clusterID,
 				"--mode", "auto",
 				"--schedule", scheduled,
-				"--control-plane",
 				"-y",
 			)
 			defer upgradeService.DeleteUpgrade("-c", clusterID, "-y")
@@ -978,7 +949,6 @@ var _ = Describe("ROSA HCP cluster upgrade",
 			output, err := upgradeService.Upgrade(
 				"-c", clusterID,
 				"--mode", "manual",
-				"--control-plane",
 				"--version", targetVersion,
 				"-y",
 			)
@@ -1021,7 +991,6 @@ var _ = Describe("ROSA HCP cluster upgrade",
 				"--version", targetVersion,
 				"--schedule-date", scheduledDate,
 				"--schedule-time", scheduledTime,
-				"--control-plane",
 				"--mode", "manual",
 				"-y",
 			)
@@ -1111,7 +1080,6 @@ var _ = Describe("ROSA HCP cluster upgrade",
 						"--version", upgradeVersion,
 						"--schedule-date", scheduledDate,
 						"--schedule-time", scheduledTime,
-						"--control-plane",
 						"--mode", "manual",
 						"-y",
 					)

--- a/tests/e2e/test_rosacli_user_role.go
+++ b/tests/e2e/test_rosacli_user_role.go
@@ -195,7 +195,7 @@ var _ = Describe("Edit user role", labels.Feature.UserRole, func() {
 			userRoleArnsToClean = append(userRoleArnsToClean, foundUserRole.RoleArn)
 
 			By("UnLink user-role")
-			output, err = ocmResourceService.LinkUserRole("--role-arn", foundUserRole.RoleArn, "-y")
+			output, err = ocmResourceService.UnlinkUserRole("--role-arn", foundUserRole.RoleArn, "-y")
 			Expect(err).To(BeNil())
 			textData = rosaClient.Parser.TextData.Input(output).Parse().Tip()
 			Expect(textData).Should(ContainSubstring("Successfully unlinked role"))


### PR DESCRIPTION
- 77159: The file system on prowci is read-only, adjust to use temp dir to create clouldformation file.And also fix some design change
- 77829: Fix expectred error message
- 52419: fix to use correct command to unlink user role
- 54469: To use temp dir for manual mode local files to avoid 'Permission deny'
- 75534: add the step to initiate the cluster_id and testClusterName in BeforeEach to avoid the failure across test cases in the same block
- 64187: '--control-plane' is removed since [OCM-7330](https://issues.redhat.com/browse/OCM-7330) was merged, remove the check for its help message
- 73814: remove the checkpoint of the requiredment of '--control-plane' for hostedcp upgrade

And remove all '--control-plane' flag in the cases of hostedcp cluster upgrade

local logs are https://privatebin.corp.redhat.com/?ea2cd1948eadcaa6#56R4VteuVkGfUeKER6mudem8LjMoAPVosdm2Jdb4ojzZ