### PR TITLE
OCM-14095 | test: fix ids: 72536,67348,75227,70370

### DIFF
--- a/tests/e2e/hcp_external_auth_test.go
+++ b/tests/e2e/hcp_external_auth_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/openshift/rosa/tests/ci/labels"
+	"github.com/openshift/rosa/tests/utils/config"
 	"github.com/openshift/rosa/tests/utils/exec/rosacli"
 	"github.com/openshift/rosa/tests/utils/helper"
 )
@@ -156,6 +157,11 @@ var _ = Describe("External auth provider", labels.Feature.ExternalAuthProvider, 
 		It("create/list/describe/delete external_auth for a HCP cluster can work well via rosa client - [id:72536]",
 			labels.Critical, labels.Runtime.Day2,
 			func() {
+				clusterConfig, err := config.ParseClusterProfile()
+				Expect(err).ToNot(HaveOccurred())
+				if clusterConfig.ExternalAuthentication {
+					Skip("It is only for external_auth_config disabled clusters")
+				}
 				var (
 					consoleClientID      = "abc"
 					consoleClientSecrect = "efgh"

--- a/tests/e2e/rosa_autoscaler_test.go
+++ b/tests/e2e/rosa_autoscaler_test.go
@@ -277,13 +277,8 @@ var _ = Describe("Autoscaler", labels.Feature.Autoscaler, func() {
 									"ERR: Hosted Control Plane clusters do not support cluster-autoscaler configuration"))
 
 						By("Describe the autoscaler of the cluster")
-						output, err := rosaClient.AutoScaler.DescribeAutoScaler(clusterID)
-						Expect(err).To(HaveOccurred())
-						textData = rosaClient.Parser.TextData.Input(output).Parse().Tip()
-						Expect(textData).
-							To(
-								ContainSubstring(
-									"ERR: Hosted Control Plane clusters do not support cluster-autoscaler configuration"))
+						_, err = rosaClient.AutoScaler.DescribeAutoScaler(clusterID)
+						Expect(err).NotTo(HaveOccurred())
 
 						By("Edit the autoscaler of the cluster")
 						resp, err = rosaClient.AutoScaler.EditAutoScaler(clusterID, "--ignore-daemonsets-utilization",

--- a/tests/e2e/test_rosacli_network_verifier.go
+++ b/tests/e2e/test_rosacli_network_verifier.go
@@ -285,7 +285,7 @@ var _ = Describe("Network verifier",
 					func(context.Context) (bool, error) {
 						clusterDetail, err = clusterService.DescribeClusterAndReflect(clusterID)
 						if !strings.Contains(clusterDetail.FailedInflightChecks,
-							fmt.Sprintf("rosa verify network -c %s", clusterID)) {
+							"rosa verify network -c ") {
 							return false, err
 						}
 						return true, err

--- a/tests/e2e/test_rosacli_node_pool.go
+++ b/tests/e2e/test_rosacli_node_pool.go
@@ -1677,7 +1677,7 @@ var _ = Describe("Edit nodepool",
 					constants.RequiredEc2MetadataHttpTokens}
 
 				for _, imdsv2Value := range imdsv2Values {
-					machinePool_Name := helper.GenerateRandomName("ocp-75227", 2)
+					machinePool_Name := helper.GenerateRandomName("ocp-75227", 3)
 					By("Create a machinepool with --ec2-metadata-http-tokens = " + imdsv2Value)
 					output, err := machinePoolService.CreateMachinePool(clusterID,
 						machinePool_Name,
@@ -1700,7 +1700,7 @@ var _ = Describe("Edit nodepool",
 				}
 
 				By("Try to create machinepool to the cluster by setting invalid value of --ec2-metadata-http-tokens")
-				machinePool_Name := helper.GenerateRandomName("ocp-75227", 2)
+				machinePool_Name := helper.GenerateRandomName("ocp-75227", 3)
 				output, err := machinePoolService.CreateMachinePool(clusterID,
 					machinePool_Name,
 					"--replicas", "3",


### PR DESCRIPTION
- 72536: It canot create external_auth_provider on the cluster which has already configured that, skip it if the cluster is configured with external_auth_provider
- 67348: design change, describe autoscaler is supported since [OCM-13946](https://issues.redhat.com/browse/OCM-13946)
- 75227:  it generated a dulicated machinepool name with two random charactors suffix. I will use a suffix of three charactor to decrease its happening
- 70370: The expected message of 'Failed Inflight Checks' is using cluster name actually, not the cluster id. Simplify the expected message.

Logs: https://privatebin.corp.redhat.com/?0f7901212a32a060#79asrSNRauy6KGPEijeVaks6zmBnDsPMMPNAASwaZ3wH