### PR TITLE
OCM-16535 | feat: Introduce warning + dry run mode for upgrading clusters

### DIFF
--- a/cmd/rosa/structure_test/command_args/rosa/upgrade/cluster/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/upgrade/cluster/command_args.yml
@@ -11,3 +11,4 @@
 - name: interactive
 - name: profile
 - name: region
+- name: dry-run


### PR DESCRIPTION
Gives users an option to use `--dry-run` when upgrading a cluster, to ACK gates prior to attempting an upgrade. There is also a warning when not using dry run telling the user about it

Classic example:

```
❯ ./rosa upgrade cluster -c hkep-test --dry-run
I: Running in dry-run mode. Will not perform cluster upgrade
? IAM Roles/Policies upgrade mode: auto
? Version (default = '4.18.21'): 4.18.7
I: Ensuring account and operator role policies for cluster '2kl9i8eittnkvfbhjjpv75fckq33b2vr' are compatible with upgrade.
I: Account roles/policies for cluster '2kl9i8eittnkvfbhjjpv75fckq33b2vr' are already up-to-date.
I: Operator roles/policies associated with the cluster '2kl9i8eittnkvfbhjjpv75fckq33b2vr' are already up-to-date.
I: Account and operator roles for cluster 'hkep-test' are compatible with upgrade
I: Upgrading cluster '2kl9i8eittnkvfbhjjpv75fckq33b2vr' should succeed. Please wait 1 to 2 minutes, then rerun this command without the '--dry-run' flag, to allow time for the acknowledged agreements to be reflected.

❯ ./rosa upgrade cluster -c hkep-test
? IAM Roles/Policies upgrade mode: auto
? Version (default = '4.18.21'): 4.18.7
I: Ensuring account and operator role policies for cluster '2kl9i8eittnkvfbhjjpv75fckq33b2vr' are compatible with upgrade.
I: Account roles/policies for cluster '2kl9i8eittnkvfbhjjpv75fckq33b2vr' are already up-to-date.
I: Operator roles/policies associated with the cluster '2kl9i8eittnkvfbhjjpv75fckq33b2vr' are already up-to-date.
I: Account and operator roles for cluster 'hkep-test' are compatible with upgrade
? Are you sure you want to upgrade cluster to version '4.18.7'? Yes
W: To check and acknowledge gates prior to scheduling an upgrade, run this command with '--dry-run'
I: Upgrade successfully scheduled for cluster 'hkep-test'
```

HCP example:

```
❯ ./rosa upgrade cluster -c hkep --dry-run
I: Running in dry-run mode. Will not perform cluster upgrade
? IAM Roles/Policies upgrade mode: auto
? Version (default = '4.18.21'): 4.18.7
I: Ensuring account and operator role policies for cluster '2klq6032lap97bralrmq9iom66bcojf9' are compatible with upgrade.
time=2025-08-14T10:44:27-04:00 level=info msg=Ignored check for policy key 'sts_hcp_ec2_registry_permission_policy' (zero egress feature toggle is not enabled)
I: Account roles with the prefix 'ManagedOpenShift' have attached managed policies.
I: Cluster 'hkep' operator roles have attached managed policies. An upgrade isn't needed
I: Account and operator roles for cluster 'hkep' are compatible with upgrade
I: Upgrading cluster '2klq6032lap97bralrmq9iom66bcojf9' should succeed. Please wait 1 to 2 minutes, then rerun this command without the '--dry-run' flag, to allow time for the acknowledged agreements to be reflected.

❯ ./rosa upgrade cluster -c hkep
? IAM Roles/Policies upgrade mode: auto
? Version (default = '4.18.21'): 4.18.7
I: Ensuring account and operator role policies for cluster '2klq6032lap97bralrmq9iom66bcojf9' are compatible with upgrade.
ytime=2025-08-14T10:44:57-04:00 level=info msg=Ignored check for policy key 'sts_hcp_ec2_registry_permission_policy' (zero egress feature toggle is not enabled)
I: Account roles with the prefix 'ManagedOpenShift' have attached managed policies.
I: Cluster 'hkep' operator roles have attached managed policies. An upgrade isn't needed
I: Account and operator roles for cluster 'hkep' are compatible with upgrade
? Are you sure you want to upgrade cluster to version '4.18.7'? Yes
W: To check and acknowledge gates prior to scheduling an upgrade, run this command with '--dry-run'
I: Upgrade successfully scheduled for cluster 'hkep'
```