### PR TITLE
ACM-18622 | feat: Expose functionality for creating Account/Operator roles and OIDC con…

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -41,9 +41,9 @@ import (
 
 	"github.com/openshift/rosa/cmd/create/admin"
 	"github.com/openshift/rosa/cmd/create/idp"
-	"github.com/openshift/rosa/cmd/create/oidcprovider"
 	"github.com/openshift/rosa/cmd/create/operatorroles"
 	clusterdescribe "github.com/openshift/rosa/cmd/describe/cluster"
+	"github.com/openshift/rosa/cmd/dlt/oidcprovider"
 	installLogs "github.com/openshift/rosa/cmd/logs/install"
 	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
@@ -3550,7 +3550,7 @@ func run(cmd *cobra.Command, _ []string) {
 // clusterConfigFor builds the cluster spec for the OCM API from our command-line options.
 // TODO: eventually, this method signature should be func(args) ocm.Spec.
 func clusterConfigFor(
-	reporter *reporter.Object,
+	reporter reporter.Logger,
 	clusterConfig ocm.Spec,
 	awsCreator *aws.Creator,
 	awsCredentialsGetter aws.AccessKeyGetter,
@@ -4226,7 +4226,7 @@ func getExpectedResourceIDForAccRole(hostedCPPolicies bool, roleARN string, role
 	return strings.ToLower(fmt.Sprintf("%s-%s-Role", rolePrefix, accountRoles[roleType].Name)), rolePrefix, nil
 }
 
-func getInitialValidSubnets(awsClient aws.Client, ids []string, r *reporter.Object) ([]ec2types.Subnet, error) {
+func getInitialValidSubnets(awsClient aws.Client, ids []string, r reporter.Logger) ([]ec2types.Subnet, error) {
 	var initialValidSubnets []ec2types.Subnet
 	rhManagedSubnets := []string{}
 	localZoneSubnets := []string{}

--- a/cmd/create/cmd.go
+++ b/cmd/create/cmd.go
@@ -33,11 +33,11 @@ import (
 	"github.com/openshift/rosa/cmd/create/network"
 	"github.com/openshift/rosa/cmd/create/ocmrole"
 	"github.com/openshift/rosa/cmd/create/oidcconfig"
-	"github.com/openshift/rosa/cmd/create/oidcprovider"
 	"github.com/openshift/rosa/cmd/create/operatorroles"
 	"github.com/openshift/rosa/cmd/create/service"
 	"github.com/openshift/rosa/cmd/create/tuningconfigs"
 	"github.com/openshift/rosa/cmd/create/userrole"
+	"github.com/openshift/rosa/cmd/dlt/oidcprovider"
 	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 )

--- a/cmd/create/machinepool/options.go
+++ b/cmd/create/machinepool/options.go
@@ -8,7 +8,7 @@ import (
 const instanceType = "m5.xlarge"
 
 type CreateMachinepoolOptions struct {
-	reporter *reporter.Object
+	reporter reporter.Logger
 
 	args *mpOpts.CreateMachinepoolUserOptions
 }

--- a/cmd/create/network/options.go
+++ b/cmd/create/network/options.go
@@ -6,7 +6,7 @@ import (
 )
 
 type Options struct {
-	reporter *reporter.Object
+	reporter reporter.Logger
 
 	args *opts.NetworkUserOptions
 }

--- a/cmd/create/oidcprovider/cmd.go
+++ b/cmd/create/oidcprovider/cmd.go
@@ -228,6 +228,16 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 }
 
+func CreateOIDCProvider(r *rosa.Runtime, oidcConfigId string, clusterId string, isProgrammaticallyCalled bool) error {
+	args.oidcConfigId = oidcConfigId
+	oidcConfig, err := r.OCMClient.GetOidcConfig(oidcConfigId)
+	if err != nil {
+		return fmt.Errorf("There was a problem retrieving OIDC Config '%s': %v", oidcConfigId, err)
+	}
+	oidcEndpointURL := oidcConfig.IssuerUrl()
+	return createProvider(r, oidcEndpointURL, clusterId, isProgrammaticallyCalled)
+}
+
 func createProvider(r *rosa.Runtime, oidcEndpointUrl string, clusterId string, isProgrammaticallyCalled bool) error {
 	inputBuilder := cmv1.NewOidcThumbprintInput()
 	if (isProgrammaticallyCalled || clusterId == "") && args.oidcConfigId != "" {

--- a/cmd/create/operatorroles/by_prefix.go
+++ b/cmd/create/operatorroles/by_prefix.go
@@ -76,7 +76,22 @@ func handleOperatorRolesPrefixOptions(r *rosa.Runtime, cmd *cobra.Command) {
 	}
 }
 
-func handleOperatorRoleCreationByPrefix(r *rosa.Runtime, env string,
+func CreateOperatorRoles(r *rosa.Runtime, env string, permissionsBoundary string, mode string, policies map[string]*cmv1.AWSSTSPolicy, defaultPolicyVersion string, isSharedVpc bool,
+	prefix string, hostedCp bool, installerRoleArn string, forcePolicyCreation bool, oidcConfigId string, sharedVpcRoleArn string, channelGroup string, vpcEndpointRoleArn string) error {
+	args.prefix = prefix
+	args.hostedCp = hostedCp
+	args.installerRoleArn = installerRoleArn
+	args.permissionsBoundary = permissionsBoundary
+	args.forcePolicyCreation = forcePolicyCreation
+	args.oidcConfigId = oidcConfigId
+	args.sharedVpcRoleArn = sharedVpcRoleArn
+	args.channelGroup = channelGroup
+	args.vpcEndpointRoleArn = vpcEndpointRoleArn
+
+	return HandleOperatorRoleCreationByPrefix(r, env, permissionsBoundary, mode, policies, defaultPolicyVersion, isSharedVpc)
+}
+
+func HandleOperatorRoleCreationByPrefix(r *rosa.Runtime, env string,
 	permissionsBoundary string, mode string,
 	policies map[string]*cmv1.AWSSTSPolicy,
 	defaultPolicyVersion string, isSharedVpc bool) error {

--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -371,7 +371,7 @@ func run(cmd *cobra.Command, argv []string) {
 			r.Reporter.Errorf("Error getting latest version: %s", err)
 			os.Exit(1)
 		}
-		err = handleOperatorRoleCreationByPrefix(r, env, permissionsBoundary,
+		err = HandleOperatorRoleCreationByPrefix(r, env, permissionsBoundary,
 			mode, policies, latestPolicyVersion, isHcpSharedVpc)
 		if err != nil {
 			r.Reporter.Errorf("Error creating operator roles: %s", err)

--- a/cmd/create/userrole/cmd.go
+++ b/cmd/create/userrole/cmd.go
@@ -32,7 +32,7 @@ import (
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/ocm"
-	rprtr "github.com/openshift/rosa/pkg/reporter"
+	"github.com/openshift/rosa/pkg/reporter"
 	"github.com/openshift/rosa/pkg/rosa"
 )
 
@@ -312,7 +312,7 @@ func createRoles(r *rosa.Runtime,
 	return roleARN, nil
 }
 
-func generateUserRolePolicyFiles(reporter *rprtr.Object, env string, partition string, accountID string,
+func generateUserRolePolicyFiles(reporter reporter.Logger, env string, partition string, accountID string,
 	policies map[string]*cmv1.AWSSTSPolicy) error {
 	filename := fmt.Sprintf("sts_%s_trust_policy", aws.OCMUserRolePolicyFile)
 	policyDetail := aws.GetPolicyDetails(policies, filename)

--- a/cmd/describe/ingress/options.go
+++ b/cmd/describe/ingress/options.go
@@ -11,7 +11,7 @@ type DescribeIngressUserOptions struct {
 }
 
 type DescribeIngressOptions struct {
-	reporter *reporter.Object
+	reporter reporter.Logger
 	args     DescribeIngressUserOptions
 }
 

--- a/cmd/describe/machinepool/options.go
+++ b/cmd/describe/machinepool/options.go
@@ -11,7 +11,7 @@ type DescribeMachinepoolUserOptions struct {
 }
 
 type DescribeMachinepoolOptions struct {
-	reporter *reporter.Object
+	reporter reporter.Logger
 
 	args *DescribeMachinepoolUserOptions
 }

--- a/cmd/dlt/machinepool/options.go
+++ b/cmd/dlt/machinepool/options.go
@@ -12,7 +12,7 @@ type DeleteMachinepoolUserOptions struct {
 }
 
 type DeleteMachinepoolOptions struct {
-	reporter *reporter.Object
+	reporter reporter.Logger
 
 	args *DeleteMachinepoolUserOptions
 }

--- a/cmd/edit/machinepool/options.go
+++ b/cmd/edit/machinepool/options.go
@@ -24,7 +24,7 @@ type EditMachinepoolUserOptions struct {
 }
 
 type EditMachinepoolOptions struct {
-	reporter *reporter.Object
+	reporter reporter.Logger
 
 	args *EditMachinepoolUserOptions
 }

--- a/cmd/login/cmd.go
+++ b/cmd/login/cmd.go
@@ -40,7 +40,7 @@ import (
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/properties"
-	rprtr "github.com/openshift/rosa/pkg/reporter"
+	"github.com/openshift/rosa/pkg/reporter"
 	"github.com/openshift/rosa/pkg/rosa"
 )
 
@@ -497,7 +497,7 @@ func tokenType(jwtToken *jwt.Token) (typ string, err error) {
 	return
 }
 
-func Call(cmd *cobra.Command, argv []string, reporter *rprtr.Object) error {
+func Call(cmd *cobra.Command, argv []string, reporter reporter.Logger) error {
 	loginFlags := []string{"token-url", "client-id", "client-secret", "scope", arguments.NewEnvFlag, "token", "insecure"}
 	hasLoginFlags := false
 	// Check if the user set login flags

--- a/cmd/register/oidcconfig/cmd.go
+++ b/cmd/register/oidcconfig/cmd.go
@@ -24,7 +24,7 @@ import (
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
-	"github.com/openshift/rosa/cmd/create/oidcprovider"
+	"github.com/openshift/rosa/cmd/dlt/oidcprovider"
 	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
 	. "github.com/openshift/rosa/pkg/constants"

--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -35,7 +35,7 @@ import (
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/ocm"
-	rprtr "github.com/openshift/rosa/pkg/reporter"
+	"github.com/openshift/rosa/pkg/reporter"
 	"github.com/openshift/rosa/pkg/rosa"
 )
 
@@ -267,7 +267,7 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 }
 
-func LogError(key string, ocmClient *ocm.Client, defaultPolicyVersion string, err error, reporter *rprtr.Object) {
+func LogError(key string, ocmClient *ocm.Client, defaultPolicyVersion string, err error, reporter reporter.Logger) {
 	reporter.Debugf("Logging throttle error")
 	if strings.Contains(err.Error(), "Throttling") {
 		ocmClient.LogEvent(key, map[string]string{
@@ -278,7 +278,7 @@ func LogError(key string, ocmClient *ocm.Client, defaultPolicyVersion string, er
 	}
 }
 
-func upgradeAccountRolePolicies(reporter *rprtr.Object, awsClient aws.Client, prefix string, partition string,
+func upgradeAccountRolePolicies(reporter reporter.Logger, awsClient aws.Client, prefix string, partition string,
 	accountID string, policies map[string]*cmv1.AWSSTSPolicy, policyVersion string,
 	policyPath string, isVersionChosen bool) error {
 	for file, role := range aws.AccountRoles {

--- a/cmd/upgrade/roles/cmd.go
+++ b/cmd/upgrade/roles/cmd.go
@@ -39,7 +39,7 @@ import (
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/ocm"
-	rprtr "github.com/openshift/rosa/pkg/reporter"
+	"github.com/openshift/rosa/pkg/reporter"
 	"github.com/openshift/rosa/pkg/rosa"
 )
 
@@ -498,7 +498,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 }
 
-func LogError(key string, ocmClient *ocm.Client, defaultPolicyVersion string, err error, reporter *rprtr.Object) {
+func LogError(key string, ocmClient *ocm.Client, defaultPolicyVersion string, err error, reporter reporter.Logger) {
 	reporter.Debugf("Logging throttle error")
 	if strings.Contains(err.Error(), "Throttling") {
 		ocmClient.LogEvent(key, map[string]string{
@@ -546,7 +546,7 @@ func handleAccountRolePolicyARN(
 
 func upgradeAccountRolePoliciesFromCluster(
 	mode string,
-	reporter *rprtr.Object,
+	reporter reporter.Logger,
 	awsClient aws.Client,
 	cluster *v1.Cluster,
 	partition string,
@@ -769,7 +769,7 @@ func upgradeOperatorPolicies(
 
 func upgradeOperatorRolePoliciesFromCluster(
 	mode string,
-	reporter *rprtr.Object,
+	reporter reporter.Logger,
 	awsClient aws.Client,
 	partition string,
 	accountID string,

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -122,7 +122,7 @@ type Client interface {
 	ValidateQuota() (bool, error)
 	TagUserRegion(username string, region string) error
 	GetClusterRegionTagForUser(username string) (string, error)
-	EnsureRole(reporter *reporter.Object, name string, policy string, permissionsBoundary string,
+	EnsureRole(reporter reporter.Logger, name string, policy string, permissionsBoundary string,
 		version string, tagList map[string]string, path string, managedPolicies bool) (string, error)
 	ValidateRoleNameAvailable(name string) (err error)
 	PutRolePolicy(roleName string, policyName string, policy string) error
@@ -130,7 +130,7 @@ type Client interface {
 		path string) (string, error)
 	EnsurePolicy(policyArn string, document string, version string, tagList map[string]string,
 		path string) (string, error)
-	AttachRolePolicy(reporter *reporter.Object, roleName string, policyARN string) error
+	AttachRolePolicy(reporter reporter.Logger, roleName string, policyARN string) error
 	CreateOpenIDConnectProvider(issuerURL string, thumbprint string, clusterID string) (string, error)
 	DeleteOpenIDConnectProvider(providerURL string) error
 	HasOpenIDConnectProvider(issuerURL string, partition string, accountID string) (bool, error)
@@ -252,7 +252,7 @@ type awsClient struct {
 	useLocalCredentials bool
 }
 
-func CreateNewClientOrExit(logger *logrus.Logger, reporter *reporter.Object) Client {
+func CreateNewClientOrExit(logger *logrus.Logger, reporter reporter.Logger) Client {
 	awsClient, err := NewClient().
 		Logger(logger).
 		Build()

--- a/pkg/aws/client_mock.go
+++ b/pkg/aws/client_mock.go
@@ -61,7 +61,7 @@ func (mr *MockClientMockRecorder) AddRoleTag(roleName, key, value any) *gomock.C
 }
 
 // AttachRolePolicy mocks base method.
-func (m *MockClient) AttachRolePolicy(reporter *reporter.Object, roleName, policyARN string) error {
+func (m *MockClient) AttachRolePolicy(reporter reporter.Logger, roleName, policyARN string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AttachRolePolicy", reporter, roleName, policyARN)
 	ret0, _ := ret[0].(error)
@@ -379,7 +379,7 @@ func (mr *MockClientMockRecorder) EnsurePolicy(policyArn, document, version, tag
 }
 
 // EnsureRole mocks base method.
-func (m *MockClient) EnsureRole(reporter *reporter.Object, name, policy, permissionsBoundary, version string, tagList map[string]string, path string, managedPolicies bool) (string, error) {
+func (m *MockClient) EnsureRole(reporter reporter.Logger, name, policy, permissionsBoundary, version string, tagList map[string]string, path string, managedPolicies bool) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnsureRole", reporter, name, policy, permissionsBoundary, version, tagList, path, managedPolicies)
 	ret0, _ := ret[0].(string)

--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -32,6 +32,7 @@ import (
 	"github.com/openshift/rosa/pkg/constants"
 	"github.com/openshift/rosa/pkg/fedramp"
 	"github.com/openshift/rosa/pkg/helper"
+	"github.com/openshift/rosa/pkg/reporter"
 	rprtr "github.com/openshift/rosa/pkg/reporter"
 )
 
@@ -180,7 +181,7 @@ func getClientDetails(awsClient *awsClient) (*sts.GetCallerIdentityOutput, bool,
 
 // Currently user can rosa init using the region from their config or using --region
 // When checking for cloud formation we need to check in the region used by the user
-func GetAWSClientForUserRegion(reporter *rprtr.Object, logger *logrus.Logger,
+func GetAWSClientForUserRegion(reporter reporter.Logger, logger *logrus.Logger,
 	supportedRegions []string, useLocalCreds bool) Client {
 	// Get AWS region from env
 	awsRegionInUserConfig, err := GetRegion(arguments.GetRegion())
@@ -634,7 +635,7 @@ func GetInstallerAccountRoleName(cluster *cmv1.Cluster) (string, error) {
 	return GetAccountRoleName(cluster, AccountRoles[InstallerAccountRole].Name)
 }
 
-func GenerateOperatorRolePolicyFiles(reporter *rprtr.Object, policies map[string]*cmv1.AWSSTSPolicy,
+func GenerateOperatorRolePolicyFiles(reporter reporter.Logger, policies map[string]*cmv1.AWSSTSPolicy,
 	credRequests map[string]*cmv1.STSOperator, sharedVpcRoleArn string, partition string) error {
 	isSharedVpc := sharedVpcRoleArn != ""
 	for credrequest := range credRequests {
@@ -660,7 +661,7 @@ func GenerateOperatorRolePolicyFiles(reporter *rprtr.Object, policies map[string
 	return nil
 }
 
-func GenerateAccountRolePolicyFiles(reporter *rprtr.Object, env string, policies map[string]*cmv1.AWSSTSPolicy,
+func GenerateAccountRolePolicyFiles(reporter rprtr.Logger, env string, policies map[string]*cmv1.AWSSTSPolicy,
 	skipPermissionFiles bool, accountRoles map[string]AccountRole, partition string) error {
 	for file := range accountRoles {
 		//Get trust policy
@@ -689,7 +690,7 @@ func GenerateAccountRolePolicyFiles(reporter *rprtr.Object, env string, policies
 	return nil
 }
 
-func generatePermissionPolicyFile(reporter *rprtr.Object, file string, policies map[string]*cmv1.AWSSTSPolicy) error {
+func generatePermissionPolicyFile(reporter rprtr.Logger, file string, policies map[string]*cmv1.AWSSTSPolicy) error {
 	filename := fmt.Sprintf("sts_%s_permission_policy", file)
 	policyDetail := GetPolicyDetails(policies, filename)
 	if policyDetail == "" {
@@ -775,7 +776,7 @@ func FindFirstAttachedPolicy(policiesDetails []PolicyDetail) PolicyDetail {
 }
 
 func UpgradeOperatorRolePolicies(
-	reporter *rprtr.Object,
+	reporter reporter.Logger,
 	awsClient Client,
 	partition string,
 	accountID string,

--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -167,7 +167,7 @@ var roleTypeMap = map[string]string{
 	WorkerAccountRole:       WorkerAccountRoleType,
 }
 
-func (c *awsClient) EnsureRole(reporter *reporter.Object, name string, policy string, permissionsBoundary string,
+func (c *awsClient) EnsureRole(reporter reporter.Logger, name string, policy string, permissionsBoundary string,
 	version string, tagList map[string]string, path string, managedPolicies bool) (string, error) {
 	output, err := c.iamClient.GetRole(context.Background(), &iam.GetRoleInput{
 		RoleName: aws.String(name),
@@ -261,7 +261,7 @@ func (c *awsClient) ValidateRoleNameAvailable(name string) (err error) {
 	return fmt.Errorf("Error validating role name '%s': %v", name, err)
 }
 
-func (c *awsClient) createRole(reporter *reporter.Object, name string, policy string,
+func (c *awsClient) createRole(reporter reporter.Logger, name string, policy string,
 	permissionsBoundary string, tagList map[string]string, path string) (string, error) {
 	if !RoleNameRE.MatchString(name) {
 		return "", fmt.Errorf("Role name is invalid")
@@ -475,7 +475,7 @@ func (c *awsClient) hasCompatibleMajorMinorVersionTags(iamTags []iamtypes.Tag, v
 	return false, nil
 }
 
-func (c *awsClient) AttachRolePolicy(reporter *reporter.Object, roleName string, policyARN string) error {
+func (c *awsClient) AttachRolePolicy(reporter reporter.Logger, roleName string, policyARN string) error {
 	_, err := c.iamClient.AttachRolePolicy(context.Background(), &iam.AttachRolePolicyInput{
 		RoleName:  aws.String(roleName),
 		PolicyArn: aws.String(policyARN),

--- a/pkg/aws/sts.go
+++ b/pkg/aws/sts.go
@@ -31,7 +31,7 @@ import (
 
 	awscbRoles "github.com/openshift/rosa/pkg/aws/commandbuilder/helper/roles"
 	"github.com/openshift/rosa/pkg/aws/tags"
-	rprtr "github.com/openshift/rosa/pkg/reporter"
+	"github.com/openshift/rosa/pkg/reporter"
 )
 
 func (c *awsClient) DeleteUserRole(roleName string) error {
@@ -148,7 +148,7 @@ func SortRolesByLinkedRole(roles []Role) {
 	})
 }
 
-func UpgradeOperatorPolicies(reporter *rprtr.Object, awsClient Client, partition string, accountID string,
+func UpgradeOperatorPolicies(reporter reporter.Logger, awsClient Client, partition string, accountID string,
 	prefix string, policies map[string]string, defaultPolicyVersion string,
 	credRequests map[string]*cmv1.STSOperator, path string) error {
 	for credrequest, operator := range credRequests {

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -156,7 +156,7 @@ func RemoveStrFromSlice(s []string, str string) []string {
 	return s
 }
 
-func DisplaySpinnerWithDelay(reporter *reporter.Object, infoMessage string, delay time.Duration) {
+func DisplaySpinnerWithDelay(reporter reporter.Logger, infoMessage string, delay time.Duration) {
 	if reporter.IsTerminal() {
 		spin := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
 		reporter.Infof(infoMessage)

--- a/pkg/ocm/client.go
+++ b/pkg/ocm/client.go
@@ -56,7 +56,7 @@ func NewClientWithConnection(connection *sdk.Connection) *Client {
 	}
 }
 
-func CreateNewClientOrExit(logger *logrus.Logger, reporter *reporter.Object) *Client {
+func CreateNewClientOrExit(logger *logrus.Logger, reporter reporter.Logger) *Client {
 	client, err := NewClient().
 		Logger(logger).
 		Build()

--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -893,7 +893,7 @@ func (c *Client) GetVersionsList(channelGroup string, defaultFirst bool) ([]stri
 	return versionList, nil
 }
 
-func ValidateOperatorRolesMatchOidcProvider(reporter *reporter.Object, awsClient aws.Client,
+func ValidateOperatorRolesMatchOidcProvider(reporter reporter.Logger, awsClient aws.Client,
 	operatorIAMRoleList []OperatorIAMRole, oidcEndpointUrl string,
 	clusterVersion string, expectedOperatorRolePath string,
 	accountRolesHasManagedPolicies bool, logOperatorRoles bool) error {

--- a/pkg/options/machinepool/create.go
+++ b/pkg/options/machinepool/create.go
@@ -58,7 +58,7 @@ const (
 )
 
 type CreateMachinepoolOptions struct {
-	reporter *reporter.Object
+	reporter reporter.Logger
 
 	args *CreateMachinepoolUserOptions
 }

--- a/pkg/options/network/create.go
+++ b/pkg/options/network/create.go
@@ -40,7 +40,7 @@ type NetworkUserOptions struct {
 }
 
 type NetworkOptions struct {
-	reporter *reporter.Object
+	reporter reporter.Logger
 	args     *NetworkUserOptions
 }
 

--- a/pkg/policy/policy_service.go
+++ b/pkg/policy/policy_service.go
@@ -36,7 +36,7 @@ const (
 
 type PolicyService interface {
 	ValidateAttachOptions(roleName string, policyArns []string) error
-	AutoAttachArbitraryPolicy(reporter *reporter.Object, roleName string,
+	AutoAttachArbitraryPolicy(reporter reporter.Logger, roleName string,
 		policyArns []string, accountID, orgID string) error
 	ManualAttachArbitraryPolicy(roleName string, policyArns []string, accountID, orgID string) string
 	ValidateDetachOptions(roleName string, policyArns []string) error
@@ -76,7 +76,7 @@ func (p *policyService) ValidateDetachOptions(roleName string, policyArns []stri
 	return validateRoleAndPolicies(p.AWSClient, roleName, policyArns)
 }
 
-func (p *policyService) AutoAttachArbitraryPolicy(reporter *reporter.Object, roleName string, policyArns []string,
+func (p *policyService) AutoAttachArbitraryPolicy(reporter reporter.Logger, roleName string, policyArns []string,
 	accountID, orgID string) error {
 	for _, policyArn := range policyArns {
 		err := p.AWSClient.AttachRolePolicy(reporter, roleName, policyArn)

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -25,6 +25,23 @@ import (
 	"github.com/openshift/rosa/pkg/debug"
 )
 
+type Logger interface {
+	// Debugf logs a debug message with formatted arguments.
+	Debugf(format string, args ...interface{})
+
+	// Errorf logs an error message with formatted arguments and returns an error.
+	Errorf(format string, args ...interface{}) error
+
+	// Infof logs an info message with formatted arguments.
+	Infof(format string, args ...interface{})
+
+	// IsTerminal checks if the output is a terminal.
+	IsTerminal() bool
+
+	// Warnf logs a warning message with formatted arguments.
+	Warnf(format string, args ...interface{})
+}
+
 // Object is the reported object used by the tool. It prints the messages to the standard output or
 // error streams.
 type Object struct {

--- a/pkg/rosa/runtime.go
+++ b/pkg/rosa/runtime.go
@@ -15,7 +15,7 @@ import (
 )
 
 type Runtime struct {
-	Reporter   *reporter.Object
+	Reporter   reporter.Logger
 	Logger     *logrus.Logger
 	OCMClient  *ocm.Client
 	AWSClient  aws.Client


### PR DESCRIPTION
We want to use existing rosa functionality to create Account/Operator roles and OIDC config/provider in CAPA https://github.com/kubernetes-sigs/cluster-api-provider-aws 

I tried to expose functionality for creating Account/Operator roles and OIDC config/provider without affecting too much of existing code. I have create new public functions for each object that we need.

Also I have created `type Logger interface`  in `reporter.go` to be able to customize logging.

https://issues.redhat.com/browse/ACM-18622
