### PR TITLE
OCM-13520 | feat: Disable SDN->OVN migration feature for 1.2.50

### DIFF
--- a/cmd/edit/cluster/cmd.go
+++ b/cmd/edit/cluster/cmd.go
@@ -191,7 +191,7 @@ func init() {
 		"Account ID used for billing subscriptions purchased through the AWS console for ROSA",
 	)
 
-	flags.StringVar(
+	/*flags.StringVar(
 		&args.networkType,
 		"network-type",
 		"",
@@ -206,7 +206,7 @@ func init() {
 			"OVN-Kubernetes. Must be supplied as a string=value pair with any of 'join', 'transit', 'masquerade' "+
 			"followed by a CIDR. \nExample: '--ovn-internal-subnets=\"join=192.168.255.0/24,transit=192.168.255.0/24,"+
 			"masquerade=192.168.255.0/24\"'",
-	)
+	)*/
 }
 
 func run(cmd *cobra.Command, _ []string) {

--- a/cmd/rosa/structure_test/command_args/rosa/edit/cluster/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/edit/cluster/command_args.yml
@@ -21,5 +21,5 @@
 - name: registry-config-platform-allowlist
 - name: registry-config-additional-trusted-ca
 - name: billing-account
-- name: network-type
-- name: ovn-internal-subnets
+#- name: network-type
+#- name: ovn-internal-subnets


### PR DESCRIPTION
Removes flags used for SDN->OVN migration for 1.2.50 - will be added back in 1.2.51

Concerns with backend forced the feature to be moved to next version and released at an irregular time