### PR TITLE
OCM-16865 |  fix: private subnets when using privateAPI:no privateIngress:yes

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2330,8 +2330,10 @@ func run(cmd *cobra.Command, _ []string) {
 				}
 			}
 		}
+		privateValueToCheck := privateLink
 		if isHostedCP && !subnetsProvided {
 			interactive.Enable()
+			privateValueToCheck = private
 		}
 		if ((privateLink && !subnetsProvided) || interactive.Enabled()) &&
 			len(options) > 0 && (!multiAZ || len(mapAZCreated) >= 3 || isHostedCP) {
@@ -2342,7 +2344,7 @@ func run(cmd *cobra.Command, _ []string) {
 				Options:  options,
 				Default:  defaultOptions,
 				Validators: []interactive.Validator{
-					interactive.SubnetsValidator(awsClient, multiAZ, privateLink, isHostedCP),
+					interactive.SubnetsValidator(awsClient, multiAZ, privateValueToCheck, isHostedCP, privateIngress),
 				},
 			})
 			if err != nil {
@@ -2362,8 +2364,8 @@ func run(cmd *cobra.Command, _ []string) {
 				// Hosted cluster should validate that
 				// - Public hosted clusters have at least one public subnet
 				// - Private hosted clusters have all subnets private, except when those clusters have public ingress
-				privateSubnetsCount, err = ocm.ValidateHostedClusterSubnets(awsClient, privateLink, subnetIDs,
-					args.privateIngress)
+				privateSubnetsCount, err = ocm.ValidateHostedClusterSubnets(awsClient, private, subnetIDs,
+					privateIngress)
 			}
 			if err != nil {
 				r.Reporter.Errorf("%s", err)

--- a/pkg/interactive/validation.go
+++ b/pkg/interactive/validation.go
@@ -226,7 +226,8 @@ func RegExpBoolean(restr string) Validator {
 
 // SubnetsCountValidator get a slice of `[]core.OptionAnswer` as an interface.
 // e.g. core.OptionAnswer { Value: subnet-04f67939f44a97dbe (us-west-2b), Index: 0 }
-func SubnetsValidator(awsClient aws.Client, multiAZ bool, privateLink bool, hostedCP bool) Validator {
+func SubnetsValidator(awsClient aws.Client, multiAZ bool, privateValue bool, hostedCP bool,
+	privateIngress bool) Validator {
 	return func(input interface{}) (err error) {
 		if answers, ok := input.([]core.OptionAnswer); ok {
 			if hostedCP {
@@ -235,11 +236,10 @@ func SubnetsValidator(awsClient aws.Client, multiAZ bool, privateLink bool, host
 					subnetIDs[i] = aws.ParseOption(subnet.Value)
 				}
 
-				privateIngress := false
-				_, err = ocm.ValidateHostedClusterSubnets(awsClient, privateLink, subnetIDs, privateIngress)
+				_, err = ocm.ValidateHostedClusterSubnets(awsClient, privateValue, subnetIDs, privateIngress)
 				return err
 			}
-			return ocm.ValidateSubnetsCount(multiAZ, privateLink, len(answers))
+			return ocm.ValidateSubnetsCount(multiAZ, privateValue, len(answers))
 		}
 		return fmt.Errorf("can only validate a slice of string, got %v", input)
 	}

--- a/pkg/interactive/validation_test.go
+++ b/pkg/interactive/validation_test.go
@@ -123,7 +123,7 @@ var _ = Describe("SubnetsValidator", func() {
 
 	Context("When cluster is hosted", func() {
 		It("Returns an error when the number of subnets is not at least two", func() {
-			validator = SubnetsValidator(mockClient, false, false, true)
+			validator = SubnetsValidator(mockClient, false, false, true, false)
 			answers := []core.OptionAnswer{
 				{Value: "subnet-public-1 (us-west-2a)"},
 			}
@@ -135,7 +135,7 @@ var _ = Describe("SubnetsValidator", func() {
 		})
 
 		It("Returns an error when the number of public subnets is not at least one", func() {
-			validator = SubnetsValidator(mockClient, false, false, true)
+			validator = SubnetsValidator(mockClient, false, false, true, false)
 			answers := []core.OptionAnswer{
 				{Value: "subnet-private-2 (us-west-2a)"},
 				{Value: "subnet-private-3 (us-west-2b)"},
@@ -160,7 +160,7 @@ var _ = Describe("SubnetsValidator", func() {
 
 	Context("When cluster is not hosted", func() {
 		It("Returns and error when the number of subnets is not correct", func() {
-			validator = SubnetsValidator(mockClient, true, true, false)
+			validator = SubnetsValidator(mockClient, true, true, false, true)
 			answers := []core.OptionAnswer{
 				{Value: "subnet-123 (us-west-2a)"},
 				{Value: "subnet-456 (us-west-2b)"},
@@ -173,7 +173,7 @@ var _ = Describe("SubnetsValidator", func() {
 		})
 
 		It("Should not return an error when the number of subnets is correct", func() {
-			validator = SubnetsValidator(mockClient, true, true, false)
+			validator = SubnetsValidator(mockClient, true, true, false, true)
 			answers := []core.OptionAnswer{
 				{Value: "subnet-123 (us-west-2a)"},
 				{Value: "subnet-456 (us-west-2b)"},

--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -787,7 +787,7 @@ func ValidateHostedClusterSubnets(awsClient aws.Client, isPrivate bool, subnetID
 		if publicSubnetsCount > 0 {
 			return 0, fmt.Errorf("The number of public subnets for a private hosted cluster should be zero")
 		}
-	} else {
+	} else if !privateIngress {
 		if publicSubnetsCount == 0 {
 			return 0, fmt.Errorf("The number of public subnets for a public hosted " +
 				"cluster should be at least one")


### PR DESCRIPTION
With 3 private subnets selected, it was impossible to create a hostedcp cluster using private Ingress but not private API. This MR fixes that, and allows cluster creation with this configuration