### PR TITLE
OCM-16776 | test: automate id:55979,36293

### DIFF
--- a/tests/e2e/test_rosacli_machine_pool.go
+++ b/tests/e2e/test_rosacli_machine_pool.go
@@ -84,9 +84,38 @@ var _ = Describe("Create machinepool",
 					"auto_scaling": {"--enable-autoscaling", "--max-replicas", maxReplicas,
 						"--min-replicas", minReplicas, "--labels", labels_2},
 				}
+				By("Check the output colume of the machinepool list with --dedicated-host/--all/--az-type/--win-li flags")
+				resp, err := machinePoolService.ListAndReflectMachinePools(
+					clusterID,
+					"--all",
+				)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp.MachinePools[0].AZType).ToNot(BeEmpty())
+				Expect(resp.MachinePools[0].DedicatedHost).ToNot(BeEmpty())
+				Expect(resp.MachinePools[0].WINLIEnable).ToNot(BeEmpty())
+
+				resp, err = machinePoolService.ListAndReflectMachinePools(
+					clusterID,
+					"--az-type",
+					"--dedicated-host",
+				)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp.MachinePools[0].AZType).ToNot(BeEmpty())
+				Expect(resp.MachinePools[0].DedicatedHost).ToNot(BeEmpty())
+				Expect(resp.MachinePools[0].WINLIEnable).To(BeEmpty())
+
+				resp, err = machinePoolService.ListAndReflectMachinePools(
+					clusterID,
+					"--win-li",
+					"--dedicated-host",
+				)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp.MachinePools[0].AZType).To(BeEmpty())
+				Expect(resp.MachinePools[0].DedicatedHost).ToNot(BeEmpty())
+				Expect(resp.MachinePools[0].WINLIEnable).ToNot(BeEmpty())
 
 				By("List the default machinepool of the cluster")
-				resp, err := machinePoolService.ListAndReflectMachinePools(clusterID)
+				resp, err = machinePoolService.ListAndReflectMachinePools(clusterID)
 				Expect(err).ToNot(HaveOccurred())
 				mpID := helper.GenerateRandomName("mp-36293", 2)
 				mpIDcounter := 1
@@ -708,11 +737,12 @@ var _ = Describe("Create machinepool",
 				defer machinePoolService.DeleteMachinePool(clusterID, localZoneMpName)
 
 				By("List the machinepools and check")
-				mpList, err := machinePoolService.ListAndReflectMachinePools(clusterID)
+				mpList, err := machinePoolService.ListAndReflectMachinePools(clusterID, "--az-type")
 				Expect(err).ToNot(HaveOccurred())
 				mp := mpList.Machinepool(localZoneMpName)
 				Expect(mp.Replicas).To(Equal("1-2"))
 				Expect(mp.Subnets).To(Equal(privateSubnet.ID))
+				Expect(mp.AZType).To(Equal("LocalZone"))
 			})
 		Context("validation", func() {
 			It("will validate name/replicas/labels/taints  - [id:67057]",

--- a/tests/utils/exec/rosacli/machinepool_service.go
+++ b/tests/utils/exec/rosacli/machinepool_service.go
@@ -21,7 +21,7 @@ import (
 type MachinePoolService interface {
 	ResourcesCleaner
 
-	ListMachinePool(clusterID string) (bytes.Buffer, error)
+	ListMachinePool(clusterID string, flags ...string) (bytes.Buffer, error)
 	DescribeMachinePool(clusterID string, mpID string) (bytes.Buffer, error)
 	CreateMachinePool(clusterID string, name string, flags ...string) (bytes.Buffer, error)
 	EditMachinePool(clusterID string, machinePoolName string, flags ...string) (bytes.Buffer, error)
@@ -29,7 +29,7 @@ type MachinePoolService interface {
 
 	ReflectMachinePoolList(result bytes.Buffer) (mpl MachinePoolList, err error)
 	ReflectMachinePoolDescription(result bytes.Buffer) (*MachinePoolDescription, error)
-	ListAndReflectMachinePools(clusterID string) (mpl MachinePoolList, err error)
+	ListAndReflectMachinePools(clusterID string, flags ...string) (mpl MachinePoolList, err error)
 	DescribeAndReflectMachinePool(clusterID string, name string) (*MachinePoolDescription, error)
 
 	ReflectNodePoolList(result bytes.Buffer) (*NodePoolList, error)
@@ -79,6 +79,9 @@ type MachinePool struct {
 	Subnets          string `json:"SUBNETS,omitempty"`
 	SpotInstances    string `json:"SPOT INSTANCES,omitempty"`
 	SecurityGroupIDs string `json:"SG IDs,omitempty"`
+	AZType           string `json:"AZ TYPE,omitempty"`
+	WINLIEnable      string `json:"WIN-LI ENABLED,omitempty"`
+	DedicatedHost    string `json:"DEDICATED HOST,omitempty"`
 }
 type MachinePoolList struct {
 	MachinePools []*MachinePool `json:"MachinePools,omitempty"`
@@ -169,10 +172,13 @@ func (m *machinepoolService) CreateMachinePool(
 }
 
 // List MachinePool
-func (m *machinepoolService) ListMachinePool(clusterID string) (bytes.Buffer, error) {
+func (m *machinepoolService) ListMachinePool(clusterID string, flags ...string) (bytes.Buffer, error) {
 	listMachinePool := m.client.Runner.
 		Cmd("list", "machinepool").
 		CmdFlags("-c", clusterID)
+	if len(flags) > 0 {
+		listMachinePool.AddCmdFlags(flags...)
+	}
 	return listMachinePool.Run()
 }
 
@@ -240,9 +246,9 @@ func (m *machinepoolService) ReflectMachinePoolList(result bytes.Buffer) (mpl Ma
 }
 
 // Pasrse the result of 'rosa list machinepool' to MachinePoolList struct
-func (m *machinepoolService) ListAndReflectMachinePools(clusterID string) (mpl MachinePoolList, err error) {
+func (m *machinepoolService) ListAndReflectMachinePools(clusterID string, flags ...string) (mpl MachinePoolList, err error) {
 	mpl = MachinePoolList{}
-	output, err := m.ListMachinePool(clusterID)
+	output, err := m.ListMachinePool(clusterID, flags...)
 	if err != nil {
 		return mpl, err
 	}


### PR DESCRIPTION
Add checkpoints on 77159,81295 for new feature of https://issues.redhat.com/browse/OCM-1599.
OCP-55979 covers the checkpoint to check the 'AZ TYPE' in the output.
OCP-36293 adds the checkpoint for all new added column. 
As the win-li and dedicated hosted machinepool is not supported on rosacli yet, the e2e checkpoints for them will be added in future after they are supported.

The logs on local is https://privatebin.corp.redhat.com/?5398da6147eb791d#BF64APCec9yiiV67QgdxmfyvgsRU3iRfTNa7Lqz7DgFa