### PR TITLE
OCM-15992 | fix: Remove check stopping private ingress changes

### DIFF
--- a/pkg/interactive/validation.go
+++ b/pkg/interactive/validation.go
@@ -235,7 +235,8 @@ func SubnetsValidator(awsClient aws.Client, multiAZ bool, privateLink bool, host
 					subnetIDs[i] = aws.ParseOption(subnet.Value)
 				}
 
-				_, err = ocm.ValidateHostedClusterSubnets(awsClient, privateLink, subnetIDs)
+				privateIngress := false
+				_, err = ocm.ValidateHostedClusterSubnets(awsClient, privateLink, subnetIDs, privateIngress)
 				return err
 			}
 			return ocm.ValidateSubnetsCount(multiAZ, privateLink, len(answers))

--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -103,7 +103,7 @@ type Spec struct {
 	HostPrefix                     int
 	Private                        *bool
 	PrivateLink                    *bool
-	PrivateIngress                 bool
+	PrivateIngress                 *bool
 
 	// Properties
 	CustomProperties map[string]string
@@ -1130,30 +1130,37 @@ func (c *Client) createClusterSpec(config Spec) (*cmv1.Cluster, error) {
 		clusterBuilder = clusterBuilder.Htpasswd(htPasswdIDP)
 	}
 
-	if !reflect.DeepEqual(config.DefaultIngress, NewDefaultIngressSpec()) {
-		defaultIngress := cmv1.NewIngress().Default(true)
-		if len(config.DefaultIngress.RouteSelectors) != 0 {
-			defaultIngress.RouteSelectors(config.DefaultIngress.RouteSelectors)
-		}
-		if len(config.DefaultIngress.ExcludedNamespaces) != 0 {
-			defaultIngress.ExcludedNamespaces(config.DefaultIngress.ExcludedNamespaces...)
-		}
-		if !helper.Contains([]string{"", consts.SkipSelectionOption}, config.DefaultIngress.WildcardPolicy) {
-			defaultIngress.RouteWildcardPolicy(v1.WildcardPolicy(config.DefaultIngress.WildcardPolicy))
-		}
-		if !helper.Contains([]string{"", consts.SkipSelectionOption}, config.DefaultIngress.NamespaceOwnershipPolicy) {
-			defaultIngress.RouteNamespaceOwnershipPolicy(
-				v1.NamespaceOwnershipPolicy(config.DefaultIngress.NamespaceOwnershipPolicy))
-		}
+	// Build default ingress if changes detected in config
+	defaultIngress := cmv1.NewIngress().Default(true)
+	if len(config.DefaultIngress.RouteSelectors) != 0 {
+		defaultIngress.RouteSelectors(config.DefaultIngress.RouteSelectors)
+	}
+	if len(config.DefaultIngress.ExcludedNamespaces) != 0 {
+		defaultIngress.ExcludedNamespaces(config.DefaultIngress.ExcludedNamespaces...)
+	}
+	if !helper.Contains([]string{"", consts.SkipSelectionOption}, config.DefaultIngress.WildcardPolicy) {
+		defaultIngress.RouteWildcardPolicy(v1.WildcardPolicy(config.DefaultIngress.WildcardPolicy))
+	}
+	if !helper.Contains([]string{"", consts.SkipSelectionOption}, config.DefaultIngress.NamespaceOwnershipPolicy) {
+		defaultIngress.RouteNamespaceOwnershipPolicy(
+			v1.NamespaceOwnershipPolicy(config.DefaultIngress.NamespaceOwnershipPolicy))
+	}
 
-		// Decide ingress listening method if HCP and not fedramp enabled
-		if !fedramp.Enabled() && config.Hypershift.Enabled {
-			if config.PrivateIngress {
+	// Decide ingress listening method if HCP and not fedramp enabled
+	isHcpNotFedramp := !fedramp.Enabled() && config.Hypershift.Enabled
+	if isHcpNotFedramp {
+		if config.PrivateIngress != nil {
+			if *config.PrivateIngress {
 				defaultIngress.Listening(cmv1.ListeningMethodInternal)
 			} else {
-				defaultIngress.Listening(clusterApiListeningMethod)
+				defaultIngress.Listening(cmv1.ListeningMethodExternal)
 			}
+		} else {
+			defaultIngress.Listening(clusterApiListeningMethod)
 		}
+	}
+
+	if !reflect.DeepEqual(config.DefaultIngress, NewDefaultIngressSpec()) || isHcpNotFedramp {
 		clusterBuilder.Ingresses(cmv1.NewIngressList().Items(defaultIngress))
 	}
 

--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -751,7 +751,9 @@ func ValidateSubnetsCount(multiAZ bool, privateLink bool, subnetsInputCount int)
 	return nil
 }
 
-func ValidateHostedClusterSubnets(awsClient aws.Client, isPrivate bool, subnetIDs []string) (int, error) {
+func ValidateHostedClusterSubnets(awsClient aws.Client, isPrivate bool, subnetIDs []string,
+	privateIngress bool) (int, error) {
+
 	if isPrivate && len(subnetIDs) < 1 {
 		return 0, fmt.Errorf("The number of subnets for a private hosted cluster should be at least one")
 	}
@@ -781,7 +783,7 @@ func ValidateHostedClusterSubnets(awsClient aws.Client, isPrivate bool, subnetID
 	privateSubnetCount := len(privateSubnets)
 	publicSubnetsCount := len(subnets) - privateSubnetCount
 
-	if isPrivate {
+	if isPrivate && privateIngress {
 		if publicSubnetsCount > 0 {
 			return 0, fmt.Errorf("The number of public subnets for a private hosted cluster should be zero")
 		}

--- a/pkg/ocm/helpers_test.go
+++ b/pkg/ocm/helpers_test.go
@@ -468,12 +468,12 @@ var _ = Describe("ValidateHostedClusterSubnets for Private Cluster", func() {
 	})
 	It("should not return an error when only private subnets are present for a private cluster", func() {
 		mockClient.EXPECT().FilterVPCsPrivateSubnets(gomock.Any()).Return([]ec2types.Subnet{subnets[1]}, nil)
-		_, err := ValidateHostedClusterSubnets(mockClient, true, []string{"subnet-private-2"})
+		_, err := ValidateHostedClusterSubnets(mockClient, true, []string{"subnet-private-2"}, true)
 		Expect(err).NotTo(HaveOccurred())
 	})
 	It("should return an error when public subnets are present for a private cluster", func() {
 		mockClient.EXPECT().FilterVPCsPrivateSubnets(gomock.Any()).Return([]ec2types.Subnet{}, nil)
-		_, err := ValidateHostedClusterSubnets(mockClient, true, ids)
+		_, err := ValidateHostedClusterSubnets(mockClient, true, ids, true)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal("The number of public subnets for a private hosted cluster should be zero"))
 	})


### PR DESCRIPTION
* Removes `if !reflect.DeepEqual(config.DefaultIngress, NewDefaultIngressSpec()) {` check when creating cluster spec
* * Replicates behavior in that it only adds the modified default ingress when something is changed, but now includes Private Ingress in that check
* * Fixes issue where private ingress would not be set unless default ingress had another change