### PR TITLE
OCM-17617 | ci: fix the error obtaining VCS status with the GOFLAGS in Dockerfile.konflux

### DIFF
--- a/images/Dockerfile.konflux
+++ b/images/Dockerfile.konflux
@@ -17,8 +17,8 @@ RUN wget https://go.dev/dl/go1.22.3.linux-amd64.tar.gz && \
     rm go1.22.3.linux-amd64.tar.gz
 
 ENV GOTOOLCHAIN=local
-ENV GOFLAGS=-buildvcs=false
 RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.13.2
+RUN go env -w GOFLAGS=-buildvcs=false
 RUN make release
 
 FROM registry.access.redhat.com/ubi9/ubi:latest


### PR DESCRIPTION
rosa-cli-e2e-test-on-push job failed with bellow error, https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-terraform-tenant/applications/rh-rosa-cli/pipelineruns/rosa-cli-e2e-test-on-push-6sk28/logs?task=build-container

```
bash ./hack/build_cli.sh
error obtaining VCS status: exit status 128
    Use -buildvcs=false to disable VCS stamping. 
```

It is caused by the cloned repo missing complete .git file then fails when 'go build'.

Although the dockerfile has `ENV GOFLAGS=-buildvcs=false`, it cannot take effect in the 'make release' step.

The coming fix is using 'RUN go env -w GOFLAGS=-buildvcs=false' to set the global golang env variable which will be used for `go build` in the 'make release' step.