### PR TITLE
OCM-16081 | ci: Add new attribute default_ingress_private for HCP profiles

### DIFF
--- a/tests/ci/data/profiles/external.yaml
+++ b/tests/ci/data/profiles/external.yaml
@@ -77,6 +77,7 @@ profiles:
     additional_principals: false
     imdsv2: "required"
     private: false
+    default_ingress_private: false
     etcd_encryption: true
     autoscale: true
     kms_key: true
@@ -113,6 +114,7 @@ profiles:
     sts: true
     byo_vpc: true
     private: true
+    default_ingress_private: true
     additional_principals: true
     imdsv2: ""
     etcd_encryption: false
@@ -141,6 +143,7 @@ profiles:
     sts: true
     byo_vpc: true
     private: false
+    default_ingress_private: false
     additional_principals: false
     imdsv2: "optional"
     etcd_encryption: true
@@ -170,6 +173,7 @@ profiles:
     sts: true
     byo_vpc: true
     private: false
+    default_ingress_private: false
     additional_principals: false
     imdsv2: "optional"
     etcd_encryption: true
@@ -206,6 +210,7 @@ profiles:
     additional_principals: false
     imdsv2: "required"
     private: true
+    default_ingress_private: true
     etcd_encryption: true
     autoscale: true
     kms_key: true
@@ -240,6 +245,7 @@ profiles:
     additional_principals: false
     imdsv2: "required"
     private: false
+    default_ingress_private: false
     etcd_encryption: true
     autoscale: true
     kms_key: true


### PR DESCRIPTION
According to this https://github.com/openshift/rosa/pull/2937, do the change.
Here is the log
```
yingzhan@yingzhan-mac  ~/ying-work/code/rosa   ying-fix ±  ginkgo run --label-filter day1 tests/e2e --timeout 1h && ginkgo run --label-filter day1-readiness tests/e2e --timeout 2h 
Running Suite: ROSA CLI e2e tests suite - /Users/yingzhan/ying-work/code/rosa/tests/e2e
=======================================================================================
Random Seed: 1752115636

Will run 1 of 268 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSStime="2025-07-10 10:51:08" level=info msg="Got aws shared credential file path: /Users/yingzhan/.aws/cre_shared "
time="2025-07-10 10:51:11" level=info msg="Going to prepare a vpc with name ying-0710-jdyxo, on region us-west-2, with cidr 10.0.0.0/16 "
time="2025-07-10 10:51:11" level=info msg="Going to create vpc and the follow resources on zones: "
time="2025-07-10 10:51:13" level=info msg="Create vpc success vpc-0e70542298c58314d"
time="2025-07-10 10:51:13" level=info msg="Tag resource vpc-0e70542298c58314d successfully"
time="2025-07-10 10:51:13" level=info msg="Created vpc with ID vpc-0e70542298c58314d"
time="2025-07-10 10:51:13" level=info msg="VPC created on AWS with id: vpc-0e70542298c58314d"
time="2025-07-10 10:51:14" level=info msg="Modify vpc dns attribute DnsHostnames successfully for vpc-0e70542298c58314d"
time="2025-07-10 10:51:14" level=info msg="VPC DNS Updated on AWS with id: vpc-0e70542298c58314d"
time="2025-07-10 10:51:14" level=info msg="Create igw success: igw-0485538de5e7515f5"
time="2025-07-10 10:51:15" level=info msg="Attach igw success: igw-0485538de5e7515f5"
time="2025-07-10 10:51:15" level=info msg="Prepare vpc internetgateway for vpc vpc-0e70542298c58314d"
time="2025-07-10 10:51:15" level=info msg="Create subnets successfully"
time="2025-07-10 10:51:15" level=info msg="Create vpc chain successfully. Enjoy it."
time="2025-07-10 10:51:15" level=info msg="Going to prepare proper pair of subnets"
time="2025-07-10 10:51:15" level=info msg="Got no public subnet for current zone us-west-2a, going to create one"
time="2025-07-10 10:51:15" level=info msg="Created subnet subnet-0ebf75fb5f98f8a92 for vpc vpc-0e70542298c58314d"
time="2025-07-10 10:51:16" level=info msg="Created subnet with ID subnet-0ebf75fb5f98f8a92"
time="2025-07-10 10:51:17" level=info msg="Associate route table success rtbassoc-07e3405781244e923"
time="2025-07-10 10:51:18" level=info msg="Create route success for route table: rtb-0d40e2ec68fb33402"
time="2025-07-10 10:51:18" level=info msg="Tag resource subnet-0ebf75fb5f98f8a92 successfully"
time="2025-07-10 10:51:18" level=info msg="Got no proper private subnet for current zone us-west-2a, going to create one"
time="2025-07-10 10:51:19" level=info msg="Created subnet subnet-07c2b9c05456dc0fc for vpc vpc-0e70542298c58314d"
time="2025-07-10 10:51:20" level=info msg="Created subnet with ID subnet-07c2b9c05456dc0fc"
time="2025-07-10 10:51:20" level=info msg="Associate route table success rtbassoc-0fcba34dcb4e12f51"
time="2025-07-10 10:51:21" level=info msg="Allocated EIP eipalloc-09a7babf5ae9c824d with ip 100.20.178.163"
time="2025-07-10 10:51:21" level=info msg="Create nat success: nat-03e4dbf37a754b673"
time="2025-07-10 10:52:41" level=info msg="Create route success for route table: rtb-03d0b9aa2d370917b"
time="2025-07-10 10:52:41" level=info msg="Tag resource subnet-07c2b9c05456dc0fc successfully"
time="2025-07-10 10:52:41" level=info msg="Going to prepare proper pair of subnets"
time="2025-07-10 10:52:41" level=info msg="Subnet subnet-0ebf75fb5f98f8a92 in zone: us-west-2a, region us-west-2"
time="2025-07-10 10:52:41" level=info msg="Subnet subnet-07c2b9c05456dc0fc in zone: us-west-2a, region us-west-2"
time="2025-07-10 10:52:41" level=info msg="Got no public subnet for current zone us-west-2b, going to create one"
time="2025-07-10 10:52:41" level=info msg="Created subnet subnet-0024c941cb01ac351 for vpc vpc-0e70542298c58314d"
time="2025-07-10 10:52:42" level=info msg="Created subnet with ID subnet-0024c941cb01ac351"
time="2025-07-10 10:52:43" level=info msg="Associate route table success rtbassoc-03a1b2f90e4a58887"
time="2025-07-10 10:52:43" level=info msg="Create route success for route table: rtb-083eed87e299e7240"
time="2025-07-10 10:52:44" level=info msg="Tag resource subnet-0024c941cb01ac351 successfully"
time="2025-07-10 10:52:44" level=info msg="Got no proper private subnet for current zone us-west-2b, going to create one"
time="2025-07-10 10:52:45" level=info msg="Created subnet subnet-027aba2e44ca17e5f for vpc vpc-0e70542298c58314d"
time="2025-07-10 10:52:45" level=info msg="Created subnet with ID subnet-027aba2e44ca17e5f"
time="2025-07-10 10:52:46" level=info msg="Associate route table success rtbassoc-07a7550b017ca32e5"
time="2025-07-10 10:52:46" level=info msg="Found existing nat gateway: nat-03e4dbf37a754b673"
time="2025-07-10 10:52:47" level=info msg="Create route success for route table: rtb-03eacfacb11677772"
time="2025-07-10 10:52:47" level=info msg="Tag resource subnet-027aba2e44ca17e5f successfully"
time="2025-07-10 10:52:47" level=info msg="Going to prepare proper pair of subnets"
time="2025-07-10 10:52:47" level=info msg="Subnet subnet-0ebf75fb5f98f8a92 in zone: us-west-2a, region us-west-2"
time="2025-07-10 10:52:47" level=info msg="Subnet subnet-07c2b9c05456dc0fc in zone: us-west-2a, region us-west-2"
time="2025-07-10 10:52:47" level=info msg="Subnet subnet-0024c941cb01ac351 in zone: us-west-2b, region us-west-2"
time="2025-07-10 10:52:47" level=info msg="Subnet subnet-027aba2e44ca17e5f in zone: us-west-2b, region us-west-2"
time="2025-07-10 10:52:47" level=info msg="Got no public subnet for current zone us-west-2c, going to create one"
time="2025-07-10 10:52:48" level=info msg="Created subnet subnet-040fa6cb5602b08a5 for vpc vpc-0e70542298c58314d"
time="2025-07-10 10:52:48" level=info msg="Created subnet with ID subnet-040fa6cb5602b08a5"
time="2025-07-10 10:52:49" level=info msg="Associate route table success rtbassoc-0446e16eec087a4fa"
time="2025-07-10 10:52:50" level=info msg="Create route success for route table: rtb-0654d220795ac9d8c"
time="2025-07-10 10:52:50" level=info msg="Tag resource subnet-040fa6cb5602b08a5 successfully"
time="2025-07-10 10:52:50" level=info msg="Got no proper private subnet for current zone us-west-2c, going to create one"
time="2025-07-10 10:52:51" level=info msg="Created subnet subnet-04f7781cbfe283bf8 for vpc vpc-0e70542298c58314d"
time="2025-07-10 10:52:52" level=info msg="Created subnet with ID subnet-04f7781cbfe283bf8"
time="2025-07-10 10:52:52" level=info msg="Associate route table success rtbassoc-01ae0dea4c961d55a"
time="2025-07-10 10:52:52" level=info msg="Found existing nat gateway: nat-03e4dbf37a754b673"
time="2025-07-10 10:52:54" level=info msg="Create route success for route table: rtb-08b16a8195c8d7677"
time="2025-07-10 10:52:54" level=info msg="Tag resource subnet-04f7781cbfe283bf8 successfully"
•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 268 Specs in 1117.064 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 267 Skipped
PASS

Ginkgo ran 1 suite in 18m47.239772417s
Test Suite Passed
Running Suite: ROSA CLI e2e tests suite - /Users/yingzhan/ying-work/code/rosa/tests/e2e
=======================================================================================
Random Seed: 1752116764

Will run 1 of 268 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 268 Specs in 14.453 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 267 Skipped
PASS

Ginkgo ran 1 suite in 26.676594709s
Test Suite Passed
```