### PR TITLE
OCM-13947 | feat: Enable deleting HCP autoscaler + test modification

### DIFF
--- a/cmd/dlt/autoscaler/cmd.go
+++ b/cmd/dlt/autoscaler/cmd.go
@@ -62,10 +62,6 @@ func DeleteAutoscalerRunner() rosa.CommandRunner {
 			return err
 		}
 
-		if cluster.Hypershift().Enabled() {
-			return fmt.Errorf("Hosted Control Plane clusters do not support cluster-autoscaler configuration")
-		}
-
 		if !confirm.Confirm("delete cluster autoscaler?") {
 			return nil
 		}


### PR DESCRIPTION
Allows deletion of HCP autoscaler (tested manually)

Also modifies tests to remove validation check + add test case for HCP