### PR TITLE
OCM-15907 | feat: Introduce warning + validation for govcloud env choice

### DIFF
--- a/pkg/fedramp/config.go
+++ b/pkg/fedramp/config.go
@@ -32,6 +32,15 @@ func IsGovRegion(region string) bool {
 	return false
 }
 
+func IsValidEnv(env string) bool {
+	for _, r := range URLAliases {
+		if r == env {
+			return true
+		}
+	}
+	return false
+}
+
 // JumpAccounts are the various of AWS accounts used for the installer jump role in the various OCM environments
 var JumpAccounts = map[string]string{
 	"production":  "448648337690",

--- a/pkg/ocm/config.go
+++ b/pkg/ocm/config.go
@@ -31,6 +31,7 @@ import (
 )
 
 const Production = "production"
+const ProductionAlias = "prod"
 
 // URLAliases allows the value of the `--env` option to map to the various API URLs.
 var URLAliases = map[string]string{


### PR DESCRIPTION
https://github.com/openshift/rosa/issues/2894

Logging into govcloud via ROSA CLI could be finicky if the user did not supply a correct environment.

--------

From #2894:

```
rosa login --env prod --govcloud --admin --region us-gov-west-1
To login to your Red Hat account, get an offline access token at
? Copy the token and paste it here:
```

This doesn't show a link to get token or throw an error that "prod" is not recognized.

```
rosa login --env production --govcloud --admin --region us-gov-west-1
To login to your Red Hat account, get an offline access token at https://api-admin.openshiftusgov.com/auth
? Copy the token and paste it here:
```

The proper value is production.

--------

This has been improved upon by introducing a warning when a user provides an incorrect env for a govcloud login attempt. And in general, `prod` is now an alias for `production` (with a warning telling the user explicitly what is happening when aliased)