### PR TITLE
OCM-15883 | fix: Use `arn:aws-us-gov` for s3 policy in govcloud

### DIFF
--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -1146,6 +1146,23 @@ const ReadOnlyAnonUserPolicyTemplate = `{
 	]
 }`
 
+const ReadOnlyAnonUserPolicyTemplateGovcloud = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "AllowReadPublicAccess",
+			"Principal": "*",
+			"Effect": "Allow",
+			"Action": [
+				"s3:GetObject"
+			],
+			"Resource": [
+				"arn:aws-us-gov:s3:::%s/*"
+			]
+		}
+	]
+}`
+
 func (c *awsClient) CreateS3Bucket(bucketName string, region string) error {
 	_, err := c.s3Client.HeadBucket(context.TODO(), &s3.HeadBucketInput{
 		Bucket: aws.String(bucketName),
@@ -1180,9 +1197,14 @@ func (c *awsClient) CreateS3Bucket(bucketName string, region string) error {
 		return err
 	}
 
+	policyTemplate := ReadOnlyAnonUserPolicyTemplate
+	if fedramp.Enabled() {
+		policyTemplate = ReadOnlyAnonUserPolicyTemplateGovcloud
+	}
+
 	_, err = c.s3Client.PutBucketPolicy(context.TODO(), &s3.PutBucketPolicyInput{
 		Bucket: aws.String(bucketName),
-		Policy: aws.String(fmt.Sprintf(ReadOnlyAnonUserPolicyTemplate, bucketName)),
+		Policy: aws.String(fmt.Sprintf(policyTemplate, bucketName)),
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes issue where policy had invalid resource when creating OIDC config in ROSA CLI. This was specifically from creating the s3 bucket for the OIDC config, which had the incorrect `arn:aws` prefix on the Resource block

This has been updated to have the govcloud one when fedramp is enabled