### PR TITLE
OCM-13390 | feat: Proper validation + test; HCPSVPC on fedramp

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -17,7 +17,6 @@ limitations under the License.
 package accountroles
 
 import (
-	"github.com/openshift/rosa/pkg/fedramp"
 	"os"
 	"strings"
 
@@ -27,6 +26,7 @@ import (
 	"github.com/openshift/rosa/cmd/verify/oc"
 	"github.com/openshift/rosa/cmd/verify/quota"
 	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/fedramp"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/ocm"

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2419,7 +2419,7 @@ func run(cmd *cobra.Command, _ []string) {
 		if isHostedCP {
 			isHcpSharedVpc = true
 			err = validateHcpSharedVpcArgs(route53RoleArn, vpcEndpointRoleArn, ingressPrivateHostedZoneId,
-				hcpInternalCommunicationHostedZoneId)
+				hcpInternalCommunicationHostedZoneId, fedramp.Enabled())
 			if err != nil {
 				r.Reporter.Errorf("Error when validating flags: %v", err)
 				os.Exit(1)

--- a/cmd/create/cluster/validation.go
+++ b/cmd/create/cluster/validation.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 )
@@ -13,10 +14,31 @@ const (
 	hcpSharedVpcFlagNotFilledErrorMsg = "must supply '%s' flag when creating a Hosted Control Plane shared VPC cluster"
 
 	isNotValidArnErrorMsg = "ARN supplied with flag '%s' is not a valid ARN format"
+
+	isNotGovcloudFeature = "Hosted Control Plane shared VPC clusters are not supported on Govcloud regions; %s"
+	pleaseRemoveFlags    = "Please remove the following flags: %s"
 )
 
 func validateHcpSharedVpcArgs(route53RoleArn string, vpcEndpointRoleArn string,
-	ingressPrivateHostedZoneId string, hcpInternalCommunicationHostedZoneId string) error {
+	ingressPrivateHostedZoneId string, hcpInternalCommunicationHostedZoneId string, fedrampEnabled bool) error {
+
+	if fedrampEnabled {
+		stringsUsed := []string{}
+		for key, val := range map[string]string{
+			route53RoleArnFlag:                       route53RoleArn,
+			vpcEndpointRoleArnFlag:                   vpcEndpointRoleArn,
+			ingressPrivateHostedZoneIdFlag:           ingressPrivateHostedZoneId,
+			hcpInternalCommunicationHostedZoneIdFlag: hcpInternalCommunicationHostedZoneId,
+		} {
+			if val != "" {
+				stringsUsed = append(stringsUsed, key)
+			}
+		}
+		if len(stringsUsed) > 0 {
+			flags := "'" + strings.Join(stringsUsed, "', '") + "'"
+			return fmt.Errorf(isNotGovcloudFeature, fmt.Sprintf(pleaseRemoveFlags, flags))
+		}
+	}
 
 	if route53RoleArn == "" {
 		return fmt.Errorf(hcpSharedVpcFlagNotFilledErrorMsg, route53RoleArnFlag)

--- a/cmd/create/cluster/validation_test.go
+++ b/cmd/create/cluster/validation_test.go
@@ -15,42 +15,55 @@ var _ = Describe("Test validation functions", func() {
 	Context("Validation of HCP shared VPC", func() {
 		When("isHostedCp", func() {
 			It("OK: Passes validation (all flags filled out and correct format", func() {
-				err := validateHcpSharedVpcArgs(validTestArn, validTestArn, "123", "123")
+				err := validateHcpSharedVpcArgs(validTestArn, validTestArn, "123", "123", false)
 				Expect(err).ToNot(HaveOccurred())
 			})
 			It("KO: Invalid Route53 ARN", func() {
-				err := validateHcpSharedVpcArgs(invalidTestArn, validTestArn, "123", "123")
+				err := validateHcpSharedVpcArgs(invalidTestArn, validTestArn, "123", "123", false)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(isNotValidArnErrorMsg, route53RoleArnFlag)))
 			})
 			It("KO: invalid VPC Endpoint ARN", func() {
-				err := validateHcpSharedVpcArgs(validTestArn, invalidTestArn, "123", "123")
+				err := validateHcpSharedVpcArgs(validTestArn, invalidTestArn, "123", "123", false)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(isNotValidArnErrorMsg, vpcEndpointRoleArnFlag)))
 			})
 			It("KO: Route53 ARN flag not populated", func() {
-				err := validateHcpSharedVpcArgs("", validTestArn, "123", "123")
+				err := validateHcpSharedVpcArgs("", validTestArn, "123", "123", false)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(hcpSharedVpcFlagNotFilledErrorMsg,
 					route53RoleArnFlag)))
 			})
 			It("KO: VPC Endpoint ARN flag not populated", func() {
-				err := validateHcpSharedVpcArgs(validTestArn, "", "123", "123")
+				err := validateHcpSharedVpcArgs(validTestArn, "", "123", "123", false)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(hcpSharedVpcFlagNotFilledErrorMsg,
 					vpcEndpointRoleArnFlag)))
 			})
 			It("KO: Ingress Private Hosted Zone ID flag not populated", func() {
-				err := validateHcpSharedVpcArgs(validTestArn, validTestArn, "", "123")
+				err := validateHcpSharedVpcArgs(validTestArn, validTestArn, "", "123", false)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(hcpSharedVpcFlagNotFilledErrorMsg,
 					ingressPrivateHostedZoneIdFlag)))
 			})
 			It("KO: HCP Internal Communication Hosted Zone ID flag not populated", func() {
-				err := validateHcpSharedVpcArgs(validTestArn, validTestArn, "123", "")
+				err := validateHcpSharedVpcArgs(validTestArn, validTestArn, "123", "", false)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(hcpSharedVpcFlagNotFilledErrorMsg,
 					hcpInternalCommunicationHostedZoneIdFlag)))
+			})
+			It("KO: HCP Shared VPC cluster fails to validate on govcloud/fedramp", func() {
+				err := validateHcpSharedVpcArgs(validTestArn, validTestArn, "123", "123", true)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(isNotGovcloudFeature,
+					fmt.Sprintf(pleaseRemoveFlags, ""),
+				),
+				))
+				// Must be `ContainSubstring` because for some reason `strings.Join()` puts strings in a random order
+				Expect(err.Error()).To(ContainSubstring("'" + route53RoleArnFlag + "'"))
+				Expect(err.Error()).To(ContainSubstring("'" + vpcEndpointRoleArnFlag + "'"))
+				Expect(err.Error()).To(ContainSubstring("'" + ingressPrivateHostedZoneIdFlag + "'"))
+				Expect(err.Error()).To(ContainSubstring("'" + hcpInternalCommunicationHostedZoneIdFlag + "'"))
 			})
 		})
 	})


### PR DESCRIPTION
Introduces proper validation of HCP Shared VPC on fedramp env, as well as tells the user which flags they should remove to stop getting the validation error

Introduces test as well for this validation