### PR TITLE
OCM-14214 | fix: Calculate default NP values when create/edit np

### DIFF
--- a/cmd/edit/machinepool/cmd_test.go
+++ b/cmd/edit/machinepool/cmd_test.go
@@ -109,6 +109,8 @@ var _ = Describe("Edit Machinepool", func() {
 				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
 				// First get
 				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, nodePoolResponse))
+				// Second get
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, nodePoolResponse))
 				// Edit
 				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, ""))
 				t.SetCluster(clusterId, mockClusterReady)
@@ -129,6 +131,8 @@ var _ = Describe("Edit Machinepool", func() {
 				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
 				// First get
 				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, nodePoolAutoResponse))
+				// Second get
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, nodePoolResponse))
 				// Edit
 				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, ""))
 				t.SetCluster(clusterId, mockClusterReady)

--- a/pkg/machinepool/machinepool.go
+++ b/pkg/machinepool/machinepool.go
@@ -957,18 +957,20 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 	sumOfMaxReplicas := maxReplicas
 	sumOfMinReplicas := minReplicas
 
-	for _, np := range cluster.NodePools().Items() {
+	nodepools, err := r.OCMClient.GetNodePools(cluster.ID())
+	if err != nil {
+		r.Reporter.Errorf("Error getting node pools from cluster '%s': %s", cluster.ID(), err)
+	}
+
+	for _, np := range nodepools {
 		// If autoscaling, calculate min and max, use min and max in separate messages below
-		autoscaling, ok := np.GetAutoscaling()
-		if !ok || autoscaling == nil {
-			npReplicas, ok := np.GetReplicas()
-			if !ok {
-				return fmt.Errorf("Failed to get node pool replicas for hosted cluster '%s': %v", clusterKey, err)
-			}
+		npAutoscaling, ok := np.GetAutoscaling()
+		if !ok || npAutoscaling == nil {
+			npReplicas, _ := np.GetReplicas()
 			sumOfReplicas += npReplicas
 		} else {
-			sumOfMaxReplicas += autoscaling.MaxReplica()
-			sumOfMinReplicas += autoscaling.MinReplica()
+			sumOfMaxReplicas += npAutoscaling.MaxReplica()
+			sumOfMinReplicas += npAutoscaling.MinReplica()
 		}
 	}
 
@@ -1833,18 +1835,20 @@ func editNodePool(cmd *cobra.Command, nodePoolID string,
 	sumOfMaxReplicas := maxReplicas
 	sumOfMinReplicas := minReplicas
 
-	for _, np := range cluster.NodePools().Items() {
+	nodepools, err := r.OCMClient.GetNodePools(cluster.ID())
+	if err != nil {
+		r.Reporter.Errorf("Error getting node pools from cluster '%s': %s", cluster.ID(), err)
+	}
+
+	for _, np := range nodepools {
 		// If autoscaling, calculate min and max, use min and max in separate messages below
-		autoscaling, ok := np.GetAutoscaling()
-		if !ok || autoscaling == nil {
-			npReplicas, ok := np.GetReplicas()
-			if !ok {
-				return fmt.Errorf("Failed to get node pool replicas for hosted cluster '%s': %v", clusterKey, err)
-			}
+		npAutoscaling, ok := np.GetAutoscaling()
+		if !ok || npAutoscaling == nil {
+			npReplicas, _ := np.GetReplicas()
 			sumOfReplicas += npReplicas
 		} else {
-			sumOfMaxReplicas += autoscaling.MaxReplica()
-			sumOfMinReplicas += autoscaling.MinReplica()
+			sumOfMaxReplicas += npAutoscaling.MaxReplica()
+			sumOfMinReplicas += npAutoscaling.MinReplica()
 		}
 	}
 

--- a/pkg/machinepool/machinepool_test.go
+++ b/pkg/machinepool/machinepool_test.go
@@ -1485,6 +1485,8 @@ var _ = Describe("NodePools", func() {
 			nodePoolObj, err := cmv1.NewNodePool().ID("np-1").Build()
 			Expect(err).ToNot(HaveOccurred())
 			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, FormatResources(nodePoolObj)))
+			nodePoolResponse := test.FormatNodePoolList([]*cmv1.NodePool{nodePoolObj})
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, nodePoolResponse))
 			err = machinePool.CreateNodePools(t.RosaRuntime, cmd, clusterKey, cluster, nil, &args)
 			Expect(err).To(Not(HaveOccurred()))
 		})


### PR DESCRIPTION
Issue was that the default node pool values were not being calculated for the info/warning msgs that print when doing risky scaling choices

This was because the cluster API response does not contain default NPs, had to use a separate API endpoint

So if the default NP had 50 nodes, and the new one had 50, the "total" this code would return would be `50` instead of `100`