### PR TITLE
OCM-15190 | feat: Remove default channelgroup from edit/cluster

### DIFF
--- a/cmd/edit/cluster/cmd.go
+++ b/cmd/edit/cluster/cmd.go
@@ -214,7 +214,7 @@ func init() {
 	flags.StringVar(
 		&args.channelGroup,
 		"channel-group",
-		ocm.DefaultChannelGroup,
+		"",
 		"Changes the channel group used for cluster versions. "+
 			"Channel group is the name of the channel where this image belongs, for example \"stable\" or \"eus\".",
 	)


### PR DESCRIPTION
Removes the default `"stable"` channel group value from `edit/cluster`