### PR TITLE
OCM-17271 | test: fix ids: 41549,72538

### DIFF
--- a/tests/e2e/test_rosacli_cluster.go
+++ b/tests/e2e/test_rosacli_cluster.go
@@ -1824,7 +1824,7 @@ var _ = Describe("Create cluster with invalid options will",
 
 			})
 
-		It("to validate the invalid proxy when create cluster - [id:q]", labels.Medium, labels.Runtime.Day1Negative,
+		It("to validate the invalid proxy when create cluster - [id:45509]", labels.Medium, labels.Runtime.Day1Negative,
 			func() {
 				zone := constants.CommonAWSRegion + "a"
 				clusterName := "rosacli-45509"
@@ -2694,6 +2694,7 @@ var _ = Describe("HCP cluster creation negative testing",
 
 				By("Create a private cluster with 1 private subnet")
 				rosalCommand.AddFlags("--private")
+				rosalCommand.AddFlags("--default-ingress-private")
 				rosalCommand.ReplaceFlagValue(map[string]string{"--subnet-ids": subnetMap["private"][0]})
 				out, err = rosaClient.Runner.RunCMD(strings.Split(rosalCommand.GetFullCommand(), " "))
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/e2e/test_rosacli_cluster_post.go
+++ b/tests/e2e/test_rosacli_cluster_post.go
@@ -298,9 +298,11 @@ var _ = Describe("Healthy check",
 				func() {
 					private := constants.No
 					ingressPrivate := "false"
-					if clusterConfig.PrivateLink {
+					if clusterConfig.Private {
 						private = constants.Yes
-						ingressPrivate = "true" // nolint
+					}
+					if clusterConfig.DefaultIngressPrivate {
+						ingressPrivate = "true"
 					}
 					By("Describe the cluster the cluster should be private")
 					clusterDescription, err := clusterService.DescribeClusterAndReflect(clusterID)

--- a/tests/utils/config/cluster.go
+++ b/tests/utils/config/cluster.go
@@ -116,6 +116,7 @@ type ClusterConfig struct {
 	Hypershift                bool                      `json:"hypershift,omitempty"`
 	MultiAZ                   bool                      `json:"multi_az,omitempty"`
 	Private                   bool                      `json:"private,omitempty"`
+	DefaultIngressPrivate     bool                      `json:"default_ingress_private,omitempty"`
 	PrivateLink               bool                      `json:"private_link,omitempty"`
 	Sts                       bool                      `json:"sts,omitempty"`
 	AuditLogArn               string                    `json:"audit_log_arn,omitempty"`

--- a/tests/utils/handler/cluster_handler.go
+++ b/tests/utils/handler/cluster_handler.go
@@ -455,6 +455,7 @@ func (ch *clusterHandler) GenerateClusterCreateFlags() ([]string, error) {
 	}
 	if ch.profile.ClusterConfig.DefaultIngressPrivate {
 		flags = append(flags, "--default-ingress-private")
+		ch.clusterConfig.DefaultIngressPrivate = ch.profile.ClusterConfig.DefaultIngressPrivate
 	}
 
 	if ch.profile.ClusterConfig.AdminEnabled {

--- a/tests/utils/handler/interface.go
+++ b/tests/utils/handler/interface.go
@@ -60,7 +60,7 @@ type ClusterConfig struct {
 	MultiAZ                       bool   `yaml:"multi_az,omitempty" json:"multi_az,omitempty"`
 	NetworkingSet                 bool   `yaml:"networking,omitempty" json:"networking,omitempty"`
 	PrivateLink                   bool   `yaml:"private_link,omitempty" json:"private_link,omitempty"`
-	DefaultIngressPrivate         bool   `yaml:"default_ingress_private,omitempty" json:"default_ingress_private,omitempty"`
+	DefaultIngressPrivate         bool   `yaml:"default_ingress_private,omitempty"`
 	Private                       bool   `yaml:"private,omitempty" json:"private,omitempty"`
 	ProxyEnabled                  bool   `yaml:"proxy_enabled,omitempty" json:"proxy_enabled,omitempty"`
 	STS                           bool   `yaml:"sts,omitempty" json:"sts,omitempty"`


### PR DESCRIPTION
- 41549: update checkpoint for new change of private api and ingress feature
- 72538: Use private and default-ingress-private to test the private hosted-cp custer

logs: https://privatebin.corp.redhat.com/?4f6102059a4dbc2b#E7v5qTaXKLpTaiRxHTjhCVbmovNjPK5VRq6iSc6M58u5