### PR TITLE
OCM-16933 | test: automate id:83155 as day1 and day1-post of api and ingress private

### DIFF
--- a/tests/ci/data/profiles/rosa-hcp.yaml
+++ b/tests/ci/data/profiles/rosa-hcp.yaml
@@ -12,6 +12,7 @@ profiles:
     additional_principals: false
     imdsv2: "required"
     private: false
+    default_ingress_private: false
     etcd_encryption: true
     autoscale: true
     kms_key: true
@@ -46,6 +47,7 @@ profiles:
     sts: true
     byo_vpc: true
     private: true
+    default_ingress_private : true
     additional_principals: true
     imdsv2: ""
     etcd_encryption: false
@@ -73,6 +75,7 @@ profiles:
     sts: true
     byo_vpc: true
     private: false
+    default_ingress_private: false
     additional_principals: false
     imdsv2: "optional"
     etcd_encryption: true
@@ -107,6 +110,7 @@ profiles:
     sts: true
     byo_vpc: true
     private: false
+    default_ingress_private: false
     additional_principals: false
     imdsv2: "optional"
     etcd_encryption: true
@@ -136,6 +140,7 @@ profiles:
     sts: true
     byo_vpc: true
     private: false
+    default_ingress_private: false
     additional_principals: false
     imdsv2: "optional"
     etcd_encryption: true
@@ -172,6 +177,7 @@ profiles:
     additional_principals: false
     imdsv2: "required"
     private: false
+    default_ingress_private: false
     etcd_encryption: true
     autoscale: true
     kms_key: true

--- a/tests/utils/handler/cluster_handler.go
+++ b/tests/utils/handler/cluster_handler.go
@@ -456,6 +456,9 @@ func (ch *clusterHandler) GenerateClusterCreateFlags() ([]string, error) {
 			ch.profile.ClusterConfig.PrivateLink = true
 		}
 	}
+	if ch.profile.ClusterConfig.DefaultIngressPrivate {
+		flags = append(flags, "--default-ingress-private")
+	}
 
 	if ch.profile.ClusterConfig.AdminEnabled {
 		// Comment below part due to OCM-7112
@@ -608,7 +611,8 @@ func (ch *clusterHandler) GenerateClusterCreateFlags() ([]string, error) {
 			PrivateSubnetIds: strings.Join(subnets["private"], ","),
 			PublicSubnetIds:  strings.Join(subnets["public"], ","),
 		}
-		if ch.profile.ClusterConfig.PrivateLink {
+		if (ch.profile.ClusterConfig.PrivateLink && !ch.profile.ClusterConfig.HCP) ||
+			(ch.profile.ClusterConfig.HCP && ch.profile.ClusterConfig.Private && ch.profile.ClusterConfig.DefaultIngressPrivate) {
 			log.Logger.Info("Got private link set to true. Only set private subnets to cluster flags")
 			subnetsFlagValue = strings.Join(subnets["private"], ",")
 			ch.clusterConfig.Subnets = &ClusterConfigure.Subnets{

--- a/tests/utils/handler/interface.go
+++ b/tests/utils/handler/interface.go
@@ -60,6 +60,7 @@ type ClusterConfig struct {
 	MultiAZ                       bool   `yaml:"multi_az,omitempty" json:"multi_az,omitempty"`
 	NetworkingSet                 bool   `yaml:"networking,omitempty" json:"networking,omitempty"`
 	PrivateLink                   bool   `yaml:"private_link,omitempty" json:"private_link,omitempty"`
+	DefaultIngressPrivate         bool   `yaml:"default_ingress_private,omitempty" json:"default_ingress_private,omitempty"`
 	Private                       bool   `yaml:"private,omitempty" json:"private,omitempty"`
 	ProxyEnabled                  bool   `yaml:"proxy_enabled,omitempty" json:"proxy_enabled,omitempty"`
 	STS                           bool   `yaml:"sts,omitempty" json:"sts,omitempty"`


### PR DESCRIPTION
Automated id:83155 as day1 and day1-post of api and ingress private.
The log on local is https://privatebin.corp.redhat.com/?27b8bf4f2c240dda#8XcsE8GgEePJ6X2Tv4CbNrt5hZGZKoVvjdbTAvrV5dM7