### PR TITLE
OCM-17311 | chore: Bump CLI version on master to 1.2.55

### DIFF
--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,7 +18,7 @@ limitations under the License.
 
 package info
 
-const DefaultVersion = "1.2.53"
+const DefaultVersion = "1.2.55"
 
 // Build contains the short Git SHA of the CLI at the point it was build. Set via `-ldflags` at build time
 var Build = "local"


### PR DESCRIPTION
Bumps version on master as part of the release process