### PR TITLE
OCM-14545 | ci: Support security group and proxy settings for hosted-cp shared vpc profile

### DIFF
--- a/tests/ci/data/profiles/rosa-hcp.yaml
+++ b/tests/ci/data/profiles/rosa-hcp.yaml
@@ -176,7 +176,7 @@ profiles:
     autoscale: true
     kms_key: true
     networking: true
-    proxy_enabled: false
+    proxy_enabled: true
     label_enabled: false
     zones: ""
     tag_enabled: true
@@ -188,7 +188,7 @@ profiles:
     volume_size: 75
     disable_uwm: true
     autoscaler_enabled: false
-    additional_sg_number: 0
+    additional_sg_number: 3
     registries_config: true
     blocked_registries: true
   account-role:

--- a/tests/utils/handler/interface.go
+++ b/tests/utils/handler/interface.go
@@ -84,6 +84,7 @@ type Resources struct {
 	VpcID                        string                `json:"vpc_id,omitempty"`
 	HCPRoute53ShareRole          string                `json:"hcp_route53_share_role,omitempty"`
 	HCPVPCEndpointShareRole      string                `json:"hcp_vpc_endpoint_share_role,omitempty"`
+	ProxyInstanceID              string                `json:"proxy_instance_id,omitempty"`
 }
 
 type FromSharedAWSAccount struct {
@@ -108,4 +109,5 @@ type ProxyDetail struct {
 	HTTPProxy        string
 	CABundleFilePath string
 	NoProxy          string
+	InstanceID       string
 }

--- a/tests/utils/handler/resources_handler.go
+++ b/tests/utils/handler/resources_handler.go
@@ -208,6 +208,17 @@ func (rh *resourcesHandler) DestroyResources() (errors []error) {
 			rh.registerDNSDomain("")
 		}
 	}
+	// Delete proxy resourses
+	if resources.ProxyInstanceID != "" {
+		err = rh.CleanupProxyResources(
+			resources.ProxyInstanceID,
+			resources.FromSharedAWSAccount != nil && resources.FromSharedAWSAccount.VPC,
+		)
+		success := destroyLog(err, "proxy resources")
+		if success {
+			rh.registerProxyInstanceID("")
+		}
+	}
 	// delete resource share
 	if resources.ResourceShareArn != "" {
 		log.Logger.Infof("Find prepared resource share: %s", resources.ResourceShareArn)
@@ -450,6 +461,11 @@ func (rh *resourcesHandler) registerVpcID(vpcID string, fromSharedAccount bool) 
 
 func (rh *resourcesHandler) registerVPC(vpc *vpc_client.VPC) error {
 	rh.vpc = vpc
+	return rh.saveToFile()
+}
+
+func (rh *resourcesHandler) registerProxyInstanceID(proxyInsID string) error {
+	rh.resources.ProxyInstanceID = proxyInsID
 	return rh.saveToFile()
 }
 


### PR DESCRIPTION
- Add proxy cleanup step for all jobs to support the proxy on hosted-cp vpc cluster. It met error when clean up VPC as some proxy resources are not cleaned before this change
- Support security group settings on hosted-cp shared-vpc profile by adding the sg into the shared resources
- enable proxy and security group settings on 'rosa-hcp-shared-vpc-advanced' profile

Below testing on local are passed:
- day1 and destroy with 'rosa-hcp-shared-vpc-advanced' profile which proxy and sg setting are enabled
- day1 and destroy with 'rosa-advance' profile which proxy and sg setting are enabled