### PR TITLE
OCM-17713 | ci: To use single quotes for image_tag to avoid treating as a literal string

### DIFF
--- a/.tekton/rosa-cli-e2e-test-push.yaml
+++ b/.tekton/rosa-cli-e2e-test-push.yaml
@@ -28,7 +28,7 @@ spec:
   - name: dockerfile
     value: /images/Dockerfile.konflux
   - name: image_tag
-    value: "{{ image_tag }}"
+    value: '{{image_tag}}'
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.


### PR DESCRIPTION
It should use single quotes for image_tag to avoid treating as a literal string.

failure job: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-terraform-tenant/applications/rh-rosa-cli/pipelineruns/rosa-cli-e2e-test-on-push-dccz6/logs?task=apply-tags

`
step-apply-additional-tags-from-parameter :-
Applying tag {{ image_tag }}
time="2025-08-13T13:36:14Z" level=fatal msg="Invalid destination name docker://quay.io/redhat-user-workloads/rh-terraform-tenant/rosa-cli-e2e-test:{{ image_tag }}: invalid reference format"
`