### PR TITLE
OCM-14608 | test: fix id: 36293 improvement for the testing machine pool ids

### DIFF
--- a/tests/e2e/test_rosacli_machine_pool.go
+++ b/tests/e2e/test_rosacli_machine_pool.go
@@ -88,10 +88,11 @@ var _ = Describe("Create machinepool",
 				By("List the default machinepool of the cluster")
 				resp, err := machinePoolService.ListAndReflectMachinePools(clusterID)
 				Expect(err).ToNot(HaveOccurred())
-
+				mpID := helper.GenerateRandomName("mp-36293", 2)
+				mpIDcounter := 1
 				for key, flags := range reqFlags {
 					By("Create machinepools to the cluster")
-					mpID := helper.GenerateRandomName("mp-36293", 2)
+					mpID := fmt.Sprintf("%s-%d", mpID, mpIDcounter)
 					output, err := machinePoolService.CreateMachinePool(clusterID, mpID, flags...)
 					Expect(err).ToNot(HaveOccurred())
 					textData := rosaClient.Parser.TextData.Input(output).Parse().Tip()
@@ -130,6 +131,7 @@ var _ = Describe("Create machinepool",
 						Expect(out.Machinepool(mpID).Labels).To(
 							Equal(strings.Join(helper.ParseCommaSeparatedStrings(labels_2), ", ")))
 					}
+					mpIDcounter++
 				}
 			})
 


### PR DESCRIPTION
Recently in the periodic job, 36293 met two times failure as duplicated testing machine pool name generated by `helper.GenerateRandomName("mp-36293", 2)`.
To improve, we will generator the based machine pool id one time for the for loop, and add a suffix of counter to make sure the duplicated machine pool id issue doesn't happen.
The failed jobs are

- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-rosa-master-e2e-rosa-sts-advanced-critical-high-f3/1896554720881807360
- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-rosa-master-e2e-rosa-sts-advanced-prod-critical-high-f3/1898171155454365696

Logs on local is https://privatebin.corp.redhat.com/?8f934c472ce7fdd2#82vmg11szkGjuKRPoK3zkNeyL5aUb4KKRo2HyRp9DGLg