### PR TITLE
OCM-15005 | feat: sort CF template parameters in help output

### DIFF
--- a/cmd/create/network/cmd.go
+++ b/cmd/create/network/cmd.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -59,7 +60,14 @@ func NewNetworkCommand() *cobra.Command {
 					}
 
 					fmt.Printf("Available parameters in %s/%s:\n", filepath.Base(filepath.Dir(path)), d.Name())
+					paramNames := make([]string, len(parameters))
+					i := 0
 					for paramName := range parameters {
+						paramNames[i] = paramName
+						i++
+					}
+					slices.Sort(paramNames)
+					for _, paramName := range paramNames {
 						fmt.Printf("  %s\n", paramName)
 					}
 					fmt.Printf("  %s\n", "Tags")
@@ -86,7 +94,14 @@ func NewNetworkCommand() *cobra.Command {
 			}
 
 			fmt.Printf("Available parameters in default template:\n")
+			paramNames := make([]string, len(parameters))
+			i := 0
 			for paramName := range parameters {
+				paramNames[i] = paramName
+				i++
+			}
+			slices.Sort(paramNames)
+			for _, paramName := range paramNames {
 				fmt.Printf("  %s\n", paramName)
 			}
 			fmt.Printf("  %s\n", "Tags")

--- a/pkg/options/network/create.go
+++ b/pkg/options/network/create.go
@@ -15,9 +15,13 @@ const (
 	long    = "Network AWS cloudformation stack using predefined yaml templates. "
 	example = `  # Create a AWS cloudformation stack
   rosa create network <template-name> --param Param1=Value1 --param Param2=Value2 ` +
-		"\n\n" + `  # ROSA quick start HCP VPC example` +
+		"\n\n" + `  # ROSA quick start HCP VPC example with one availability zone` +
 		"\n" + `  rosa create network rosa-quickstart-default-vpc --param Region=us-west-2` +
 		` --param Name=quickstart-stack --param AvailabilityZoneCount=1` +
+		` --param VpcCidr=10.0.0.0/16` +
+		"\n\n" + `  # ROSA quick start HCP VPC example with two explicit availability zones` +
+		"\n" + `  rosa create network rosa-quickstart-default-vpc --param Region=us-west-2` +
+		` --param Name=quickstart-stack` +
 		` --param AZ1=us-west-2b --param AZ2=us-west-2d --param VpcCidr=10.0.0.0/16` +
 		"\n\n" + `  # To delete the AWS cloudformation stack` +
 		"\n" + `  aws cloudformation delete-stack --stack-name <name> --region <region>` +


### PR DESCRIPTION
Before (random order of the template parameters):
```
$ rosa create network -h 
Available parameters in default template:
  VpcCidr
  Name
  AZ4
  AvailabilityZoneCount
  AZ3
  AZ1
  Region
  AZ2
  Tags
...
```

After (sorted order of the template parameters):
```
$ rosa create network -h 
Available parameters in default template:
  AZ1
  AZ2
  AZ3
  AZ4
  AvailabilityZoneCount
  Name
  Region
  VpcCidr
  Tags
...
```

Closes https://github.com/openshift/rosa/pull/2841