### PR TITLE
OCM-13916 | test: fix ids: 52419,52693,54469,77962,77910,46310,70370

### DIFF
--- a/tests/e2e/test_rosacli_cluster.go
+++ b/tests/e2e/test_rosacli_cluster.go
@@ -641,7 +641,7 @@ var _ = Describe("Edit cluster validation should", labels.Feature.Cluster, func(
 				return
 			}
 			originalHttpProxy, originalHTTPSProxy, originalNoProxy, originalCAFile := "", "", "", ""
-			if clusterConfig.Proxy.Enabled {
+			if clusterConfig.Proxy != nil && clusterConfig.Proxy.Enabled {
 				originalHttpProxy,
 					originalHTTPSProxy,
 					originalNoProxy, originalCAFile =

--- a/tests/e2e/test_rosacli_network_verifier.go
+++ b/tests/e2e/test_rosacli_network_verifier.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift/rosa/tests/ci/labels"
 	"github.com/openshift/rosa/tests/utils/config"
 	"github.com/openshift/rosa/tests/utils/exec/rosacli"
+	"github.com/openshift/rosa/tests/utils/handler"
 	"github.com/openshift/rosa/tests/utils/helper"
 )
 
@@ -209,6 +210,13 @@ var _ = Describe("Network verifier",
 		It("verify that network will be failed if it can't reach to cluster subnet via the rosa cli - [id:70370]",
 			labels.Medium, labels.Runtime.Destructive,
 			func() {
+				profile := handler.LoadProfileYamlFileByENV()
+
+				By("Skip if it is a shared-vpc cluster")
+				if profile.ClusterConfig.SharedVPC {
+					Skip("Skip this case as it is a shared-vpc cluster")
+				}
+
 				By("Prepare a ready byo vpc ROSA cluster")
 				isBYOVPC, err := clusterService.IsBYOVPCCluster(clusterID)
 				Expect(err).To(BeNil())

--- a/tests/e2e/test_rosacli_operator_roles.go
+++ b/tests/e2e/test_rosacli_operator_roles.go
@@ -1343,6 +1343,11 @@ var _ = Describe("Create/Delete operator roles for hosted-cp shared vpc", labels
 			installerRole := accountRoleList.InstallerRole(accrolePrefix, true)
 			installerRoleArn := installerRole.RoleArn
 
+			By("Go to temp dir to execute aws commands then back to the default dir at last")
+			tempDir, err := os.MkdirTemp("", "*")
+			Expect(err).To(BeNil())
+			rosaClient.Runner.SetDir(tempDir)
+
 			By("Create operator roles for hosted-cp shared vpc in manual mode")
 			operatorRolePrefix = helper.GenerateRandomString(5)
 			output, err = ocmResourceService.CreateOperatorRoles(

--- a/tests/e2e/test_rosacli_user_role.go
+++ b/tests/e2e/test_rosacli_user_role.go
@@ -33,6 +33,9 @@ var _ = Describe("Edit user role", labels.Feature.UserRole, func() {
 
 		By("Get the default dir")
 		defaultDir = rosaClient.Runner.GetDir()
+
+		By("Init userRoleArnsToClean")
+		userRoleArnsToClean = []string{}
 	})
 	AfterEach(func() {
 		By("Go back original by setting runner dir")


### PR DESCRIPTION
- 52419,52693: inital 'userRoleArnsToClean' in Before each to avoid the interference between multiple cases
- 54469,77962,77910: Add step to go to the temp dir for manual mode to fix the permission issue in the default dir
- 46310: Check if clusterConfig.Proxy is nil before acesssing its field to avoid invalid memory address failure
- 70370: Skip this destructive case on shared-vpc cluster as the VPC of the cluster owned by second AWS account


logs: https://privatebin.corp.redhat.com/?ce368a7076daf425#HVyWk1c2xtv5gon9czgs5uugwmiCWskCp6LiHoG3w412