### PR TITLE
OCM-14441 | test: fix ids: 75256,72195

### DIFF
--- a/tests/ci/data/profiles/rosa-hcp.yaml
+++ b/tests/ci/data/profiles/rosa-hcp.yaml
@@ -176,7 +176,7 @@ profiles:
     autoscale: true
     kms_key: true
     networking: true
-    proxy_enabled: true
+    proxy_enabled: false
     label_enabled: false
     zones: ""
     tag_enabled: true

--- a/tests/e2e/hcp_machine_pool_test.go
+++ b/tests/e2e/hcp_machine_pool_test.go
@@ -77,6 +77,11 @@ var _ = Describe("HCP Machine Pool", labels.Feature.Machinepool, func() {
 			sgPrefix := helper.GenerateRandomName("72195", 2)
 			sgIDs, err := vpcClient.CreateAdditionalSecurityGroups(3, sgPrefix, "testing for case 72195")
 			Expect(err).ToNot(HaveOccurred())
+			defer func(sgs []string) {
+				for _, sg := range sgs {
+					vpcClient.AWSClient.DeleteSecurityGroup(sg)
+				}
+			}(sgIDs)
 
 			By("Create machinepool with security groups set")
 			mpName := "mp-72195"

--- a/tests/e2e/test_rosacli_cluster_post.go
+++ b/tests/e2e/test_rosacli_cluster_post.go
@@ -751,11 +751,7 @@ var _ = Describe("Post-Check testing for cluster deletion",
 			func() {
 				clusterID = config.GetClusterID()
 				By("Skip if the cluster is non-sts")
-				isHostedCP, err := clusterService.IsHostedCPCluster(clusterID)
-				Expect(err).To(BeNil())
-				IsSTS, err := clusterService.IsSTSCluster(clusterID)
-				Expect(err).To(BeNil())
-				if !(isHostedCP || IsSTS) {
+				if !profile.ClusterConfig.STS {
 					Skip("Skip this case as it doesn't supports on not-sts clusters")
 				}
 				By("Check the operator-roles is deleted")


### PR DESCRIPTION
- 75256: In the post step, the cluster has deleted. Update to use cluster config for skip step
- 72195: Add defer step to delete the security group creared in this case to avoid resource leak
- Disable proxy setting on rosa-hcp-shared-vpc-advanced profile to avoid destroy step failed. the destyor step of periodic-ci-openshift-rosa-master-e2e-rosa-hcp-shared-vpc-critical-high-f3 will be with one error as the sg of the proxy is created with aws account1 while the DeleteVPCChain uses the aws account2, no permission to delete the sg of the proxy. A new CI feature will be added later, try to support full cycle of the proxy and sg on shared-vpc cluster

logs:https://privatebin.corp.redhat.com/?608fb26e529b6b38#4ZjFbGR8H87VnZVRvtUz3dj9nScYPRg6TndNnFKeh9wA