### PR TITLE
OCM-13516 | fix: Rename key values used for migration API request

### DIFF
--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -630,14 +630,14 @@ func (c *Client) UpdateCluster(clusterKey string, creator *aws.Creator, config S
 		if len(config.OvnInternalSubnetConfiguration) > 0 {
 			// Create a builder for the specific migration type's configuration if necessary
 			sdnToOvnBuilder := &v1.SdnToOvnClusterMigrationBuilder{}
-			if _, ok := config.OvnInternalSubnetConfiguration[JoinIpv4]; ok {
-				sdnToOvnBuilder.JoinIpv4(config.OvnInternalSubnetConfiguration[JoinIpv4])
+			if _, ok := config.OvnInternalSubnetConfiguration[SubnetConfigJoin]; ok {
+				sdnToOvnBuilder.JoinIpv4(config.OvnInternalSubnetConfiguration[SubnetConfigJoin])
 			}
-			if _, ok := config.OvnInternalSubnetConfiguration[TransitIpv4]; ok {
-				sdnToOvnBuilder.TransitIpv4(config.OvnInternalSubnetConfiguration[TransitIpv4])
+			if _, ok := config.OvnInternalSubnetConfiguration[SubnetConfigTransit]; ok {
+				sdnToOvnBuilder.TransitIpv4(config.OvnInternalSubnetConfiguration[SubnetConfigTransit])
 			}
-			if _, ok := config.OvnInternalSubnetConfiguration[MasqueradeIpv4]; ok {
-				sdnToOvnBuilder.MasqueradeIpv4(config.OvnInternalSubnetConfiguration[MasqueradeIpv4])
+			if _, ok := config.OvnInternalSubnetConfiguration[SubnetConfigMasquerade]; ok {
+				sdnToOvnBuilder.MasqueradeIpv4(config.OvnInternalSubnetConfiguration[SubnetConfigMasquerade])
 			}
 			requestBuilder.SdnToOvn(sdnToOvnBuilder)
 		}

--- a/pkg/ocm/migrations.go
+++ b/pkg/ocm/migrations.go
@@ -9,10 +9,6 @@ import (
 )
 
 const (
-	TransitIpv4    = "transit_ipv4"
-	JoinIpv4       = "join_ipv4"
-	MasqueradeIpv4 = "masquerade_ipv4"
-
 	SubnetConfigTransit    = "transit"
 	SubnetConfigMasquerade = "masquerade"
 	SubnetConfigJoin       = "join"


### PR DESCRIPTION
Values with `_ipv4` were incorrectly used after SDK change, not populating the internal subnets when the request was made