### PR TITLE
OCM-15880 | ci: Add integration pipeline on Konflux

### DIFF
--- a/.tekton/hcp-advanced-e2e-test.yaml
+++ b/.tekton/hcp-advanced-e2e-test.yaml
@@ -1,0 +1,111 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  annotations:
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "6"
+    pipelinesascode.tekton.dev/on-cel-expression:  |
+      event == "push" || (event == "pull_request" && pull_request_title.startsWith("e2e_trigger_"))
+  name: hcp-advanced-e2e-test
+spec:
+  params:
+    - description: 'Snapshot of the application'
+      name: SNAPSHOT
+      default: '{"components": [{"name":"test-app", "containerImage": "quay.io/example/repo:latest"}]}'
+      type: string
+    - description: 'Expected output'
+      name: EXPECTED_OUTPUT
+      default: "default"
+      type: string
+    - description: 'Secret Ref for the testing'
+      name: SECRET_REF
+      default: "rosacli-ci"
+      type: string
+    - description: 'Tasks git repo'
+      name: TASKS_REPO
+      default: "git@github.com:openshift/rosa.git"
+      type: string
+    - name: OCM_LOGIN_ENV
+      type: string
+      description: "the channel group of hcp-advance-e2e-test"
+      default: "stable"
+    - name: AWS_REGION
+      type: string
+      description: "the aws region using for this job"
+      default: "us-west-2"
+
+  tasks:
+    - name: test-metadata
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/konflux-qe-definitions.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: common/tasks/test-metadata/0.1/test-metadata.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+        - name: test-name
+          value: $(context.pipelineRun.name)
+    - name: hcp-advance-e2e-test
+      retries: 0
+      timeout: 6h
+      runAfter:
+        - test-metadata
+      params:
+        - name: container-image
+          value: "quay.io/redhat-user-workloads/rh-terraform-tenant/rosa:latest"
+        - name: git-repo
+          value: "$(tasks.test-metadata.results.git-url)"
+        - name: git-revision
+          value: "$(tasks.test-metadata.results.git-revision)"
+        - name: secret-ref
+          value: $(params.SECRET_REF)
+        - name: channel-group
+          value: $(params.OCM_LOGIN_ENV)
+        - name: aws-region
+          value: $(params.AWS_REGION)
+        - name: cluster-profile
+          value: "rosa-hcp-advanced"
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: $(params.TASKS_REPO)
+          - name: revision
+            value: master
+          - name: pathInRepo
+            value: .tekton/tasks/e2e-task.yaml
+  finally:  
+    - name: e2e-clean-up
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: $(params.TASKS_REPO)
+          - name: revision
+            value: master
+          - name: pathInRepo
+            value: .tekton/tasks/e2e-clean-up-task.yaml
+      retries: 0
+      timeout: 1h
+      runAfter:
+        - test-metadata
+      params:
+        - name: container-image
+          value: "quay.io/redhat-user-workloads/rh-terraform-tenant/rosa:latest"
+        - name: git-repo
+          value: "$(tasks.test-metadata.results.git-url)"
+        - name: git-revision
+          value: "$(tasks.test-metadata.results.git-revision)"
+        - name: secret-ref
+          value: $(params.SECRET_REF)
+        - name: channel-group
+          value: $(params.OCM_LOGIN_ENV)
+        - name: aws-region
+          value: $(params.AWS_REGION)
+        - name: cluster-profile
+          value: "rosa-hcp-advanced"

--- a/.tekton/rosa-push.yaml
+++ b/.tekton/rosa-push.yaml
@@ -516,6 +516,9 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: ADDITIONAL_TAGS
+        value:
+        - latest
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/steps/clean-up-step.yaml
+++ b/.tekton/steps/clean-up-step.yaml
@@ -1,0 +1,74 @@
+apiVersion: tekton.dev/v1beta1
+kind: StepAction
+metadata:
+  name: clean-up
+spec:
+  description: |
+    This is a step to clean up all testing resources
+  image: $(params.container-image)
+  imagePullPolicy: Always
+  workingDir: /rosa
+  params:
+    - name: container-image
+    - name: secret-volume
+    - name: output-volume
+    - name: secret-ref
+    - name: channel-group
+    - name: aws-region
+    - name: cluster-profile
+  results:
+    - name: passed
+      description: It shows if the step is passed or failed
+    - name: failedCases
+      description: It shows the failed cases run the the test
+  volumeMounts:
+    - name: $(params.secret-volume)
+      mountPath: /mnt/secrets
+    - name: $(params.output-volume)
+      mountPath: /tests/output
+  env:
+    - name: AWS_CREDENTIALS
+      value: "/mnt/secrets/aws_cred"
+    - name: AWS_SHAREDVPC_CREDENTIALS
+      value: "/mnt/secrets/aws_cred"
+    - name: OCM_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: $(params.secret-ref)
+          key: oex_org_admin_token
+    - name: OCM_LOGIN_ENV
+      value: $(params.channel-group)
+    - name: AWS_REGION
+      value: $(params.aws-region)
+    - name: TEST_PROFILE
+      value: $(params.cluster-profile)
+  
+  script: |
+    #!/bin/bash
+    # setup rosacli
+    source ./tests/prow_ci.sh
+    configure_aws "${AWS_CREDENTIALS}" "${AWS_REGION}"
+    configure_aws_shared_vpc "${AWS_SHAREDVPC_CREDENTIALS}/.awscred_shared_account"
+
+    rosa login --env ${OCM_LOGIN_ENV} --token ${OCM_TOKEN}
+    rosa whoami
+
+    # run destroy case to clean up all testing resources
+    go install github.com/onsi/ginkgo/v2/ginkgo@latest
+    ginkgo ./tests/e2e --ginkgo.v --ginkgo.no-color \
+      --ginkgo.timeout "1h" \
+      --ginkgo.label-filter "destroy"
+    rc1=$?
+
+     # run destroy-post case to check if all resources are cleaned up
+    ginkgo ./tests/e2e --ginkgo.v --ginkgo.no-color \
+      --ginkgo.timeout "30m" \
+      --ginkgo.label-filter "destroy-post"
+    rc2=$?
+    if [ $rc1 -ne 0 ] || [ $rc2 -ne 0 ]; then
+      exit 1
+    fi
+
+    
+
+

--- a/.tekton/steps/run-e2e-day1-step.yaml
+++ b/.tekton/steps/run-e2e-day1-step.yaml
@@ -1,0 +1,73 @@
+apiVersion: tekton.dev/v1beta1
+kind: StepAction
+metadata:
+  name: run-e2e-day1
+spec:
+  description: |
+    This is a day1 step to prepare cluster for rosacli job
+  image: $(params.container-image)
+  imagePullPolicy: Always
+  workingDir: /rosa
+  params:
+    - name: container-image
+    - name: secret-volume
+    - name: output-volume
+    - name: secret-ref
+    - name: channel-group
+    - name: aws-region
+    - name: cluster-profile
+  volumeMounts:
+    - name: $(params.secret-volume)
+      mountPath: /mnt/secrets
+    - name: $(params.output-volume)
+      mountPath: /tests/output
+  env:
+    - name: AWS_CREDENTIALS
+      value: "/mnt/secrets/aws_cred"
+    - name: AWS_SHAREDVPC_CREDENTIALS
+      value: "/mnt/secrets/aws_cred"
+    - name: OCM_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: $(params.secret-ref)
+          key: oex_org_admin_token
+    - name: OCM_LOGIN_ENV
+      value: $(params.channel-group)
+    - name: AWS_REGION
+      value: $(params.aws-region)
+    - name: TEST_PROFILE
+      value: $(params.cluster-profile)
+  
+  script: |
+    #!/bin/bash
+    # setup rosacli
+    source ./tests/prow_ci.sh
+    configure_aws "${AWS_CREDENTIALS}" "${AWS_REGION}"
+    configure_aws_shared_vpc "${AWS_SHAREDVPC_CREDENTIALS}/.awscred_shared_account"
+
+    rosa login --env ${OCM_LOGIN_ENV} --token ${OCM_TOKEN}
+    rosa whoami
+    rosa version
+
+    # day1: prepare testing cluster
+    go install github.com/onsi/ginkgo/v2/ginkgo@latest
+    ginkgo ./tests/e2e --ginkgo.v --ginkgo.no-color \
+      --ginkgo.timeout "100m" \
+      --ginkgo.label-filter "day1"
+    rc1=$?
+
+    # cluster setup readiness step
+    ginkgo ./tests/e2e --ginkgo.v --ginkgo.no-color \
+      --ginkgo.timeout "60m" \
+      --ginkgo.label-filter "day1-readiness"
+    rc2=$?
+    
+    # day1-post check
+    ginkgo ./tests/e2e --ginkgo.v --ginkgo.no-color \
+      --ginkgo.timeout "60m" \
+      --ginkgo.label-filter "day1-post"
+    rc3=$?
+    if [ $rc1 -ne 0 ] || [ $rc2 -ne 0 ] || [ $rc3 -ne 0 ]; then
+      exit 1
+    fi
+

--- a/.tekton/steps/run-e2e-day2-step.yaml
+++ b/.tekton/steps/run-e2e-day2-step.yaml
@@ -1,0 +1,65 @@
+apiVersion: tekton.dev/v1beta1
+kind: StepAction
+metadata:
+  name: run-e2e-day2
+spec:
+  description: |
+    This is a day2 step to run day2 cases on the prepared cluster
+  image: $(params.container-image)
+  imagePullPolicy: Always
+  workingDir: /rosa
+  params:
+    - name: container-image
+    - name: secret-volume
+    - name: output-volume
+    - name: secret-ref
+    - name: channel-group
+    - name: aws-region
+    - name: cluster-profile
+  volumeMounts:
+    - name: $(params.secret-volume)
+      mountPath: /mnt/secrets
+    - name: $(params.output-volume)
+      mountPath: /tests/output
+  env:
+    - name: AWS_CREDENTIALS
+      value: "/mnt/secrets/aws_cred"
+    - name: AWS_SHAREDVPC_CREDENTIALS
+      value: "/mnt/secrets/aws_cred"
+    - name: OCM_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: $(params.secret-ref)
+          key: oex_org_admin_token
+    - name: OCM_LOGIN_ENV
+      value: $(params.channel-group)
+    - name: AWS_REGION
+      value: $(params.aws-region)
+    - name: TEST_PROFILE
+      value: $(params.cluster-profile)
+  
+  script: |
+    #!/bin/bash
+    # setup rosacli
+    source ./tests/prow_ci.sh
+    configure_aws "${AWS_CREDENTIALS}" "${AWS_REGION}"
+    configure_aws_shared_vpc "${AWS_SHAREDVPC_CREDENTIALS}/.awscred_shared_account"
+
+    rosa login --env ${OCM_LOGIN_ENV} --token ${OCM_TOKEN}
+    rosa whoami
+
+    # run day2 cases
+    ginkgo ./tests/e2e --ginkgo.v --ginkgo.no-color \
+      --ginkgo.timeout "4h" \
+      --ginkgo.label-filter "day2"
+    rc1=$?
+
+    # run day2 destructive cases
+    go install github.com/onsi/ginkgo/v2/ginkgo@latest
+    ginkgo ./tests/e2e --ginkgo.v --ginkgo.no-color \
+      --ginkgo.timeout "2h" \
+      --ginkgo.label-filter "destructive"
+    rc2=$?
+    if [ $rc1 -ne 0 ] || [ $rc2 -ne 0 ]; then
+      exit 1
+    fi

--- a/.tekton/tasks/e2e-clean-up-task.yaml
+++ b/.tekton/tasks/e2e-clean-up-task.yaml
@@ -1,0 +1,58 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: e2e-clean-up
+spec:
+  description: |
+    This is a task to clean up all testing resources
+  params:
+    - name: git-revision
+      type: string
+      default: "master"
+      description: "The revision (branch or tag) of the Git repository to checkout."
+    - name: git-repo
+      type: string
+      default: "https://github.com:openshift/rosa.git"
+      description: "The revision (branch or tag) of the Git repository to checkout."
+    - name: container-image
+      type: string
+      description: "Contain the container name from Konflux Snapshot."
+      default: "quay.io/redhat-user-workloads/rh-terraform-tenant/rosa:latest"
+    - name: secret-ref
+      type: string
+      description: secret-volume used for the testing
+      default: "rosacli-ci"
+    - name: cluster-profile
+      type: string
+      description: cluster-profile used for the cluster creation
+      default: ""
+  steps:
+    - name: clean-up
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: $(params.git-repo).git
+          - name: revision
+            value: $(params.git-revision)
+          - name: pathInRepo
+            value: .tekton/steps/clean-up-step.yaml
+      params:
+        - name: container-image
+          value: $(params.container-image)
+        - name: output-volume
+          value: output-volume
+        - name: secret-volume
+          value: secret-volume
+        - name: secret-ref
+          value: $(params.secret-ref)
+        - name: service
+          value: $(params.service)
+        - name: cluster-profile
+          value: $(params.cluster-profile)
+  volumes:
+    - name: output-volume
+      emptyDir: {}
+    - name: secret-volume
+      secret:
+        secretName: $(params.secret-ref)

--- a/.tekton/tasks/e2e-task.yaml
+++ b/.tekton/tasks/e2e-task.yaml
@@ -1,0 +1,81 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: e2e-task
+spec:
+  description: |
+    This task run the rosacli e2e tests based on given profile
+  params:
+    - name: git-revision
+      type: string
+      default: "master"
+      description: "The revision (branch or tag) of the Git repository to checkout."
+    - name: git-repo
+      type: string
+      default: "https://github.com:openshift/rosa.git"
+      description: "The revision (branch or tag) of the Git repository to checkout."
+    - name: container-image
+      type: string
+      description: "Contain the container name from Konflux Snapshot."
+      default: "quay.io/redhat-user-workloads/rh-terraform-tenant/rosa:latest"
+    - name: secret-ref
+      type: string
+      description: secret-volume used for the testing
+      default: "rosacli-ci"
+    - name: cluster-profile
+      type: string
+      description: cluster-profile used for the cluster creation
+      default: ""
+  steps:
+    - name: run-e2e-day1
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: $(params.git-repo).git
+          - name: revision
+            value: $(params.git-revision)
+          - name: pathInRepo
+            value: .tekton/steps/run-e2e-day1-step.yaml
+      params:
+        - name: container-image
+          value: $(params.container-image)
+        - name: output-volume
+          value: output-volume
+        - name: secret-volume
+          value: secret-volume
+        - name: secret-ref
+          value: $(params.secret-ref)
+        - name: service
+          value: $(params.service)
+        - name: cluster-profile
+          value: $(params.cluster-profile)
+    - name: run-e2e-day2
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: $(params.git-repo).git
+          - name: revision
+            value: $(params.git-revision)
+          - name: pathInRepo
+            value: .tekton/steps/run-e2e-day2-step.yaml
+      params:
+        - name: container-image
+          value: $(params.container-image)
+        - name: output-volume
+          value: output-volume
+        - name: secret-volume
+          value: secret-volume
+        - name: secret-ref
+          value: $(params.secret-ref)
+        - name: service
+          value: $(params.service)
+        - name: cluster-profile
+          value: $(params.cluster-profile)
+  volumes:
+    - name: output-volume
+      emptyDir: {}
+    - name: secret-volume
+      secret:
+        secretName: $(params.secret-ref)


### PR DESCRIPTION
- Add integration testing pipeline used to run e2e testing with the releasing image
- Add the first hcp-advanced  e2e testing job and will add more jobs after checking it works well
- Add an additional tag on the push image, this tag will be used by other pipeline to use the latest pushed image

To easy trigger the job to debug the first job, the trigger condition is a PR which title starts with e2e_trigger. It will be upgrade to trigger following the PUSH pipeline after the test of the pipeline is done and works well.