### PR TITLE
OSD-28968 | ci: Add a new registry list

### DIFF
--- a/tests/utils/handler/cluster_handler.go
+++ b/tests/utils/handler/cluster_handler.go
@@ -832,7 +832,7 @@ func (ch *clusterHandler) GenerateClusterCreateFlags() ([]string, error) {
 		)
 		if ch.profile.ClusterConfig.AllowedRegistries {
 			flags = append(flags,
-				"--registry-config-allowed-registries", "allowed.example.com,quay.io,*.redhat.com",
+				"--registry-config-allowed-registries", "quay.io,*.redhat.com,*.ci.openshift.org",
 			)
 		} else if ch.profile.ClusterConfig.BlockedRegistries {
 			flags = append(flags,


### PR DESCRIPTION
multiarch-tuning-operator step is added in rosa-hcp job.The job failed to pull the image of the operator from [registry.ci.openshift.org](http://registry.ci.openshift.org/) for rosa HCP cluster.
So add. it in allowed list