### PR TITLE
OCM-17058 | feat: Update mirror and base releases folder URI

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,8 +16,8 @@ import (
 )
 
 const (
-	DownloadLatestMirrorFolder = "https://mirror.openshift.com/pub/openshift-v4/clients/rosa/latest/"
-	baseReleasesFolder         = "https://mirror.openshift.com/pub/openshift-v4/clients/rosa/"
+	DownloadLatestMirrorFolder = "https://mirror.openshift.com/pub/cgw/rosa/latest/"
+	baseReleasesFolder         = "https://mirror.openshift.com/pub/cgw/rosa/"
 	ConsoleLatestFolder        = "https://console.redhat.com/openshift/downloads#tool-rosa"
 )
 


### PR DESCRIPTION
Changes download links for ROSA CLI in `pkg/version/version.go`