### PR TITLE
OCM-15096 | feat: Introduce `channel-group` in edit/cluster

### DIFF
--- a/cmd/edit/cluster/cmd.go
+++ b/cmd/edit/cluster/cmd.go
@@ -73,6 +73,9 @@ var args struct {
 	// SDN -> OVN Migration
 	networkType        string
 	ovnInternalSubnets string
+
+	// Added for EUS region support
+	channelGroup string
 }
 
 var clusterRegistryConfigArgs *clusterregistryconfig.ClusterRegistryConfigArgs
@@ -206,6 +209,14 @@ func init() {
 			"OVN-Kubernetes. Must be supplied as a string=value pair with any of 'join', 'transit', 'masquerade' "+
 			"followed by a CIDR. \nExample: '--ovn-internal-subnets=\"join=192.168.255.0/24,transit=192.168.255.0/24,"+
 			"masquerade=192.168.255.0/24\"'",
+	)
+
+	flags.StringVar(
+		&args.channelGroup,
+		"channel-group",
+		ocm.DefaultChannelGroup,
+		"Changes the channel group used for cluster versions. "+
+			"Channel group is the name of the channel where this image belongs, for example \"stable\" or \"eus\".",
 	)
 }
 
@@ -868,6 +879,10 @@ func run(cmd *cobra.Command, _ []string) {
 	// sets the billing account only if it has changed
 	if billingAccount != "" && billingAccount != cluster.AWS().BillingAccountID() {
 		clusterConfig.BillingAccount = billingAccount
+	}
+
+	if args.channelGroup != "" {
+		clusterConfig.ChannelGroup = args.channelGroup
 	}
 
 	r.Reporter.Debugf("Updating cluster '%s'", clusterKey)

--- a/cmd/rosa/structure_test/command_args/rosa/edit/cluster/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/edit/cluster/command_args.yml
@@ -23,3 +23,4 @@
 - name: billing-account
 - name: network-type
 - name: ovn-internal-subnets
+- name: channel-group

--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -588,6 +588,13 @@ func (c *Client) UpdateCluster(clusterKey string, creator *aws.Creator, config S
 		clusterBuilder = clusterBuilder.ExpirationTimestamp(config.Expiration)
 	}
 
+	// Update channel group
+	if config.ChannelGroup != "" {
+		clusterBuilder.Version(cmv1.NewVersion().
+			ChannelGroup(config.ChannelGroup),
+		)
+	}
+
 	// Scale cluster
 	clusterNodesBuilder, updateNodes := c.getClusterNodesBuilder(config)
 	if updateNodes {


### PR DESCRIPTION
API body on changing channel-group:

```
time=2025-04-07T15:19:43-04:00 level=debug msg={
  "kind": "Cluster",
  "api": {
    "listening": "external"
  },
  "disable_user_workload_monitoring": false,
  "version": {
    "kind": "Version",
    "channel_group": "nightly"
  }
}
```

-------------

Response when version is not supported in channel group from API:

```
E: Failed to update cluster: status is 400, identifier is '400', code is 'CLUSTERS-MGMT-400', at '2025-04-07T19:19:44Z' and operation identifier is 'XXXX': The current version '4.18.6' is not available for the desired channel group 'nightly'
```

-------------

Version cannot be edited, only the channel group. If a user gets an error about unsupported version, they are to upgrade the version before editing the channel group.
