### PR TITLE
OCM-10979 | fix: Bump Go version to 1.23.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,7 @@
 
 version: "2"
 run:
-  go: "1.23"
+  go: "1.23.1"
   issues-exit-code: 1
   modules-download-mode: readonly
 issues:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/rosa
 
-go 1.23
+go 1.23.1
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.15


### PR DESCRIPTION
Bumps ROSA CLI to 1.23.1