### PR TITLE
OCM-15682 | ci: Add new tag for unused subnets

### DIFF
--- a/tests/ci/config/config.go
+++ b/tests/ci/config/config.go
@@ -72,6 +72,7 @@ type ClusterENVVariables struct {
 	Replicas            string `env:"REPLICAS" default:""`
 	MultiAZ             string `env:"MULTI_AZ" default:""`
 	AllowRegistries     string `env:"ALLOW_REGISTRIES" default:""`
+	Add_UnManaged_Tag   string `env:"ADD_UNMANAGED_TAG" default:"false"`
 	UseLocalCredentials bool   `env:"USE_LOCAL_CREDENTIALS" default:"false"`
 }
 
@@ -154,6 +155,7 @@ func init() {
 		Replicas:            os.Getenv("REPLICAS"),
 		MultiAZ:             os.Getenv("MULTI_AZ"),
 		AllowRegistries:     os.Getenv("ALLOW_REGISTRIES"),
+		Add_UnManaged_Tag:   os.Getenv("ADD_UNMANAGED_TAG"),
 		UseLocalCredentials: useLocalCredentials,
 	}
 

--- a/tests/utils/handler/interface.go
+++ b/tests/utils/handler/interface.go
@@ -73,6 +73,7 @@ type ClusterConfig struct {
 	FedRAMP                       bool   `yaml:"fedramp" json:"fedramp,omitempty"`
 	ZeroEgress                    bool   `yaml:"zero_egress" json:"zero_egress,omitempty"`
 	UseLocalCredentials           bool   `yaml:"use_local_credentials,omitempty" json:"use_local_credentials,omitempty"`
+	Add_UnManaged_Tag             bool   `yaml:"add_unmanaged_tag" json:"add_unmanaged_tag,omitempty"`
 }
 
 // Resources will record the resources prepared


### PR DESCRIPTION
[OCM-15682](https://issues.redhat.com//browse/OCM-15682): Add new tag for unused subnets when creating clusters.It is due to OCP new feature:[OCPSTRAT-569](https://issues.redhat.com/browse/OCPSTRAT-569)

Run it in local with 4.18 and 4.19 version,cluster can be ready
```
ginkgo run --label-filter day1 tests/e2e --timeout 1h && ginkgo run --label-filter day1-readiness tests/e2e --timeout 2h 
Running Suite: ROSA CLI e2e tests suite - /Users/yingzhan/ying-work/code/rosa/tests/e2e
=======================================================================================
Random Seed: 1747643497

Will run 1 of 266 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSStime="2025-05-19 16:36:38" level=info msg="Going to prepare a vpc with name ying-0519-n6juw, on region us-east-2, with cidr 10.0.0.0/16 "
time="2025-05-19 16:36:39" level=info msg="Going to create vpc and the follow resources on zones: "
time="2025-05-19 16:36:41" level=info msg="Create vpc success vpc-000c3c8f722259a65"
time="2025-05-19 16:36:42" level=info msg="Tag resource vpc-000c3c8f722259a65 successfully"
time="2025-05-19 16:36:42" level=info msg="Created vpc with ID vpc-000c3c8f722259a65"
time="2025-05-19 16:36:42" level=info msg="VPC created on AWS with id: vpc-000c3c8f722259a65"
time="2025-05-19 16:36:42" level=info msg="Modify vpc dns attribute DnsHostnames successfully for vpc-000c3c8f722259a65"
time="2025-05-19 16:36:42" level=info msg="VPC DNS Updated on AWS with id: vpc-000c3c8f722259a65"
time="2025-05-19 16:36:43" level=info msg="Create igw success: igw-0a4ffa1a91df21da0"
time="2025-05-19 16:36:43" level=info msg="Attach igw success: igw-0a4ffa1a91df21da0"
time="2025-05-19 16:36:43" level=info msg="Prepare vpc internetgateway for vpc vpc-000c3c8f722259a65"
time="2025-05-19 16:36:43" level=info msg="Create subnets successfully"
time="2025-05-19 16:36:43" level=info msg="Create vpc chain successfully. Enjoy it."
time="2025-05-19 16:36:43" level=info msg="Going to prepare proper pair of subnets"
time="2025-05-19 16:36:43" level=info msg="Got no public subnet for current zone us-east-2a, going to create one"
time="2025-05-19 16:36:44" level=info msg="Created subnet subnet-05fd32977ba17cab9 for vpc vpc-000c3c8f722259a65"
time="2025-05-19 16:36:45" level=info msg="Created subnet with ID subnet-05fd32977ba17cab9"
time="2025-05-19 16:36:46" level=info msg="Associate route table success rtbassoc-0ba0fb89163014f1c"
time="2025-05-19 16:36:47" level=info msg="Create route success for route table: rtb-00d4d381ba522f829"
time="2025-05-19 16:36:48" level=info msg="Tag resource subnet-05fd32977ba17cab9 successfully"
time="2025-05-19 16:36:48" level=info msg="Got no proper private subnet for current zone us-east-2a, going to create one"
time="2025-05-19 16:36:49" level=info msg="Created subnet subnet-0ae4519fb3ab1d7ae for vpc vpc-000c3c8f722259a65"
time="2025-05-19 16:36:50" level=info msg="Created subnet with ID subnet-0ae4519fb3ab1d7ae"
time="2025-05-19 16:36:50" level=info msg="Associate route table success rtbassoc-07764a3d8fd53688d"
time="2025-05-19 16:36:51" level=info msg="Allocated EIP eipalloc-0899be9c9bb01901d with ip 3.18.43.90"
time="2025-05-19 16:36:52" level=info msg="Create nat success: nat-0603fe0a2d31bd926"
time="2025-05-19 16:38:31" level=info msg="Create route success for route table: rtb-03fad045bb80f03f4"
time="2025-05-19 16:38:32" level=info msg="Tag resource subnet-0ae4519fb3ab1d7ae successfully"
time="2025-05-19 16:38:32" level=info msg="Going to prepare proper pair of subnets"
time="2025-05-19 16:38:32" level=info msg="Subnet subnet-05fd32977ba17cab9 in zone: us-east-2a, region us-east-2"
time="2025-05-19 16:38:32" level=info msg="Subnet subnet-0ae4519fb3ab1d7ae in zone: us-east-2a, region us-east-2"
time="2025-05-19 16:38:32" level=info msg="Got no public subnet for current zone us-east-2b, going to create one"
time="2025-05-19 16:38:32" level=info msg="Created subnet subnet-04ecdadee9df37415 for vpc vpc-000c3c8f722259a65"
time="2025-05-19 16:38:33" level=info msg="Created subnet with ID subnet-04ecdadee9df37415"
time="2025-05-19 16:38:35" level=info msg="Associate route table success rtbassoc-0796e503cb0947842"
time="2025-05-19 16:38:35" level=info msg="Create route success for route table: rtb-0512392817f573dd7"
time="2025-05-19 16:38:36" level=info msg="Tag resource subnet-04ecdadee9df37415 successfully"
time="2025-05-19 16:38:36" level=info msg="Got no proper private subnet for current zone us-east-2b, going to create one"
time="2025-05-19 16:38:37" level=info msg="Created subnet subnet-0cce2a926b7203b47 for vpc vpc-000c3c8f722259a65"
time="2025-05-19 16:38:38" level=info msg="Created subnet with ID subnet-0cce2a926b7203b47"
time="2025-05-19 16:38:38" level=info msg="Associate route table success rtbassoc-0c0e75ea5d3c89521"
time="2025-05-19 16:38:39" level=info msg="Found existing nat gateway: nat-0603fe0a2d31bd926"
time="2025-05-19 16:38:40" level=info msg="Create route success for route table: rtb-04696c8a47fa225d5"
time="2025-05-19 16:38:40" level=info msg="Tag resource subnet-0cce2a926b7203b47 successfully"
time="2025-05-19 16:38:40" level=info msg="Going to prepare proper pair of subnets"
time="2025-05-19 16:38:40" level=info msg="Subnet subnet-05fd32977ba17cab9 in zone: us-east-2a, region us-east-2"
time="2025-05-19 16:38:40" level=info msg="Subnet subnet-0ae4519fb3ab1d7ae in zone: us-east-2a, region us-east-2"
time="2025-05-19 16:38:40" level=info msg="Subnet subnet-04ecdadee9df37415 in zone: us-east-2b, region us-east-2"
time="2025-05-19 16:38:40" level=info msg="Subnet subnet-0cce2a926b7203b47 in zone: us-east-2b, region us-east-2"
time="2025-05-19 16:38:40" level=info msg="Got no public subnet for current zone us-east-2c, going to create one"
time="2025-05-19 16:38:41" level=info msg="Created subnet subnet-0a170f3578d675a7c for vpc vpc-000c3c8f722259a65"
time="2025-05-19 16:38:41" level=info msg="Created subnet with ID subnet-0a170f3578d675a7c"
time="2025-05-19 16:38:43" level=info msg="Associate route table success rtbassoc-0381233cbffb00dda"
time="2025-05-19 16:38:43" level=info msg="Create route success for route table: rtb-0c2ff902da0b70ea8"
time="2025-05-19 16:38:44" level=info msg="Tag resource subnet-0a170f3578d675a7c successfully"
time="2025-05-19 16:38:44" level=info msg="Got no proper private subnet for current zone us-east-2c, going to create one"
time="2025-05-19 16:38:46" level=info msg="Created subnet subnet-085b30be103a124d0 for vpc vpc-000c3c8f722259a65"
time="2025-05-19 16:38:47" level=info msg="Created subnet with ID subnet-085b30be103a124d0"
time="2025-05-19 16:38:48" level=info msg="Associate route table success rtbassoc-015eaf3ffadf7b190"
time="2025-05-19 16:38:48" level=info msg="Found existing nat gateway: nat-0603fe0a2d31bd926"
time="2025-05-19 16:38:49" level=info msg="Create route success for route table: rtb-0b08c75b652d40d54"
time="2025-05-19 16:38:49" level=info msg="Tag resource subnet-085b30be103a124d0 successfully"
time="2025-05-19 16:39:13" level=info msg="Tag resource subnet-05fd32977ba17cab9 successfully"
time="2025-05-19 16:39:34" level=info msg="Tag resource subnet-04ecdadee9df37415 successfully"
time="2025-05-19 16:39:55" level=info msg="Tag resource subnet-0a170f3578d675a7c successfully"
time="2025-05-19 16:40:05" level=info msg="Got the image ID : ami-0100e595e1cc1ff7f"
time="2025-05-19 16:40:05" level=info msg="Create security group sg-009a05bc489c1cc58 success for vpc-000c3c8f722259a65"
time="2025-05-19 16:40:06" level=info msg="Tag resource sg-009a05bc489c1cc58 successfully"
time="2025-05-19 16:40:06" level=info msg="Created tagged security group with ID sg-009a05bc489c1cc58"
time="2025-05-19 16:40:07" level=info msg="Authorize security group success sg-009a05bc489c1cc58"
time="2025-05-19 16:40:07" level=info msg="Authorize security group success sg-009a05bc489c1cc58"
time="2025-05-19 16:40:07" level=info msg="Authorize SG sg-009a05bc489c1cc58 prepared successfully for proxy."
time="2025-05-19 16:40:07" level=info msg="Create key pair key-0f4c9bb0d42ab7c48 successfully\n"
time="2025-05-19 16:40:08" level=info msg="Tag resource key-0f4c9bb0d42ab7c48 successfully"
time="2025-05-19 16:40:09" level=info msg="Waiting for below instances ready: i-0d73f67b3dc3d22c4"
time="2025-05-19 16:40:11" level=info msg="Check instances status of i-0d73f67b3dc3d22c4"
time="2025-05-19 16:40:12" level=info msg="Instance ID i-0d73f67b3dc3d22c4 is in status of not-applicable"
time="2025-05-19 16:40:12" level=info msg="Instance ID i-0d73f67b3dc3d22c4 is in state of pending"
time="2025-05-19 16:41:12" level=info msg="Check instances status of i-0d73f67b3dc3d22c4"
time="2025-05-19 16:41:12" level=info msg="Instance ID i-0d73f67b3dc3d22c4 is in status of initializing"
time="2025-05-19 16:41:12" level=info msg="Instance ID i-0d73f67b3dc3d22c4 is in state of running"
time="2025-05-19 16:41:12" level=info msg="All instances running"
time="2025-05-19 16:41:12" level=info msg="Launch proxy instance i-0d73f67b3dc3d22c4 succeed"
time="2025-05-19 16:41:13" level=info msg="Tag resource i-0d73f67b3dc3d22c4 successfully"
time="2025-05-19 16:41:13" level=info msg="Allocated EIP eipalloc-07a2ec11f35c04c40 with ip 18.219.182.148"
time="2025-05-19 16:41:13" level=info msg="Successfully allocated EIP: 18.219.182.148"
time="2025-05-19 16:41:14" level=info msg="Successfully allocated 18.219.182.148 with instance i-0d73f67b3dc3d22c4.\n\tallocation id: eipalloc-07a2ec11f35c04c40, association id: eipassoc-0ba58f5c53851b58f\n"
time="2025-05-19 16:41:14" level=info msg="Prepare EIP successfully for the proxy preparation. Launch with IP: 18.219.182.148"
time="2025-05-19 16:43:55" level=info msg="Preparing OCM testing kms key"
time="2025-05-19 16:45:29" level=info msg="Configuring sts roles to key polilies of arn:aws:kms:us-east-2:301721915996:key/3a022c2c-cf52-4605-99a2-c56b2e8b0e04"
•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 266 Specs in 828.199 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 265 Skipped
PASS

Ginkgo ran 1 suite in 14m0.019711s
Test Suite Passed
Running Suite: ROSA CLI e2e tests suite - /Users/yingzhan/ying-work/code/rosa/tests/e2e
=======================================================================================
Random Seed: 1747644338

Will run 1 of 266 specs
SSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 266 Specs in 3373.247 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 265 Skipped
PASS

Ginkgo ran 1 suite in 56m21.278967417s
Test Suite Passed
```