### PR TITLE
OCM-14643 | test: fix ids: 71174,72538

### DIFF
--- a/tests/e2e/test_rosacli_cluster.go
+++ b/tests/e2e/test_rosacli_cluster.go
@@ -2517,7 +2517,7 @@ var _ = Describe("HCP cluster creation negative testing",
 			labels.Low, labels.Runtime.Day1Negative,
 			func() {
 				By("Create hcp cluster using non-default ingress settings")
-				clusterName := helper.GenerateRandomName("cluster-71174", 2)
+				clusterName := helper.GenerateRandomName("c71174", 2)
 				replacingFlags := map[string]string{
 					"-c":              clusterName,
 					"--cluster-name":  clusterName,
@@ -2561,7 +2561,7 @@ var _ = Describe("HCP cluster creation negative testing",
 				resourcesHandler := clusterHandler.GetResourcesHandler()
 				vpc, err := resourcesHandler.PrepareVPC(vpcName, "", false, false)
 				Expect(err).ToNot(HaveOccurred())
-				defer vpc.DeleteVPCChain()
+				// defer vpc.DeleteVPCChain()
 
 				subnetMap, err := resourcesHandler.PrepareSubnets([]string{}, true)
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
- 71174 : "shared VPC is only supported for cluster which has a name no longer than 15 characters or with a cluster domain prefix", update the cluster name for testing
- 72538 : in AfterEach, it failed to delete the VPC which has aleady cleaned by defer block in the case

The job which above failed cases is https://redhat-internal.slack.com/archives/C0519LZH1RA/p1741879180718189

logs on local:
https://privatebin.corp.redhat.com/?eabfaa95a27130c8#FwfQ9WEW13JsTgbn8McWUjZxpfRdX9bXkZ5jqdVmJg7M