### PR TITLE
OCM-15097 | feat: Un-hide `channel-group` flag in create/cluster

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -439,7 +439,6 @@ func initFlags(cmd *cobra.Command) {
 		ocm.DefaultChannelGroup,
 		"Channel group is the name of the group where this image belongs, for example \"stable\" or \"fast\".",
 	)
-	flags.MarkHidden("channel-group")
 
 	flags.StringVar(
 		&args.flavour,


### PR DESCRIPTION
Unhides the `channel-group` flag in `create/cluster` - related to EUS region support ([OCM-15097](https://issues.redhat.com//browse/OCM-15097))