### PR TITLE
OCM-15990 | feat: Rename CAPA logger something more identifiable

### DIFF
--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -238,7 +238,7 @@ type AccessKeyGetter interface {
 // ClientBuilder contains the information and logic needed to build a new AWS client.
 type ClientBuilder struct {
 	logger              *logrus.Logger
-	logrLogger          *logr.Logger
+	capaLogger          *logr.Logger
 	region              *string
 	credentials         *AccessKey
 	useLocalCredentials bool
@@ -343,8 +343,8 @@ func (b *ClientBuilder) Logger(value *logrus.Logger) *ClientBuilder {
 	return b
 }
 
-func (b *ClientBuilder) LogrLogger(value *logr.Logger) *ClientBuilder {
-	b.logrLogger = value
+func (b *ClientBuilder) CapaLogger(value *logr.Logger) *ClientBuilder {
+	b.capaLogger = value
 	return b
 }
 
@@ -455,7 +455,7 @@ func (b *ClientBuilder) BuildSession() (aws.Config, error) {
 // Build uses the information stored in the builder to build a new AWS client.
 func (b *ClientBuilder) Build() (Client, error) {
 	// Check parameters:
-	if b.logger == nil && b.logrLogger == nil {
+	if b.logger == nil && b.capaLogger == nil {
 		return nil, fmt.Errorf("logger is mandatory")
 	}
 
@@ -497,7 +497,7 @@ func (b *ClientBuilder) Build() (Client, error) {
 	// Create and populate the object:
 	c := &awsClient{
 		cfg:                 cfg,
-		logger:              NewLoggerWrapper(b.logger, b.logrLogger),
+		logger:              NewLoggerWrapper(b.logger, b.capaLogger),
 		iamClient:           iam.NewFromConfig(cfg),
 		ec2Client:           ec2.NewFromConfig(cfg),
 		orgClient:           organizations.NewFromConfig(cfg),

--- a/pkg/aws/logging.go
+++ b/pkg/aws/logging.go
@@ -26,10 +26,10 @@ import (
 type LoggerWrapper struct {
 	loggerType   string
 	logrusLogger *logrus.Logger
-	logrLogger   *logr.Logger
+	capaLogger   *logr.Logger
 }
 
-func NewLoggerWrapper(logrusLog *logrus.Logger, logrLog *logr.Logger) *LoggerWrapper {
+func NewLoggerWrapper(logrusLog *logrus.Logger, capaLogger *logr.Logger) *LoggerWrapper {
 	if logrusLog != nil {
 		return &LoggerWrapper{
 			loggerType:   "logrus",
@@ -37,10 +37,10 @@ func NewLoggerWrapper(logrusLog *logrus.Logger, logrLog *logr.Logger) *LoggerWra
 		}
 	}
 
-	if logrLog != nil {
+	if capaLogger != nil {
 		return &LoggerWrapper{
-			loggerType: "logr",
-			logrLogger: logrLog,
+			loggerType: "capa",
+			capaLogger: capaLogger,
 		}
 	}
 
@@ -51,8 +51,8 @@ func (lw *LoggerWrapper) GetLevel() (lvl int) {
 	switch lw.loggerType {
 	case "logrus":
 		lvl = int(lw.logrusLogger.GetLevel())
-	case "logr":
-		lvl = lw.logrLogger.GetV()
+	case "capa":
+		lvl = lw.capaLogger.GetV()
 	}
 
 	return lvl
@@ -62,8 +62,8 @@ func (lw *LoggerWrapper) Debug(args ...interface{}) {
 	switch lw.loggerType {
 	case "logrus":
 		lw.logrusLogger.Debug(args...)
-	case "logr":
-		lw.logrLogger.Info(args[0].(string))
+	case "capa":
+		lw.capaLogger.Info(args[0].(string))
 	}
 }
 
@@ -71,8 +71,8 @@ func (lw *LoggerWrapper) Info(args ...interface{}) {
 	switch lw.loggerType {
 	case "logrus":
 		lw.logrusLogger.Info(args...)
-	case "logr":
-		lw.logrLogger.Info(args[0].(string))
+	case "capa":
+		lw.capaLogger.Info(args[0].(string))
 	}
 }
 
@@ -80,8 +80,8 @@ func (lw *LoggerWrapper) Warn(args ...interface{}) {
 	switch lw.loggerType {
 	case "logrus":
 		lw.logrusLogger.Warn(args...)
-	case "logr":
-		lw.logrLogger.Info(args[0].(string))
+	case "capa":
+		lw.capaLogger.Info(args[0].(string))
 	}
 }
 
@@ -89,8 +89,8 @@ func (lw *LoggerWrapper) Error(args ...interface{}) {
 	switch lw.loggerType {
 	case "logrus":
 		lw.logrusLogger.Error(args...)
-	case "logr":
-		lw.logrLogger.Error(fmt.Errorf("awsClient error"), args[0].(string))
+	case "capa":
+		lw.capaLogger.Error(fmt.Errorf("awsClient error"), args[0].(string))
 	}
 }
 
@@ -98,7 +98,7 @@ func (lw *LoggerWrapper) Fatal(args ...interface{}) {
 	switch lw.loggerType {
 	case "logrus":
 		lw.logrusLogger.Fatal(args...)
-	case "logr":
-		lw.logrLogger.Error(fmt.Errorf("awsClient error"), args[0].(string))
+	case "capa":
+		lw.capaLogger.Error(fmt.Errorf("awsClient error"), args[0].(string))
 	}
 }


### PR DESCRIPTION
`logrLogger` could be confusing to new contributors to ROSA CLI, since we have `logrus.Logger` as our normal logger in the CLI. Changing the name to `capaLogger` would improve readability and reduce confusion on which logger to use