### PR TITLE
Revert "OCM-17311 | chore: Bump release version to v1.2.55"

### DIFF
--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,7 +18,7 @@ limitations under the License.
 
 package info
 
-const DefaultVersion = "1.2.55"
+const DefaultVersion = "1.2.55-RC1"
 
 // Build contains the short Git SHA of the CLI at the point it was build. Set via `-ldflags` at build time
 var Build = "local"


### PR DESCRIPTION
Reverts openshift/rosa#2960