### PR TITLE
OCM-14453 | chore: Bump version of ROSA CLI to 1.2.52

### DIFF
--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,7 +18,7 @@ limitations under the License.
 
 package info
 
-const DefaultVersion = "1.2.51"
+const DefaultVersion = "1.2.52"
 
 // Build contains the short Git SHA of the CLI at the point it was build. Set via `-ldflags` at build time
 var Build = "local"


### PR DESCRIPTION
Bumps version to current version, protocol for releases