### PR TITLE
OCM-15880 | ci: Update to use https url as TASKS_REPO value

### DIFF
--- a/.tekton/hcp-advanced-e2e-test.yaml
+++ b/.tekton/hcp-advanced-e2e-test.yaml
@@ -23,7 +23,7 @@ spec:
       type: string
     - description: 'Tasks git repo'
       name: TASKS_REPO
-      default: "git@github.com:openshift/rosa.git"
+      default: "https://github.com/openshift/rosa.git"
       type: string
     - name: OCM_LOGIN_ENV
       type: string
@@ -92,8 +92,6 @@ spec:
             value: .tekton/tasks/e2e-clean-up-task.yaml
       retries: 0
       timeout: 1h
-      runAfter:
-        - test-metadata
       params:
         - name: container-image
           value: "quay.io/redhat-user-workloads/rh-terraform-tenant/rosa:latest"

--- a/.tekton/steps/run-e2e-day2-step.yaml
+++ b/.tekton/steps/run-e2e-day2-step.yaml
@@ -6,7 +6,6 @@ spec:
   description: |
     This is a day2 step to run day2 cases on the prepared cluster
   image: $(params.container-image)
-  imagePullPolicy: Always
   workingDir: /rosa
   params:
     - name: container-image


### PR DESCRIPTION
[OCM-15880](https://issues.redhat.com//browse/OCM-15880) | ci: Update to use https url as TASKS_REPO value