### PR TITLE
OCM-8373 | CI: Initial support for FedRAMP

### DIFF
--- a/tests/ci/data/profiles/rosa-classic.yaml
+++ b/tests/ci/data/profiles/rosa-classic.yaml
@@ -69,6 +69,42 @@ profiles:
   account-role:
     path: "/test/"
     permission_boundary: "arn:aws:iam::aws:policy/AdministratorAccess"
+- as: rosa-fedramp
+  version: "4.14"
+  channel_group: "stable"
+  region: "us-gov-east-1"
+  cluster:
+    multi_az: true
+    instance_type: ""
+    hcp: false
+    sts: true
+    byo_vpc: true
+    private_link: true
+    private: true
+    etcd_encryption: false
+    fips: true
+    autoscale: true
+    kms_key: false
+    networking: false
+    proxy_enabled: false
+    label_enabled: false
+    tag_enabled: false
+    zones: ""
+    imdsv2: ""
+    shared_vpc: false
+    ingress_customized: false
+    oidc_config: managed
+    admin_enabled: false
+    volume_size: 150
+    autoscaler_enabled: false
+    disable_uwm: false
+    name_length: 15
+    domain_prefix_enabled: false
+    additional_sg_number: 0
+    fedramp: true
+  account-role:
+    path: ""
+    permission_boundary: ""
 - as: rosa-shared-vpc
   version: latest
   channel_group: stable

--- a/tests/ci/labels/category.go
+++ b/tests/ci/labels/category.go
@@ -6,3 +6,4 @@ import (
 
 // Exclude in CI
 var Exclude = Label("Exclude")
+var FedRAMP = Label("FedRAMP")

--- a/tests/e2e/test_rosacli_cluster.go
+++ b/tests/e2e/test_rosacli_cluster.go
@@ -250,7 +250,7 @@ var _ = Describe("Edit cluster",
 			})
 
 		It("can edit privacy and workload monitoring via rosa-cli - [id:60275]",
-			labels.Critical, labels.Runtime.Day2,
+			labels.Critical, labels.Runtime.Day2, labels.FedRAMP,
 			func() {
 				By("Check the cluster is private cluster")
 				private, err := clusterService.IsPrivateCluster(clusterID)

--- a/tests/e2e/test_rosacli_cluster_post.go
+++ b/tests/e2e/test_rosacli_cluster_post.go
@@ -294,7 +294,7 @@ var _ = Describe("Healthy check",
 					Expect(etcdEncryption).To(BeTrue())
 				})
 
-			It("with private_link will work - [id:41549]", labels.Runtime.Day1Post, labels.Critical,
+			It("with private_link will work - [id:41549]", labels.Runtime.Day1Post, labels.Critical, labels.FedRAMP,
 				func() {
 					private := constants.No
 					ingressPrivate := "false"
@@ -746,7 +746,7 @@ var _ = Describe("Post-Check testing for cluster deletion",
 
 			})
 		It("to verify the sts cluster is deleted successfully - [id:75256]",
-			labels.High, labels.Runtime.DestroyPost,
+			labels.High, labels.Runtime.DestroyPost, labels.FedRAMP,
 			func() {
 				By("Check the operator-roles is deleted")
 				clusterDetail, err := handler.ParseClusterDetail()
@@ -867,7 +867,7 @@ var _ = Describe("Post-Check testing for cluster creation",
 				}
 			})
 		It("to verify sts cluster is created successfully - [id:41822]",
-			labels.High, labels.Runtime.Day1Post,
+			labels.High, labels.Runtime.Day1Post, labels.FedRAMP,
 			func() {
 				By("Check the cluster is STS cluster")
 				profile := handler.LoadProfileYamlFileByENV()
@@ -890,6 +890,8 @@ var _ = Describe("Post-Check testing for cluster creation",
 				By("Check the sts cluster created with IAM roles")
 				if profile.ClusterConfig.HCP {
 					Expect(len(clusterDescription.OperatorIAMRoles)).To(Equal(8))
+				} else if profile.ClusterConfig.FedRAMP {
+					Expect(len(clusterDescription.OperatorIAMRoles)).To(Equal(7))
 				} else {
 					Expect(len(clusterDescription.OperatorIAMRoles)).To(Equal(6))
 				}

--- a/tests/e2e/test_rosacli_idp.go
+++ b/tests/e2e/test_rosacli_idp.go
@@ -59,7 +59,7 @@ var _ = Describe("Edit IDP",
 		})
 
 		It("can create/describe/delete admin user - [id:35878]",
-			labels.Critical, labels.Runtime.Day2,
+			labels.Critical, labels.Runtime.Day2, labels.FedRAMP,
 			func() {
 				var (
 					idpType    = "htpasswd"
@@ -158,7 +158,7 @@ var _ = Describe("Edit IDP",
 			})
 
 		It("can create/List/Delete IDPs for rosa clusters - [id:35896]",
-			labels.Critical, labels.Runtime.Day2,
+			labels.Critical, labels.Runtime.Day2, labels.FedRAMP,
 			func() {
 				// common IDP variables
 				var (

--- a/tests/e2e/test_rosacli_idp_user.go
+++ b/tests/e2e/test_rosacli_idp_user.go
@@ -44,7 +44,7 @@ var _ = Describe("Edit IDP User",
 		})
 
 		It("can grant/list/revoke users - [id:36128]",
-			labels.Critical, labels.Runtime.Day2,
+			labels.Critical, labels.Runtime.Day2, labels.FedRAMP,
 			func() {
 				var (
 					dedicatedAdminsGroupName = "dedicated-admins"

--- a/tests/e2e/test_rosacli_machine_pool.go
+++ b/tests/e2e/test_rosacli_machine_pool.go
@@ -65,6 +65,7 @@ var _ = Describe("Create machinepool",
 		It("can create/list machinepool - [id:36293]",
 			labels.Critical,
 			labels.Runtime.Day2,
+			labels.FedRAMP,
 			func() {
 				By("Check help info for create machinepool")
 				_, err := machinePoolService.RetrieveHelpForCreate()
@@ -1128,7 +1129,7 @@ var _ = Describe("Edit machinepool",
 		})
 
 		It("will succeed - [id:38838]",
-			labels.High, labels.Runtime.Day2,
+			labels.High, labels.Runtime.Day2, labels.FedRAMP,
 			func() {
 				By("Check help message")
 				output, err := machinePoolService.EditMachinePool(clusterID, "", "-h")

--- a/tests/utils/handler/interface.go
+++ b/tests/utils/handler/interface.go
@@ -61,6 +61,7 @@ type ClusterConfig struct {
 	AllowedRegistries             bool   `yaml:"allowed_registries" json:"allowed_registries,omitempty"`
 	BlockedRegistries             bool   `yaml:"blocked_registries" json:"blocked_registries,omitempty"`
 	ManualCreationMode            bool   `yaml:"manual_creation_mode" json:"manual_creation_mode,omitempty"`
+	FedRAMP                       bool   `yaml:"fedramp" json:"fedramp,omitempty"`
 }
 
 // Resources will record the resources prepared


### PR DESCRIPTION
I added labels to all test cases that are currently automated and in the FedRAMP regression test suite. I also added a new profile that creates a cluster that works in FedRAMP, and made a few small changes to support some differences between FedRAMP and commercial. 