### PR TITLE
chore: bump version for 1.2.53 release

### DIFF
--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,7 +18,7 @@ limitations under the License.
 
 package info
 
-const DefaultVersion = "1.2.52"
+const DefaultVersion = "1.2.53"
 
 // Build contains the short Git SHA of the CLI at the point it was build. Set via `-ldflags` at build time
 var Build = "local"


### PR DESCRIPTION
relates to https://github.com/Homebrew/homebrew-core/pull/221768