### PR TITLE
OCM-17617 | ci: Use CEL expressions to decide the additioanl tag on the e2e-test image

### DIFF
--- a/.tekton/rosa-cli-e2e-test-push.yaml
+++ b/.tekton/rosa-cli-e2e-test-push.yaml
@@ -8,6 +8,8 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push"
+    pipelinesascode.tekton.dev/params: |
+      image_tag = target_branch.startsWith("refs/tags/v") ? "e2e_test_" + target_branch.split("/").last() : "e2e_test_latest"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: rh-rosa-cli
@@ -25,8 +27,8 @@ spec:
     value: quay.io/redhat-user-workloads/rh-terraform-tenant/rosa-cli-e2e-test:{{revision}}
   - name: dockerfile
     value: /images/Dockerfile.konflux
-  - name: target_branch
-    value: '{{target_branch}}'
+  - name: image_tag
+    value: "{{ image_tag }}"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
@@ -525,13 +527,13 @@ spec:
         operator: in
         values:
         - "false"
-    - name: apply-tags-released
+    - name: apply-tags
       params:
       - name: IMAGE
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: ADDITIONAL_TAGS
         value:
-        - e2e_test_releasing_latest
+        - $(params.image_tag)
       runAfter:
       - build-image-index
       taskRef:
@@ -543,32 +545,6 @@ spec:
         - name: kind
           value: task
         resolver: bundles
-      when:
-        - input: $(params.target_branch)
-          operator: startsWith
-          values: ["refs/tags/v"]
-    - name: apply-tags-latest
-      params:
-      - name: IMAGE
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: ADDITIONAL_TAGS
-        value:
-        - e2e_test_latest
-      runAfter:
-      - build-image-index
-      taskRef:
-        params:
-        - name: name
-          value: apply-tags
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:1c6f673fe100a49f58aaef62580c8adf0c397790964f4e7bac7fcd3f4d07c92e
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-        - input: $(params.target_branch)
-          operator: notin
-          values: ["refs/tags/v"]
     - name: push-dockerfile
       params:
       - name: IMAGE


### PR DESCRIPTION
With the previous update, the rosa-cli-e2e-test-push job failed with error bellow,https://github.com/openshift/rosa/runs/47680169287 
`Tekton Controller has reported this error: admission webhook "validation.webhook.pipeline.tekton.dev" denied the request: validation failed: invalid value: operator "startsWith" is not recognized. valid operators: in,notin: spec.pipelineSpec.tasks[15].when[0]`

Thinking of a new workaround to support to add different tags on test images by using CEL expressions.