### PR TITLE
OCM-16257 | ci: Adjust destroy step to support Konflux e2e CI cleanup step

### DIFF
--- a/tests/ci/config/config.go
+++ b/tests/ci/config/config.go
@@ -16,16 +16,17 @@ var Test *TestConfig
 // TestConfig contains platforms info for the rosacli testing
 type TestConfig struct {
 	// Env is the OpenShift Cluster Management environment used to provision clusters.
-	ENV               string `env:"OCM_LOGIN_ENV" default:""`
-	TestProfile       string `env:"TEST_PROFILE" default:""`
-	ResourcesDir      string `env:"RESOURCES_DIR" default:""`
-	OutputDir         string `env:"OUTPUT_DIR" default:""`
-	YAMLProfilesDir   string `env:"TEST_PROFILE_DIR" default:""`
-	RootDir           string `env:"WORKSPACE" default:""`
-	ClusterConfigFile string
-	ArtifactDir       string `env:"ARTIFACT_DIR" default:""`
-	UserDataFile      string
-	CreateCommandFile string
+	ENV                 string `env:"OCM_LOGIN_ENV" default:""`
+	TestProfile         string `env:"TEST_PROFILE" default:""`
+	ResourcesDir        string `env:"RESOURCES_DIR" default:""`
+	OutputDir           string `env:"OUTPUT_DIR" default:""`
+	YAMLProfilesDir     string `env:"TEST_PROFILE_DIR" default:""`
+	RootDir             string `env:"WORKSPACE" default:""`
+	ClusterConfigFile   string
+	ArtifactDir         string `env:"ARTIFACT_DIR" default:""`
+	UserDataFile        string
+	KonfluxUserDataFile string
+	CreateCommandFile   string
 	// Temporary file to compatible to current CI jobs. Will remove once all CI jobs migration finished
 	ClusterIDFile     string
 	APIURLFile        string
@@ -103,6 +104,7 @@ func init() {
 	}
 	Test.ClusterConfigFile = path.Join(Test.OutputDir, "cluster-config")
 	Test.UserDataFile = path.Join(Test.OutputDir, "resources.json")
+	Test.KonfluxUserDataFile = path.Join(Test.OutputDir, "konflux_resources.json")
 	Test.APIURLFile = path.Join(Test.OutputDir, "api.url")
 
 	// Temporary files to compatible to current CI jobs. Will remove once all CI jobs migration finished

--- a/tests/ci/labels/runtime.go
+++ b/tests/ci/labels/runtime.go
@@ -14,15 +14,16 @@ var E2EReport = Label("e2e-report")
 // The lables is always defined on each test case.
 type runtimeLabels struct {
 	// Test cases based on a cluster created by profiles.
-	Day1          Labels
-	Day1Readiness Labels
-	Day1Post      Labels
-	Day2Readiness Labels
-	Day2          Labels
-	Upgrade       Labels
-	Destructive   Labels
-	Destroy       Labels
-	DestroyPost   Labels
+	Day1             Labels
+	Day1Readiness    Labels
+	Day1Post         Labels
+	Day2Readiness    Labels
+	Day2             Labels
+	Upgrade          Labels
+	Destructive      Labels
+	Destroy          Labels
+	DestroyPost      Labels
+	DestroyOnKonflux Labels
 
 	// Test cases beyond the cluster created by profiles.
 	Day1Supplemental Labels
@@ -46,6 +47,7 @@ func initRuntime() *runtimeLabels {
 	rLabels.Destroy = Label("destroy")
 	rLabels.DestroyPost = Label("destroy-post")
 	rLabels.Day2Readiness = Label("day2-readiness")
+	rLabels.DestroyOnKonflux = Label("destroy-on-konflux")
 
 	rLabels.Day1Supplemental = Label("day1-supplemental")
 	rLabels.OCMResources = Label("ocm-resources")

--- a/tests/e2e/e2e_tear_down_test.go
+++ b/tests/e2e/e2e_tear_down_test.go
@@ -25,3 +25,17 @@ var _ = Describe("Cluster destroy", labels.Feature.Cluster, func() {
 			Expect(len(errs)).To(Equal(0), fmt.Sprintf("Errors while destroying the cluster: %v", errors.Join(errs...)))
 		})
 })
+
+var _ = Describe("Cluster destroy on Konflux", labels.Feature.Cluster, func() {
+	It("by profile",
+		labels.Runtime.DestroyOnKonflux,
+		labels.Critical,
+		func() {
+			client := rosacli.NewClient()
+			profile := handler.LoadProfileYamlFileByENV()
+			clusterHandler, err := handler.NewClusterHandlerForKonflux(client, profile)
+			Expect(err).ToNot(HaveOccurred())
+			var errs = clusterHandler.Destroy()
+			Expect(len(errs)).To(Equal(0), fmt.Sprintf("Errors while destroying the cluster: %v", errors.Join(errs...)))
+		})
+})

--- a/tests/utils/handler/interface.go
+++ b/tests/utils/handler/interface.go
@@ -78,6 +78,7 @@ type ClusterConfig struct {
 
 // Resources will record the resources prepared
 type Resources struct {
+	ClusterID                    string                `json:"cluster_id,omitempty"`
 	AccountRolesPrefix           string                `json:"account_roles_prefix,omitempty"`
 	AdditionalPrincipals         string                `json:"additional_principals,omitempty"`
 	AuditLogArn                  string                `json:"audit_log,omitempty"`


### PR DESCRIPTION
The volume cannot be shared between Konflux steps with the final step in one task and our previous destroy step uses the resource file under tests/output/<profile>, so we need to do some adjustment to support Konflux CI cleanup step.

    Store all resources information in konflux_resources.json for final step to do cleanup
    Create a new scenario with 'destroy-on-konflux' filter to run cleanup step

Here is the log on my local, https://privatebin.corp.redhat.com/?f660a57dfdc403a2#5TeHJ4T8wAAf3DSrHNZijuQDRffiZVZpzo5URQeSnnif the setup and destroy step works well.
