### PR TITLE
OCM-15880 | ci: Remove `runAfter` from `finally` block

### DIFF
--- a/.tekton/hcp-advanced-e2e-test.yaml
+++ b/.tekton/hcp-advanced-e2e-test.yaml
@@ -9,6 +9,9 @@ metadata:
   name: hcp-advanced-e2e-test
 spec:
   params:
+    - description: Initialize SSH agent
+      name: SSH
+      command: eval $(ssh-agent -s) && ssh-add ~/.ssh/id_rsa
     - description: 'Snapshot of the application'
       name: SNAPSHOT
       default: '{"components": [{"name":"test-app", "containerImage": "quay.io/example/repo:latest"}]}'

--- a/.tekton/hcp-advanced-e2e-test.yaml
+++ b/.tekton/hcp-advanced-e2e-test.yaml
@@ -9,9 +9,6 @@ metadata:
   name: hcp-advanced-e2e-test
 spec:
   params:
-    - description: Initialize SSH agent
-      name: SSH
-      command: eval $(ssh-agent -s) && ssh-add ~/.ssh/id_rsa
     - description: 'Snapshot of the application'
       name: SNAPSHOT
       default: '{"components": [{"name":"test-app", "containerImage": "quay.io/example/repo:latest"}]}'

--- a/.tekton/hcp-advanced-e2e-test.yaml
+++ b/.tekton/hcp-advanced-e2e-test.yaml
@@ -92,8 +92,6 @@ spec:
             value: .tekton/tasks/e2e-clean-up-task.yaml
       retries: 0
       timeout: 1h
-      runAfter:
-        - test-metadata
       params:
         - name: container-image
           value: "quay.io/redhat-user-workloads/rh-terraform-tenant/rosa:latest"


### PR DESCRIPTION
Removes the `runAfter` block in the `e2e_tests_cleanup` `finally` block of the Tekton config. This caused a failure, because you cannot `runAfter` another test in a `finally` task, it is already decided by the keyword `finally`