### PR TITLE
OCM-14323 | test: fix ids: 75445,64620

### DIFF
--- a/tests/e2e/test_rosacli_upgrade.go
+++ b/tests/e2e/test_rosacli_upgrade.go
@@ -499,7 +499,6 @@ var _ = Describe("Cluster Upgrade testing",
 					}
 				}
 			})
-
 		It("to upgrade wide AMI roles with the managed policies in manual mode - [id:75445]",
 			labels.Critical, labels.Runtime.Upgrade, func() {
 				By("Check the cluster version and compare with the profile to decide if skip this case")
@@ -542,7 +541,7 @@ var _ = Describe("Cluster Upgrade testing",
 						"policies. An upgrade isn't needed", resourcesHandler.GetOperatorRolesPrefix()))
 				} else {
 					By("Find STS Classic cluster upgrade version")
-					classicUpgradingVersion, upgradingMajorVersion, err := clusterVersionList.FindUpperYStreamVersion(
+					classicUpgradingVersion, _, err := clusterVersionList.FindUpperYStreamVersion(
 						profile.ChannelGroup, clusterVersion)
 					Expect(err).To(BeNil())
 					if classicUpgradingVersion == "" {
@@ -601,6 +600,8 @@ var _ = Describe("Cluster Upgrade testing",
 					Expect(err).To(BeNil())
 
 					By("Check account role version")
+					expectedPolicyVersion, err := clusterVersionList.FindDefaultUpdatedPolicyVersion()
+					Expect(err).To(BeNil())
 					for _, accArn := range accRoles {
 						fmt.Println("accArn: ", accArn)
 						parse, err := arn.Parse(accArn)
@@ -611,7 +612,7 @@ var _ = Describe("Cluster Upgrade testing",
 						Expect(err).To(BeNil())
 						for _, tag := range accRole.Tags {
 							if *tag.Key == versionTagName {
-								Expect(*tag.Value).To(Equal(upgradingMajorVersion))
+								Expect(*tag.Value).To(Equal(expectedPolicyVersion))
 							}
 						}
 					}
@@ -629,7 +630,7 @@ var _ = Describe("Cluster Upgrade testing",
 						Expect(err).To(BeNil())
 						for _, tag := range policy.Tags {
 							if *tag.Key == versionTagName {
-								Expect(*tag.Value).To(Equal(upgradingMajorVersion))
+								Expect(*tag.Value).To(Equal(expectedPolicyVersion))
 							}
 						}
 					}

--- a/tests/utils/exec/rosacli/version_service.go
+++ b/tests/utils/exec/rosacli/version_service.go
@@ -469,3 +469,15 @@ func (vl *OpenShiftVersionTableList) FindUpperYStreamVersion(channelGroup string
 		return upgradingVersion, upgradingMajorVersion, nil
 	}
 }
+
+// This function will find the expected version of IAM roles after manual upgrade
+// The version actually is the mayjor version of the latest cluster version
+func (vl *OpenShiftVersionTableList) FindDefaultUpdatedPolicyVersion() (string, error) {
+	sortedVersionList, err := vl.Sort(true)
+	if err != nil {
+		return "", err
+	}
+	latestVersionFromOutput := sortedVersionList.OpenShiftVersions[0].Version
+	latestMajorVersion := helper.SplitMajorVersion(latestVersionFromOutput)
+	return latestMajorVersion, nil
+}


### PR DESCRIPTION
- 64620: The extracted url is empty. It cannot be reproduced on local. Add '--output json' on the command and enrich the info message when the output is not expected
- 75445: failed as the expected policy version is the latest version of candidate channel group , need a small fix on automation code

logs:https://privatebin.corp.redhat.com/?d9f73496e4e876d6#Hrd61KbaUx3U74fUxzgwPfqt1EBv18qnv4BD6mjqEpax