### PR TITLE
OCM-13951 | fix: Change error output for failed inflight check

### DIFF
--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -636,7 +636,7 @@ func run(cmd *cobra.Command, argv []string) {
 		if len(summaries) > 0 {
 			str += fmt.Sprintf("Failed Inflight Checks:\n%s\n", strings.Join(summaries, "\n"))
 			str += fmt.Sprintf("\tPlease run `rosa verify network -c %s` after adjusting"+
-				" the cluster's network configuration to remove the warning", cluster.ID())
+				" the cluster's network configuration to remove the warning", cluster.Name())
 		}
 	}
 


### PR DESCRIPTION
Error output contained command to run with `-c CLUSTER_ID` - this is incorrect and caused an error on its own, the output should contain a cluster name instead when using `-c`