### PR TITLE
OCM-17244 | test: fix id: 68971 and fix preparation to not use private-link flag anymore for hcp cluster

### DIFF
--- a/tests/e2e/test_rosacli_cluster.go
+++ b/tests/e2e/test_rosacli_cluster.go
@@ -906,6 +906,9 @@ var _ = Describe("Additional security groups validation",
 				pickedVersions, err := versionList.FilterVersionsSameMajorAndEqualOrLowerThanMinor(4, 13, false)
 				Expect(err).To(BeNil())
 				Expect(len(pickedVersions.OpenShiftVersions) > 0).To(BeTrue())
+				if len(pickedVersions.OpenShiftVersions) <= 0 {
+					Skip("There is no version bellow 4.14.0, skip this case")
+				}
 				ocpVersionBelow4_14 = pickedVersions.OpenShiftVersions[0].Version
 
 				By("Prepare a vpc for the testing")

--- a/tests/utils/handler/cluster_handler.go
+++ b/tests/utils/handler/cluster_handler.go
@@ -452,9 +452,6 @@ func (ch *clusterHandler) GenerateClusterCreateFlags() ([]string, error) {
 	if ch.profile.ClusterConfig.Private {
 		flags = append(flags, "--private")
 		ch.clusterConfig.Private = ch.profile.ClusterConfig.Private
-		if ch.profile.ClusterConfig.HCP {
-			ch.profile.ClusterConfig.PrivateLink = true
-		}
 	}
 	if ch.profile.ClusterConfig.DefaultIngressPrivate {
 		flags = append(flags, "--default-ingress-private")


### PR DESCRIPTION
- If the cluster is hosted-cp, don't use private-link flag anymore
- 68971: Skip if there is no version bellow 4.13

logs on my local is https://privatebin.corp.redhat.com/?ce9f9f42ae5d14d5#B2v8MJd3LsdTWKBcDFGCT9bGF1xaHifssSvnxnTKpQMU