### PR TITLE
OCM-16926 | feat: Update help message for private-link to 'deprecate' for HCP

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -543,7 +543,9 @@ func initFlags(cmd *cobra.Command) {
 		"private-link",
 		false,
 		"Provides private connectivity between VPCs, AWS services, and your on-premises networks, "+
-			"without exposing your traffic to the public internet.",
+			"without exposing your traffic to the public internet.\n\n"+
+			"--private-link is only to be used with Classic clusters after ROSA CLI v1.2.55. \n"+
+			"For Hosted Control Plane clusters, use the '--private' and '--default-ingress-private' flags instead.",
 	)
 
 	flags.BoolVar(


### PR DESCRIPTION
We cannot deprecate fully, since we don't know if the customer is using HCP when the CLI is built. Deprecating mid-run of the command, which is our only option for CobraCLI deprecation, will not work whatsoever like intended (nothing will happen). 
Therefore, the best solution, as provided by @yuwang-RH in this ticket, is to update the `--private-link` help message itself to let the customer know that it is deprecated specifically for `v1.2.55` and beyond. And the solution to this deprecation is to use the `--private` and `--default-ingress-private` flags for HCP clusters