### PR TITLE
OCM-16406 | test: fix ids: 77829,81295,77140,81295,75921,56786

### DIFF
--- a/tests/e2e/hcp_machine_pool_test.go
+++ b/tests/e2e/hcp_machine_pool_test.go
@@ -536,7 +536,7 @@ var _ = Describe("HCP Machine Pool", labels.Feature.Machinepool, func() {
 			By("with wrong instance-type")
 			_, err = machinePoolService.CreateMachinePool(clusterID, "anything", "--replicas", "2", "--instance-type", "wrong")
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).Should(ContainSubstring("Expected a valid instance type"))
+			Expect(err.Error()).Should(ContainSubstring("is not supported in availability zone"))
 
 			By("with non existing subnet")
 			_, err = machinePoolService.CreateMachinePool(clusterID, "anything", "--replicas", "2", "--subnet", "subnet-xxx")

--- a/tests/utils/constants/general.go
+++ b/tests/utils/constants/general.go
@@ -27,6 +27,6 @@ const (
 )
 
 const (
-	BillingAccount        = "301721915996"
-	ChangedBillingAccount = "361660083367"
+	BillingAccount        = "090777400063"
+	ChangedBillingAccount = "487962084830"
 )

--- a/tests/utils/exec/rosacli/cmd_parser.go
+++ b/tests/utils/exec/rosacli/cmd_parser.go
@@ -153,6 +153,7 @@ func (td *textData) YamlToObj(obj interface{}) (err error) {
 func escapeYamlStringValues(input string) (string, error) {
 	var lines []string
 	scanner := bufio.NewScanner(strings.NewReader(input))
+	reLeadingZeroNum := regexp.MustCompile(`^0\d+$`)
 	for scanner.Scan() {
 		line := scanner.Text()
 		key, value, found := strings.Cut(line, ":")
@@ -160,7 +161,10 @@ func escapeYamlStringValues(input string) (string, error) {
 			value = strings.TrimSpace(value)
 
 			// Checks to perform
-			if !strings.HasPrefix(value, "'") && strings.Contains(value, ": ") {
+			if reLeadingZeroNum.MatchString(value) {
+				// If the value is a number with leading zero, add quotes
+				line = fmt.Sprintf("%s: \"%s\"", key, value)
+			} else if !strings.HasPrefix(value, "'") && strings.Contains(value, ": ") {
 				line = fmt.Sprintf("%s: '%s'", key, value)
 			}
 		}


### PR DESCRIPTION
-     77829,81295,77140,81295: new aws account 090777400063 parsing issue. Fix it by preprocessing the raw input string in escapeYamlStringValues
-     75921: Update the testing billing for new OCM account
-     56786: error message have changed, update the expected error message

Logs on local are here https://privatebin.corp.redhat.com/?47489464ef6a2cc1#8SGVuMjAXmSaT45bHmhy8X7oP2A3CUG9FUS9ma3FnXKL