### PR TITLE
OCM-14846 | feat: allow specifying availability zones for CF stack creation

### DIFF
--- a/cmd/create/network/templates/rosa-quickstart-default-vpc/cloudformation.yaml
+++ b/cmd/create/network/templates/rosa-quickstart-default-vpc/cloudformation.yaml
@@ -1,7 +1,9 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: CloudFormation template to create a ROSA Quickstart default VPC.
-  This CloudFormation template may not work with rosa CLI versions later than 1.2.47. 
+  This CloudFormation template may not work with rosa CLI versions later than 1.2.48.
   Please ensure that you are using the compatible CLI version before deploying this template.
+
+Transform: 'AWS::LanguageExtensions'
 
 Parameters:
   AvailabilityZoneCount:
@@ -10,6 +12,9 @@ Parameters:
     Default: 1
     MinValue: 1
     MaxValue: 3
+  AvailabilityZones:
+    Type: CommaDelimitedList
+    Description: "List of Availability Zones to use"
   Region:
     Type: String
     Description: "AWS Region"
@@ -23,9 +28,13 @@ Parameters:
     Default: '10.0.0.0/16'
 
 Conditions:
-  HasAZ1: !Equals [!Ref AvailabilityZoneCount, 1]
-  HasAZ2: !Equals [!Ref AvailabilityZoneCount, 2]
-  HasAZ3: !Equals [!Ref AvailabilityZoneCount, 3] 
+  AZ3Explicit: !Equals [Fn::Length: !Ref AvailabilityZones, 3]
+  AZ2Explicit: !Or [!Equals [Fn::Length: !Ref AvailabilityZones, 2], !Condition AZ3Explicit]
+  AZ1Explicit: !Or [!Equals [Fn::Length: !Ref AvailabilityZones, 1], !Condition AZ2Explicit]
+
+  HasAZ1: !Or [!Equals [!Ref AvailabilityZoneCount, 1], !Condition AZ1Explicit]
+  HasAZ2: !Or [!Equals [!Ref AvailabilityZoneCount, 2], !Condition AZ2Explicit]
+  HasAZ3: !Or [!Equals [!Ref AvailabilityZoneCount, 3], !Condition AZ3Explicit]
 
   One:
     Fn::Or:
@@ -71,7 +80,7 @@ Resources:
     Properties:
       VpcId: !Ref VPC
       CidrBlock: !Select [0, !Cidr [!Ref VpcCidr, 6, 8]]
-      AvailabilityZone: !Select [0, !GetAZs '']
+      AvailabilityZone: !If [AZ1Explicit, !Select [0, !Ref AvailabilityZones], !Select [0, !GetAZs '']]
       MapPublicIpOnLaunch: true
       Tags:
         - Key: Name
@@ -91,7 +100,7 @@ Resources:
     Properties:
       VpcId: !Ref VPC
       CidrBlock: !Select [1, !Cidr [!Ref VpcCidr, 6, 8]]
-      AvailabilityZone: !Select [0, !GetAZs '']
+      AvailabilityZone: !If [AZ1Explicit, !Select [0, !Ref AvailabilityZones], !Select [0, !GetAZs '']]
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
@@ -111,7 +120,7 @@ Resources:
     Properties:
       VpcId: !Ref VPC
       CidrBlock: !Select [2, !Cidr [!Ref VpcCidr, 6, 8]]
-      AvailabilityZone: !Select [1, !GetAZs '']
+      AvailabilityZone: !If [AZ2Explicit, !Select [1, !Ref AvailabilityZones], !Select [1, !GetAZs '']]
       MapPublicIpOnLaunch: true
       Tags:
         - Key: Name
@@ -131,7 +140,7 @@ Resources:
     Properties:
       VpcId: !Ref VPC
       CidrBlock: !Select [3, !Cidr [!Ref VpcCidr, 6, 8]]
-      AvailabilityZone: !Select [1, !GetAZs '']
+      AvailabilityZone: !If [AZ2Explicit, !Select [1, !Ref AvailabilityZones], !Select [1, !GetAZs '']]
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
@@ -151,7 +160,7 @@ Resources:
     Properties:
       VpcId: !Ref VPC
       CidrBlock: !Select [4, !Cidr [!Ref VpcCidr, 6, 8]]
-      AvailabilityZone: !Select [2, !GetAZs '']
+      AvailabilityZone: !If [AZ3Explicit, !Select [2, !Ref AvailabilityZones], !Select [2, !GetAZs '']]
       MapPublicIpOnLaunch: true
       Tags:
         - Key: Name
@@ -171,7 +180,7 @@ Resources:
     Properties:
       VpcId: !Ref VPC
       CidrBlock: !Select [5, !Cidr [!Ref VpcCidr, 6, 8]]
-      AvailabilityZone: !Select [2, !GetAZs '']
+      AvailabilityZone: !If [AZ3Explicit, !Select [2, !Ref AvailabilityZones], !Select [2, !GetAZs '']]
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
@@ -581,4 +590,3 @@ Outputs:
     Value: !Ref EcrDkrVPCEndpoint
     Export:
       Name: !Sub "${Name}-EcrDkrVPCEndpointId"
-      

--- a/pkg/aws/cloudformation.go
+++ b/pkg/aws/cloudformation.go
@@ -206,7 +206,9 @@ func buildCreateStackInput(cfTemplateBody, stackName string) *cloudformation.Cre
 	// Special cloudformation capabilities are required to create IAM resources in AWS
 	cfCapabilityIAM := cloudformationtypes.CapabilityCapabilityIam
 	cfCapabilityNamedIAM := cloudformationtypes.CapabilityCapabilityNamedIam
-	cfTemplateCapabilities := []cloudformationtypes.Capability{cfCapabilityIAM, cfCapabilityNamedIAM}
+	cfCapabilityAutoExpand := cloudformationtypes.CapabilityCapabilityAutoExpand
+	cfTemplateCapabilities := []cloudformationtypes.Capability{
+		cfCapabilityIAM, cfCapabilityNamedIAM, cfCapabilityAutoExpand}
 
 	return &cloudformation.CreateStackInput{
 		Capabilities: cfTemplateCapabilities,
@@ -220,7 +222,9 @@ func buildUpdateStackInput(cfTemplateBody, stackName string) *cloudformation.Upd
 	// Special cloudformation capabilities are required to update IAM resources in AWS
 	cfCapabilityIAM := cloudformationtypes.CapabilityCapabilityIam
 	cfCapabilityNamedIAM := cloudformationtypes.CapabilityCapabilityNamedIam
-	cfTemplateCapabilities := []cloudformationtypes.Capability{cfCapabilityIAM, cfCapabilityNamedIAM}
+	cfCapabilityAutoExpand := cloudformationtypes.CapabilityCapabilityAutoExpand
+	cfTemplateCapabilities := []cloudformationtypes.Capability{
+		cfCapabilityIAM, cfCapabilityNamedIAM, cfCapabilityAutoExpand}
 
 	return &cloudformation.UpdateStackInput{
 		Capabilities: cfTemplateCapabilities,

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -74,6 +74,7 @@ func (s *network) CreateStack(templateFile *string, templateBody *[]byte,
 		Capabilities: []cfTypes.Capability{
 			cfTypes.CapabilityCapabilityIam,
 			cfTypes.CapabilityCapabilityNamedIam,
+			cfTypes.CapabilityCapabilityAutoExpand,
 		},
 	})
 	if err != nil {

--- a/pkg/options/network/create.go
+++ b/pkg/options/network/create.go
@@ -17,7 +17,8 @@ const (
   rosa create network <template-name> --param Param1=Value1 --param Param2=Value2 ` +
 		"\n\n" + `  # ROSA quick start HCP VPC example` +
 		"\n" + `  rosa create network rosa-quickstart-default-vpc --param Region=us-west-2` +
-		` --param Name=quickstart-stack --param AvailabilityZoneCount=1 --param VpcCidr=10.0.0.0/16` +
+		` --param Name=quickstart-stack --param AvailabilityZoneCount=1` +
+		` --param AvailabilityZones=us-west-2b,us-west-2d --param VpcCidr=10.0.0.0/16` +
 		"\n\n" + `  # To delete the AWS cloudformation stack` +
 		"\n" + `  aws cloudformation delete-stack --stack-name <name> --region <region>` +
 		"\n\n" + `# TEMPLATE_NAME:` +


### PR DESCRIPTION
This pull request extends the default cloudformation template so that is is possible to specify availability zones to be used during the stack creation:
```
rosa create network --param Region=us-west-2 --param Name=stack01 --param AvailabilityZones=us-west-2b,us-west-2d
```

Closes: [OCM-14846](https://issues.redhat.com/browse/OCM-14846)