### PR TITLE
OCM-4649 | feat: /UX\ Output of `list account-roles` sorted by '-HCP-'

### DIFF
--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -877,6 +877,9 @@ func (c *awsClient) mapToAccountRole(version string, role iamtypes.Role) (Role, 
 func (c *awsClient) mapToAccountRoles(version string, roles []iamtypes.Role) ([]Role, error) {
 	emptyRole := Role{}
 	var accountRoles []Role
+
+	sortAccountRolesByHCPSuffix(roles)
+
 	for _, role := range roles {
 		if !checkIfAccountRole(role.RoleName) {
 			continue


### PR DESCRIPTION
Sorts account-roles in a non-intrusive way (only visually for output) when running `rosa list account-roles`.

This sorts by 1st) Clumping roles of the same group together (I.E. same prefix) and 2nd) by whether or not the roles contain `-HCP-`.

Original output:

```
<prefix>-ControlPlane-Role
<prefix>-HCP-ROSA-Installer-Role
<prefix>-HCP-ROSA-Support-Role
<prefix>-HCP-ROSA-Worker-Role
<prefix>-Installer-Role
<prefix>-Support-Role
<prefix>-Worker-Role
```

New output:

```
<prefix>-HCP-ROSA-Installer-Role
<prefix>-HCP-ROSA-Support-Role
<prefix>-HCP-ROSA-Worker-Role
<prefix>-Installer-Role
<prefix>-Support-Role
<prefix>-Worker-Role
<prefix>-ControlPlane-Role
```