### PR TITLE
OCM-16902 | fix: Pass in non-args privteIngress value

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2359,7 +2359,7 @@ func run(cmd *cobra.Command, _ []string) {
 				// - Public hosted clusters have at least one public subnet
 				// - Private hosted clusters have all subnets private, except when those clusters have public ingress
 				privateSubnetsCount, err = ocm.ValidateHostedClusterSubnets(awsClient, privateLink, subnetIDs,
-					args.privateIngress)
+					privateIngress)
 			}
 			if err != nil {
 				r.Reporter.Errorf("%s", err)


### PR DESCRIPTION
Should fix an issue where when using interactive mode, you are unable to create a cluster with `private API` + `private Ingress` via interactive mode. This is because the args values for `privateIngress` (what is provided when the command runs, only) was used in place of the value which is updated by interactive mode