### PR TITLE
OCM-15511 | ci: Use cluster spec to check the ready and waiting status in the Day1Readiness step

### DIFF
--- a/tests/utils/exec/rosacli/cluster_service.go
+++ b/tests/utils/exec/rosacli/cluster_service.go
@@ -506,11 +506,11 @@ func (c *clusterService) WaitForClusterPassUninstalled(clusterID string, interva
 func (c *clusterService) WaitForClusterPassWaiting(clusterID string, interval int, timeoutMin int) error {
 	endTime := time.Now().Add(time.Duration(timeoutMin) * time.Minute)
 	for time.Now().Before(endTime) {
-		output, err := c.DescribeClusterAndReflect(clusterID)
+		clusterJsonData, err := c.GetJSONClusterDescription(clusterID)
 		if err != nil {
 			return err
 		}
-		if !strings.Contains(output.State, constants.Waiting) {
+		if clusterJsonData.DigString("state") != constants.Waiting {
 			log.Logger.Infof("Cluster %s is not in waiting state anymore", clusterID)
 			return nil
 		}

--- a/tests/utils/handler/cluster_handler.go
+++ b/tests/utils/handler/cluster_handler.go
@@ -878,6 +878,11 @@ func (ch *clusterHandler) WaitForClusterReady(timeoutMin int) error {
 	endTime := time.Now().Add(time.Duration(timeoutMin) * time.Minute)
 	sleepTime := 0
 	for time.Now().Before(endTime) {
+		clusterJsonData, _ := clusterService.GetJSONClusterDescription(clusterID)
+		if clusterJsonData.DigString("state") == constants.Ready {
+			log.Logger.Infof("Cluster %s is ready now.", clusterID)
+			return nil
+		}
 		description, err := clusterService.DescribeClusterAndReflect(clusterID)
 		if err != nil {
 			return err
@@ -886,9 +891,6 @@ func (ch *clusterHandler) WaitForClusterReady(timeoutMin int) error {
 		ch.clusterDetail.ConsoleURL = description.ConsoleURL
 		ch.clusterDetail.InfraID = description.InfraID
 		switch description.State {
-		case constants.Ready:
-			log.Logger.Infof("Cluster %s is ready now.", clusterID)
-			return nil
 		case constants.Uninstalling:
 			return fmt.Errorf("cluster %s is %s now. Cannot wait for it ready",
 				clusterID, constants.Uninstalling)


### PR DESCRIPTION
In some period jobs, some are failed at Day1Readiness step because the waiting status cannot be parsed from the output of 'rosa describe cluster'. Another problem is that some cluster state is ready but the description is "Cluster is installing"
Failed jobs examples:

- https://redhat-internal.slack.com/archives/C0519LZH1RA/p1745260818333859
- https://redhat-internal.slack.com/archives/C0519LZH1RA/p1745701457257459

 
the Day1Readiness is a step for cluster preparation, using cluster spec of `rosa describe cluster -o json` has no impact for the case checkpoint, will fix above issues to increase the job pass ratio.

local log is here: https://privatebin.corp.redhat.com/?b4b1bb2af7084358#74C47Coo7H59h66zetBzKxSGYsqojmTQcNMhFoZ8kqLL