### PR TITLE
OCM-13946 | feat: Remove HCP gate on `describe/autoscaler`

### DIFF
--- a/cmd/describe/autoscaler/cmd_test.go
+++ b/cmd/describe/autoscaler/cmd_test.go
@@ -11,7 +11,6 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	. "github.com/openshift-online/ocm-sdk-go/testing"
 
-	"github.com/openshift/rosa/pkg/clusterautoscaler"
 	"github.com/openshift/rosa/pkg/output"
 	. "github.com/openshift/rosa/pkg/test"
 )
@@ -66,23 +65,6 @@ var _ = Describe("rosa describe autoscaler", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(
 				Equal("There is no cluster with identifier or name 'cluster'"))
-		})
-
-		It("Returns an error if the cluster is HCP", func() {
-			cluster := MockCluster(func(c *cmv1.ClusterBuilder) {
-				h := &cmv1.HypershiftBuilder{}
-				h.Enabled(true)
-				c.Hypershift(h)
-			})
-
-			t.SetCluster(cluster.Name(), cluster)
-			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, FormatClusterList([]*cmv1.Cluster{cluster})))
-
-			runner := DescribeAutoscalerRunner()
-			err := runner(context.Background(), t.RosaRuntime, nil, nil)
-
-			Expect(err).NotTo(BeNil())
-			Expect(err.Error()).To(ContainSubstring(clusterautoscaler.NoHCPAutoscalerSupportMessage))
 		})
 
 		It("Returns an error if the cluster is not ready", func() {

--- a/pkg/clusterautoscaler/validation.go
+++ b/pkg/clusterautoscaler/validation.go
@@ -14,10 +14,6 @@ const (
 )
 
 func IsAutoscalerSupported(runtime *rosa.Runtime, cluster *cmv1.Cluster) error {
-	if cluster.Hypershift().Enabled() {
-		return fmt.Errorf(NoHCPAutoscalerSupportMessage)
-
-	}
 
 	if cluster.State() != cmv1.ClusterStateReady {
 		return fmt.Errorf(ClusterNotReadyMessage, runtime.ClusterKey, cluster.State())

--- a/pkg/clusterautoscaler/validation_test.go
+++ b/pkg/clusterautoscaler/validation_test.go
@@ -18,17 +18,17 @@ var _ = Describe("Cluster Autoscaler validations", func() {
 		t = test.NewTestRuntime()
 	})
 
-	It("Determines Autoscalers are not valid for HCP clusters", func() {
+	It("Determines ready, HCP cluster can support Autoscaler", func() {
 
 		cluster := test.MockCluster(func(c *cmv1.ClusterBuilder) {
 			h := &cmv1.HypershiftBuilder{}
 			h.Enabled(true)
 			c.Hypershift(h)
+			c.State(cmv1.ClusterStateReady)
 		})
 
 		err := IsAutoscalerSupported(t.RosaRuntime, cluster)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal(NoHCPAutoscalerSupportMessage))
+		Expect(err).To(BeNil())
 
 	})
 


### PR DESCRIPTION
```
./rosa describe autoscaler -c hk-hcp

Balance Similar Node Groups:               No
Skip Nodes With Local Storage:             No
Log Verbosity:                             0
Ignore DaemonSets Utilization:             No
Maximum Node Provision Time:               15m
Maximum Pod Grace Period:                  600
Pod Priority Threshold:                    -10
Resource Limits:
 - Maximum Nodes:                          0
 - Minimum Number of Cores:                0
 - Maximum Number of Cores:                0
 - Minimum Memory (GiB):                   0
 - Maximum Memory (GiB):                   0
Scale Down:
 - Enabled:                                No
 - Node Utilization Threshold:             
```

^ Example with a default HCP cluster

This MR is the first in a series of MRs to support CRUD operations for autoscalers with HCP clusters

This MR specifically removes the gate for HCP on `describe/autoscaler` - Following will be support for `describe/cluster`