### PR TITLE
OCM-15757 | ci: Change triggers for konflux, get PR pipeline passing

### DIFF
--- a/.tekton/rosa-pull-request.yaml
+++ b/.tekton/rosa-pull-request.yaml
@@ -8,8 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "release_1.2.53"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: rh-rosa-cli

--- a/.tekton/rosa-push.yaml
+++ b/.tekton/rosa-push.yaml
@@ -7,8 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release_1.2.53"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch.startsWith("refs/tags/release_")
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: rh-rosa-cli

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM registry.access.redhat.com/ubi9/go-toolset:latest AS builder
+COPY . .
+
+ENV GOFLAGS=-buildvcs=false
+RUN git config --global --add safe.directory /opt/app-root/src && \
+    make release
+
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest
+LABEL description="ROSA CLI"
+LABEL io.k8s.description="ROSA CLI"
+LABEL com.redhat.component="rh-rosa-cli"
+LABEL distribution-scope="release"
+LABEL name="rh-rosa-cli" release="vX.Y" url="https://github.com/openshift/rosa"
+LABEL vendor="Red Hat, Inc."
+LABEL version="vX.Y"
+
+COPY --from=builder /opt/app-root/src/releases /releases

--- a/Makefile
+++ b/Makefile
@@ -122,26 +122,8 @@ check-release-config:
 local-release:
 	$(GORELEASER) release --snapshot --clean
 
-# builds and publishes a pre-release of changes from the last release tag
-.PHONY: pre-release
-prerelease:
-	$(GORELEASER) release --clean
-
 # builds and publishes a latest release from tag set as env-ver GORELEASER_PREVIOUS_TAG
 # leave GORELEASER_PREVIOUS_TAG empty to build from last release tag
 .PHONY: release
 release:
-	@if [ -n "$(GORELEASER_PREVIOUS_TAG)" ]; then \
-		read -p "GORELEASER_PREVIOUS_TAG is set to '$(GORELEASER_PREVIOUS_TAG)'. Is this the correct tag for the last release? (y/N) " confirm; \
-		if [ "$$confirm" != "y" ]; then \
-			echo "Aborting release."; \
-			exit 1; \
-		fi \
-	else \
-		read -p "GORELEASER_PREVIOUS_TAG is not set. Do you want to proceed with building and publishing the release from the last release tag? (y/N) " confirm; \
-		if [ "$$confirm" != "y" ]; then \
-			echo "Aborting release."; \
-			exit 1; \
-		fi \
-	fi; \
-	$(GORELEASER) release --clean
+	bash ./hack/build_cli.sh

--- a/hack/build_cli.sh
+++ b/hack/build_cli.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#This script invoked via a make target by the Dockerfile
+#which builds a cli wrapper container that contains all release images
+archs=(amd64)
+oses=(darwin linux windows)
+
+mkdir -p releases
+
+build_release() {
+for os in ${oses[@]}
+do
+  for arch in ${archs[@]}
+  do
+    if [[ $os == "windows" ]]; then
+        extension=".exe"
+    fi
+    GOOS=${os} GOARCH=${arch} go build -o /tmp/ocm_${os}_${arch} ./cmd/ocm
+    mv /tmp/ocm_${os}_${arch} ocm${extension}
+    zip releases/ocm_${os}_${arch}.zip ocm${extension}
+    rm ocm${extension}
+  done
+done
+cd releases
+}
+
+build_release


### PR DESCRIPTION
Makes the PR pipeline run for every `master` branch push

Makes the on-push pipeline run for every `release_...` tag made