### PR TITLE
OCM-14796 | ci: increase the wait time for cluster installing in Day1Readiness step

### DIFF
--- a/tests/ci/config/config.go
+++ b/tests/ci/config/config.go
@@ -55,7 +55,7 @@ type GlobalENVVariables struct {
 	Region                string `env:"REGION" default:""`
 	ProvisionShard        string `env:"PROVISION_SHARD" default:""`
 	NamePrefix            string `env:"NAME_PREFIX"`
-	ClusterWaitingTime    int    `env:"CLUSTER_TIMEOUT" default:"60"`
+	ClusterWaitingTime    int    `env:"CLUSTER_TIMEOUT" default:"90"`
 	WaitSetupClusterReady bool   `env:"WAIT_SETUP_CLUSTER_READY" default:"true"`
 	AWSCredetialsFile     string `env:"AWS_SHARED_CREDENTIALS_FILE" default:""`
 	SVPC_CREDENTIALS_FILE string `env:"SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE" default:""`

--- a/tests/utils/handler/cluster_handler.go
+++ b/tests/utils/handler/cluster_handler.go
@@ -866,7 +866,7 @@ func (ch *clusterHandler) WaitForClusterReady(timeoutMin int) error {
 		ch.saveToFile()
 	}()
 	clusterService := ch.rosaClient.Cluster
-	err = clusterService.WaitForClusterPassWaiting(clusterID, 1, 2)
+	err = clusterService.WaitForClusterPassWaiting(clusterID, 2, 20)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
It met timeout error when waiting for cluster installing in Day1Readiness step,
```
[FAILED] Unexpected error:
      <*errors.errorString | 0xc000ca4cf0>: 
      timeout for cluster stuck waiting after 2 mins
      {
          s: "timeout for cluster stuck waiting after 2 mins",
      }
  occurred
```
To increase the wait time in this ticket