### PR TITLE
OCM-16905 | feat: Introduce `--private-ingress` to cluster cmd

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -4088,10 +4088,14 @@ func buildCommand(spec ocm.Spec, operatorRolesPrefix string,
 	if spec.HostPrefix != 0 {
 		command += fmt.Sprintf(" --host-prefix %d", spec.HostPrefix)
 	}
-	if spec.PrivateLink != nil && *spec.PrivateLink {
+	if !spec.Hypershift.Enabled && spec.PrivateLink != nil && *spec.PrivateLink {
 		command += " --private-link"
-	} else if spec.Private != nil && *spec.Private {
+	}
+	if spec.Hypershift.Enabled && spec.Private != nil && *spec.Private {
 		command += " --private"
+	}
+	if spec.Hypershift.Enabled && spec.PrivateIngress != nil && *spec.PrivateIngress {
+		command += " --default-ingress-private"
 	}
 	if len(spec.SubnetIds) > 0 {
 		command += fmt.Sprintf(" --subnet-ids %s", strings.Join(spec.SubnetIds, ","))


### PR DESCRIPTION
Adds `--private-ingress` to the generated cluster command which is spat out when creating a new cluster. Also introduces a fix for `--private` and `--private-link` to only allow each to show up in that generated command when the correct architecture is used. This fixes any issues where `--private-link` would still have a value, even though it is not used, and therefore `--private` would not be included in an HCP cluster's spat-out-command