### PR TITLE
OCM-13681 | fix: Do not error/exit when fail to describe migrations

### DIFF
--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -201,8 +201,7 @@ func run(cmd *cobra.Command, argv []string) {
 	migrationsStr := ""
 	collection, err := r.OCMClient.FetchClusterMigrations(cluster.ID())
 	if err != nil {
-		r.Reporter.Errorf("Failed to get cluster migrations: %v", err)
-		os.Exit(1)
+		r.Reporter.Warnf("Failed to get cluster migrations: %v", err)
 	}
 
 	if len(collection.Items().Items()) > 0 {


### PR DESCRIPTION
Causes failure to create cluster when feature toggle is disabled in Clusters Service