### PR TITLE
OCM-14417 | fix: Bug with upgrading cluster and missing account roles

### DIFF
--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -1428,6 +1428,10 @@ func (c *awsClient) GetAttachedPolicyWithTags(role *string,
 	if err != nil && !awserr.IsNoSuchEntityException(err) {
 		return policies, excludedPolicies, err
 	}
+	if attachedPoliciesOutput == nil || attachedPoliciesOutput.AttachedPolicies == nil {
+		return policies, excludedPolicies, errors.UserErrorf("Unable to get attached policies for cluster (possibly " +
+			"missing account roles, try running 'rosa create account-roles' again)")
+	}
 
 	for _, policy := range attachedPoliciesOutput.AttachedPolicies {
 		hasTags, err := doesPolicyHaveTags(c.iamClient, policy.PolicyArn, tagFilter)


### PR DESCRIPTION
An error occurs when deleting a support role, for example, then trying to upgrade a cluster. The error is a PANIC due to the AWS SDK not returning an error, and instead returning empty role lists + a nil role output. 

Checking for nil after the error check fixes the PANIC