### PR TITLE
OCM-4667 | feat: added new warnings and validations to account-role

### DIFF
--- a/pkg/helper/roles/helpers.go
+++ b/pkg/helper/roles/helpers.go
@@ -43,6 +43,22 @@ func GetOperatorRoleName(cluster *cmv1.Cluster, missingOperator *cmv1.STSOperato
 	return awsCommonUtils.TruncateRoleName(role)
 }
 
+func CheckHasRedHatManagedTag(arn string, awsClient aws.Client) bool {
+	roleName, err := awsClient.GetRoleByARN(arn)
+	if err != nil {
+		return false
+	}
+
+	roleTags := roleName.Tags
+	for _, tag := range roleTags {
+		if *tag.Key == tags.RedHatManaged {
+			return true
+		}
+	}
+
+	return false
+}
+
 func BuildMissingOperatorRoleCommand(
 	missingRoles map[string]*cmv1.STSOperator,
 	cluster *cmv1.Cluster,


### PR DESCRIPTION
# Details

This PR improves the UX when handling account roles and introduces a new check to verify whether a role is **managed by Red Hat** or not and some warnings.

---

# How to Test

Before running the test cases, create an account role with version `4.13` using the following command:

```bash
./rosa create account-roles --mode auto --version 4.13
```

---

##  Test Case 1 – Selecting a Different OpenShift Version

1. Run the command:

    ```bash
    ./rosa create cluster --hosted-cp --mode auto
    ```

2. During the interactive flow:
   - Select an account role tied to version **4.13**
   - Then choose a **different OpenShift version**, e.g., `4.14`

3. You should see the following **warnings**, and the command **will NOT stop running**:

    ```
    W: Account roles not created by ROSA CLI cannot be listed, updated, or upgraded. Use ROSA CLI to create them before proceeding.
    W: No suitable accounts with ROSA CLI-created account roles were found. You can manually set them in the next steps or run 'rosa create account-roles' to create them first.
    ```

---

## Test Case 2 – Selecting the Same OpenShift Version

1. Run the command:

    ```bash
    ./rosa create cluster --hosted-cp --mode auto
    ```

2. During the interactive flow:
   - Select an account role tied to version **4.13**
   - Then choose the **same OpenShift version**, `4.13`

3. You should see the following **warning**, and the command **will NOT stop running**:

    ```
    W: Account roles not created by ROSA CLI cannot be listed, updated, or upgraded. Use ROSA CLI to create them before proceeding.
    ```

---

## Additional Info

If the selected role is **not managed by Red Hat**, the following warning should appear:

```
W: The role 'ROLE_NAME' is not a Red Hat managed role
```

---

# Ticket

Closes [[OCM-4667](https://issues.redhat.com/browse/OCM-4667)](https://issues.redhat.com/browse/OCM-4667)