### PR TITLE
OCM-15990 | feat: New CF routines in awsClient for RosaNetwork in CAPA

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,7 @@ require (
 	github.com/dvsekhvalnov/jose2go v1.6.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fatih/color v1.7.0 // indirect
-	github.com/go-logr/logr v1.4.1 // indirect
+	github.com/go-logr/logr v1.4.1
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect

--- a/pkg/aws/api_interface/cloudformation_api_client.go
+++ b/pkg/aws/api_interface/cloudformation_api_client.go
@@ -40,6 +40,10 @@ type CloudFormationApiClient interface {
 		params *cloudformation.DescribeStackInstanceInput, optFns ...func(*cloudformation.Options),
 	) (*cloudformation.DescribeStackInstanceOutput, error)
 
+	DescribeStackResources(ctx context.Context,
+		params *cloudformation.DescribeStackResourcesInput, optFns ...func(*cloudformation.Options),
+	) (*cloudformation.DescribeStackResourcesOutput, error)
+
 	DescribeStackSetOperation(ctx context.Context,
 		params *cloudformation.DescribeStackSetOperationInput, optFns ...func(*cloudformation.Options),
 	) (*cloudformation.DescribeStackSetOperationOutput, error)

--- a/pkg/aws/client_mock.go
+++ b/pkg/aws/client_mock.go
@@ -5,10 +5,12 @@
 package aws
 
 import (
+	"context"
 	io "io"
 	reflect "reflect"
 
 	aws "github.com/aws/aws-sdk-go-v2/aws"
+	cftypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	iam "github.com/aws/aws-sdk-go-v2/service/iam"
 	types0 "github.com/aws/aws-sdk-go-v2/service/iam/types"
@@ -1591,4 +1593,63 @@ func (m *MockAccessKeyGetter) GetLocalAWSAccessKeys() (*AccessKey, error) {
 func (mr *MockAccessKeyGetterMockRecorder) GetLocalAWSAccessKeys() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLocalAWSAccessKeys", reflect.TypeOf((*MockAccessKeyGetter)(nil).GetLocalAWSAccessKeys))
+}
+
+// CreateStackWithParamsTags mocks base method.
+func (m *MockClient) CreateStackWithParamsTags(ctx context.Context, cfTemplateBody, stackName string, stackParams, stackTags map[string]string) (*string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateStackWithParamsTags", cfTemplateBody, stackName, stackParams, stackTags)
+	ret0, _ := ret[0].(*string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateStackWithParamsTags indicates an expected call of CreateStackWithParamsTags.
+func (mr *MockClientMockRecorder) CreateStackWithParamsTags(ctx context.Context, cfTemplateBody, stackName string, stackParams, stackTags map[string]string) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateStackWithParamsTags", reflect.TypeOf((*MockClient)(nil).CreateStackWithParamsTags), cfTemplateBody, stackName, stackParams, stackTags)
+}
+
+// GetCFStack mocks base method.
+func (m *MockClient) GetCFStack(ctx context.Context, stackName string) (*cftypes.Stack, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCFStack", ctx, stackName)
+	ret0, _ := ret[0].(*cftypes.Stack)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCFStack indicates an expected call of GetCFStack.
+func (mr *MockClientMockRecorder) GetCFStack(ctx context.Context, stackName string) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCFStack", reflect.TypeOf((*MockClient)(nil).GetCFStack), ctx, stackName)
+}
+
+// DescribeCFStackResources mocks base method.
+func (m *MockClient) DescribeCFStackResources(ctx context.Context, stackName string) (*[]cftypes.StackResource, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeCFStackResources", ctx, stackName)
+	ret0, _ := ret[0].(*[]cftypes.StackResource)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeCFStackResources indicates an expected call of DescribeCFStackResources.
+func (mr *MockClientMockRecorder) DescribeCFStackResources(ctx context.Context, stackName string) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeCFStackResources", reflect.TypeOf((*MockClient)(nil).DescribeCFStackResources), ctx, stackName)
+}
+
+// DeleteCFStack mocks base method.
+func (m *MockClient) DeleteCFStack(ctx context.Context, stackName string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteCFStack", ctx, stackName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteCFStack indicates an expected call of DeleteCFStack.
+func (mr *MockClientMockRecorder) DeleteCFStack(ctx context.Context, stackName string) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCFStack", reflect.TypeOf((*MockClient)(nil).DeleteCFStack), ctx, stackName)
 }

--- a/pkg/aws/client_test.go
+++ b/pkg/aws/client_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Client", func() {
 		mockSecretsManagerAPI = mocks.NewMockSecretsManagerApiClient(mockCtrl)
 		client = New(
 			awsSdk.Config{},
-			logrus.New(),
+			NewLoggerWrapper(logrus.New(), nil),
 			mockIamAPI,
 			mockEC2API,
 			mocks.NewMockOrganizationsApiClient(mockCtrl),

--- a/pkg/aws/cloudformation.go
+++ b/pkg/aws/cloudformation.go
@@ -115,7 +115,7 @@ func (c *awsClient) EnsureOsdCcsAdminUser(stackName string, adminUserName string
 
 func (c *awsClient) CreateStack(cfTemplateBody, stackName string) (bool, error) {
 	// Create cloudformation stack
-	_, err := c.cfClient.CreateStack(context.Background(), buildCreateStackInput(cfTemplateBody, stackName))
+	_, err := c.cfClient.CreateStack(context.Background(), buildCreateStackInput(cfTemplateBody, stackName, []cloudformationtypes.Parameter{}, []cloudformationtypes.Tag{}))
 	if err != nil {
 		return false, err
 	}
@@ -126,6 +126,69 @@ func (c *awsClient) CreateStack(cfTemplateBody, stackName string) (bool, error) 
 	}
 
 	return true, nil
+}
+
+func (c *awsClient) CreateStackWithParamsTags(ctx context.Context, cfTemplateBody, stackName string, stackParams, stackTags map[string]string) (*string, error) {
+	// stack tags
+	var cfTags []cloudformationtypes.Tag
+	for k, v := range stackTags {
+		cfTags = append(cfTags, cloudformationtypes.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		})
+	}
+
+	// Create a slice for CloudFormation parameters
+	var cfParams []cloudformationtypes.Parameter
+	for k, v := range stackParams {
+		cfParams = append(cfParams, cloudformationtypes.Parameter{
+			ParameterKey:   aws.String(k),
+			ParameterValue: aws.String(v),
+		})
+	}
+
+	// Create cloudformation stack
+	stackOutput, err := c.cfClient.CreateStack(ctx, buildCreateStackInput(cfTemplateBody, stackName, cfParams, cfTags))
+	if err != nil {
+		return nil, err
+	}
+
+	return stackOutput.StackId, nil
+}
+
+func (c *awsClient) GetCFStack(ctx context.Context, stackName string) (*cloudformationtypes.Stack, error) {
+	output, err := c.cfClient.DescribeStacks(ctx, &cloudformation.DescribeStacksInput{
+		StackName: aws.String(stackName),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(output.Stacks) == 0 {
+		return nil, fmt.Errorf("No CF stacks with name %s found", stackName)
+	}
+
+	return &output.Stacks[0], nil
+}
+
+func (c *awsClient) DescribeCFStackResources(ctx context.Context, stackName string) (*[]cloudformationtypes.StackResource, error) {
+	output, err := c.cfClient.DescribeStackResources(ctx, &cloudformation.DescribeStackResourcesInput{
+		StackName: aws.String(stackName),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &output.StackResources, nil
+}
+
+func (c *awsClient) DeleteCFStack(ctx context.Context, stackName string) error {
+	_, err := c.cfClient.DeleteStack(ctx, &cloudformation.DeleteStackInput{
+		StackName: aws.String(stackName),
+	})
+
+	return err
 }
 
 func (c *awsClient) UpdateStack(cfTemplateBody, stackName string) error {
@@ -202,7 +265,7 @@ func (c *awsClient) DeleteOsdCcsAdminUser(stackName string) error {
 }
 
 // Build cloudformation create stack input
-func buildCreateStackInput(cfTemplateBody, stackName string) *cloudformation.CreateStackInput {
+func buildCreateStackInput(cfTemplateBody, stackName string, cfParams []cloudformationtypes.Parameter, cfTags []cloudformationtypes.Tag) *cloudformation.CreateStackInput {
 	// Special cloudformation capabilities are required to create IAM resources in AWS
 	cfCapabilityIAM := cloudformationtypes.CapabilityCapabilityIam
 	cfCapabilityNamedIAM := cloudformationtypes.CapabilityCapabilityNamedIam
@@ -214,6 +277,8 @@ func buildCreateStackInput(cfTemplateBody, stackName string) *cloudformation.Cre
 		Capabilities: cfTemplateCapabilities,
 		StackName:    aws.String(stackName),
 		TemplateBody: aws.String(cfTemplateBody),
+		Parameters:   cfParams,
+		Tags:         cfTags,
 	}
 }
 

--- a/pkg/aws/logging.go
+++ b/pkg/aws/logging.go
@@ -1,0 +1,104 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/sirupsen/logrus"
+)
+
+type LoggerWrapper struct {
+	loggerType   string
+	logrusLogger *logrus.Logger
+	logrLogger   *logr.Logger
+}
+
+func NewLoggerWrapper(logrusLog *logrus.Logger, logrLog *logr.Logger) *LoggerWrapper {
+	if logrusLog != nil {
+		return &LoggerWrapper{
+			loggerType:   "logrus",
+			logrusLogger: logrusLog,
+		}
+	}
+
+	if logrLog != nil {
+		return &LoggerWrapper{
+			loggerType: "logr",
+			logrLogger: logrLog,
+		}
+	}
+
+	return nil
+}
+
+func (lw *LoggerWrapper) GetLevel() (lvl int) {
+	switch lw.loggerType {
+	case "logrus":
+		lvl = int(lw.logrusLogger.GetLevel())
+	case "logr":
+		lvl = lw.logrLogger.GetV()
+	}
+
+	return lvl
+}
+
+func (lw *LoggerWrapper) Debug(args ...interface{}) {
+	switch lw.loggerType {
+	case "logrus":
+		lw.logrusLogger.Debug(args...)
+	case "logr":
+		lw.logrLogger.Info(args[0].(string))
+	}
+}
+
+func (lw *LoggerWrapper) Info(args ...interface{}) {
+	switch lw.loggerType {
+	case "logrus":
+		lw.logrusLogger.Info(args...)
+	case "logr":
+		lw.logrLogger.Info(args[0].(string))
+	}
+}
+
+func (lw *LoggerWrapper) Warn(args ...interface{}) {
+	switch lw.loggerType {
+	case "logrus":
+		lw.logrusLogger.Warn(args...)
+	case "logr":
+		lw.logrLogger.Info(args[0].(string))
+	}
+}
+
+func (lw *LoggerWrapper) Error(args ...interface{}) {
+	switch lw.loggerType {
+	case "logrus":
+		lw.logrusLogger.Error(args...)
+	case "logr":
+		lw.logrLogger.Error(fmt.Errorf("awsClient error"), args[0].(string))
+	}
+}
+
+func (lw *LoggerWrapper) Fatal(args ...interface{}) {
+	switch lw.loggerType {
+	case "logrus":
+		lw.logrusLogger.Fatal(args...)
+	case "logr":
+		lw.logrLogger.Error(fmt.Errorf("awsClient error"), args[0].(string))
+	}
+}

--- a/pkg/aws/mocks/cloudformation_api_client_mock.go
+++ b/pkg/aws/mocks/cloudformation_api_client_mock.go
@@ -359,3 +359,23 @@ func (mr *MockCloudFormationApiClientMockRecorder) UpdateStack(ctx, params any, 
 	varargs := append([]any{ctx, params}, optFns...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStack", reflect.TypeOf((*MockCloudFormationApiClient)(nil).UpdateStack), varargs...)
 }
+
+// DescribeStackResources mocks base method.
+func (m *MockCloudFormationApiClient) DescribeStackResources(ctx context.Context, params *cloudformation.DescribeStackResourcesInput, optFns ...func(*cloudformation.Options)) (*cloudformation.DescribeStackResourcesOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, params}
+	for _, a := range optFns {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeStackResources", varargs...)
+	ret0, _ := ret[0].(*cloudformation.DescribeStackResourcesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeStackResources indicates an expected call of DescribeStackResources.
+func (mr *MockCloudFormationApiClientMockRecorder) DescribeStackResources(ctx, params any, optFns ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, params}, optFns...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackResources", reflect.TypeOf((*MockCloudFormationApiClient)(nil).DescribeStackResources), varargs...)
+}

--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -1151,7 +1151,7 @@ func (c *awsClient) DeleteOperatorRole(roleName string, managedPolicies bool,
 					sharedVpcPoliciesNotDeleted[*policyOutput.Policy.Arn] = false
 
 					// Add to list of sharedVpc policies to be actually deleted
-					c.logger.Infof("Deleting policy '%s'", policy)
+					c.logger.Info(fmt.Sprintf("Deleting policy '%s'", policy))
 					sharedVpcHcpPolicies = append(sharedVpcHcpPolicies, policy)
 				} else {
 					// Print warning message after all roles are checked (will result in duplicated warnings without
@@ -1255,11 +1255,11 @@ func (c *awsClient) DeleteAccountRole(roleName string, prefix string, managedPol
 			}
 			if containsManagedTag && containsHcpSharedVpcTag {
 				if *policyOutput.Policy.AttachmentCount == 0 {
-					c.logger.Infof("Deleting policy '%s'", policy)
+					c.logger.Info(fmt.Sprintf("Deleting policy '%s'", policy))
 					sharedVpcHcpPolicies = append(sharedVpcHcpPolicies, policy)
 				} else {
-					c.logger.Warnf("Unable to delete policy %s: Policy still attached to %v other resource(s)",
-						*policyOutput.Policy.PolicyName, *policyOutput.Policy.AttachmentCount)
+					c.logger.Warn(fmt.Sprintf("Unable to delete policy %s: Policy still attached to %v other resource(s)",
+						*policyOutput.Policy.PolicyName, *policyOutput.Policy.AttachmentCount))
 				}
 			}
 		}
@@ -2186,7 +2186,7 @@ func (c *awsClient) validateManagedPolicy(policies map[string]*cmv1.AWSSTSPolicy
 	if err != nil {
 		// EC2 policy is only available to orgs for zero-egress feature toggle enabled
 		if policyKey == WorkerEC2RegistryKey {
-			c.logger.Infof("Ignored check for policy key '%s' (zero egress feature toggle is not enabled)", policyKey)
+			c.logger.Info(fmt.Sprintf("Ignored check for policy key '%s' (zero egress feature toggle is not enabled)", policyKey))
 			return nil
 		}
 		return err

--- a/pkg/aws/policies_test.go
+++ b/pkg/aws/policies_test.go
@@ -249,7 +249,7 @@ var _ = Describe("Is Policy Compatible", func() {
 		mockSecretsManagerAPI = mocks.NewMockSecretsManagerApiClient(mockCtrl)
 		client = New(
 			awsSdk.Config{},
-			logrus.New(),
+			NewLoggerWrapper(logrus.New(), nil),
 			mockIamAPI,
 			mockEC2API,
 			mocks.NewMockOrganizationsApiClient(mockCtrl),
@@ -837,7 +837,7 @@ var _ = Describe("validateManagedPolicy", func() {
 		mockIamAPI = mocks.NewMockIamApiClient(mockCtrl)
 		client = awsClient{
 			iamClient: mockIamAPI,
-			logger:    logging.NewLogger(),
+			logger:    NewLoggerWrapper(logging.NewLogger(), nil),
 		}
 	})
 


### PR DESCRIPTION
This pull request implements several things needed so that rosa-cli golang packages (the `awsClient` in particular) can be (re)used in [CAPA in rosaNetwork implementation](https://github.com/stolostron/cluster-api-installer/pull/178/files): 
* a new `awsclient.CreateStackWithParamsTags()` non-blocking routine through which it will be possible to create a new CF stack with parameters & tags
* a new `awsclient.GetCFStack()` routine to fetch cloudformation stack details
* a new `awsclient.DescribeCFStackResources()` routine to fetch list of CF stack resources
* a new `awsclient.DeleteCFStack()` routine to delete a cloudformation stack
* support for `go-logr/logr` `Logger` in `awsClient`, since that logger is the one being used in CAPA

https://issues.redhat.com/browse/OCM-15990