### PR TITLE
OCM-13520 | feat: Disable SDN->OVN migration flags for 1.2.50

### DIFF
--- a/cmd/edit/cluster/cmd.go
+++ b/cmd/edit/cluster/cmd.go
@@ -193,7 +193,7 @@ func init() {
 
 	flags.StringVar(
 		&args.networkType,
-		"network-type",
+		ocm.NetworkTypeFlagName,
 		"",
 		"Migrate a cluster's network type from OpenShiftSDN to OVN-Kubernetes",
 	)
@@ -207,6 +207,9 @@ func init() {
 			"followed by a CIDR. \nExample: '--ovn-internal-subnets=\"join=192.168.255.0/24,transit=192.168.255.0/24,"+
 			"masquerade=192.168.255.0/24\"'",
 	)
+
+	flags.MarkHidden(ocm.OvnInternalSubnetsFlagName)
+	flags.MarkHidden(ocm.NetworkTypeFlagName)
 }
 
 func run(cmd *cobra.Command, _ []string) {


### PR DESCRIPTION
Due to concerns with backend, it's been asked to disable this feature for now. I think it's best and easiest to do this via 'removing' the flags (commenting out) for this release, so the migration cannot be initiated. And allow for a simple 1.2.51 release following this