### PR TITLE
OCM-17038 | test: fix id: 60688 add unmanaged tag on the testing subnets

### DIFF
--- a/tests/e2e/e2e_day2_conf_test.go
+++ b/tests/e2e/e2e_day2_conf_test.go
@@ -74,6 +74,15 @@ var _ = Describe("Cluster Day2 preparation", labels.Feature.Cluster, func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(subNetMap).ToNot(BeNil())
 				privateSubnet := subNetMap["private"]
+				for _, subnet := range subNetMap {
+					_, err := vpcClient.AWSClient.TagResource(
+						subnet.ID,
+						map[string]string{
+							"kubernetes.io/cluster/unmanaged": "true",
+						},
+					)
+					Expect(err).ToNot(HaveOccurred())
+				}
 
 				By("Describe the cluster to get the infra ID for tagging")
 				tagKey := fmt.Sprintf("kubernetes.io/cluster/%s", clusterDetails.InfraID)

--- a/tests/e2e/hcp_machine_pool_test.go
+++ b/tests/e2e/hcp_machine_pool_test.go
@@ -666,6 +666,15 @@ var _ = Describe("HCP Machine Pool", labels.Feature.Machinepool, func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(subNetMap).ToNot(BeNil())
 				privateSubnet := subNetMap["private"]
+				for _, subnet := range subNetMap {
+					_, err := vpcClient.AWSClient.TagResource(
+						subnet.ID,
+						map[string]string{
+							"kubernetes.io/cluster/unmanaged": "true",
+						},
+					)
+					Expect(err).ToNot(HaveOccurred())
+				}
 
 				By("Create machinepool into the local zone subnet")
 				name := helper.GenerateRandomName("mp-71319", 2)

--- a/tests/e2e/test_rosacli_machine_pool.go
+++ b/tests/e2e/test_rosacli_machine_pool.go
@@ -561,6 +561,15 @@ var _ = Describe("Create machinepool",
 				Expect(err).ToNot(HaveOccurred())
 				Expect(subNetMap).ToNot(BeNil())
 				privateSubnet := subNetMap["private"]
+				for _, subnet := range subNetMap {
+					_, err := vpcClient.AWSClient.TagResource(
+						subnet.ID,
+						map[string]string{
+							"kubernetes.io/cluster/unmanaged": "true",
+						},
+					)
+					Expect(err).ToNot(HaveOccurred())
+				}
 
 				By("Describe the cluster to get the infra ID for tagging")
 				clusterDescription, err := rosaClient.Cluster.DescribeClusterAndReflect(clusterID)
@@ -675,6 +684,15 @@ var _ = Describe("Create machinepool",
 				Expect(err).ToNot(HaveOccurred())
 				Expect(subNetMap).ToNot(BeNil())
 				privateSubnet := subNetMap["private"]
+				for _, subnet := range subNetMap {
+					_, err := vpcClient.AWSClient.TagResource(
+						subnet.ID,
+						map[string]string{
+							"kubernetes.io/cluster/unmanaged": "true",
+						},
+					)
+					Expect(err).ToNot(HaveOccurred())
+				}
 
 				By("Describe the cluster to get the infra ID for tagging")
 				clusterDescription, err := rosaClient.Cluster.DescribeClusterAndReflect(clusterID)


### PR DESCRIPTION
60688 failed the unmanaged tag is needed for the subnets under the cluster vpc since cluster 4.19.

failed job : https://redhat-internal.slack.com/archives/C0519LZH1RA/p1751940209728169

fix solution:

Add 'kubernetes.io/cluster/unmanaged' tag on all day2 cases which creates testing subnets on the cluster vpc.

local log: https://privatebin.corp.redhat.com/?741a1eb8bc4d18fa#4yH6JjscnUwUT9dpB9VRdktLRSUBvgcJMGbqLx5GjT5L