### PR TITLE
OCM-16902 | fix: Fix private+privateIngress clusters + validation

### DIFF
--- a/cmd/create/cluster/validation.go
+++ b/cmd/create/cluster/validation.go
@@ -2,9 +2,14 @@ package cluster
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/interactive/securitygroups"
+	"github.com/openshift/rosa/pkg/reporter"
 )
 
 const (
@@ -59,4 +64,22 @@ func validateHcpSharedVpcArgs(route53RoleArn string, vpcEndpointRoleArn string,
 		return fmt.Errorf(hcpSharedVpcFlagNotFilledErrorMsg, hcpInternalCommunicationHostedZoneIdFlag)
 	}
 	return nil
+}
+
+func validateHcpFlags(cmd *cobra.Command, r reporter.Logger) {
+	if cmd.Flag(securitygroups.InfraSecurityGroupFlag).Changed {
+		_ = r.Errorf("Cannot use '%s' flag with Hosted Control Plane clusters, only '%s' is "+
+			"supported", securitygroups.InfraSecurityGroupFlag, securitygroups.ComputeSecurityGroupFlag)
+		os.Exit(1)
+	}
+	if cmd.Flag(securitygroups.ControlPlaneSecurityGroupFlag).Changed {
+		_ = r.Errorf("Cannot use '%s' flag with Hosted Control Plane clusters, only '%s' is "+
+			"supported", securitygroups.ControlPlaneSecurityGroupFlag, securitygroups.ComputeSecurityGroupFlag)
+		os.Exit(1)
+	}
+	if cmd.Flag(privateLinkFlagName).Changed {
+		_ = r.Errorf("Cannot use '%s' flag with Hosted Control Plane clusters, '%s' is the "+
+			"supported equivalent", privateLinkFlagName, privateFlagName)
+		os.Exit(1)
+	}
 }

--- a/pkg/interactive/validation.go
+++ b/pkg/interactive/validation.go
@@ -226,7 +226,8 @@ func RegExpBoolean(restr string) Validator {
 
 // SubnetsCountValidator get a slice of `[]core.OptionAnswer` as an interface.
 // e.g. core.OptionAnswer { Value: subnet-04f67939f44a97dbe (us-west-2b), Index: 0 }
-func SubnetsValidator(awsClient aws.Client, multiAZ bool, privateLink bool, hostedCP bool) Validator {
+func SubnetsValidator(awsClient aws.Client, multiAZ bool, privateValue bool, hostedCP bool,
+	privateIngress bool) Validator {
 	return func(input interface{}) (err error) {
 		if answers, ok := input.([]core.OptionAnswer); ok {
 			if hostedCP {
@@ -235,11 +236,10 @@ func SubnetsValidator(awsClient aws.Client, multiAZ bool, privateLink bool, host
 					subnetIDs[i] = aws.ParseOption(subnet.Value)
 				}
 
-				privateIngress := false
-				_, err = ocm.ValidateHostedClusterSubnets(awsClient, privateLink, subnetIDs, privateIngress)
+				_, err = ocm.ValidateHostedClusterSubnets(awsClient, privateValue, subnetIDs, privateIngress)
 				return err
 			}
-			return ocm.ValidateSubnetsCount(multiAZ, privateLink, len(answers))
+			return ocm.ValidateSubnetsCount(multiAZ, privateValue, len(answers))
 		}
 		return fmt.Errorf("can only validate a slice of string, got %v", input)
 	}

--- a/pkg/interactive/validation_test.go
+++ b/pkg/interactive/validation_test.go
@@ -123,7 +123,7 @@ var _ = Describe("SubnetsValidator", func() {
 
 	Context("When cluster is hosted", func() {
 		It("Returns an error when the number of subnets is not at least two", func() {
-			validator = SubnetsValidator(mockClient, false, false, true)
+			validator = SubnetsValidator(mockClient, false, false, true, false)
 			answers := []core.OptionAnswer{
 				{Value: "subnet-public-1 (us-west-2a)"},
 			}
@@ -135,7 +135,7 @@ var _ = Describe("SubnetsValidator", func() {
 		})
 
 		It("Returns an error when the number of public subnets is not at least one", func() {
-			validator = SubnetsValidator(mockClient, false, false, true)
+			validator = SubnetsValidator(mockClient, false, false, true, false)
 			answers := []core.OptionAnswer{
 				{Value: "subnet-private-2 (us-west-2a)"},
 				{Value: "subnet-private-3 (us-west-2b)"},
@@ -160,7 +160,7 @@ var _ = Describe("SubnetsValidator", func() {
 
 	Context("When cluster is not hosted", func() {
 		It("Returns and error when the number of subnets is not correct", func() {
-			validator = SubnetsValidator(mockClient, true, true, false)
+			validator = SubnetsValidator(mockClient, true, true, false, true)
 			answers := []core.OptionAnswer{
 				{Value: "subnet-123 (us-west-2a)"},
 				{Value: "subnet-456 (us-west-2b)"},
@@ -173,7 +173,7 @@ var _ = Describe("SubnetsValidator", func() {
 		})
 
 		It("Should not return an error when the number of subnets is correct", func() {
-			validator = SubnetsValidator(mockClient, true, true, false)
+			validator = SubnetsValidator(mockClient, true, true, false, true)
 			answers := []core.OptionAnswer{
 				{Value: "subnet-123 (us-west-2a)"},
 				{Value: "subnet-456 (us-west-2b)"},


### PR DESCRIPTION
Fixes issue where HCP clusters failed to validate with `private` and `private-ingress` set to `true`. Also added validation for users who try to use `--private-link` with HCP clusters