### PR TITLE
OCM-14168 | feat: Disable interactive mode when editing HCP autoscaler

### DIFF
--- a/cmd/edit/autoscaler/cmd.go
+++ b/cmd/edit/autoscaler/cmd.go
@@ -22,6 +22,7 @@ import (
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
+	errors "github.com/zgalor/weberr"
 
 	"github.com/openshift/rosa/pkg/clusterautoscaler"
 	"github.com/openshift/rosa/pkg/interactive"
@@ -83,6 +84,10 @@ func EditAutoscalerRunner(autoscalerArgs *clusterautoscaler.AutoscalerArgs) rosa
 		}
 
 		if cluster.Hypershift().Enabled() {
+			if interactive.Enabled() {
+				return errors.UserErrorf("Editing a Hosted Control Plane cluster autoscaler does not support " +
+					"interactive mode")
+			}
 			ok, err := clusterautoscaler.ValidateAutoscalerFlagsForHostedCp(argsPrefix, command)
 			if !ok || err != nil {
 				return err
@@ -100,7 +105,8 @@ func EditAutoscalerRunner(autoscalerArgs *clusterautoscaler.AutoscalerArgs) rosa
 				"You should first create it via 'rosa create autoscaler'", clusterKey)
 		}
 
-		if !clusterautoscaler.IsAutoscalerSetViaCLI(command.Flags(), argsPrefix) && !interactive.Enabled() {
+		if !clusterautoscaler.IsAutoscalerSetViaCLI(command.Flags(), argsPrefix) && !interactive.Enabled() &&
+			!cluster.Hypershift().Enabled() {
 			interactive.Enable()
 			r.Reporter.Infof("Enabling interactive mode")
 		}

--- a/pkg/clusterautoscaler/flags.go
+++ b/pkg/clusterautoscaler/flags.go
@@ -817,6 +817,7 @@ func BuildAutoscalerOptions(spec *ocm.AutoscalerConfig, prefix string) string {
 
 func CreateAutoscalerConfig(args *AutoscalerArgs) (*ocm.AutoscalerConfig, error) {
 	gpuLimits := []ocm.GPULimit{}
+
 	for _, entry := range args.ResourceLimits.GPULimits {
 		gpuLimit, err := parseGPULimit(entry)
 		if err != nil {

--- a/pkg/clusterautoscaler/validation.go
+++ b/pkg/clusterautoscaler/validation.go
@@ -53,6 +53,26 @@ func ValidateAutoscalerFlagsForHostedCp(prefix string, cmd *cobra.Command) (bool
 		}
 	}
 
+	mustHaveAtLeastOneList := []string{
+		maxNodesTotalFlag,
+		podPriorityThresholdFlag,
+		maxPodGracePeriodFlag,
+		maxNodeProvisionTimeFlag,
+	}
+
+	atLeastOneChanged := false
+	for _, flag := range mustHaveAtLeastOneList {
+		if cmd.Flag(fmt.Sprintf("%s%s", prefix, flag)).Changed {
+			atLeastOneChanged = true
+		}
+	}
+
+	if !atLeastOneChanged {
+		return false, errors.UserErrorf("Must supply at least one of the following flags: '%s', '%s', '%s', '%s'."+
+			" Editing a Hosted Control Plane cluster autoscaler does not support interactive mode.", maxNodesTotalFlag,
+			podPriorityThresholdFlag, maxPodGracePeriodFlag, maxNodeProvisionTimeFlag)
+	}
+
 	return true, nil
 }
 


### PR DESCRIPTION
Disables interactive mode for edit/autoscaler for HCP clusters + adds some validation to provide the user with helpful messages