### PR TITLE
OCM-16579 | test: fix ids: 43070,62083,57441,81295,77140

### DIFF
--- a/tests/e2e/test_rosacli_account_roles.go
+++ b/tests/e2e/test_rosacli_account_roles.go
@@ -217,8 +217,7 @@ var _ = Describe("Edit account roles", labels.Feature.AccountRoles, func() {
 			Expect(textData).To(ContainSubstring("Successfully deleted the classic account roles"))
 
 			By("List account-roles to check they are deleted")
-			accountRoleList, _, err = ocmResourceService.ListAccountRole()
-			Expect(err).To(BeNil())
+			accountRoleList, _, _ = ocmResourceService.ListAccountRole()
 
 			accountRoleSetB = accountRoleList.AccountRoles(userRolePrefixB)
 			accountRoleSetH = accountRoleList.AccountRoles(userRolePrefixH)
@@ -284,8 +283,7 @@ var _ = Describe("Edit account roles", labels.Feature.AccountRoles, func() {
 			Expect(textData).To(ContainSubstring("Successfully deleted the hosted CP account roles"))
 
 			By("List account-roles to check they are deleted")
-			accountRoleList, _, err := ocmResourceService.ListAccountRole()
-			Expect(err).To(BeNil())
+			accountRoleList, _, _ := ocmResourceService.ListAccountRole()
 			Expect(len(accountRoleList.AccountRoles(accrolePrefix))).To(Equal(0))
 		})
 
@@ -339,8 +337,7 @@ var _ = Describe("Edit account roles", labels.Feature.AccountRoles, func() {
 			Expect(textData).To(ContainSubstring("Successfully deleted the hosted CP account roles"))
 
 			By("List account-roles to check they are deleted")
-			accountRoleList, _, err := ocmResourceService.ListAccountRole()
-			Expect(err).To(BeNil())
+			accountRoleList, _, _ := ocmResourceService.ListAccountRole()
 			Expect(len(accountRoleList.AccountRoles(accrolePrefix))).To(Equal(0))
 		})
 

--- a/tests/prow_ci.sh
+++ b/tests/prow_ci.sh
@@ -99,6 +99,7 @@ rosa_login () {
   echo "[CI] Running rosa/ocm login based on env $1"
   rosa login --env "${ocmENV}" --token "${ocmToken}"
   ocm login --url "${ocmENV}" --token "${ocmToken}"
+  rosa init
 }
 
 # generate_label_filter_switch is used to generate label-filter for the test run


### PR DESCRIPTION
- 43070,62083,57441: there will be error if no any account roles exists.
- 81295,77140: maximum number of addresses has been reached, do some improvement for this case to delete the SF immediately after each creation step
- Add `rosa init` command in rosa_login function which is used for CI

The logs on local is here:
https://privatebin.corp.redhat.com/?2985a780f9009598#J9EpUi7CFu7u24gva9NRk5eGH2aU2bGadiRto2ekMbSt