### PR TITLE
OCM-15600 | feat: Clean up UX + remove billing account checks for HCP govcloud

### DIFF
--- a/cmd/create/cluster/validation.go
+++ b/cmd/create/cluster/validation.go
@@ -17,6 +17,8 @@ const (
 
 	isNotGovcloudFeature = "Hosted Control Plane shared VPC clusters are not supported on Govcloud regions; %s"
 	pleaseRemoveFlags    = "Please remove the following flags: %s"
+
+	billingAccountsHcpErrorMsg = "Billing accounts are only supported for non-govcloud Hosted Control Plane clusters"
 )
 
 func validateHcpSharedVpcArgs(route53RoleArn string, vpcEndpointRoleArn string,


### PR DESCRIPTION
Removes billing account ID when using HCP on fedramp, as well as forces the FIPS check in the same situation. Also added some UX in the form of warning the user they 1) don't need the billing account ID flag, and 2) informs them where it comes from