### PR TITLE
OCM-14892 | feat: ability to specify 4 availability zones

### DIFF
--- a/cmd/create/network/cloudformation.go
+++ b/cmd/create/network/cloudformation.go
@@ -8,8 +8,6 @@ Description: CloudFormation template to create a ROSA Quickstart default VPC.
   This CloudFormation template may not work with rosa CLI versions later than 1.2.48.
   Please ensure that you are using the compatible CLI version before deploying this template.
 
-Transform: 'AWS::LanguageExtensions'
-
 Parameters:
   AvailabilityZoneCount:
     Type: Number
@@ -17,9 +15,18 @@ Parameters:
     Default: 1
     MinValue: 1
     MaxValue: 3
-  AvailabilityZones:
-    Type: CommaDelimitedList
-    Description: "List of Availability Zones to use"
+  AZ1:
+    Type: String
+    Description: "First availability zone to use"
+    Default: ""
+  AZ2:
+    Type: String
+    Description: "Second availability zone to use"
+    Default: ""
+  AZ3:
+    Type: String
+    Description: "Third availability zone to use"
+    Default: ""
   Region:
     Type: String
     Description: "AWS Region"
@@ -33,24 +40,20 @@ Parameters:
     Default: '10.0.0.0/16'
 
 Conditions:
-  AZ3Explicit: !Equals [Fn::Length: !Ref AvailabilityZones, 3]
-  AZ2Explicit: !Or [!Equals [Fn::Length: !Ref AvailabilityZones, 2], !Condition AZ3Explicit]
-  AZ1Explicit: !Or [!Equals [Fn::Length: !Ref AvailabilityZones, 1], !Condition AZ2Explicit]
+  AZ1Explicit: !Not [!Equals [!Ref AZ1, ""]]
+  AZ2Explicit: !Not [!Equals [!Ref AZ2, ""]]
+  AZ3Explicit: !Not [!Equals [!Ref AZ3, ""]]
 
-  HasAZ1: !Or [!Equals [!Ref AvailabilityZoneCount, 1], !Condition AZ1Explicit]
-  HasAZ2: !Or [!Equals [!Ref AvailabilityZoneCount, 2], !Condition AZ2Explicit]
-  HasAZ3: !Or [!Equals [!Ref AvailabilityZoneCount, 3], !Condition AZ3Explicit]
+  ExplicitAZs:   !Or [!Condition AZ1Explicit, !Condition AZ2Explicit, !Condition AZ3Explicit]
+  NoExplicitAZs: !Not [!Condition ExplicitAZs]
 
-  One:
-    Fn::Or:
-      - Condition: HasAZ1
-      - Condition: HasAZ2
-      - Condition: HasAZ3
+  AZ3Implicit: !Equals [!Ref AvailabilityZoneCount, 3]
+  AZ2Implicit: !Or [!Equals [!Ref AvailabilityZoneCount, 2], !Condition AZ3Implicit]
+  AZ1Implicit: !Or [!Equals [!Ref AvailabilityZoneCount, 1], !Condition AZ2Implicit]
 
-  Two:
-    Fn::Or:
-      - Condition: HasAZ3
-      - Condition: HasAZ2
+  One:   !Or [!And [!Condition ExplicitAZs, !Condition AZ1Explicit], !And [!Condition NoExplicitAZs, !Condition AZ1Implicit]]
+  Two:   !Or [!And [!Condition ExplicitAZs, !Condition AZ2Explicit], !And [!Condition NoExplicitAZs, !Condition AZ2Implicit]]
+  Three: !Or [!And [!Condition ExplicitAZs, !Condition AZ3Explicit], !And [!Condition NoExplicitAZs, !Condition AZ3Implicit]]
 
 Resources:
   VPC:
@@ -80,12 +83,12 @@ Resources:
         - !Ref PrivateRouteTable
 
   SubnetPublic1:
-    Condition: One
     Type: AWS::EC2::Subnet
+    Condition: One
     Properties:
       VpcId: !Ref VPC
       CidrBlock: !Select [0, !Cidr [!Ref VpcCidr, 6, 8]]
-      AvailabilityZone: !If [AZ1Explicit, !Select [0, !Ref AvailabilityZones], !Select [0, !GetAZs '']]
+      AvailabilityZone: !If [ExplicitAZs, !Ref AZ1, !Select [0, !GetAZs '']]
       MapPublicIpOnLaunch: true
       Tags:
         - Key: Name
@@ -95,17 +98,17 @@ Resources:
         - Key: 'rosa_hcp_policies'
           Value: 'true'
         - Key: 'service'
-          Value: 'ROSA' 
+          Value: 'ROSA'
         - Key: 'kubernetes.io/role/elb'
           Value: '1'
 
   SubnetPrivate1:
-    Condition: One
     Type: AWS::EC2::Subnet
+    Condition: One
     Properties:
       VpcId: !Ref VPC
       CidrBlock: !Select [1, !Cidr [!Ref VpcCidr, 6, 8]]
-      AvailabilityZone: !If [AZ1Explicit, !Select [0, !Ref AvailabilityZones], !Select [0, !GetAZs '']]
+      AvailabilityZone: !If [ExplicitAZs, !Ref AZ1, !Select [0, !GetAZs '']]
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
@@ -115,17 +118,17 @@ Resources:
         - Key: 'rosa_hcp_policies'
           Value: 'true'
         - Key: 'service'
-          Value: 'ROSA' 
+          Value: 'ROSA'
         - Key: 'kubernetes.io/role/internal-elb'
           Value: '1'
 
   SubnetPublic2:
-    Condition: Two
     Type: AWS::EC2::Subnet
+    Condition: Two
     Properties:
       VpcId: !Ref VPC
       CidrBlock: !Select [2, !Cidr [!Ref VpcCidr, 6, 8]]
-      AvailabilityZone: !If [AZ2Explicit, !Select [1, !Ref AvailabilityZones], !Select [1, !GetAZs '']]
+      AvailabilityZone: !If [ExplicitAZs, !Ref AZ2, !Select [1, !GetAZs '']]
       MapPublicIpOnLaunch: true
       Tags:
         - Key: Name
@@ -140,12 +143,12 @@ Resources:
           Value: '1'
 
   SubnetPrivate2:
-    Condition: Two
     Type: AWS::EC2::Subnet
+    Condition: Two
     Properties:
       VpcId: !Ref VPC
       CidrBlock: !Select [3, !Cidr [!Ref VpcCidr, 6, 8]]
-      AvailabilityZone: !If [AZ2Explicit, !Select [1, !Ref AvailabilityZones], !Select [1, !GetAZs '']]
+      AvailabilityZone: !If [ExplicitAZs, !Ref AZ2, !Select [1, !GetAZs '']]
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
@@ -160,12 +163,12 @@ Resources:
           Value: '1'
 
   SubnetPublic3:
-    Condition: HasAZ3
     Type: AWS::EC2::Subnet
+    Condition: Three
     Properties:
       VpcId: !Ref VPC
       CidrBlock: !Select [4, !Cidr [!Ref VpcCidr, 6, 8]]
-      AvailabilityZone: !If [AZ3Explicit, !Select [2, !Ref AvailabilityZones], !Select [2, !GetAZs '']]
+      AvailabilityZone: !If [ExplicitAZs, !Ref AZ3, !Select [2, !GetAZs '']]
       MapPublicIpOnLaunch: true
       Tags:
         - Key: Name
@@ -180,12 +183,12 @@ Resources:
           Value: '1'
 
   SubnetPrivate3:
-    Condition: HasAZ3
     Type: AWS::EC2::Subnet
+    Condition: Three
     Properties:
       VpcId: !Ref VPC
       CidrBlock: !Select [5, !Cidr [!Ref VpcCidr, 6, 8]]
-      AvailabilityZone: !If [AZ3Explicit, !Select [2, !Ref AvailabilityZones], !Select [2, !GetAZs '']]
+      AvailabilityZone: !If [ExplicitAZs, !Ref AZ3, !Select [2, !GetAZs '']]
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
@@ -219,6 +222,7 @@ Resources:
       InternetGatewayId: !Ref InternetGateway
 
   ElasticIP1:
+    Condition: One
     Type: AWS::EC2::EIP
     Properties:
       Domain: vpc
@@ -233,6 +237,7 @@ Resources:
           Value: 'ROSA'
 
   ElasticIP2:
+    Condition: Two
     Type: AWS::EC2::EIP
     Properties:
       Domain: vpc
@@ -247,7 +252,7 @@ Resources:
           Value: 'ROSA'
 
   ElasticIP3:
-    Condition: HasAZ3
+    Condition: Three
     Type: AWS::EC2::EIP
     Properties:
       Domain: vpc
@@ -294,7 +299,7 @@ Resources:
           Value: 'ROSA'
 
   NATGateway3:
-    Condition: HasAZ3
+    Condition: Three
     Type: 'AWS::EC2::NatGateway'
     Properties:
       AllocationId: !GetAtt ElasticIP3.AllocationId
@@ -357,7 +362,7 @@ Resources:
           - Two
           - !Ref NATGateway2
           - !If
-            - HasAZ3
+            - Three
             - !Ref NATGateway3
             - !Ref "AWS::NoValue"
 
@@ -376,7 +381,7 @@ Resources:
       RouteTableId: !Ref PublicRouteTable
 
   PublicSubnetRouteTableAssociation3:
-    Condition: HasAZ3
+    Condition: Three
     Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:
       SubnetId: !Ref SubnetPublic3
@@ -397,7 +402,7 @@ Resources:
       RouteTableId: !Ref PrivateRouteTable
 
   PrivateSubnetRouteTableAssociation3:
-    Condition: HasAZ3
+    Condition: Three
     Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:
       SubnetId: !Ref SubnetPrivate3
@@ -435,11 +440,11 @@ Resources:
       ServiceName: !Sub "com.amazonaws.${Region}.ec2"
       PrivateDnsEnabled: true
       VpcEndpointType: Interface
-      SubnetIds: 
+      SubnetIds:
         - !If [One, !Ref SubnetPrivate1, !Ref "AWS::NoValue"]
         - !If [Two, !Ref SubnetPrivate2, !Ref "AWS::NoValue"]
-        - !If [HasAZ3, !Ref SubnetPrivate3, !Ref "AWS::NoValue"]
-      SecurityGroupIds: 
+        - !If [Three, !Ref SubnetPrivate3, !Ref "AWS::NoValue"]
+      SecurityGroupIds:
         - !Ref SecurityGroup
 
   KMSVPCEndpoint:
@@ -449,11 +454,11 @@ Resources:
       ServiceName: !Sub "com.amazonaws.${Region}.kms"
       PrivateDnsEnabled: true
       VpcEndpointType: Interface
-      SubnetIds: 
+      SubnetIds:
         - !If [One, !Ref SubnetPrivate1, !Ref "AWS::NoValue"]
         - !If [Two, !Ref SubnetPrivate2, !Ref "AWS::NoValue"]
-        - !If [HasAZ3, !Ref SubnetPrivate3, !Ref "AWS::NoValue"]
-      SecurityGroupIds: 
+        - !If [Three, !Ref SubnetPrivate3, !Ref "AWS::NoValue"]
+      SecurityGroupIds:
         - !Ref SecurityGroup
 
   STSVPCEndpoint:
@@ -463,11 +468,11 @@ Resources:
       ServiceName: !Sub "com.amazonaws.${Region}.sts"
       PrivateDnsEnabled: true
       VpcEndpointType: Interface
-      SubnetIds: 
+      SubnetIds:
         - !If [One, !Ref SubnetPrivate1, !Ref "AWS::NoValue"]
         - !If [Two, !Ref SubnetPrivate2, !Ref "AWS::NoValue"]
-        - !If [HasAZ3, !Ref SubnetPrivate3, !Ref "AWS::NoValue"]
-      SecurityGroupIds: 
+        - !If [Three, !Ref SubnetPrivate3, !Ref "AWS::NoValue"]
+      SecurityGroupIds:
         - !Ref SecurityGroup
 
   EcrApiVPCEndpoint:
@@ -477,11 +482,11 @@ Resources:
       ServiceName: !Sub "com.amazonaws.${Region}.ecr.api"
       PrivateDnsEnabled: true
       VpcEndpointType: Interface
-      SubnetIds: 
+      SubnetIds:
         - !If [One, !Ref SubnetPrivate1, !Ref "AWS::NoValue"]
         - !If [Two, !Ref SubnetPrivate2, !Ref "AWS::NoValue"]
-        - !If [HasAZ3, !Ref SubnetPrivate3, !Ref "AWS::NoValue"]
-      SecurityGroupIds: 
+        - !If [Three, !Ref SubnetPrivate3, !Ref "AWS::NoValue"]
+      SecurityGroupIds:
         - !Ref SecurityGroup
 
   EcrDkrVPCEndpoint:
@@ -491,11 +496,11 @@ Resources:
       ServiceName: !Sub "com.amazonaws.${Region}.ecr.dkr"
       PrivateDnsEnabled: true
       VpcEndpointType: Interface
-      SubnetIds: 
+      SubnetIds:
         - !If [One, !Ref SubnetPrivate1, !Ref "AWS::NoValue"]
         - !If [Two, !Ref SubnetPrivate2, !Ref "AWS::NoValue"]
-        - !If [HasAZ3, !Ref SubnetPrivate3, !Ref "AWS::NoValue"]
-      SecurityGroupIds: 
+        - !If [Three, !Ref SubnetPrivate3, !Ref "AWS::NoValue"]
+      SecurityGroupIds:
         - !Ref SecurityGroup
 
 Outputs:
@@ -513,13 +518,13 @@ Outputs:
 
   PublicSubnets:
     Description: "Public Subnet Ids"
-    Value: !Join [",", [!If [One, !Ref SubnetPublic1, !Ref "AWS::NoValue"], !If [Two, !Ref SubnetPublic2, !Ref "AWS::NoValue"], !If [HasAZ3, !Ref SubnetPublic3, !Ref "AWS::NoValue"]]]
+    Value: !Join [",", [!If [One, !Ref SubnetPublic1, !Ref "AWS::NoValue"], !If [Two, !Ref SubnetPublic2, !Ref "AWS::NoValue"], !If [Three, !Ref SubnetPublic3, !Ref "AWS::NoValue"]]]
     Export:
       Name: !Sub "${Name}-PublicSubnets"
 
   PrivateSubnets:
     Description: "Private Subnet Ids"
-    Value: !Join [",", [!If [One, !Ref SubnetPrivate1, !Ref "AWS::NoValue"], !If [Two, !Ref SubnetPrivate2, !Ref "AWS::NoValue"], !If [HasAZ3, !Ref SubnetPrivate3, !Ref "AWS::NoValue"]]]
+    Value: !Join [",", [!If [One, !Ref SubnetPrivate1, !Ref "AWS::NoValue"], !If [Two, !Ref SubnetPrivate2, !Ref "AWS::NoValue"], !If [Three, !Ref SubnetPrivate3, !Ref "AWS::NoValue"]]]
     Export:
       Name: !Sub "${Name}-PrivateSubnets"
 
@@ -530,13 +535,14 @@ Outputs:
       Name: !Sub "${Name}-EIP1-AllocationId"
 
   EIP2AllocationId:
+    Condition: Two
     Description: Allocation ID for ElasticIP2
     Value: !GetAtt ElasticIP2.AllocationId
     Export:
       Name: !Sub "${Name}-EIP2-AllocationId"
 
   EIP3AllocationId:
-    Condition: HasAZ3
+    Condition: Three
     Description: Allocation ID for ElasticIP3
     Value: !GetAtt ElasticIP3.AllocationId
     Export:
@@ -544,7 +550,7 @@ Outputs:
 
   NatGatewayId:
     Description: The NAT Gateway IDs
-    Value: !Join [",", [!If [One, !Ref NATGateway1, !Ref "AWS::NoValue"], !If [Two, !Ref NATGateway2, !Ref "AWS::NoValue"], !If [HasAZ3, !Ref NATGateway3, !Ref "AWS::NoValue"]]]
+    Value: !Join [",", [!If [One, !Ref NATGateway1, !Ref "AWS::NoValue"], !If [Two, !Ref NATGateway2, !Ref "AWS::NoValue"], !If [Three, !Ref NATGateway3, !Ref "AWS::NoValue"]]]
     Export:
       Name: !Sub "${Name}-NatGatewayId"
 

--- a/cmd/create/network/templates/rosa-quickstart-default-vpc/cloudformation.yaml
+++ b/cmd/create/network/templates/rosa-quickstart-default-vpc/cloudformation.yaml
@@ -3,8 +3,6 @@ Description: CloudFormation template to create a ROSA Quickstart default VPC.
   This CloudFormation template may not work with rosa CLI versions later than 1.2.48.
   Please ensure that you are using the compatible CLI version before deploying this template.
 
-Transform: 'AWS::LanguageExtensions'
-
 Parameters:
   AvailabilityZoneCount:
     Type: Number
@@ -12,9 +10,18 @@ Parameters:
     Default: 1
     MinValue: 1
     MaxValue: 3
-  AvailabilityZones:
-    Type: CommaDelimitedList
-    Description: "List of Availability Zones to use"
+  AZ1:
+    Type: String
+    Description: "First availability zone to use"
+    Default: ""
+  AZ2:
+    Type: String
+    Description: "Second availability zone to use"
+    Default: ""
+  AZ3:
+    Type: String
+    Description: "Third availability zone to use"
+    Default: ""
   Region:
     Type: String
     Description: "AWS Region"
@@ -28,24 +35,20 @@ Parameters:
     Default: '10.0.0.0/16'
 
 Conditions:
-  AZ3Explicit: !Equals [Fn::Length: !Ref AvailabilityZones, 3]
-  AZ2Explicit: !Or [!Equals [Fn::Length: !Ref AvailabilityZones, 2], !Condition AZ3Explicit]
-  AZ1Explicit: !Or [!Equals [Fn::Length: !Ref AvailabilityZones, 1], !Condition AZ2Explicit]
+  AZ1Explicit: !Not [!Equals [!Ref AZ1, ""]]
+  AZ2Explicit: !Not [!Equals [!Ref AZ2, ""]]
+  AZ3Explicit: !Not [!Equals [!Ref AZ3, ""]]
 
-  HasAZ1: !Or [!Equals [!Ref AvailabilityZoneCount, 1], !Condition AZ1Explicit]
-  HasAZ2: !Or [!Equals [!Ref AvailabilityZoneCount, 2], !Condition AZ2Explicit]
-  HasAZ3: !Or [!Equals [!Ref AvailabilityZoneCount, 3], !Condition AZ3Explicit]
+  ExplicitAZs:   !Or [!Condition AZ1Explicit, !Condition AZ2Explicit, !Condition AZ3Explicit]
+  NoExplicitAZs: !Not [!Condition ExplicitAZs]
 
-  One:
-    Fn::Or:
-      - Condition: HasAZ1
-      - Condition: HasAZ2
-      - Condition: HasAZ3
+  AZ3Implicit: !Equals [!Ref AvailabilityZoneCount, 3]
+  AZ2Implicit: !Or [!Equals [!Ref AvailabilityZoneCount, 2], !Condition AZ3Implicit]
+  AZ1Implicit: !Or [!Equals [!Ref AvailabilityZoneCount, 1], !Condition AZ2Implicit]
 
-  Two:
-    Fn::Or:
-      - Condition: HasAZ3
-      - Condition: HasAZ2
+  One:   !Or [!And [!Condition ExplicitAZs, !Condition AZ1Explicit], !And [!Condition NoExplicitAZs, !Condition AZ1Implicit]]
+  Two:   !Or [!And [!Condition ExplicitAZs, !Condition AZ2Explicit], !And [!Condition NoExplicitAZs, !Condition AZ2Implicit]]
+  Three: !Or [!And [!Condition ExplicitAZs, !Condition AZ3Explicit], !And [!Condition NoExplicitAZs, !Condition AZ3Implicit]]
 
 Resources:
   VPC:
@@ -75,12 +78,12 @@ Resources:
         - !Ref PrivateRouteTable
 
   SubnetPublic1:
-    Condition: One
     Type: AWS::EC2::Subnet
+    Condition: One
     Properties:
       VpcId: !Ref VPC
       CidrBlock: !Select [0, !Cidr [!Ref VpcCidr, 6, 8]]
-      AvailabilityZone: !If [AZ1Explicit, !Select [0, !Ref AvailabilityZones], !Select [0, !GetAZs '']]
+      AvailabilityZone: !If [ExplicitAZs, !Ref AZ1, !Select [0, !GetAZs '']]
       MapPublicIpOnLaunch: true
       Tags:
         - Key: Name
@@ -90,17 +93,17 @@ Resources:
         - Key: 'rosa_hcp_policies'
           Value: 'true'
         - Key: 'service'
-          Value: 'ROSA' 
+          Value: 'ROSA'
         - Key: 'kubernetes.io/role/elb'
           Value: '1'
 
   SubnetPrivate1:
-    Condition: One
     Type: AWS::EC2::Subnet
+    Condition: One
     Properties:
       VpcId: !Ref VPC
       CidrBlock: !Select [1, !Cidr [!Ref VpcCidr, 6, 8]]
-      AvailabilityZone: !If [AZ1Explicit, !Select [0, !Ref AvailabilityZones], !Select [0, !GetAZs '']]
+      AvailabilityZone: !If [ExplicitAZs, !Ref AZ1, !Select [0, !GetAZs '']]
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
@@ -110,17 +113,17 @@ Resources:
         - Key: 'rosa_hcp_policies'
           Value: 'true'
         - Key: 'service'
-          Value: 'ROSA' 
+          Value: 'ROSA'
         - Key: 'kubernetes.io/role/internal-elb'
           Value: '1'
 
   SubnetPublic2:
-    Condition: Two
     Type: AWS::EC2::Subnet
+    Condition: Two
     Properties:
       VpcId: !Ref VPC
       CidrBlock: !Select [2, !Cidr [!Ref VpcCidr, 6, 8]]
-      AvailabilityZone: !If [AZ2Explicit, !Select [1, !Ref AvailabilityZones], !Select [1, !GetAZs '']]
+      AvailabilityZone: !If [ExplicitAZs, !Ref AZ2, !Select [1, !GetAZs '']]
       MapPublicIpOnLaunch: true
       Tags:
         - Key: Name
@@ -135,12 +138,12 @@ Resources:
           Value: '1'
 
   SubnetPrivate2:
-    Condition: Two
     Type: AWS::EC2::Subnet
+    Condition: Two
     Properties:
       VpcId: !Ref VPC
       CidrBlock: !Select [3, !Cidr [!Ref VpcCidr, 6, 8]]
-      AvailabilityZone: !If [AZ2Explicit, !Select [1, !Ref AvailabilityZones], !Select [1, !GetAZs '']]
+      AvailabilityZone: !If [ExplicitAZs, !Ref AZ2, !Select [1, !GetAZs '']]
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
@@ -155,12 +158,12 @@ Resources:
           Value: '1'
 
   SubnetPublic3:
-    Condition: HasAZ3
     Type: AWS::EC2::Subnet
+    Condition: Three
     Properties:
       VpcId: !Ref VPC
       CidrBlock: !Select [4, !Cidr [!Ref VpcCidr, 6, 8]]
-      AvailabilityZone: !If [AZ3Explicit, !Select [2, !Ref AvailabilityZones], !Select [2, !GetAZs '']]
+      AvailabilityZone: !If [ExplicitAZs, !Ref AZ3, !Select [2, !GetAZs '']]
       MapPublicIpOnLaunch: true
       Tags:
         - Key: Name
@@ -175,12 +178,12 @@ Resources:
           Value: '1'
 
   SubnetPrivate3:
-    Condition: HasAZ3
     Type: AWS::EC2::Subnet
+    Condition: Three
     Properties:
       VpcId: !Ref VPC
       CidrBlock: !Select [5, !Cidr [!Ref VpcCidr, 6, 8]]
-      AvailabilityZone: !If [AZ3Explicit, !Select [2, !Ref AvailabilityZones], !Select [2, !GetAZs '']]
+      AvailabilityZone: !If [ExplicitAZs, !Ref AZ3, !Select [2, !GetAZs '']]
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
@@ -214,6 +217,7 @@ Resources:
       InternetGatewayId: !Ref InternetGateway
 
   ElasticIP1:
+    Condition: One
     Type: AWS::EC2::EIP
     Properties:
       Domain: vpc
@@ -228,6 +232,7 @@ Resources:
           Value: 'ROSA'
 
   ElasticIP2:
+    Condition: Two
     Type: AWS::EC2::EIP
     Properties:
       Domain: vpc
@@ -242,7 +247,7 @@ Resources:
           Value: 'ROSA'
 
   ElasticIP3:
-    Condition: HasAZ3
+    Condition: Three
     Type: AWS::EC2::EIP
     Properties:
       Domain: vpc
@@ -289,7 +294,7 @@ Resources:
           Value: 'ROSA'
 
   NATGateway3:
-    Condition: HasAZ3
+    Condition: Three
     Type: 'AWS::EC2::NatGateway'
     Properties:
       AllocationId: !GetAtt ElasticIP3.AllocationId
@@ -352,7 +357,7 @@ Resources:
           - Two
           - !Ref NATGateway2
           - !If
-            - HasAZ3
+            - Three
             - !Ref NATGateway3
             - !Ref "AWS::NoValue"
 
@@ -371,7 +376,7 @@ Resources:
       RouteTableId: !Ref PublicRouteTable
 
   PublicSubnetRouteTableAssociation3:
-    Condition: HasAZ3
+    Condition: Three
     Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:
       SubnetId: !Ref SubnetPublic3
@@ -392,7 +397,7 @@ Resources:
       RouteTableId: !Ref PrivateRouteTable
 
   PrivateSubnetRouteTableAssociation3:
-    Condition: HasAZ3
+    Condition: Three
     Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:
       SubnetId: !Ref SubnetPrivate3
@@ -430,11 +435,11 @@ Resources:
       ServiceName: !Sub "com.amazonaws.${Region}.ec2"
       PrivateDnsEnabled: true
       VpcEndpointType: Interface
-      SubnetIds: 
+      SubnetIds:
         - !If [One, !Ref SubnetPrivate1, !Ref "AWS::NoValue"]
         - !If [Two, !Ref SubnetPrivate2, !Ref "AWS::NoValue"]
-        - !If [HasAZ3, !Ref SubnetPrivate3, !Ref "AWS::NoValue"]
-      SecurityGroupIds: 
+        - !If [Three, !Ref SubnetPrivate3, !Ref "AWS::NoValue"]
+      SecurityGroupIds:
         - !Ref SecurityGroup
 
   KMSVPCEndpoint:
@@ -444,11 +449,11 @@ Resources:
       ServiceName: !Sub "com.amazonaws.${Region}.kms"
       PrivateDnsEnabled: true
       VpcEndpointType: Interface
-      SubnetIds: 
+      SubnetIds:
         - !If [One, !Ref SubnetPrivate1, !Ref "AWS::NoValue"]
         - !If [Two, !Ref SubnetPrivate2, !Ref "AWS::NoValue"]
-        - !If [HasAZ3, !Ref SubnetPrivate3, !Ref "AWS::NoValue"]
-      SecurityGroupIds: 
+        - !If [Three, !Ref SubnetPrivate3, !Ref "AWS::NoValue"]
+      SecurityGroupIds:
         - !Ref SecurityGroup
 
   STSVPCEndpoint:
@@ -458,11 +463,11 @@ Resources:
       ServiceName: !Sub "com.amazonaws.${Region}.sts"
       PrivateDnsEnabled: true
       VpcEndpointType: Interface
-      SubnetIds: 
+      SubnetIds:
         - !If [One, !Ref SubnetPrivate1, !Ref "AWS::NoValue"]
         - !If [Two, !Ref SubnetPrivate2, !Ref "AWS::NoValue"]
-        - !If [HasAZ3, !Ref SubnetPrivate3, !Ref "AWS::NoValue"]
-      SecurityGroupIds: 
+        - !If [Three, !Ref SubnetPrivate3, !Ref "AWS::NoValue"]
+      SecurityGroupIds:
         - !Ref SecurityGroup
 
   EcrApiVPCEndpoint:
@@ -472,11 +477,11 @@ Resources:
       ServiceName: !Sub "com.amazonaws.${Region}.ecr.api"
       PrivateDnsEnabled: true
       VpcEndpointType: Interface
-      SubnetIds: 
+      SubnetIds:
         - !If [One, !Ref SubnetPrivate1, !Ref "AWS::NoValue"]
         - !If [Two, !Ref SubnetPrivate2, !Ref "AWS::NoValue"]
-        - !If [HasAZ3, !Ref SubnetPrivate3, !Ref "AWS::NoValue"]
-      SecurityGroupIds: 
+        - !If [Three, !Ref SubnetPrivate3, !Ref "AWS::NoValue"]
+      SecurityGroupIds:
         - !Ref SecurityGroup
 
   EcrDkrVPCEndpoint:
@@ -486,11 +491,11 @@ Resources:
       ServiceName: !Sub "com.amazonaws.${Region}.ecr.dkr"
       PrivateDnsEnabled: true
       VpcEndpointType: Interface
-      SubnetIds: 
+      SubnetIds:
         - !If [One, !Ref SubnetPrivate1, !Ref "AWS::NoValue"]
         - !If [Two, !Ref SubnetPrivate2, !Ref "AWS::NoValue"]
-        - !If [HasAZ3, !Ref SubnetPrivate3, !Ref "AWS::NoValue"]
-      SecurityGroupIds: 
+        - !If [Three, !Ref SubnetPrivate3, !Ref "AWS::NoValue"]
+      SecurityGroupIds:
         - !Ref SecurityGroup
 
 Outputs:
@@ -508,13 +513,13 @@ Outputs:
 
   PublicSubnets:
     Description: "Public Subnet Ids"
-    Value: !Join [",", [!If [One, !Ref SubnetPublic1, !Ref "AWS::NoValue"], !If [Two, !Ref SubnetPublic2, !Ref "AWS::NoValue"], !If [HasAZ3, !Ref SubnetPublic3, !Ref "AWS::NoValue"]]]
+    Value: !Join [",", [!If [One, !Ref SubnetPublic1, !Ref "AWS::NoValue"], !If [Two, !Ref SubnetPublic2, !Ref "AWS::NoValue"], !If [Three, !Ref SubnetPublic3, !Ref "AWS::NoValue"]]]
     Export:
       Name: !Sub "${Name}-PublicSubnets"
 
   PrivateSubnets:
     Description: "Private Subnet Ids"
-    Value: !Join [",", [!If [One, !Ref SubnetPrivate1, !Ref "AWS::NoValue"], !If [Two, !Ref SubnetPrivate2, !Ref "AWS::NoValue"], !If [HasAZ3, !Ref SubnetPrivate3, !Ref "AWS::NoValue"]]]
+    Value: !Join [",", [!If [One, !Ref SubnetPrivate1, !Ref "AWS::NoValue"], !If [Two, !Ref SubnetPrivate2, !Ref "AWS::NoValue"], !If [Three, !Ref SubnetPrivate3, !Ref "AWS::NoValue"]]]
     Export:
       Name: !Sub "${Name}-PrivateSubnets"
 
@@ -525,13 +530,14 @@ Outputs:
       Name: !Sub "${Name}-EIP1-AllocationId"
 
   EIP2AllocationId:
+    Condition: Two
     Description: Allocation ID for ElasticIP2
     Value: !GetAtt ElasticIP2.AllocationId
     Export:
       Name: !Sub "${Name}-EIP2-AllocationId"
 
   EIP3AllocationId:
-    Condition: HasAZ3
+    Condition: Three
     Description: Allocation ID for ElasticIP3
     Value: !GetAtt ElasticIP3.AllocationId
     Export:
@@ -539,7 +545,7 @@ Outputs:
 
   NatGatewayId:
     Description: The NAT Gateway IDs
-    Value: !Join [",", [!If [One, !Ref NATGateway1, !Ref "AWS::NoValue"], !If [Two, !Ref NATGateway2, !Ref "AWS::NoValue"], !If [HasAZ3, !Ref NATGateway3, !Ref "AWS::NoValue"]]]
+    Value: !Join [",", [!If [One, !Ref NATGateway1, !Ref "AWS::NoValue"], !If [Two, !Ref NATGateway2, !Ref "AWS::NoValue"], !If [Three, !Ref NATGateway3, !Ref "AWS::NoValue"]]]
     Export:
       Name: !Sub "${Name}-NatGatewayId"
 

--- a/cmd/create/network/templates/rosa-quickstart-default-vpc/cloudformation.yaml
+++ b/cmd/create/network/templates/rosa-quickstart-default-vpc/cloudformation.yaml
@@ -9,7 +9,7 @@ Parameters:
     Description: "Number of Availability Zones to use"
     Default: 1
     MinValue: 1
-    MaxValue: 3
+    MaxValue: 4
   AZ1:
     Type: String
     Description: "First availability zone to use"
@@ -21,6 +21,10 @@ Parameters:
   AZ3:
     Type: String
     Description: "Third availability zone to use"
+    Default: ""
+  AZ4:
+    Type: String
+    Description: "Fourth availability zone to use"
     Default: ""
   Region:
     Type: String
@@ -38,17 +42,20 @@ Conditions:
   AZ1Explicit: !Not [!Equals [!Ref AZ1, ""]]
   AZ2Explicit: !Not [!Equals [!Ref AZ2, ""]]
   AZ3Explicit: !Not [!Equals [!Ref AZ3, ""]]
+  AZ4Explicit: !Not [!Equals [!Ref AZ4, ""]]
 
-  ExplicitAZs:   !Or [!Condition AZ1Explicit, !Condition AZ2Explicit, !Condition AZ3Explicit]
+  ExplicitAZs:   !Or [!Condition AZ1Explicit, !Condition AZ2Explicit, !Condition AZ3Explicit, !Condition AZ4Explicit]
   NoExplicitAZs: !Not [!Condition ExplicitAZs]
 
-  AZ3Implicit: !Equals [!Ref AvailabilityZoneCount, 3]
+  AZ4Implicit: !Equals [!Ref AvailabilityZoneCount, 4]
+  AZ3Implicit: !Or [!Equals [!Ref AvailabilityZoneCount, 3], !Condition AZ4Implicit]
   AZ2Implicit: !Or [!Equals [!Ref AvailabilityZoneCount, 2], !Condition AZ3Implicit]
   AZ1Implicit: !Or [!Equals [!Ref AvailabilityZoneCount, 1], !Condition AZ2Implicit]
 
   One:   !Or [!And [!Condition ExplicitAZs, !Condition AZ1Explicit], !And [!Condition NoExplicitAZs, !Condition AZ1Implicit]]
   Two:   !Or [!And [!Condition ExplicitAZs, !Condition AZ2Explicit], !And [!Condition NoExplicitAZs, !Condition AZ2Implicit]]
   Three: !Or [!And [!Condition ExplicitAZs, !Condition AZ3Explicit], !And [!Condition NoExplicitAZs, !Condition AZ3Implicit]]
+  Four:  !Or [!And [!Condition ExplicitAZs, !Condition AZ4Explicit], !And [!Condition NoExplicitAZs, !Condition AZ4Implicit]]
 
 Resources:
   VPC:
@@ -82,7 +89,7 @@ Resources:
     Condition: One
     Properties:
       VpcId: !Ref VPC
-      CidrBlock: !Select [0, !Cidr [!Ref VpcCidr, 6, 8]]
+      CidrBlock: !Select [0, !Cidr [!Ref VpcCidr, 8, 8]]
       AvailabilityZone: !If [ExplicitAZs, !Ref AZ1, !Select [0, !GetAZs '']]
       MapPublicIpOnLaunch: true
       Tags:
@@ -102,7 +109,7 @@ Resources:
     Condition: One
     Properties:
       VpcId: !Ref VPC
-      CidrBlock: !Select [1, !Cidr [!Ref VpcCidr, 6, 8]]
+      CidrBlock: !Select [1, !Cidr [!Ref VpcCidr, 8, 8]]
       AvailabilityZone: !If [ExplicitAZs, !Ref AZ1, !Select [0, !GetAZs '']]
       MapPublicIpOnLaunch: false
       Tags:
@@ -122,7 +129,7 @@ Resources:
     Condition: Two
     Properties:
       VpcId: !Ref VPC
-      CidrBlock: !Select [2, !Cidr [!Ref VpcCidr, 6, 8]]
+      CidrBlock: !Select [2, !Cidr [!Ref VpcCidr, 8, 8]]
       AvailabilityZone: !If [ExplicitAZs, !Ref AZ2, !Select [1, !GetAZs '']]
       MapPublicIpOnLaunch: true
       Tags:
@@ -142,7 +149,7 @@ Resources:
     Condition: Two
     Properties:
       VpcId: !Ref VPC
-      CidrBlock: !Select [3, !Cidr [!Ref VpcCidr, 6, 8]]
+      CidrBlock: !Select [3, !Cidr [!Ref VpcCidr, 8, 8]]
       AvailabilityZone: !If [ExplicitAZs, !Ref AZ2, !Select [1, !GetAZs '']]
       MapPublicIpOnLaunch: false
       Tags:
@@ -162,7 +169,7 @@ Resources:
     Condition: Three
     Properties:
       VpcId: !Ref VPC
-      CidrBlock: !Select [4, !Cidr [!Ref VpcCidr, 6, 8]]
+      CidrBlock: !Select [4, !Cidr [!Ref VpcCidr, 8, 8]]
       AvailabilityZone: !If [ExplicitAZs, !Ref AZ3, !Select [2, !GetAZs '']]
       MapPublicIpOnLaunch: true
       Tags:
@@ -182,12 +189,52 @@ Resources:
     Condition: Three
     Properties:
       VpcId: !Ref VPC
-      CidrBlock: !Select [5, !Cidr [!Ref VpcCidr, 6, 8]]
+      CidrBlock: !Select [5, !Cidr [!Ref VpcCidr, 8, 8]]
       AvailabilityZone: !If [ExplicitAZs, !Ref AZ3, !Select [2, !GetAZs '']]
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
           Value: !Sub "${Name}-Private-Subnet-3"
+        - Key: 'rosa_managed_policies'
+          Value: 'true'
+        - Key: 'rosa_hcp_policies'
+          Value: 'true'
+        - Key: 'service'
+          Value: 'ROSA'
+        - Key: 'kubernetes.io/role/internal-elb'
+          Value: '1'
+
+  SubnetPublic4:
+    Type: AWS::EC2::Subnet
+    Condition: Three
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Select [6, !Cidr [!Ref VpcCidr, 8, 8]]
+      AvailabilityZone: !If [ExplicitAZs, !Ref AZ4, !Select [3, !GetAZs '']]
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: !Sub "${Name}-Public-Subnet-4"
+        - Key: 'rosa_managed_policies'
+          Value: 'true'
+        - Key: 'rosa_hcp_policies'
+          Value: 'true'
+        - Key: 'service'
+          Value: 'ROSA'
+        - Key: 'kubernetes.io/role/elb'
+          Value: '1'
+
+  SubnetPrivate4:
+    Type: AWS::EC2::Subnet
+    Condition: Three
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Select [7, !Cidr [!Ref VpcCidr, 8, 8]]
+      AvailabilityZone: !If [ExplicitAZs, !Ref AZ4, !Select [3, !GetAZs '']]
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub "${Name}-Private-Subnet-4"
         - Key: 'rosa_managed_policies'
           Value: 'true'
         - Key: 'rosa_hcp_policies'
@@ -261,6 +308,21 @@ Resources:
         - Key: 'service'
           Value: 'ROSA'
 
+  ElasticIP4:
+    Condition: Four
+    Type: AWS::EC2::EIP
+    Properties:
+      Domain: vpc
+      Tags:
+        - Key: Name
+          Value: !Ref Name
+        - Key: 'rosa_managed_policies'
+          Value: 'true'
+        - Key: 'rosa_hcp_policies'
+          Value: 'true'
+        - Key: 'service'
+          Value: 'ROSA'
+
   NATGateway1:
     Condition: One
     Type: 'AWS::EC2::NatGateway'
@@ -302,6 +364,22 @@ Resources:
       Tags:
         - Key: Name
           Value: !Sub "${Name}-NAT-3"
+        - Key: 'rosa_managed_policies'
+          Value: 'true'
+        - Key: 'rosa_hcp_policies'
+          Value: 'true'
+        - Key: 'service'
+          Value: 'ROSA'
+
+  NATGateway4:
+    Condition: Four
+    Type: 'AWS::EC2::NatGateway'
+    Properties:
+      AllocationId: !GetAtt ElasticIP4.AllocationId
+      SubnetId: !Ref SubnetPublic4
+      Tags:
+        - Key: Name
+          Value: !Sub "${Name}-NAT-4"
         - Key: 'rosa_managed_policies'
           Value: 'true'
         - Key: 'rosa_hcp_policies'
@@ -359,7 +437,10 @@ Resources:
           - !If
             - Three
             - !Ref NATGateway3
-            - !Ref "AWS::NoValue"
+            - !If
+              - Four
+              - !Ref NATGateway4
+              - !Ref "AWS::NoValue"
 
   PublicSubnetRouteTableAssociation1:
     Condition: One
@@ -382,6 +463,13 @@ Resources:
       SubnetId: !Ref SubnetPublic3
       RouteTableId: !Ref PublicRouteTable
 
+  PublicSubnetRouteTableAssociation4:
+    Condition: Four
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref SubnetPublic4
+      RouteTableId: !Ref PublicRouteTable
+
   PrivateSubnetRouteTableAssociation1:
     Condition: One
     Type: AWS::EC2::SubnetRouteTableAssociation
@@ -401,6 +489,13 @@ Resources:
     Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:
       SubnetId: !Ref SubnetPrivate3
+      RouteTableId: !Ref PrivateRouteTable
+
+  PrivateSubnetRouteTableAssociation4:
+    Condition: Four
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref SubnetPrivate4
       RouteTableId: !Ref PrivateRouteTable
   
   SecurityGroup:
@@ -439,6 +534,8 @@ Resources:
         - !If [One, !Ref SubnetPrivate1, !Ref "AWS::NoValue"]
         - !If [Two, !Ref SubnetPrivate2, !Ref "AWS::NoValue"]
         - !If [Three, !Ref SubnetPrivate3, !Ref "AWS::NoValue"]
+        - !If [Four, !Ref SubnetPrivate4, !Ref "AWS::NoValue"]
+        - !If [Four, !Ref SubnetPrivate4, !Ref "AWS::NoValue"]
       SecurityGroupIds:
         - !Ref SecurityGroup
 
@@ -453,6 +550,7 @@ Resources:
         - !If [One, !Ref SubnetPrivate1, !Ref "AWS::NoValue"]
         - !If [Two, !Ref SubnetPrivate2, !Ref "AWS::NoValue"]
         - !If [Three, !Ref SubnetPrivate3, !Ref "AWS::NoValue"]
+        - !If [Four, !Ref SubnetPrivate4, !Ref "AWS::NoValue"]
       SecurityGroupIds:
         - !Ref SecurityGroup
 
@@ -467,6 +565,7 @@ Resources:
         - !If [One, !Ref SubnetPrivate1, !Ref "AWS::NoValue"]
         - !If [Two, !Ref SubnetPrivate2, !Ref "AWS::NoValue"]
         - !If [Three, !Ref SubnetPrivate3, !Ref "AWS::NoValue"]
+        - !If [Four, !Ref SubnetPrivate4, !Ref "AWS::NoValue"]
       SecurityGroupIds:
         - !Ref SecurityGroup
 
@@ -481,6 +580,7 @@ Resources:
         - !If [One, !Ref SubnetPrivate1, !Ref "AWS::NoValue"]
         - !If [Two, !Ref SubnetPrivate2, !Ref "AWS::NoValue"]
         - !If [Three, !Ref SubnetPrivate3, !Ref "AWS::NoValue"]
+        - !If [Four, !Ref SubnetPrivate4, !Ref "AWS::NoValue"]
       SecurityGroupIds:
         - !Ref SecurityGroup
 
@@ -495,7 +595,8 @@ Resources:
         - !If [One, !Ref SubnetPrivate1, !Ref "AWS::NoValue"]
         - !If [Two, !Ref SubnetPrivate2, !Ref "AWS::NoValue"]
         - !If [Three, !Ref SubnetPrivate3, !Ref "AWS::NoValue"]
-      SecurityGroupIds:
+        - !If [Four, !Ref SubnetPrivate4, !Ref "AWS::NoValue"]
+      SecurityGroupIds: 
         - !Ref SecurityGroup
 
 Outputs:
@@ -513,13 +614,13 @@ Outputs:
 
   PublicSubnets:
     Description: "Public Subnet Ids"
-    Value: !Join [",", [!If [One, !Ref SubnetPublic1, !Ref "AWS::NoValue"], !If [Two, !Ref SubnetPublic2, !Ref "AWS::NoValue"], !If [Three, !Ref SubnetPublic3, !Ref "AWS::NoValue"]]]
+    Value: !Join [",", [!If [One, !Ref SubnetPublic1, !Ref "AWS::NoValue"], !If [Two, !Ref SubnetPublic2, !Ref "AWS::NoValue"], !If [Three, !Ref SubnetPublic3, !Ref "AWS::NoValue"], !If [Four, !Ref SubnetPublic4, !Ref "AWS::NoValue"]]]
     Export:
       Name: !Sub "${Name}-PublicSubnets"
 
   PrivateSubnets:
     Description: "Private Subnet Ids"
-    Value: !Join [",", [!If [One, !Ref SubnetPrivate1, !Ref "AWS::NoValue"], !If [Two, !Ref SubnetPrivate2, !Ref "AWS::NoValue"], !If [Three, !Ref SubnetPrivate3, !Ref "AWS::NoValue"]]]
+    Value: !Join [",", [!If [One, !Ref SubnetPrivate1, !Ref "AWS::NoValue"], !If [Two, !Ref SubnetPrivate2, !Ref "AWS::NoValue"], !If [Three, !Ref SubnetPrivate3, !Ref "AWS::NoValue"], !If [Four, !Ref SubnetPublic4, !Ref "AWS::NoValue"]]]
     Export:
       Name: !Sub "${Name}-PrivateSubnets"
 
@@ -543,9 +644,16 @@ Outputs:
     Export:
       Name: !Sub "${Name}-EIP3-AllocationId"
 
+  EIP4AllocationId:
+    Condition: Four
+    Description: Allocation ID for ElasticIP4
+    Value: !GetAtt ElasticIP4.AllocationId
+    Export:
+      Name: !Sub "${Name}-EIP4-AllocationId"
+
   NatGatewayId:
     Description: The NAT Gateway IDs
-    Value: !Join [",", [!If [One, !Ref NATGateway1, !Ref "AWS::NoValue"], !If [Two, !Ref NATGateway2, !Ref "AWS::NoValue"], !If [Three, !Ref NATGateway3, !Ref "AWS::NoValue"]]]
+    Value: !Join [",", [!If [One, !Ref NATGateway1, !Ref "AWS::NoValue"], !If [Two, !Ref NATGateway2, !Ref "AWS::NoValue"], !If [Three, !Ref NATGateway3, !Ref "AWS::NoValue"], !If [Four, !Ref NATGateway4, !Ref "AWS::NoValue"]]]
     Export:
       Name: !Sub "${Name}-NatGatewayId"
 

--- a/pkg/options/network/create.go
+++ b/pkg/options/network/create.go
@@ -18,7 +18,7 @@ const (
 		"\n\n" + `  # ROSA quick start HCP VPC example` +
 		"\n" + `  rosa create network rosa-quickstart-default-vpc --param Region=us-west-2` +
 		` --param Name=quickstart-stack --param AvailabilityZoneCount=1` +
-		` --param AvailabilityZones=us-west-2b,us-west-2d --param VpcCidr=10.0.0.0/16` +
+		` --param AZ1=us-west-2b --param AZ2=us-west-2d --param VpcCidr=10.0.0.0/16` +
 		"\n\n" + `  # To delete the AWS cloudformation stack` +
 		"\n" + `  aws cloudformation delete-stack --stack-name <name> --region <region>` +
 		"\n\n" + `# TEMPLATE_NAME:` +

--- a/tests/e2e/test_rosacli_network_resources.go
+++ b/tests/e2e/test_rosacli_network_resources.go
@@ -385,7 +385,7 @@ var _ = Describe("Network Resources",
 						"--template-dir", tdpWithoutVPCCIDR, fmt.Sprintf(
 							"--param=Name=%s", tdnWithoutVPCCIDR), "--param=Region=us-west-2",
 					},
-					"Parameter 'AvailabilityZoneCount' must be a number not greater than 3": {
+					"Parameter 'AvailabilityZoneCount' must be a number not greater than 4": {
 						"--param=AvailabilityZoneCount=10", "--param=Name=invalid-az"},
 					"Parameter 'AvailabilityZoneCount' must be a number not less than 1": {
 						"--param=AvailabilityZoneCount=0", "--param=Name=invalid-az"},


### PR DESCRIPTION
This pull request:
* OCM-14892: Adds the ability to specify 4 availability zones. This is useful in regions such as us-west-2, which has more than 3 AZs.
* OCM-14863: Fixes the default CF template so that it is possible to create the cloudformation stack without having to specify availability zones or the AZ count
* OCM-14864: The default CF template has been adjusted so that when the uses specifies both the AZ count and the explicit AZs, the template will prefer the explicit AZs (i.e. the AZ count will be ignored). To achieve that, I had to get rid of the comma separated list of AZs and replace them with separate AZ parameters (`AZ1`, `AZ2`, `AZ3` and `AZ4`).

Closes: https://issues.redhat.com/browse/OCM-14846
Closes: https://issues.redhat.com/browse/OCM-14863
Closes: https://issues.redhat.com/browse/OCM-14892

Additional info on OCM-14864: with AZs explicitly specified as a comma delimited list, I had to use `Fn:Length()` for which I had to include `Transform: 'AWS::LanguageExtensions`. Currently though we would be hitting the bug / problen described in https://github.com/aws-cloudformation/cfn-language-discussion/issues/159 during the template execution: the CF engine on the AWS side would mistakenly try to evaluate `Fn:Select()` statements hidden behind a condition (i.e. you'd specify 2 zones, but the CF engine would try to evaluate also resources and outputs hidden behind `Condition: Three`, which would lead to an error).
I worked around the problem by using `AZ[1234]` string parameters instead.
