### PR TITLE
OCM-16679 | test: fix ids: 38775,75227

### DIFF
--- a/tests/e2e/rosa_autoscaler_test.go
+++ b/tests/e2e/rosa_autoscaler_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/rosa/tests/ci/labels"
 	"github.com/openshift/rosa/tests/utils/config"
 	"github.com/openshift/rosa/tests/utils/exec/rosacli"
+	"github.com/openshift/rosa/tests/utils/handler"
 	"github.com/openshift/rosa/tests/utils/helper"
 )
 
@@ -64,6 +65,10 @@ var _ = Describe("Autoscaler", labels.Feature.Autoscaler, func() {
 		It("Validation info/error about the MaxNodeLimit and MaxNodeLimitation - [id:79848]",
 			labels.Critical, labels.Runtime.Day2,
 			func() {
+				profile := handler.LoadProfileYamlFileByENV()
+				if !profile.ClusterConfig.NetworkingSet {
+					Skip("Skip this case as network configuration makes the MaxNodeLimitation less then the default maximum number since OCM-13822")
+				}
 				var (
 					minReplicas     string
 					maxReplicas     string

--- a/tests/e2e/test_rosacli_machine_pool.go
+++ b/tests/e2e/test_rosacli_machine_pool.go
@@ -804,7 +804,7 @@ var _ = Describe("Create machinepool",
 						"--instance-type", fakeInstanceType)
 					Expect(err).To(HaveOccurred())
 					Expect(output.String()).Should(
-						ContainSubstring("Expected a valid instance type: Machine type '%s' not found", fakeInstanceType))
+						ContainSubstring("Machine type '%s' is not supported for cloud provider", fakeInstanceType))
 
 					By("Set replicas and enable-autoscaling at the same time")
 					output, err = rosaClient.MachinePool.CreateMachinePool(

--- a/tests/utils/handler/cluster_handler.go
+++ b/tests/utils/handler/cluster_handler.go
@@ -567,9 +567,9 @@ func (ch *clusterHandler) GenerateClusterCreateFlags() ([]string, error) {
 	if ch.profile.ClusterConfig.NetworkingSet {
 		networking := &ClusterConfigure.Networking{
 			MachineCIDR: "10.0.0.0/16",
-			PodCIDR:     "192.168.0.0/18",
+			PodCIDR:     "10.128.0.0/14",
 			ServiceCIDR: "172.31.0.0/24",
-			HostPrefix:  "25",
+			HostPrefix:  "23",
 		}
 		flags = append(flags,
 			"--machine-cidr", networking.MachineCIDR, // Placeholder, it should be vpc CIDR


### PR DESCRIPTION
- 38775: the error message has changed, update the expected error message to fix
-  75227: It failed as change of [OCM-13822](https://issues.redhat.com/browse/OCM-13822) which adds ValidateNetworkSizeOnUpdate, update the cluster config of PodCIDR and HostPrefix to pass the ValidateNetworkSizeOnUpdate number. And also skip the case when not set profile.ClusterConfig.NetworkingSet

Logs on local is https://privatebin.corp.redhat.com/?9136803fd14b84f3#Hbe6KjfSrqeGVN91oxm3h38HcfUM2wBKmLgDzq3FG6if