### PR TITLE
OCM-13374 | feat: Disable kubelet configs for govcloud

### DIFF
--- a/pkg/machinepool/machinepool.go
+++ b/pkg/machinepool/machinepool.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/openshift/rosa/pkg/fedramp"
 	"os"
 	"regexp"
 	"slices"
@@ -762,7 +763,7 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 
 	kubeletConfigs := args.KubeletConfigs
 
-	if kubeletConfigs != "" || interactive.Enabled() {
+	if (kubeletConfigs != "" || interactive.Enabled()) && !fedramp.Enabled() {
 		var inputKubeletConfigs []string
 		// Get the list of available kubelet configs
 		availableKubeletConfigs, err := r.OCMClient.ListKubeletConfigNames(cluster.ID())


### PR DESCRIPTION
Disables kubelet configs for interactive mode with `create/machinepool` when creating nodepools in fedramp envs for HCP

API does not support this feature, using it returns a CLI-exiting error. Disabling is the path forward for `create/machinepool` functionality for HCP in fedramp envs