### PR TITLE
OCM-14736 | test: fix id:70370 and some update on rosa-private-link profile and improvement for Day1Readiness step

### DIFF
--- a/tests/ci/data/profiles/rosa-classic.yaml
+++ b/tests/ci/data/profiles/rosa-classic.yaml
@@ -41,7 +41,7 @@ profiles:
 - as: rosa-private-link
   version: latest
   channel_group: "candidate"
-  region: "us-east-1"
+  region: "us-east-2"
   cluster:
     multi_az: true
     instance_type: ""

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -42,7 +42,8 @@ var _ = Describe("Cluster preparation", labels.Feature.Cluster, func() {
 			client := rosacli.NewClient()
 			clusterHandler, err := handler.NewClusterHandlerFromFilesystem(client, profile)
 			Expect(err).ToNot(HaveOccurred())
-			clusterHandler.WaitForClusterReady(config.Test.GlobalENV.ClusterWaitingTime)
+			err = clusterHandler.WaitForClusterReady(config.Test.GlobalENV.ClusterWaitingTime)
+			Expect(err).ToNot(HaveOccurred())
 
 			clusterID := clusterHandler.GetClusterDetail().ClusterID
 			clusterService := client.Cluster
@@ -53,10 +54,10 @@ var _ = Describe("Cluster preparation", labels.Feature.Cluster, func() {
 
 			// Workaround for public HCP with proxy
 			if profile.ClusterConfig.HCP && profile.ClusterConfig.ProxyEnabled && !profile.ClusterConfig.Private {
-				clusterDNS := clusterDetails.DNS
 				jsonData, err := clusterService.GetJSONClusterDescription(clusterID)
 				Expect(err).To(BeNil())
 				clusterNoProxy := jsonData.DigString("proxy", "no_proxy")
+				clusterDNS := fmt.Sprintf("%s.%s", clusterDetails.Name, jsonData.DigString("dns", "base_domain"))
 				_, err = clusterService.EditCluster(clusterID, "--no-proxy",
 					fmt.Sprintf("%s,.%s", clusterNoProxy, clusterDNS))
 				Expect(err).To(BeNil())

--- a/tests/e2e/test_rosacli_network_verifier.go
+++ b/tests/e2e/test_rosacli_network_verifier.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -292,26 +291,8 @@ var _ = Describe("Network verifier",
 					})
 				Expect(err).To(BeNil())
 
-				for _, s := range strings.Split(subnets, ",") {
-					for _, p := range vpcClient.AllPrivateSubnetIDs() {
-						if s == p {
-							err = wait.PollUntilContextTimeout(
-								context.Background(),
-								20*time.Second,
-								300*time.Second,
-								false,
-								func(context.Context) (bool, error) {
-									clusterDetail, err = clusterService.DescribeClusterAndReflect(clusterID)
-									if !strings.Contains(clusterDetail.FailedInflightChecks,
-										fmt.Sprintf("Invalid configurations on subnet '%s' have been identified", s)) {
-										return false, err
-									}
-									return true, err
-								})
-							Expect(err).To(BeNil())
-						}
-					}
-				}
+				clusterDetail, err = clusterService.DescribeClusterAndReflect(clusterID)
+				Expect(clusterDetail.FailedInflightChecks).To(ContainSubstring("Invalid configurations on subnet"))
 			})
 
 	})


### PR DESCRIPTION
- Change region for rosa-private-link profile to avoid cluster provision failure which were met these days for many times
- 70370: Simplified the expected inflight check message to avoid case failure which inflight check result is not expected sometime
- Improve the Day1Readiness step by returning error when timeout and use the cluster spec json to get the DNS. 

logs: https://privatebin.corp.redhat.com/?c04ca6d5dd046a34#EQhUHyhFjC3cmYMFCSpauRxJ5aD1EEXqzJuR2JSbhsyX