### PR TITLE
OCM-14251 | ci: get cluster value from json data

### DIFF
--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -53,9 +53,10 @@ var _ = Describe("Cluster preparation", labels.Feature.Cluster, func() {
 			// Workaround for public HCP with proxy
 			if profile.ClusterConfig.HCP && profile.ClusterConfig.ProxyEnabled && !profile.ClusterConfig.Private {
 				clusterDNS := clusterDetails.DNS
-				_, _, clusterNoProxy :=
-					clusterService.DetectProxy(clusterDetails)
-				_, err := clusterService.EditCluster(clusterID, "--no-proxy",
+				jsonData, err := clusterService.GetJSONClusterDescription(clusterID)
+				Expect(err).To(BeNil())
+				clusterNoProxy := jsonData.DigString("proxy", "no_proxy")
+				_, err = clusterService.EditCluster(clusterID, "--no-proxy",
 					fmt.Sprintf("%s,.%s", clusterNoProxy, clusterDNS))
 				Expect(err).To(BeNil())
 			}


### PR DESCRIPTION
Here is the run log
```
yingzhan@yingzhan-mac  ~/ying-work/code/rosa   ying-fix ±  ginkgo run --label-filter day1 tests/e2e --timeout 2h && ginkgo run --label-filter day1-readiness tests/e2e --timeout 1h
Running Suite: ROSA CLI e2e tests suite - /Users/yingzhan/ying-work/code/rosa/tests/e2e
=======================================================================================
Random Seed: 1740464598
 
Will run 1 of 259 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSStime="2025-02-25 14:52:58" level=info msg="Going to prepare a vpc with name ying0225-erhwmk, on region us-west-2, with cidr 10.0.0.0/16 "
time="2025-02-25 14:52:59" level=info msg="Going to create vpc and the follow resources on zones: "
time="2025-02-25 14:53:00" level=info msg="Create vpc success vpc-07320be917c3eb042"
time="2025-02-25 14:53:00" level=info msg="Tag resource vpc-07320be917c3eb042 successfully"
time="2025-02-25 14:53:00" level=info msg="Created vpc with ID vpc-07320be917c3eb042"
time="2025-02-25 14:53:00" level=info msg="VPC created on AWS with id: vpc-07320be917c3eb042"
time="2025-02-25 14:53:01" level=info msg="Modify vpc dns attribute DnsHostnames successfully for vpc-07320be917c3eb042"
time="2025-02-25 14:53:01" level=info msg="VPC DNS Updated on AWS with id: vpc-07320be917c3eb042"
time="2025-02-25 14:53:01" level=info msg="Create igw success: igw-0519fe1a7e844c0ba"
time="2025-02-25 14:53:02" level=info msg="Attach igw success: igw-0519fe1a7e844c0ba"
time="2025-02-25 14:53:02" level=info msg="Prepare vpc internetgateway for vpc vpc-07320be917c3eb042"
time="2025-02-25 14:53:02" level=info msg="Create subnets successfully"
time="2025-02-25 14:53:02" level=info msg="Create vpc chain successfully. Enjoy it."
time="2025-02-25 14:53:02" level=info msg="Going to prepare proper pair of subnets"
time="2025-02-25 14:53:02" level=info msg="Got no public subnet for current zone us-west-2a, going to create one"
time="2025-02-25 14:53:02" level=info msg="Created subnet subnet-044882690505acf83 for vpc vpc-07320be917c3eb042"
time="2025-02-25 14:53:03" level=info msg="Created subnet with ID subnet-044882690505acf83"
time="2025-02-25 14:53:04" level=info msg="Associate route table success rtbassoc-02ef86b45b5526842"
time="2025-02-25 14:53:04" level=info msg="Create route success for route table: rtb-0d865f50dcf70d167"
time="2025-02-25 14:53:05" level=info msg="Tag resource subnet-044882690505acf83 successfully"
time="2025-02-25 14:53:05" level=info msg="Got no proper private subnet for current zone us-west-2a, going to create one"
time="2025-02-25 14:53:06" level=info msg="Created subnet subnet-0aa6de25f8a78bfa7 for vpc vpc-07320be917c3eb042"
time="2025-02-25 14:53:06" level=info msg="Created subnet with ID subnet-0aa6de25f8a78bfa7"
time="2025-02-25 14:53:07" level=info msg="Associate route table success rtbassoc-0c00132836b6352ed"
time="2025-02-25 14:53:07" level=info msg="Allocated EIP eipalloc-03b79c50a08345573 with ip 44.246.240.226"
time="2025-02-25 14:53:08" level=info msg="Create nat success: nat-09728c26768d1b21d"
time="2025-02-25 14:54:41" level=info msg="Create route success for route table: rtb-0db0603f0caab3409"
time="2025-02-25 14:54:41" level=info msg="Tag resource subnet-0aa6de25f8a78bfa7 successfully"
time="2025-02-25 14:54:41" level=info msg="Going to prepare proper pair of subnets"
time="2025-02-25 14:54:41" level=info msg="Subnet subnet-044882690505acf83 in zone: us-west-2a, region us-west-2"
time="2025-02-25 14:54:41" level=info msg="Subnet subnet-0aa6de25f8a78bfa7 in zone: us-west-2a, region us-west-2"
time="2025-02-25 14:54:41" level=info msg="Got no public subnet for current zone us-west-2b, going to create one"
time="2025-02-25 14:54:42" level=info msg="Created subnet subnet-0018b2ede8484a135 for vpc vpc-07320be917c3eb042"
time="2025-02-25 14:54:42" level=info msg="Created subnet with ID subnet-0018b2ede8484a135"
time="2025-02-25 14:54:43" level=info msg="Associate route table success rtbassoc-068ca196c8bf91260"
time="2025-02-25 14:54:44" level=info msg="Create route success for route table: rtb-055f03dfb15b5a599"
time="2025-02-25 14:54:44" level=info msg="Tag resource subnet-0018b2ede8484a135 successfully"
time="2025-02-25 14:54:44" level=info msg="Got no proper private subnet for current zone us-west-2b, going to create one"
time="2025-02-25 14:54:45" level=info msg="Created subnet subnet-02f28b429b286d8e9 for vpc vpc-07320be917c3eb042"
time="2025-02-25 14:54:46" level=info msg="Created subnet with ID subnet-02f28b429b286d8e9"
time="2025-02-25 14:54:46" level=info msg="Associate route table success rtbassoc-0f06e51c70613620c"
time="2025-02-25 14:54:46" level=info msg="Found existing nat gateway: nat-09728c26768d1b21d"
time="2025-02-25 14:54:47" level=info msg="Create route success for route table: rtb-06f37ecd12f38611c"
time="2025-02-25 14:54:47" level=info msg="Tag resource subnet-02f28b429b286d8e9 successfully"
time="2025-02-25 14:54:47" level=info msg="Going to prepare proper pair of subnets"
time="2025-02-25 14:54:47" level=info msg="Subnet subnet-044882690505acf83 in zone: us-west-2a, region us-west-2"
time="2025-02-25 14:54:47" level=info msg="Subnet subnet-0aa6de25f8a78bfa7 in zone: us-west-2a, region us-west-2"
time="2025-02-25 14:54:47" level=info msg="Subnet subnet-0018b2ede8484a135 in zone: us-west-2b, region us-west-2"
time="2025-02-25 14:54:47" level=info msg="Subnet subnet-02f28b429b286d8e9 in zone: us-west-2b, region us-west-2"
time="2025-02-25 14:54:47" level=info msg="Got no public subnet for current zone us-west-2c, going to create one"
time="2025-02-25 14:54:48" level=info msg="Created subnet subnet-09860bdb50c4da217 for vpc vpc-07320be917c3eb042"
time="2025-02-25 14:54:49" level=info msg="Created subnet with ID subnet-09860bdb50c4da217"
time="2025-02-25 14:54:49" level=info msg="Associate route table success rtbassoc-013711cf59f0f2e64"
time="2025-02-25 14:54:50" level=info msg="Create route success for route table: rtb-00f042e2df336fb51"
time="2025-02-25 14:54:50" level=info msg="Tag resource subnet-09860bdb50c4da217 successfully"
time="2025-02-25 14:54:50" level=info msg="Got no proper private subnet for current zone us-west-2c, going to create one"
time="2025-02-25 14:54:51" level=info msg="Created subnet subnet-0fa63937aae5e4e5f for vpc vpc-07320be917c3eb042"
time="2025-02-25 14:54:54" level=info msg="Created subnet with ID subnet-0fa63937aae5e4e5f"
time="2025-02-25 14:54:54" level=info msg="Associate route table success rtbassoc-0cec64b7cf26d2a5e"
time="2025-02-25 14:54:54" level=info msg="Found existing nat gateway: nat-09728c26768d1b21d"
time="2025-02-25 14:54:55" level=info msg="Create route success for route table: rtb-02f74456c46320ad3"
time="2025-02-25 14:54:56" level=info msg="Tag resource subnet-0fa63937aae5e4e5f successfully"
time="2025-02-25 14:55:36" level=info msg="Got the image ID : ami-0005ee01bca55ab66"
time="2025-02-25 14:55:37" level=info msg="Create security group sg-0d74ba79eda9820dd success for vpc-07320be917c3eb042"
time="2025-02-25 14:55:38" level=info msg="Tag resource sg-0d74ba79eda9820dd successfully"
time="2025-02-25 14:55:38" level=info msg="Created tagged security group with ID sg-0d74ba79eda9820dd"
time="2025-02-25 14:55:38" level=info msg="Authorize security group success sg-0d74ba79eda9820dd"
time="2025-02-25 14:55:38" level=info msg="Authorize security group success sg-0d74ba79eda9820dd"
time="2025-02-25 14:55:38" level=info msg="Authorize SG sg-0d74ba79eda9820dd prepared successfully for proxy."
time="2025-02-25 14:55:39" level=info msg="Create key pair key-0e88929480a6cb6ac successfully\n"
time="2025-02-25 14:55:39" level=info msg="Tag resource key-0e88929480a6cb6ac successfully"
time="2025-02-25 14:55:40" level=info msg="Waiting for below instances ready: i-0a70c204043c40a9a"
time="2025-02-25 14:55:40" level=info msg="Check instances status of i-0a70c204043c40a9a"
time="2025-02-25 14:55:41" level=info msg="Instance ID i-0a70c204043c40a9a is in status of not-applicable"
time="2025-02-25 14:55:41" level=info msg="Instance ID i-0a70c204043c40a9a is in state of pending"
time="2025-02-25 14:56:41" level=info msg="Check instances status of i-0a70c204043c40a9a"
time="2025-02-25 14:56:41" level=info msg="Instance ID i-0a70c204043c40a9a is in status of initializing"
time="2025-02-25 14:56:41" level=info msg="Instance ID i-0a70c204043c40a9a is in state of running"
time="2025-02-25 14:56:41" level=info msg="All instances running"
time="2025-02-25 14:56:41" level=info msg="Launch proxy instance i-0a70c204043c40a9a succeed"
time="2025-02-25 14:56:41" level=info msg="Tag resource i-0a70c204043c40a9a successfully"
time="2025-02-25 14:56:42" level=info msg="Allocated EIP eipalloc-0e5c86be8e91de991 with ip 52.12.147.72"
time="2025-02-25 14:56:42" level=info msg="Successfully allocated EIP: 52.12.147.72"
time="2025-02-25 14:56:43" level=info msg="Successfully allocated 52.12.147.72 with instance i-0a70c204043c40a9a.\n\tallocation id: eipalloc-0e5c86be8e91de991, association id: eipassoc-0997069e8f4e52b64\n"
time="2025-02-25 14:56:43" level=info msg="Prepare EIP successfully for the proxy preparation. Launch with IP: 52.12.147.72"
time="2025-02-25 14:59:38" level=info msg="Preparing OCM testing kms key"
time="2025-02-25 14:59:43" level=info msg="Preparing OCM testing kms key"
time="2025-02-25 15:05:21" level=info msg="Configuring sts roles to key polilies of arn:aws:kms:us-west-2:301721915996:key/edb62f99-02dd-4fa3-81d7-87a3c198fed3"
time="2025-02-25 15:05:27" level=info msg="Configuring sts roles to key polilies of arn:aws:kms:us-west-2:301721915996:key/1305e646-290b-43ac-922f-3ce59e54edb4"
•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
 
Ran 1 of 259 Specs in 3209.566 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 258 Skipped
PASS
 
Ginkgo ran 1 suite in 53m38.892333708s
Test Suite Passed
Running Suite: ROSA CLI e2e tests suite - /Users/yingzhan/ying-work/code/rosa/tests/e2e
=======================================================================================
Random Seed: 1740467817
 
Will run 1 of 259 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
 
Ran 1 of 259 Specs in 105.222 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 258 Skipped
PASS
 
Ginkgo ran 1 suite in 1m53.82677875s
Test Suite Passed
oc get co -A --kubeconfig=kubeconfig
NAME                                       VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
console                                    4.17.16   True        False         False      4h54m
csi-snapshot-controller                    4.17.16   True        False         False      5h4m
dns                                        4.17.16   True        False         False      4h56m
image-registry                             4.17.16   True        False         False      4h55m
ingress                                    4.17.16   True        False         False      4h55m
insights                                   4.17.16   True        False         False      4h56m
kube-apiserver                             4.17.16   True        False         False      5h4m
kube-controller-manager                    4.17.16   True        False         False      5h4m
kube-scheduler                             4.17.16   True        False         False      5h4m
kube-storage-version-migrator              4.17.16   True        False         False      4h45m
monitoring                                 4.17.16   True        False         False      4h50m
network                                    4.17.16   True        False         False      5h3m
node-tuning                                4.17.16   True        False         False      4h40m
openshift-apiserver                        4.17.16   True        False         False      5h4m
openshift-controller-manager               4.17.16   True        False         False      5h4m
openshift-samples                          4.17.16   True        False         False      4h56m
operator-lifecycle-manager                 4.17.16   True        False         False      5h4m
operator-lifecycle-manager-catalog         4.17.16   True        False         False      5h4m
operator-lifecycle-manager-packageserver   4.17.16   True        False         False      5h4m
service-ca                                 4.17.16   True        False         False      4h56m
storage                                    4.17.16   True        False         False      4h57m
```