### PR TITLE
OCM-16864 | fix: Introduce private API to private STS validation

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2052,7 +2052,7 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 	if interactive.Enabled() && !fedramp.Enabled() {
 		if !isHostedCP {
-			question := "Private Link cluster"
+			question := "PrivateLink cluster"
 			privateLink, err = interactive.GetBool(interactive.Input{
 				Question: question,
 				Help:     fmt.Sprintf("%s %s", cmd.Flags().Lookup("private-link").Usage, privateLinkWarning),
@@ -2065,9 +2065,8 @@ func run(cmd *cobra.Command, _ []string) {
 		} else {
 			private, err = interactive.GetBool(interactive.Input{
 				Question: "Private API",
-				Help: fmt.Sprintf("Private API allows you to change whether or not the cluster will use Private " +
-					"API"),
-				Default: args.private,
+				Help:     fmt.Sprintf("%s %s", cmd.Flags().Lookup("private").Usage, privateLinkWarning),
+				Default:  args.private,
 			})
 			if err != nil {
 				_ = r.Reporter.Errorf("Expected a valid Private API value: %s", err)
@@ -2086,8 +2085,9 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 	}
 
-	if privateLink {
+	if privateLink || (private && isHostedCP) {
 		private = true
+		privateLink = true
 	} else if isSTS && private {
 		r.Reporter.Errorf("Private STS clusters are only supported through AWS PrivateLink")
 		os.Exit(1)


### PR DESCRIPTION
Fixes [OCM-16864](https://issues.redhat.com//browse/OCM-16864), a bug where Private API was not taken into account once introduced as the alternative for classic's PrivateLink in HCP in interactive mode.

Creation of a cluster will error after saying `Yes` to the Private API prompt when using HCP clusters. Example failure happens here in the cluster creation process:

```
? AWS region (default = 'us-west-2'): us-west-2
? Private API: Yes
? Private ingress: Yes
E: Private STS clusters are only supported through AWS PrivateLink
```

# Below are test runs surrounding this same step in the cluster creation process using this MR confirming it fixes the issue

### Test runs:

HCP with private API enabled via interactive (OK):

```
? Private API: Yes
? Private ingress: Yes
? Machine CIDR: 10.0.0.0/16
```

HCP with private API and ingress disabled (KO):

```
? Private API: No
? Private ingress: No
E: Private STS clusters are only supported through AWS Private API
```

HCP with private API disabled and ingress enabled (OK):

```
? Private API: No
? Private ingress: Yes
? Machine CIDR: 10.0.0.0/16
```

Classic with AWS Private Link enabled via interactive (OK):

```
? Private Link cluster: Yes
? Machine CIDR: 10.0.0.0/16
```

Classic with AWS Private Link disabled (KO):

```
? Private Link cluster: No
E: Private STS clusters are only supported through AWS PrivateLink
```

* This MR also improves wording of a warning + the help msg for the Private API prompt involved here