### PR TITLE
OCM 6929 | fix: Improved UX for error handling in private clusters

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"os"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -2209,9 +2210,12 @@ func run(cmd *cobra.Command, _ []string) {
 			r.Reporter.Errorf("%s", filterError)
 			os.Exit(1)
 		}
+
+		var excludedPublicSubnets []string
 		if privateLink {
-			subnets = filterPrivateSubnets(subnets, r)
+			subnets, excludedPublicSubnets = filterPrivateSubnets(subnets, r)
 		}
+
 		if len(subnets) == 0 {
 			r.Reporter.Warnf("No subnets found in current region that are valid for the chosen CIDR ranges")
 			if isHostedCP {
@@ -2234,13 +2238,17 @@ func run(cmd *cobra.Command, _ []string) {
 		// Verify subnets provided exist.
 		if subnetsProvided {
 			for _, subnetArg := range subnetIDs {
-				verifiedSubnet := false
-				for _, subnet := range subnets {
-					if awssdk.ToString(subnet.SubnetId) == subnetArg {
-						verifiedSubnet = true
-					}
+				// Check if subnet is in the excluded list of public subnets
+				if slices.Contains(excludedPublicSubnets, subnetArg) {
+					r.Reporter.Errorf("Cluster is set as private, cannot use public '%s'",
+						subnetArg)
+					os.Exit(1)
 				}
-				if !verifiedSubnet {
+
+				// Check if the provided subnet exists in the filtered list
+				if !slices.ContainsFunc(subnets, func(subnet ec2types.Subnet) bool {
+					return awssdk.ToString(subnet.SubnetId) == subnetArg
+				}) {
 					r.Reporter.Errorf("Could not find the following subnet provided in region '%s': %s",
 						r.AWSClient.GetRegion(), subnetArg)
 					os.Exit(1)
@@ -3700,8 +3708,8 @@ func handleOidcConfigOptions(r *rosa.Runtime, cmd *cobra.Command, isSTS bool, is
 	return oidcConfig
 }
 
-func filterPrivateSubnets(initialSubnets []ec2types.Subnet, r *rosa.Runtime) []ec2types.Subnet {
-	excludedSubnetsDueToPublic := []string{}
+func filterPrivateSubnets(initialSubnets []ec2types.Subnet, r *rosa.Runtime) ([]ec2types.Subnet, []string) {
+	excludedPublicSubnets := []string{}
 	filteredSubnets := []ec2types.Subnet{}
 	publicSubnetMap, err := r.AWSClient.FetchPublicSubnetMap(initialSubnets)
 	if err != nil {
@@ -3712,8 +3720,8 @@ func filterPrivateSubnets(initialSubnets []ec2types.Subnet, r *rosa.Runtime) []e
 		skip := false
 		if isPublic, ok := publicSubnetMap[awssdk.ToString(subnet.SubnetId)]; ok {
 			if isPublic {
-				excludedSubnetsDueToPublic = append(
-					excludedSubnetsDueToPublic,
+				excludedPublicSubnets = append(
+					excludedPublicSubnets,
 					awssdk.ToString(subnet.SubnetId),
 				)
 				skip = true
@@ -3723,12 +3731,12 @@ func filterPrivateSubnets(initialSubnets []ec2types.Subnet, r *rosa.Runtime) []e
 			filteredSubnets = append(filteredSubnets, subnet)
 		}
 	}
-	if len(excludedSubnetsDueToPublic) > 0 {
+	if len(excludedPublicSubnets) > 0 {
 		r.Reporter.Warnf("The following subnets have been excluded"+
 			" because they have an Internet Gateway Targetded Route and the Cluster choice is private: %s",
-			helper.SliceToSortedString(excludedSubnetsDueToPublic))
+			helper.SliceToSortedString(excludedPublicSubnets))
 	}
-	return filteredSubnets
+	return filteredSubnets, excludedPublicSubnets
 }
 
 // filterCidrRangeSubnets filters the initial set of subnets to those that are part of the machine network,


### PR DESCRIPTION
# Details

Improved UX on error handling for privates clusters by adding some verifications to the subnets and better messaging to when a subnet is public and can't be used in this setting

# How to Test

## Teste Case 1

On the terminal, execute the command `./rosa create cluster --hosted-cp --mode auto SUBNET1,SUBNET2`, here you should put a private and public subnet that are located in the same region, go through the process, and after selecting the option for the cluster to be private, you should see a message saying that the command could not be executed, and the program will stop running.

## Teste Case 2

On the terminal, execute the command `./rosa create cluster --hosted-cp --mode auto`, go through the process, and after selecting the option for the cluster to be private, you should see a warning for public subnets that have been excluded from the list, and the command will NOT stop running.


# Ticketing

Closes [OCM-6929](https://issues.redhat.com/browse/OCM-6929)