### PR TITLE
OCM-13150 | ci: Enabled rosa-hcp-zero-egress profile for OCPE2E

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/nathan-fiscaletti/consolesize-go v0.0.0-20210105204122-a87d9f614b9d
 	github.com/onsi/ginkgo/v2 v2.17.1
 	github.com/onsi/gomega v1.30.0
-	github.com/openshift-online/ocm-common v0.0.16
+	github.com/openshift-online/ocm-common v0.0.21
 	github.com/openshift-online/ocm-sdk-go v0.1.459
 	github.com/pkg/errors v0.9.1
 	github.com/robfig/cron/v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -268,8 +268,8 @@ github.com/onsi/ginkgo/v2 v2.17.1 h1:V++EzdbhI4ZV4ev0UTIj0PzhzOcReJFyJaLjtSF55M8
 github.com/onsi/ginkgo/v2 v2.17.1/go.mod h1:llBI3WDLL9Z6taip6f33H76YcWtJv+7R3HigUjbIBOs=
 github.com/onsi/gomega v1.30.0 h1:hvMK7xYz4D3HapigLTeGdId/NcfQx1VHMJc60ew99+8=
 github.com/onsi/gomega v1.30.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
-github.com/openshift-online/ocm-common v0.0.16 h1:6R3g98VHK3v6imYZHD8XBieQUVFEBY3fPSv94fB/Zf4=
-github.com/openshift-online/ocm-common v0.0.16/go.mod h1:VEkuZp9aqbXtetZ5ycND6QpvhykvTuBF3oPsVM1X3vI=
+github.com/openshift-online/ocm-common v0.0.21 h1:rfp6cPPgVPk/Sm7xAsNFQHaK9Ng1bEOaGjPx0lI1hOA=
+github.com/openshift-online/ocm-common v0.0.21/go.mod h1:VEkuZp9aqbXtetZ5ycND6QpvhykvTuBF3oPsVM1X3vI=
 github.com/openshift-online/ocm-sdk-go v0.1.459 h1:n56ErJL8S2RPfpX6HGp2CmVyJ7k0GC4xnVYdO8Ky8XI=
 github.com/openshift-online/ocm-sdk-go v0.1.459/go.mod h1:CiAu2jwl3ITKOxkeV0Qnhzv4gs35AmpIzVABQLtcI2Y=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/tests/ci/data/profiles/external.yaml
+++ b/tests/ci/data/profiles/external.yaml
@@ -64,3 +64,37 @@ profiles:
   account-role:
     path: ""
     permission_boundary: ""
+- as: ocpe2e-rosa-hcp-zero-egress
+  version: latest
+  channel_group: stable
+  region: "us-west-2"
+  cluster:
+    multi_az: true
+    shared_vpc: false
+    instance_type: "m5.xlarge"
+    hcp: true
+    sts: true
+    byo_vpc: true
+    additional_principals: false
+    imdsv2: "required"
+    private: true
+    etcd_encryption: true
+    autoscale: true
+    kms_key: true
+    networking: true
+    proxy_enabled: true
+    label_enabled: false
+    zones: ""
+    tag_enabled: true
+    etcd_kms: true
+    fips: false
+    oidc_config: "managed"
+    admin_enabled: false
+    volume_size: 75
+    disable_uwm: true
+    additional_sg_number: 3
+    zero_egress: true
+  account-role:
+    customized_prefix: true
+    path: ""
+    permission_boundary: ""

--- a/tests/ci/data/profiles/rosa-hcp.yaml
+++ b/tests/ci/data/profiles/rosa-hcp.yaml
@@ -195,37 +195,3 @@ profiles:
     customized_prefix: true
     path: ""
     permission_boundary: ""
-- as: rosa-hcp-zero-egress
-  version: latest
-  channel_group: stable
-  region: "us-west-2"
-  cluster:
-    multi_az: true
-    shared_vpc: false
-    instance_type: "m5.xlarge"
-    hcp: true
-    sts: true
-    byo_vpc: true
-    additional_principals: false
-    imdsv2: "required"
-    private: true
-    etcd_encryption: true
-    autoscale: true
-    kms_key: true
-    networking: true
-    proxy_enabled: true
-    label_enabled: false
-    zones: ""
-    tag_enabled: true
-    etcd_kms: true
-    fips: false
-    oidc_config: "managed"
-    admin_enabled: false
-    volume_size: 75
-    disable_uwm: true
-    additional_sg_number: 3
-    zero_egress: false
-  account-role:
-    customized_prefix: true
-    path: ""
-    permission_boundary: ""

--- a/tests/utils/config/cluster.go
+++ b/tests/utils/config/cluster.go
@@ -22,6 +22,7 @@ type Encryption struct {
 
 type Properties struct {
 	ProvisionShardID string `json:"provision_shard_id,omitempty"`
+	ZeroEgress       bool   `json:"zero_egress,omitempty"`
 }
 
 type Sts struct {

--- a/tests/utils/handler/cluster_handler.go
+++ b/tests/utils/handler/cluster_handler.go
@@ -840,6 +840,18 @@ func (ch *clusterHandler) GenerateClusterCreateFlags() ([]string, error) {
 			)
 		}
 	}
+
+	if ch.profile.ClusterConfig.ZeroEgress {
+		err := resourcesHandler.PrepareZeroEgressResources()
+		if err != nil {
+			return flags, err
+		}
+		flags = append(flags, "--properties", fmt.Sprintf("zero_egress:%v", ch.profile.ClusterConfig.ZeroEgress))
+		ch.clusterConfig.Properties = &ClusterConfigure.Properties{
+			ZeroEgress: ch.profile.ClusterConfig.ZeroEgress,
+		}
+
+	}
 	return flags, nil
 }
 

--- a/tests/utils/handler/interface.go
+++ b/tests/utils/handler/interface.go
@@ -70,6 +70,7 @@ type ClusterConfig struct {
 	BlockedRegistries             bool   `yaml:"blocked_registries" json:"blocked_registries,omitempty"`
 	ManualCreationMode            bool   `yaml:"manual_creation_mode" json:"manual_creation_mode,omitempty"`
 	FedRAMP                       bool   `yaml:"fedramp" json:"fedramp,omitempty"`
+	ZeroEgress                    bool   `yaml:"zero_egress" json:"zero_egress,omitempty"`
 }
 
 // Resources will record the resources prepared

--- a/tests/utils/handler/profile.go
+++ b/tests/utils/handler/profile.go
@@ -109,11 +109,11 @@ func LoadProfileYamlFileByENV() *Profile {
 	if config.Test.GlobalENV.Version != "" || config.Test.GlobalENV.OpenshiftVersion != "" {
 		if config.Test.GlobalENV.Version != "" {
 			log.Logger.Infof("Got global env settings for VERSION, overwritten the profile setting with value %s",
-				config.Test.GlobalENV.OpenshiftVersion)
+				config.Test.GlobalENV.Version)
 			profile.Version = config.Test.GlobalENV.Version
 		} else {
 			log.Logger.Infof("Got global env settings for OPENSHIFT_VERSION, overwritten the profile setting with value %s",
-				config.Test.GlobalENV.Version)
+				config.Test.GlobalENV.OpenshiftVersion)
 			profile.Version = config.Test.GlobalENV.OpenshiftVersion
 		}
 	}

--- a/vendor/github.com/openshift-online/ocm-common/pkg/aws/aws_client/instance.go
+++ b/vendor/github.com/openshift-online/ocm-common/pkg/aws/aws_client/instance.go
@@ -37,6 +37,8 @@ func (client *AWSClient) LaunchInstance(subnetID string, imageID string, count i
 			instanceIDs = append(instanceIDs, *instance.InstanceId)
 		}
 		log.LogInfo("Waiting for below instances ready: %s", strings.Join(instanceIDs, "，"))
+		// Wait 2 seconds for the asynchronous bastion instance to be created
+		time.Sleep(2 * time.Second)
 		_, err = client.WaitForInstancesRunning(instanceIDs, 10)
 		if err != nil {
 			log.LogError("Error happened for instance running: %s", err)
@@ -83,6 +85,7 @@ func (client *AWSClient) WaitForInstanceReady(instanceID string, timeout time.Du
 		instanceID,
 	}
 	log.LogInfo("Waiting for below instances ready: %s ", strings.Join(instanceIDs, "|"))
+	time.Sleep(2 * time.Second)
 	_, err := client.WaitForInstancesRunning(instanceIDs, 10)
 	return err
 }

--- a/vendor/github.com/openshift-online/ocm-common/pkg/aws/aws_client/ram.go
+++ b/vendor/github.com/openshift-online/ocm-common/pkg/aws/aws_client/ram.go
@@ -2,8 +2,11 @@ package aws_client
 
 import (
 	"context"
+	"fmt"
 	"github.com/aws/aws-sdk-go-v2/service/ram"
+	"github.com/aws/aws-sdk-go-v2/service/ram/types"
 	"github.com/openshift-online/ocm-common/pkg/log"
+	"time"
 )
 
 func (awsClient AWSClient) CreateResourceShare(resourceShareName string, resourceArns []string, principles []string) (*ram.CreateResourceShareOutput, error) {
@@ -18,6 +21,22 @@ func (awsClient AWSClient) CreateResourceShare(resourceShareName string, resourc
 		log.LogError("Create resource share failed with name %s: %s", resourceShareName, err.Error())
 	} else {
 		log.LogInfo("Create resource share succeed with name %s", resourceShareName)
+	}
+	return resp, err
+}
+
+func (awsClient AWSClient) GetResourceShareAssociations(resourceShareArn string,
+	associationType types.ResourceShareAssociationType) (*ram.GetResourceShareAssociationsOutput, error) {
+	input := &ram.GetResourceShareAssociationsInput{
+		ResourceShareArns: []string{resourceShareArn},
+		AssociationType:   associationType,
+	}
+
+	resp, err := awsClient.RamClient.GetResourceShareAssociations(context.TODO(), input)
+	if err != nil {
+		log.LogError("Get resource share association failed with name %s: %s", resourceShareArn, err.Error())
+	} else {
+		log.LogInfo("Get resource share association succeed with name %s", resourceShareArn)
 	}
 	return resp, err
 }
@@ -42,4 +61,35 @@ func (awsClient AWSClient) PrepareResourceShare(resourceShareName string, resour
 	resourceShareArn := *sharedResourceOutput.ResourceShare.ResourceShareArn
 
 	return resourceShareArn, err
+}
+
+func (awsClient AWSClient) CheckSubnetResourceShareAssociationsStatus(resourceShareArn string,
+	subnetArns []string, timeout time.Duration) error {
+	endTime := time.Now().Add(timeout)
+
+	for time.Now().Before(endTime) {
+		result, err := awsClient.GetResourceShareAssociations(resourceShareArn, types.ResourceShareAssociationTypeResource)
+		if err != nil {
+			return err
+		}
+
+		activeCount := 0
+		for _, association := range result.ResourceShareAssociations {
+			for _, subnetArn := range subnetArns {
+				if *association.AssociatedEntity == subnetArn && association.Status == "ASSOCIATED" {
+					activeCount++
+					break
+				}
+			}
+		}
+
+		if activeCount == len(subnetArns) {
+			log.LogInfo("All subnets are associated.")
+			return nil
+		}
+
+		time.Sleep(10 * time.Second)
+	}
+
+	return fmt.Errorf("Subnets resource shares did not become associated within %v", timeout)
 }

--- a/vendor/github.com/openshift-online/ocm-common/pkg/aws/aws_client/role.go
+++ b/vendor/github.com/openshift-online/ocm-common/pkg/aws/aws_client/role.go
@@ -463,6 +463,33 @@ func (client *AWSClient) CreatePolicyForSharedVPC(policyName string) (string, er
 	return client.CreatePolicy(policyName, statement)
 }
 
+func (client *AWSClient) CreatePolicyForSharedVPCEndpoint(policyName string) (string, error) {
+	statement := map[string]interface{}{
+		"Sid":    "Statement1",
+		"Effect": "Allow",
+		"Action": []string{
+			"ec2:CreateVpcEndpoint",
+			"ec2:DescribeVpcEndpoints",
+			"ec2:ModifyVpcEndpoint",
+			"ec2:DeleteVpcEndpoints",
+			"ec2:CreateTags",
+			"ec2:CreateSecurityGroup",
+			"ec2:AuthorizeSecurityGroupIngress",
+			"ec2:AuthorizeSecurityGroupEgress",
+			"ec2:DeleteSecurityGroup",
+			"ec2:RevokeSecurityGroupIngress",
+			"ec2:RevokeSecurityGroupEgress",
+			"ec2:DescribeSecurityGroups",
+			"ec2:DescribeVpcs",
+			"route53:ListHostedZones",
+			"route53:ChangeResourceRecordSets",
+			"route53:ListResourceRecordSets",
+		},
+		"Resource": "*",
+	}
+	return client.CreatePolicy(policyName, statement)
+}
+
 func (client *AWSClient) CreateRoleForAdditionalPrincipals(roleName string, installerRoleArn string) (types.Role, error) {
 	statement := map[string]interface{}{
 		"Sid":    "Statement1",
@@ -495,13 +522,14 @@ func (client *AWSClient) UpdateAssumeRolePolicy(roleName string, assumeRolePolic
 	return nil
 }
 
-func (client *AWSClient) UpdateAssumeRolePolicyForSharedVPCRole(roleName string, installerRoleArn string,
-	ingressOperatorRoleArn string) error {
+func (client *AWSClient) UpdateAssumeRolePolicyForSharedVPCRole(roleName string, roleArns ...string) error {
+	roleArnsList := []string{}
+	roleArnsList = append(roleArnsList, roleArns...)
 	statement := map[string]interface{}{
 		"Sid":    "Statement1",
 		"Effect": "Allow",
 		"Principal": map[string]interface{}{
-			"AWS": []string{installerRoleArn, ingressOperatorRoleArn},
+			"AWS": roleArnsList,
 		},
 		"Action": "sts:AssumeRole",
 	}

--- a/vendor/github.com/openshift-online/ocm-common/pkg/aws/aws_client/route_table.go
+++ b/vendor/github.com/openshift-online/ocm-common/pkg/aws/aws_client/route_table.go
@@ -180,7 +180,7 @@ func (client *AWSClient) DeleteRouteTable(routeTableID string) error {
 	if err != nil {
 		return err
 	}
-	err = client.WaitForResourceDeleted(routeTableID, 5)
+	err = client.WaitForResourceDeleted(routeTableID, 10)
 	return err
 }
 func (client *AWSClient) DeleteRouteTableChain(routeTableID string) error {

--- a/vendor/github.com/openshift-online/ocm-common/pkg/aws/aws_client/vpc.go
+++ b/vendor/github.com/openshift-online/ocm-common/pkg/aws/aws_client/vpc.go
@@ -172,3 +172,18 @@ func (client *AWSClient) DeleteVPCEndpoints(vpcID string) error {
 	}
 	return err
 }
+
+func (client *AWSClient) CreateVPCEndpoint(vpcID string, serviceName string, vpcEndpointType types.VpcEndpointType) error {
+	input := &ec2.CreateVpcEndpointInput{
+		VpcId:           &vpcID,
+		ServiceName:     &serviceName,
+		VpcEndpointType: vpcEndpointType,
+	}
+	output, err := client.Ec2Client.CreateVpcEndpoint(context.TODO(), input)
+	if err != nil {
+		log.LogError("Create vpc endpoints failed: %s", err.Error())
+	} else {
+		log.LogInfo("Create vpc endpoints %s successfully", *output.VpcEndpoint.VpcEndpointId)
+	}
+	return err
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -413,7 +413,7 @@ github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
-# github.com/openshift-online/ocm-common v0.0.16
+# github.com/openshift-online/ocm-common v0.0.21
 ## explicit; go 1.21
 github.com/openshift-online/ocm-common/pkg/aws/aws_client
 github.com/openshift-online/ocm-common/pkg/aws/consts


### PR DESCRIPTION
1. Enable a new profile : ocpe2e-rosa-hcp-zero-egress. It is required to prepare some resources in the cluster VPC.Here is the [document](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_rosa_with_hcp_clusters/rosa-hcp-egress-lockdown-install#rosa-hcp-vpc-manual_rosa-hcp-egress-lockdown-install)
```
Procedure

Create the AWS security group by running the following command:

$ aws ec2 create-security-group \
        --group-name allow-inbound-traffic \
        --description "allow inbound traffic" \
        --vpc-id <vpc_id> \ [1](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_rosa_with_hcp_clusters/rosa-hcp-egress-lockdown-install#CO11-1)
        --region <aws_region> \ [2](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_rosa_with_hcp_clusters/rosa-hcp-egress-lockdown-install#CO11-2)
1
Enter your VPC’s ID.
2
Enter the AWS region where the VPC was installed.
Grant access to the security group’s ingress by running the following command:

$ aws ec2 authorize-security-group-ingress \
        --group-id <group_id> \ 1
        --protocol -1 \
        --port 0-0 \
        --cidr <vpc_cidr> \ 2
        --region <aws_region> \ 3
[1](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_rosa_with_hcp_clusters/rosa-hcp-egress-lockdown-install#CO12-1)
--group-id uses ID of the security group created with the previous command.
[2](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_rosa_with_hcp_clusters/rosa-hcp-egress-lockdown-install#CO12-2)
Enter the CIDR of your VPC.
[3](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_rosa_with_hcp_clusters/rosa-hcp-egress-lockdown-install#CO12-3)
The AWS region where you installed your VPC
Create your STS VPC endpoint by running the following command:

$ aws ec2 create-vpc-endpoint \
    --vpc-id <vpc_id> \ 1
    --service-name com.amazonaws.<aws_region>.sts \ 2
    --vpc-endpoint-type Interface
[1](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_rosa_with_hcp_clusters/rosa-hcp-egress-lockdown-install#CO13-1)
Enter your VPC’s ID.
[2](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_rosa_with_hcp_clusters/rosa-hcp-egress-lockdown-install#CO13-2)
Enter the AWS region where the VPC was installed.
Create your ECR VPC endpoints by running the following command:

$ aws ec2 create-vpc-endpoint \
    --vpc-id <vpc_id> \
    --service-name com.amazonaws.<aws_region>.ecr.dkr \ 1
    --vpc-endpoint-type Interface
```

Here is the test [log](https://privatebin.corp.redhat.com/?7d35ce3dc00d4bef#4fiMV9b1stB7WeGuX7oTKRLzhUKGd1s7XrToDJve6KDB)
