### PR TITLE
OCM-14274 | test: fix ids: 79846,46310,67348,42832

### DIFF
--- a/pkg/machinepool/machinepool.go
+++ b/pkg/machinepool/machinepool.go
@@ -556,9 +556,6 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 
 		// Filter the available list of versions for a hosted machine pool
 		filteredVersionList := versions.GetFilteredVersionList(versionList, minVersion, clusterVersion)
-		if err != nil {
-			return err
-		}
 
 		if version == "" {
 			version = clusterVersion

--- a/tests/ci/data/profiles/rosa-classic.yaml
+++ b/tests/ci/data/profiles/rosa-classic.yaml
@@ -1,6 +1,6 @@
 profiles:
 - as: rosa-advanced
-  version: "4.15"
+  version: latest
   channel_group: "candidate"
   region: "us-west-2"
   cluster:
@@ -35,7 +35,7 @@ profiles:
     path: "/test/"
     permission_boundary: "arn:aws:iam::aws:policy/AdministratorAccess"
 - as: rosa-private-link
-  version: "4.15"
+  version: latest
   channel_group: "candidate"
   region: "us-east-1"
   cluster:

--- a/tests/e2e/test_rosacli_cluster.go
+++ b/tests/e2e/test_rosacli_cluster.go
@@ -630,6 +630,11 @@ var _ = Describe("Edit cluster validation should", labels.Feature.Cluster, func(
 			By("Load the profile")
 			profile := handler.LoadProfileYamlFileByENV()
 
+			By("Skip if the cluster is no proxy setting")
+			if !profile.ClusterConfig.ProxyEnabled {
+				Skip("This feature only work for the cluster with proxy setting")
+			}
+
 			By("Edit cluster with invalid http_proxy set")
 			if !profile.ClusterConfig.BYOVPC {
 				output, err := clusterService.EditCluster(clusterID,


### PR DESCRIPTION
79846: fix some mistake of for block which leads failure
46310: Skip if the cluster is without proxy setting
67348: Fix the error message when edit autoscaler with unsupported flags on hosted-cp cluster
42832: Fix the failure by updating the cluster version in profile

local logs: https://privatebin.corp.redhat.com/?20ae6f10c37973c3#ZeQfeh5p5QKNaQ4oRsPwx4uhzoHCUhH8X6qeUkiUZfc