### PR TITLE
OCM-13049 | ci: Add the workaround for public HCP with proxy to make all operators ready

### DIFF
--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"fmt"
 	"path"
 	"time"
 
@@ -42,14 +43,24 @@ var _ = Describe("Cluster preparation", labels.Feature.Cluster, func() {
 			Expect(err).ToNot(HaveOccurred())
 			clusterHandler.WaitForClusterReady(config.Test.GlobalENV.ClusterWaitingTime)
 
+			clusterID := clusterHandler.GetClusterDetail().ClusterID
+			clusterService := client.Cluster
+			output, err := clusterService.DescribeCluster(clusterID)
+			Expect(err).To(BeNil())
+			clusterDetails, err := clusterService.ReflectClusterDescription(output)
+			Expect(err).To(BeNil())
+
+			// Workaround for public HCP with proxy
+			if profile.ClusterConfig.HCP && profile.ClusterConfig.ProxyEnabled && !profile.ClusterConfig.Private {
+				clusterDNS := clusterDetails.DNS
+				_, _, clusterNoProxy :=
+					clusterService.DetectProxy(clusterDetails)
+				_, err := clusterService.EditCluster(clusterID, "--no-proxy",
+					fmt.Sprintf("%s,.%s", clusterNoProxy, clusterDNS))
+				Expect(err).To(BeNil())
+			}
 			// For HCP cluster with other network type,it is required to set one configure:cilium
 			if profile.ClusterConfig.HCP && profile.ClusterConfig.NetworkType == "other" {
-				clusterID := clusterHandler.GetClusterDetail().ClusterID
-				clusterService := client.Cluster
-				output, err := clusterService.DescribeCluster(clusterID)
-				Expect(err).To(BeNil())
-				clusterDetails, err := clusterService.ReflectClusterDescription(output)
-				Expect(err).To(BeNil())
 				if clusterDetails.ExternalAuthentication == "Enabled" {
 					By("Create a fake external auth provider to avoid failure of console operator")
 					value := []string{

--- a/tests/e2e/test_rosacli_cluster_post.go
+++ b/tests/e2e/test_rosacli_cluster_post.go
@@ -478,7 +478,8 @@ var _ = Describe("Healthy check",
 							clusterService.DetectProxy(clusterDescription)
 						Expect(clusterConfig.Proxy.Http).To(Equal(clusterHTTPProxy))
 						Expect(clusterConfig.Proxy.Https).To(Equal(clusterHTTPSProxy))
-						Expect(clusterConfig.Proxy.NoProxy).To(Equal(clusterNoProxy))
+						// Here is workaround in e2e_setup_test.go for HCP with proxy
+						Expect(clusterNoProxy).To(ContainSubstring(clusterConfig.Proxy.NoProxy))
 						Expect(clusterDescription.AdditionalTrustBundle).To(Equal("REDACTED"))
 					} else {
 						Expect(clusterDescription.Proxy).To(BeEmpty())


### PR DESCRIPTION
https://privatebin.corp.redhat.com/?0f0656885e0a482e#2KS2VSfQUyVSSGogMaq3bsvw86rQSUQPN1JuWW2a78kC