### PR TITLE
OCM-15158 | feat: Removed duplicated-from-API validation (machinepools)

### DIFF
--- a/pkg/ocm/machines.go
+++ b/pkg/ocm/machines.go
@@ -19,7 +19,6 @@ package ocm
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	amsv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -262,12 +261,7 @@ func (mtl *MachineTypeList) ValidateMachineType(machineType string, multiAZ bool
 	v := mtl.Find(machineType)
 
 	if v == nil {
-		allMachineTypes := strings.Join(mtl.IDs(), " ")
-		allAvailabilityZones := strings.Join(mtl.AvailabilityZones, ",")
-		err := fmt.Errorf("Machine type '%s' not found in availability zones '%s' for region: '%s'\n"+
-			"Available machine type list: %s",
-			machineType, allAvailabilityZones, mtl.Region, allMachineTypes)
-		return err
+		return nil // Replaced not-found error with a preflight in CS (validateZoneSupportInstanceType)
 	}
 
 	if !v.HasQuota(multiAZ) {


### PR DESCRIPTION
In the API, we have a preflight which covers this validation case: https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/blob/master/cmd/clusters-service/service/aws_preflight/preflight_service.go#L442

It has been asked to remove from the CLI, so errors are consistent.

2 tests have also been removed, since they relate to the functionality which this validation provided