### PR TITLE
OCM-15397 | ci: Support cluster autoscaler day2 action for HCP cluster

### DIFF
--- a/tests/ci/config/config.go
+++ b/tests/ci/config/config.go
@@ -76,9 +76,10 @@ type ClusterENVVariables struct {
 }
 
 type Day2ConfENVVariables struct {
-	LocalZoneMP    bool `env:"LOCAL_ZONE_MP" default:"false"`
-	TuningConfig   bool `env:"TUNING_CONFIG" default:"false"`
-	TuningConfigMP bool `env:"TUNING_CONFIG_MP" default:"false"`
+	LocalZoneMP       bool `env:"LOCAL_ZONE_MP" default:"false"`
+	TuningConfig      bool `env:"TUNING_CONFIG" default:"false"`
+	TuningConfigMP    bool `env:"TUNING_CONFIG_MP" default:"false"`
+	ClusterAutoScaler bool `env:"CLUSTER_AUTOSCALER" default:"false"`
 }
 
 func init() {
@@ -159,10 +160,12 @@ func init() {
 	local_zone_mp, _ := strconv.ParseBool(helper.ReadENVWithDefaultValue("LOCAL_ZONE_MP", "false"))
 	tuning_config, _ := strconv.ParseBool(helper.ReadENVWithDefaultValue("TUNING_CONFIG", "false"))
 	tuning_config_mp, _ := strconv.ParseBool(helper.ReadENVWithDefaultValue("TUNING_CONFIG_MP", "false"))
+	cluster_autoscaler, _ := strconv.ParseBool(helper.ReadENVWithDefaultValue("CLUSTER_AUTOSCALER", "false"))
 	Test.Day2ConfENV = &Day2ConfENVVariables{
-		LocalZoneMP:    local_zone_mp,
-		TuningConfig:   tuning_config,
-		TuningConfigMP: tuning_config_mp,
+		LocalZoneMP:       local_zone_mp,
+		TuningConfig:      tuning_config,
+		TuningConfigMP:    tuning_config_mp,
+		ClusterAutoScaler: cluster_autoscaler,
 	}
 
 }

--- a/tests/ci/data/profiles/external.yaml
+++ b/tests/ci/data/profiles/external.yaml
@@ -100,6 +100,8 @@ profiles:
     customized_prefix: true
     path: ""
     permission_boundary: ""
+  day2-conf:
+    cluster-autoscaler: true
 - as: ocpe2e-rosa-hcp-pl
   version: latest
   channel_group: stable
@@ -129,7 +131,7 @@ profiles:
     permission_boundary: "arn:aws:iam::aws:policy/AdministratorAccess"
 - as: ocpe2e-rosa-hcp-upgrade-y-stream
   version: "y-1"
-  channel_group: stable
+  channel_group: candidate
   region: "us-west-2"
   cluster:
     multi_az: true

--- a/tests/e2e/e2e_day2_conf_test.go
+++ b/tests/e2e/e2e_day2_conf_test.go
@@ -1,0 +1,148 @@
+package e2e
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openshift-online/ocm-common/pkg/test/vpc_client"
+
+	"github.com/openshift/rosa/tests/ci/labels"
+	utilConfig "github.com/openshift/rosa/tests/utils/config"
+	"github.com/openshift/rosa/tests/utils/exec/rosacli"
+	"github.com/openshift/rosa/tests/utils/handler"
+	"github.com/openshift/rosa/tests/utils/helper"
+	"github.com/openshift/rosa/tests/utils/log"
+)
+
+var _ = Describe("Cluster Day2 preparation", labels.Feature.Cluster, func() {
+
+	It("to prepare day2 conf for cluster",
+		labels.Runtime.Day2Readiness,
+		func() {
+			profile := handler.LoadProfileYamlFileByENV()
+			client := rosacli.NewClient()
+			clusterHandler, err := handler.NewClusterHandlerFromFilesystem(client, profile)
+			Expect(err).ToNot(HaveOccurred())
+
+			clusterID := clusterHandler.GetClusterDetail().ClusterID
+			clusterService := client.Cluster
+			output, err := clusterService.DescribeCluster(clusterID)
+			Expect(err).To(BeNil())
+			clusterDetails, err := clusterService.ReflectClusterDescription(output)
+			Expect(err).To(BeNil())
+
+			clusterConfig, err := utilConfig.ParseClusterProfile()
+			Expect(err).To(BeNil())
+
+			//Edit cluster default autoscaler for HCP cluster
+			if profile.Day2Config != nil && profile.Day2Config.ClusterAutoScaler && profile.ClusterConfig.HCP {
+				By("Edit the autoscaler with custom values")
+				podPriorityThreshold := "1000"
+				maxNodeProvisionTime := "50m"
+				maxPodGracePeriod := "700"
+				maxNodesTotal := "100"
+				_, err = client.AutoScaler.EditAutoScaler(clusterID,
+					"--pod-priority-threshold", podPriorityThreshold,
+					"--max-node-provision-time", maxNodeProvisionTime,
+					"--max-pod-grace-period", maxPodGracePeriod,
+					"--max-nodes-total", maxNodesTotal,
+				)
+				Expect(err).ToNot(HaveOccurred())
+				log.Logger.Infof("Update cluster autoscaler successfully")
+			}
+
+			//Create machinepool with local zone for cluster
+			if profile.Day2Config != nil && profile.Day2Config.LocalZoneMP && !profile.ClusterConfig.HCP {
+				if profile.ClusterConfig.BYOVPC == false {
+					Skip("This day2 config only work for byovpc cluster")
+				}
+				By("Prepare a subnet out of the cluster creation subnet")
+				subnets := helper.ParseCommaSeparatedStrings(clusterConfig.Subnets.PrivateSubnetIds)
+
+				By("Build vpc client to find a local zone for subnet preparation")
+				vpcClient, err := vpc_client.GenerateVPCBySubnet(subnets[0], clusterConfig.Region)
+				Expect(err).ToNot(HaveOccurred())
+
+				zones, err := vpcClient.AWSClient.ListAvaliableZonesForRegion(clusterConfig.Region, "local-zone")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(zones)).ToNot(BeZero(), "No local zone found in the region")
+				localZone := zones[0]
+
+				By("Prepare the subnet for the picked zone")
+				subNetMap, err := vpcClient.PreparePairSubnetByZone(localZone)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(subNetMap).ToNot(BeNil())
+				privateSubnet := subNetMap["private"]
+
+				By("Describe the cluster to get the infra ID for tagging")
+				tagKey := fmt.Sprintf("kubernetes.io/cluster/%s", clusterDetails.InfraID)
+				_, err = vpcClient.AWSClient.TagResource(privateSubnet.ID, map[string]string{
+					tagKey: "shared",
+				})
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Find a machinetype supported by the zone")
+				instanceTypes, err := vpcClient.AWSClient.ListAvaliableInstanceTypesForRegion(
+					clusterConfig.Region, localZone)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Create temporary account-roles for instance type list")
+				namePrefix := helper.GenerateRandomName("test-day2-conf", 2)
+				majorVersion := helper.SplitMajorVersion(clusterConfig.Version.RawID)
+				_, err = client.OCMResource.CreateAccountRole("--mode", "auto",
+					"--prefix", namePrefix,
+					"--version", majorVersion,
+					"--channel-group", clusterConfig.Version.ChannelGroup,
+					"-y")
+				Expect(err).ToNot(HaveOccurred())
+
+				var accountRoles *rosacli.AccountRolesUnit
+				accRoleList, _, err := client.OCMResource.ListAccountRole()
+				Expect(err).ToNot(HaveOccurred())
+				accountRoles = accRoleList.DigAccountRoles(namePrefix, false)
+
+				defer func() {
+					_, err = client.OCMResource.DeleteAccountRole(
+						"--prefix", namePrefix,
+						"--mode", "auto",
+						"-y")
+					Expect(err).ToNot(HaveOccurred())
+				}()
+
+				rosaSupported, _, err := client.OCMResource.ListInstanceTypes(
+					"--region", clusterConfig.Region,
+					"--role-arn", accountRoles.InstallerRole,
+				)
+				Expect(err).ToNot(HaveOccurred())
+
+				bothSupported := []string{}
+				for _, rosains := range rosaSupported.InstanceTypesList {
+					if helper.SliceContains(instanceTypes, rosains.ID) {
+						bothSupported = append(bothSupported, rosains.ID)
+					}
+				}
+				Expect(bothSupported).ToNot(BeEmpty(), "There are no instance types supported in the zone")
+				instanceType := bothSupported[0]
+
+				By("Create machinepool with the subnet specified will succeed")
+				localZoneMpName := "localz-day2-conf"
+				_, err = client.MachinePool.CreateMachinePool(clusterID, localZoneMpName,
+					"--replicas", "1",
+					"--subnet", privateSubnet.ID,
+					"--instance-type", instanceType,
+					"--labels", "prowci=true,node-role.kubernetes.io/edge=",
+					"--taints", "prowci=true:NoSchedule,node-role.kubernetes.io/edge=:NoSchedule",
+				)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("List the machinepools and check")
+				mpList, err := client.MachinePool.ListAndReflectMachinePools(clusterID)
+				Expect(err).ToNot(HaveOccurred())
+				mp := mpList.Machinepool(localZoneMpName)
+				Expect(mp.Replicas).To(Equal("1"))
+				Expect(mp.Subnets).To(Equal(privateSubnet.ID))
+				log.Logger.Infof("Create machine pool with local zone successfully")
+			}
+		})
+})

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -7,7 +7,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/openshift-online/ocm-common/pkg/test/vpc_client"
 
 	"github.com/openshift/rosa/tests/ci/config"
 	"github.com/openshift/rosa/tests/ci/labels"
@@ -142,113 +141,5 @@ var _ = Describe("Cluster preparation", labels.Feature.Cluster, func() {
 				}
 			}
 
-		})
-
-	It("to prepare day2 conf for cluster",
-		labels.Runtime.Day2Readiness,
-		func() {
-			profile := handler.LoadProfileYamlFileByENV()
-			client := rosacli.NewClient()
-			clusterHandler, err := handler.NewClusterHandlerFromFilesystem(client, profile)
-			Expect(err).ToNot(HaveOccurred())
-
-			clusterID := clusterHandler.GetClusterDetail().ClusterID
-			clusterService := client.Cluster
-			output, err := clusterService.DescribeCluster(clusterID)
-			Expect(err).To(BeNil())
-			clusterDetails, err := clusterService.ReflectClusterDescription(output)
-			Expect(err).To(BeNil())
-
-			clusterConfig, err := utilConfig.ParseClusterProfile()
-			Expect(err).To(BeNil())
-
-			if profile.ClusterConfig.BYOVPC == false {
-				Skip("This day2 config only work for byovpc cluster")
-			}
-
-			//Create local zone for cluster
-			if profile.Day2Config != nil && profile.Day2Config.LocalZoneMP {
-				By("Prepare a subnet out of the cluster creation subnet")
-				subnets := helper.ParseCommaSeparatedStrings(clusterConfig.Subnets.PrivateSubnetIds)
-
-				By("Build vpc client to find a local zone for subnet preparation")
-				vpcClient, err := vpc_client.GenerateVPCBySubnet(subnets[0], clusterConfig.Region)
-				Expect(err).ToNot(HaveOccurred())
-
-				zones, err := vpcClient.AWSClient.ListAvaliableZonesForRegion(clusterConfig.Region, "local-zone")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(len(zones)).ToNot(BeZero(), "No local zone found in the region")
-				localZone := zones[0]
-
-				By("Prepare the subnet for the picked zone")
-				subNetMap, err := vpcClient.PreparePairSubnetByZone(localZone)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(subNetMap).ToNot(BeNil())
-				privateSubnet := subNetMap["private"]
-
-				By("Describe the cluster to get the infra ID for tagging")
-				tagKey := fmt.Sprintf("kubernetes.io/cluster/%s", clusterDetails.InfraID)
-				vpcClient.AWSClient.TagResource(privateSubnet.ID, map[string]string{
-					tagKey: "shared",
-				})
-
-				By("Find a machinetype supported by the zone")
-				instanceTypes, err := vpcClient.AWSClient.ListAvaliableInstanceTypesForRegion(
-					clusterConfig.Region, localZone)
-				Expect(err).ToNot(HaveOccurred())
-
-				By("Create temporary account-roles for instance type list")
-				namePrefix := helper.GenerateRandomName("test-day2-conf", 2)
-				majorVersion := helper.SplitMajorVersion(clusterConfig.Version.RawID)
-				_, err = client.OCMResource.CreateAccountRole("--mode", "auto",
-					"--prefix", namePrefix,
-					"--version", majorVersion,
-					"--channel-group", clusterConfig.Version.ChannelGroup,
-					"-y")
-				Expect(err).ToNot(HaveOccurred())
-
-				var accountRoles *rosacli.AccountRolesUnit
-				accRoleList, _, err := client.OCMResource.ListAccountRole()
-				Expect(err).ToNot(HaveOccurred())
-				accountRoles = accRoleList.DigAccountRoles(namePrefix, false)
-
-				defer client.OCMResource.DeleteAccountRole(
-					"--prefix", namePrefix,
-					"--mode", "auto",
-					"-y")
-
-				rosaSupported, _, err := client.OCMResource.ListInstanceTypes(
-					"--region", clusterConfig.Region,
-					"--role-arn", accountRoles.InstallerRole,
-				)
-				Expect(err).ToNot(HaveOccurred())
-
-				bothSupported := []string{}
-				for _, rosains := range rosaSupported.InstanceTypesList {
-					if helper.SliceContains(instanceTypes, rosains.ID) {
-						bothSupported = append(bothSupported, rosains.ID)
-					}
-				}
-				Expect(bothSupported).ToNot(BeEmpty(), "There are no instance types supported in the zone")
-				instanceType := bothSupported[0]
-
-				By("Create machinepool with the subnet specified will succeed")
-				localZoneMpName := "localz-day2-conf"
-				_, err = client.MachinePool.CreateMachinePool(clusterID, localZoneMpName,
-					"--replicas", "1",
-					"--subnet", privateSubnet.ID,
-					"--instance-type", instanceType,
-					"--labels", "prowci=true,node-role.kubernetes.io/edge=",
-					"--taints", "prowci=true:NoSchedule,node-role.kubernetes.io/edge=:NoSchedule",
-				)
-				Expect(err).ToNot(HaveOccurred())
-
-				By("List the machinepools and check")
-				mpList, err := client.MachinePool.ListAndReflectMachinePools(clusterID)
-				Expect(err).ToNot(HaveOccurred())
-				mp := mpList.Machinepool(localZoneMpName)
-				Expect(mp.Replicas).To(Equal("1"))
-				Expect(mp.Subnets).To(Equal(privateSubnet.ID))
-			}
 		})
 })

--- a/tests/utils/handler/interface.go
+++ b/tests/utils/handler/interface.go
@@ -14,9 +14,10 @@ type Profile struct {
 
 // Day2Config will map the configuration of day2-conf from profile settings
 type Day2Config struct {
-	LocalZoneMP    bool `yaml:"local-zone-mp,omitempty"`
-	TuningConfig   bool `yaml:" tuning-config,omitempty"`
-	TuningConfigMP bool `yaml:" tuning-config-mp,omitempty"`
+	LocalZoneMP       bool `yaml:"local-zone-mp,omitempty"`
+	TuningConfig      bool `yaml:"tuning-config,omitempty"`
+	TuningConfigMP    bool `yaml:"tuning-config-mp,omitempty"`
+	ClusterAutoScaler bool `yaml:"cluster-autoscaler,omitempty"`
 }
 
 // AccountRoleConfig will map the configuration of account roles from profile settings

--- a/tests/utils/handler/profile.go
+++ b/tests/utils/handler/profile.go
@@ -196,5 +196,12 @@ func LoadProfileYamlFileByENV() *Profile {
 			profile.Day2Config.LocalZoneMP = config.Test.Day2ConfENV.LocalZoneMP
 		}
 	}
+	if config.Test.Day2ConfENV.ClusterAutoScaler {
+		if profile.Day2Config != nil {
+			log.Logger.Infof("Got global env settings for LOCAL_ZONE_MP, overwritten the profile setting with value %v",
+				config.Test.Day2ConfENV.ClusterAutoScaler)
+			profile.Day2Config.ClusterAutoScaler = config.Test.Day2ConfENV.ClusterAutoScaler
+		}
+	}
 	return profile
 }


### PR DESCRIPTION
[OCM-15397](https://issues.redhat.com//browse/OCM-15397): support  cluster autoscaler day2 action after cluster creation
```
 ginkgo run --label-filter day2-readiness tests/e2e --timeout 2h
Running Suite: ROSA CLI e2e tests suite - /Users/yingzhan/ying-work/code/rosa/tests/e2e
=======================================================================================
Random Seed: 1745845618

Will run 1 of 266 specs
•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 266 Specs in 11.233 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 265 Skipped
PASS

ocm get  /api/clusters_mgmt/v1/clusters/2iedb0cnc0kvkmt9gec9qqqir1ndm9ia/autoscaler
{
  "kind":"ClusterAutoscaler",
  "href":"/api/clusters_mgmt/v1/clusters/2iedb0cnc0kvkmt9gec9qqqir1ndm9ia/autoscaler",
  "max_pod_grace_period":700,
  "pod_priority_threshold":1000,
  "max_node_provision_time":"50m",
  "resource_limits": {
    "max_nodes_total":100
  }
}
```