### PR TITLE
OCM-1599 | fix: updated strings and tests to match

### DIFF
--- a/pkg/machinepool/helper.go
+++ b/pkg/machinepool/helper.go
@@ -31,9 +31,9 @@ const (
 	zoneTypeStandard   = "Standard"
 	zoneTypeNA         = "N/A"
 
-	boolStringTrue    = "true"
-	boolStringFalse   = "false"
-	boolStringUnknown = "unknown"
+	displayValueYes     = "Yes"
+	displayValueNo      = "No"
+	displayValueUnknown = "Unknown"
 
 	imageTypeWindows = "windows"
 
@@ -431,34 +431,34 @@ func getZoneType(machinePool *cmv1.MachinePool) string {
 
 func isWinLIEnabled(labels map[string]string) string {
 	if val, ok := labels[labelImageType]; ok && strings.ToLower(val) == imageTypeWindows {
-		return boolStringTrue
+		return displayValueYes
 	}
-	return boolStringFalse
+	return displayValueNo
 }
 
 func isDedicatedHost(machinePool *cmv1.MachinePool, runtime *rosa.Runtime) string {
 	if machinePool == nil {
-		return boolStringFalse
+		return displayValueNo
 	}
 
 	awsConfig := machinePool.AWS()
 	if awsConfig == nil {
-		return boolStringFalse
+		return displayValueNo
 	}
 
 	awsMachinePoolID := awsConfig.ID()
 	if awsMachinePoolID == "" || runtime == nil || runtime.AWSClient == nil {
-		return boolStringFalse
+		return displayValueNo
 	}
 
 	hasDedicatedHost, err := runtime.AWSClient.CheckIfMachinePoolHasDedicatedHost([]string{awsMachinePoolID})
 	if err != nil {
 		_ = runtime.Reporter.Errorf("Failed to check dedicated host status: %v", err)
-		return boolStringUnknown
+		return displayValueUnknown
 	}
 
 	if hasDedicatedHost {
-		return boolStringTrue
+		return displayValueYes
 	}
-	return boolStringFalse
+	return displayValueNo
 }

--- a/pkg/machinepool/helper_test.go
+++ b/pkg/machinepool/helper_test.go
@@ -714,56 +714,56 @@ var _ = Describe("getZoneType Function", func() {
 })
 
 var _ = Describe("isWinLIEnabled Function", func() {
-	It("should return 'true' when image_type label is 'windows'", func() {
+	It("should return 'Yes' when image_type label is 'windows'", func() {
 		labels := map[string]string{
 			labelImageType: imageTypeWindows,
 		}
 		result := isWinLIEnabled(labels)
-		Expect(result).To(Equal(boolStringTrue))
+		Expect(result).To(Equal(displayValueYes))
 	})
 
-	It("should return 'false' when image_type label is not 'windows'", func() {
+	It("should return 'No' when image_type label is not 'windows'", func() {
 		labels := map[string]string{
 			labelImageType: "linux",
 		}
 		result := isWinLIEnabled(labels)
-		Expect(result).To(Equal(boolStringFalse))
+		Expect(result).To(Equal(displayValueNo))
 	})
 
-	It("should return 'false' when image_type label is empty", func() {
+	It("should return 'No' when image_type label is empty", func() {
 		labels := map[string]string{
 			labelImageType: "",
 		}
 		result := isWinLIEnabled(labels)
-		Expect(result).To(Equal(boolStringFalse))
+		Expect(result).To(Equal(displayValueNo))
 	})
 
-	It("should return 'false' when image_type label is not present", func() {
+	It("should return 'No' when image_type label is not present", func() {
 		labels := map[string]string{
 			"other_label": "some_value",
 		}
 		result := isWinLIEnabled(labels)
-		Expect(result).To(Equal(boolStringFalse))
+		Expect(result).To(Equal(displayValueNo))
 	})
 
-	It("should return 'false' when labels map is empty", func() {
+	It("should return 'No' when labels map is empty", func() {
 		labels := map[string]string{}
 		result := isWinLIEnabled(labels)
-		Expect(result).To(Equal(boolStringFalse))
+		Expect(result).To(Equal(displayValueNo))
 	})
 
-	It("should return 'false' when labels map is nil", func() {
+	It("should return 'No' when labels map is nil", func() {
 		var labels map[string]string
 		result := isWinLIEnabled(labels)
-		Expect(result).To(Equal(boolStringFalse))
+		Expect(result).To(Equal(displayValueNo))
 	})
 
-	It("should return 'false' when image_type contains 'windows' but is not exactly 'windows'", func() {
+	It("should return 'No' when image_type contains 'windows' but is not exactly 'windows'", func() {
 		labels := map[string]string{
 			labelImageType: "windows-server",
 		}
 		result := isWinLIEnabled(labels)
-		Expect(result).To(Equal(boolStringFalse))
+		Expect(result).To(Equal(displayValueNo))
 	})
 
 	It("should work with other labels present", func() {
@@ -773,7 +773,7 @@ var _ = Describe("isWinLIEnabled Function", func() {
 			"team":         "platform",
 		}
 		result := isWinLIEnabled(labels)
-		Expect(result).To(Equal(boolStringTrue))
+		Expect(result).To(Equal(displayValueYes))
 	})
 })
 
@@ -801,40 +801,40 @@ var _ = Describe("isDedicatedHost Function", func() {
 		mockCtrl.Finish()
 	})
 
-	It("should return 'false' when machine pool is nil", func() {
+	It("should return 'No' when machine pool is nil", func() {
 		result := isDedicatedHost(nil, runtime)
-		Expect(result).To(Equal(boolStringFalse))
+		Expect(result).To(Equal(displayValueNo))
 	})
 
-	It("should return 'false' when machine pool has no AWS configuration", func() {
+	It("should return 'No' when machine pool has no AWS configuration", func() {
 		machinePool, err := cmv1.NewMachinePool().Build()
 		Expect(err).ToNot(HaveOccurred())
 
 		result := isDedicatedHost(machinePool, runtime)
-		Expect(result).To(Equal(boolStringFalse))
+		Expect(result).To(Equal(displayValueNo))
 	})
 
-	It("should return 'false' when machine pool AWS ID is empty", func() {
+	It("should return 'No' when machine pool AWS ID is empty", func() {
 		machinePool, err := cmv1.NewMachinePool().
 			AWS(cmv1.NewAWSMachinePool().ID("")).
 			Build()
 		Expect(err).ToNot(HaveOccurred())
 
 		result := isDedicatedHost(machinePool, runtime)
-		Expect(result).To(Equal(boolStringFalse))
+		Expect(result).To(Equal(displayValueNo))
 	})
 
-	It("should return 'false' when runtime is nil", func() {
+	It("should return 'No' when runtime is nil", func() {
 		machinePool, err := cmv1.NewMachinePool().
 			AWS(cmv1.NewAWSMachinePool().ID("mp-12345")).
 			Build()
 		Expect(err).ToNot(HaveOccurred())
 
 		result := isDedicatedHost(machinePool, nil)
-		Expect(result).To(Equal(boolStringFalse))
+		Expect(result).To(Equal(displayValueNo))
 	})
 
-	It("should return 'false' when runtime AWSClient is nil", func() {
+	It("should return 'No' when runtime AWSClient is nil", func() {
 		machinePool, err := cmv1.NewMachinePool().
 			AWS(cmv1.NewAWSMachinePool().ID("mp-12345")).
 			Build()
@@ -842,10 +842,10 @@ var _ = Describe("isDedicatedHost Function", func() {
 
 		runtimeWithoutClient := &rosa.Runtime{AWSClient: nil, Reporter: mockReporter}
 		result := isDedicatedHost(machinePool, runtimeWithoutClient)
-		Expect(result).To(Equal(boolStringFalse))
+		Expect(result).To(Equal(displayValueNo))
 	})
 
-	It("should return 'true' when machine pool has dedicated host", func() {
+	It("should return 'Yes' when machine pool has dedicated host", func() {
 		const testMachinePoolID = "mp-12345"
 		machinePool, err := cmv1.NewMachinePool().
 			AWS(cmv1.NewAWSMachinePool().ID(testMachinePoolID)).
@@ -857,10 +857,10 @@ var _ = Describe("isDedicatedHost Function", func() {
 			Return(true, nil)
 
 		result := isDedicatedHost(machinePool, runtime)
-		Expect(result).To(Equal(boolStringTrue))
+		Expect(result).To(Equal(displayValueYes))
 	})
 
-	It("should return 'false' when machine pool does not have dedicated host", func() {
+	It("should return 'No' when machine pool does not have dedicated host", func() {
 		const testMachinePoolID = "mp-12345"
 		machinePool, err := cmv1.NewMachinePool().
 			AWS(cmv1.NewAWSMachinePool().ID(testMachinePoolID)).
@@ -872,10 +872,10 @@ var _ = Describe("isDedicatedHost Function", func() {
 			Return(false, nil)
 
 		result := isDedicatedHost(machinePool, runtime)
-		Expect(result).To(Equal(boolStringFalse))
+		Expect(result).To(Equal(displayValueNo))
 	})
 
-	It("should return 'unknown' when AWS client returns an error", func() {
+	It("should return 'Unknown' when AWS client returns an error", func() {
 		const testMachinePoolID = "mp-12345"
 		machinePool, err := cmv1.NewMachinePool().
 			AWS(cmv1.NewAWSMachinePool().ID(testMachinePoolID)).
@@ -888,11 +888,11 @@ var _ = Describe("isDedicatedHost Function", func() {
 			Return(false, expectedError)
 
 		result := isDedicatedHost(machinePool, runtime)
-		Expect(result).To(Equal(boolStringUnknown))
+		Expect(result).To(Equal(displayValueUnknown))
 	})
 
 	// Optional: Test specifically for the nil reporter case
-	It("should return 'unknown' when AWS client returns an error and reporter is nil", func() {
+	It("should return 'Unknown' when AWS client returns an error and reporter is nil", func() {
 		const testMachinePoolID = "mp-12345"
 		machinePool, err := cmv1.NewMachinePool().
 			AWS(cmv1.NewAWSMachinePool().ID(testMachinePoolID)).
@@ -905,6 +905,6 @@ var _ = Describe("isDedicatedHost Function", func() {
 			Return(false, expectedError)
 
 		result := isDedicatedHost(machinePool, runtime)
-		Expect(result).To(Equal(boolStringUnknown))
+		Expect(result).To(Equal(displayValueUnknown))
 	})
 })

--- a/pkg/machinepool/machinepool_test.go
+++ b/pkg/machinepool/machinepool_test.go
@@ -385,7 +385,7 @@ var _ = Describe("Machinepool and nodepool", func() {
 			out := getMachinePoolsString(r, cluster.MachinePools().Slice(), args)
 
 			expectedOutput := "ID\tAUTOSCALING\tREPLICAS\tINSTANCE TYPE\tLABELS\tTAINTS\tAVAILABILITY ZONES\tSUBNETS\tSPOT INSTANCES\tDISK SIZE\tSG IDS\tAZ TYPE\tWIN-LI ENABLED\tDEDICATED HOST\n" +
-				"mp-1\tNo\t3\tm5.large\t\t\t\t\tNo\tdefault\t\tN/A\tfalse\tfalse\n"
+				"mp-1\tNo\t3\tm5.large\t\t\t\t\tNo\tdefault\t\tN/A\tNo\tNo\n"
 			Expect(out).To(Equal(expectedOutput))
 		})
 
@@ -419,7 +419,7 @@ var _ = Describe("Machinepool and nodepool", func() {
 			out := getMachinePoolsString(r, cluster.MachinePools().Slice(), args)
 
 			expectedOutput := "ID\tAUTOSCALING\tREPLICAS\tINSTANCE TYPE\tSPOT INSTANCES\tDISK SIZE\tDEDICATED HOST\n" +
-				"mp-1\tNo\t3\tm5.large\tNo\tdefault\tfalse\n"
+				"mp-1\tNo\t3\tm5.large\tNo\tdefault\tNo\n"
 			Expect(out).To(Equal(expectedOutput))
 		})
 
@@ -436,7 +436,7 @@ var _ = Describe("Machinepool and nodepool", func() {
 			out := getMachinePoolsString(r, cluster.MachinePools().Slice(), args)
 
 			expectedOutput := "ID\tAUTOSCALING\tREPLICAS\tINSTANCE TYPE\tSPOT INSTANCES\tDISK SIZE\tWIN-LI ENABLED\n" +
-				"mp-1\tNo\t3\tm5.large\tNo\tdefault\tfalse\n"
+				"mp-1\tNo\t3\tm5.large\tNo\tdefault\tNo\n"
 			Expect(out).To(Equal(expectedOutput))
 		})
 
@@ -453,7 +453,7 @@ var _ = Describe("Machinepool and nodepool", func() {
 			out := getMachinePoolsString(r, cluster.MachinePools().Slice(), args)
 
 			expectedOutput := "ID\tAUTOSCALING\tREPLICAS\tINSTANCE TYPE\tSPOT INSTANCES\tDISK SIZE\tAZ TYPE\tDEDICATED HOST\n" +
-				"mp-1\tNo\t3\tm5.large\tNo\tdefault\tN/A\tfalse\n"
+				"mp-1\tNo\t3\tm5.large\tNo\tdefault\tN/A\tNo\n"
 			Expect(out).To(Equal(expectedOutput))
 		})
 


### PR DESCRIPTION
# Details

This PR changes the strings on the list machine pool command to match the other columns
---
# Ticket
Closes [OCM-16798](https://issues.redhat.com/browse/OCM-16798)