### PR TITLE
OCM-17643 | fix: Fix retrieving versions for listing CLI versions

### DIFF
--- a/pkg/version/retriever.go
+++ b/pkg/version/retriever.go
@@ -47,6 +47,7 @@ func (r retriever) RetrieveLatestVersionFromMirror() (*goVer.Version, error) {
 	if err != nil {
 		return nil, fmt.Errorf("there was a problem retrieving possible versions from mirror: %v", err)
 	}
+	possibleVersions = parseVersionURIsToVersionStreams(possibleVersions)
 	if len(possibleVersions) == 0 {
 		return nil, fmt.Errorf("no versions available in mirror %s", baseReleasesFolder)
 	}
@@ -116,4 +117,24 @@ func (r retriever) RetrievePossibleVersionsFromMirror() ([]string, error) {
 	}
 	r.logger.Debugf("Versions available for download: %v", possibleVersions)
 	return possibleVersions, nil
+}
+
+func parseVersionURIsToVersionStreams(uriList []string) []string {
+	parsedList := make([]string, len(uriList))
+	for i, uri := range uriList {
+		if strings.HasPrefix(uri, "https://") {
+			// Needs to be parsed, find last segment
+			split := strings.Split(uri, "/")
+			slashCount := strings.Count(uri, "/")
+
+			parsedList[i] = split[slashCount]
+			for len(split[slashCount]) == 0 {
+				parsedList[i] = split[slashCount-1]
+				slashCount--
+			}
+		} else {
+			parsedList[i] = uri
+		}
+	}
+	return parsedList
 }

--- a/pkg/version/retriever_test.go
+++ b/pkg/version/retriever_test.go
@@ -201,4 +201,27 @@ var _ = Describe("RetrievePossibleVersionsFromMirror", func() {
 			Expect(versions).To(Equal(expectedVersions))
 		})
 	})
+
+	When("Version URIs are converted into version strings properly", func() {
+		It("should return version streams", func() {
+			testVersions := []string{"https://www.test.com/version/pub/.../1.2.54/", "https://downloadlink.net/v/1.2.4",
+				"https://test.com/version/pub/1.1/", "https://zzz.zz/z///zz/1"}
+			output := parseVersionURIsToVersionStreams(testVersions)
+			Expect(output).To(Equal([]string{"1.2.54", "1.2.4", "1.1", "1"}))
+		})
+
+		It("should handle edge cases correctly", func() {
+			testVersions := []string{"https://www.test.com/version/pub/latest/", "https://downloadlink.net/v/latest",
+				"https:////////1.2.3", "https:////test/test/test/test/2.0.0/", "https:///test//test//2.1/////////////"}
+			output := parseVersionURIsToVersionStreams(testVersions)
+			Expect(output).To(Equal([]string{"latest", "latest", "1.2.3", "2.0.0", "2.1"}))
+		})
+
+		It("should not parse non-https URIs", func() {
+			testVersions := []string{"$HOME/test/1.2.3/", "http://malicious-website.com/version/1.2.54/",
+				"/123/", "1.2.54"}
+			output := parseVersionURIsToVersionStreams(testVersions)
+			Expect(output).To(Equal(testVersions))
+		})
+	})
 })

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,8 +16,8 @@ import (
 )
 
 const (
-	DownloadLatestMirrorFolder = "https://mirror.openshift.com/pub/openshift-v4/clients/rosa/latest/"
-	baseReleasesFolder         = "https://mirror.openshift.com/pub/openshift-v4/clients/rosa/"
+	DownloadLatestMirrorFolder = "https://mirror.openshift.com/pub/cgw/rosa/latest/"
+	baseReleasesFolder         = "https://mirror.openshift.com/pub/cgw/rosa/"
 	ConsoleLatestFolder        = "https://console.redhat.com/openshift/downloads#tool-rosa"
 )
 


### PR DESCRIPTION
Fixes issue brought up by customers and internal users, where after moving from ART to CGW for the CLI's download mirror, redirects were not working as expected. We must migrate the links within the CLI, as well as get the version retrieval service working with the new website