### PR TITLE
OCM-16119 | fix: No region set for command which needs no region, `list/clusters`

### DIFF
--- a/cmd/list/cluster/cmd.go
+++ b/cmd/list/cluster/cmd.go
@@ -68,7 +68,7 @@ func listClustersUsingAccountRole(creator *aws.Creator, runtime *rosa.Runtime) (
 }
 
 func run(_ *cobra.Command, _ []string) {
-	r := rosa.NewRuntime().WithAWS().WithOCM()
+	r := rosa.NewRuntime().WithAWSWarnInsteadOfExit().WithOCM()
 	defer r.Cleanup()
 
 	// Retrieve the list of clusters:


### PR DESCRIPTION
* Fixes https://github.com/openshift/rosa/issues/2907 and https://github.com/openshift/rosa/issues/1386
* Fixes [OCM-16119](https://issues.redhat.com//browse/OCM-16119)

The issue stemmed from the AWS client needed to be used when listing clusters. The command is region-agnostic, but the client was created using `WithAWS` which always exits when no region is set with an error. 

To fix this, I introduced an "overloaded" function called `WithAWSWarnInsteadOfExit` to warn about no region being set and continue, rather than error+exit.
