### PR TITLE
OCM-15770 | ci: Change on-push pipeline to trigger with tags that start with `v`

### DIFF
--- a/.tekton/rosa-push.yaml
+++ b/.tekton/rosa-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch.startsWith("refs/tags/release_")
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch.startsWith("refs/tags/v")
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: rh-rosa-cli


### PR DESCRIPTION
This way, any tag made with `v...` will be considered a release and will trigger a build. Can also be used for prereleases and testing the pipeline