### PR TITLE
OCM-15880 | ci: Add GOFLAGS=-buildvcs=false env in Dockerfile.konflux

### DIFF
--- a/images/Dockerfile.konflux
+++ b/images/Dockerfile.konflux
@@ -17,6 +17,7 @@ RUN wget https://go.dev/dl/go1.22.3.linux-amd64.tar.gz && \
     rm go1.22.3.linux-amd64.tar.gz
 
 ENV GOTOOLCHAIN=local
+ENV GOFLAGS=-buildvcs=false
 RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.13.2
 RUN make release
 


### PR DESCRIPTION
Add GOFLAGS=-buildvcs=false env in Dockerfile.konflux to avoid bellow error when build-container:
```
[1/2] STEP 10/10: RUN make release
bash ./hack/build_cli.sh
error obtaining VCS status: exit status 128
Use -buildvcs=false to disable VCS stamping. 
```