### PR TITLE
OCM-17719 | feat: Deprecate user workload monitoring toggle

### DIFF
--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -457,11 +457,6 @@ func run(cmd *cobra.Command, argv []string) {
 		deleteProtection,
 		cluster.CreationTimestamp().Format("Jan _2 2006 15:04:05 MST"))
 
-	str = fmt.Sprintf("%s"+
-		"User Workload Monitoring:   %s\n",
-		str,
-		getUseworkloadMonitoring(cluster.DisableUserWorkloadMonitoring()))
-
 	if cluster.FIPS() {
 		str = fmt.Sprintf("%s"+
 			"FIPS mode:                  %s\n",
@@ -841,13 +836,6 @@ func getDetailsLink(environment string) string {
 	default:
 		return ""
 	}
-}
-
-func getUseworkloadMonitoring(disabled bool) string {
-	if disabled {
-		return DisabledOutput
-	}
-	return EnabledOutput
 }
 
 func formatCluster(cluster *cmv1.Cluster, scheduledUpgrade *cmv1.UpgradePolicy,

--- a/pkg/arguments/arguments.go
+++ b/pkg/arguments/arguments.go
@@ -36,6 +36,9 @@ const boolType string = "bool"
 
 const regionFlagName = "region"
 const regionDeprecationMessage = "Region flag will be removed from this command in future versions"
+const DisableWorkloadMonitoringDeprecationMessage = "Disabling user workload monitoring" +
+	" (--disable-workload-monitoring) is deprecated and will be removed in a future version of ROSA CLI.\nPlease" +
+	" update your usage to avoid issues when this endpoint is removed."
 
 const MustUseBothFlagsErrorMessage = "Must supply '%s' flag when using the '%s' flag"
 

--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -626,10 +626,6 @@ func (c *Client) UpdateCluster(clusterKey string, creator *aws.Creator, config S
 		)
 	}
 
-	if config.DisableWorkloadMonitoring != nil {
-		clusterBuilder = clusterBuilder.DisableUserWorkloadMonitoring(*config.DisableWorkloadMonitoring)
-	}
-
 	// SDN -> OVN Migration
 	if config.NetworkType == NetworkTypes[1] {
 		// Create a request body for the specific cluster migration.
@@ -844,10 +840,6 @@ func (c *Client) createClusterSpec(config Spec) (*cmv1.Cluster, error) {
 
 	if config.DomainPrefix != "" {
 		clusterBuilder.DomainPrefix(config.DomainPrefix)
-	}
-
-	if config.DisableWorkloadMonitoring != nil {
-		clusterBuilder = clusterBuilder.DisableUserWorkloadMonitoring(*config.DisableWorkloadMonitoring)
 	}
 
 	registryConfigBuilder, err := BuildRegistryConfig(config)

--- a/tests/utils/handler/cluster_handler.go
+++ b/tests/utils/handler/cluster_handler.go
@@ -765,10 +765,6 @@ func (ch *clusterHandler) GenerateClusterCreateFlags() ([]string, error) {
 		flags = append(flags, "--disable-scp-checks")
 		ch.clusterConfig.DisableScpChecks = true
 	}
-	if ch.profile.ClusterConfig.DisableUserWorKloadMonitoring {
-		flags = append(flags, "--disable-workload-monitoring")
-		ch.clusterConfig.DisableWorkloadMonitoring = true
-	}
 	if ch.profile.ClusterConfig.EtcdKMS {
 		keyArn, err := resourcesHandler.PrepareKMSKey(false, "rosacli", ch.profile.ClusterConfig.HCP, true)
 		if err != nil {


### PR DESCRIPTION
* Deprecates and hides the disable-workload-monitoring flag in both edit+create -> cluster
* Also removes the printout from describe -> cluster
* Removes all logic surrounding disable-workload-monitoring besides the existence of it within the cluster spec struct + flags (though, flags are hidden, and there is no usage of the user-given value)

Example of create/edit:

```
❯ ./rosa create cluster --sts --mode auto --disable-workload-monitoring
Flag --disable-workload-monitoring has been deprecated, Disabling user workload monitoring (--disable-workload-monitoring) is deprecated and will be removed in a future version of ROSA CLI.
Please update your usage to avoid issues when this endpoint is removed.
I: Enabling interactive mode
? Cluster name: [? for help]
E: Expected a valid cluster name: interrupt

❯ ./rosa edit cluster --disable-workload-monitoring -c fake-cluster
Flag --disable-workload-monitoring has been deprecated, Disabling user workload monitoring (--disable-workload-monitoring) is deprecated and will be removed in a future version of ROSA CLI.
Please update your usage to avoid issues when this endpoint is removed.
E: Failed to get cluster 'fake-cluster': There is no cluster with identifier or name 'fake-cluster'
```

Describe:

```
❯ ./rosa describe cluster -c vkareh-iam

Name:                       vkareh-iam
Domain Prefix:              vkareh-iam
Display Name:               vkareh-iam
ID:                         XXX
External ID:                XXX
Control Plane:              Customer Hosted
OpenShift Version:          4.17.4
Channel Group:              stable
DNS:                        XXX
AWS Account:                XXX
API URL:                    XXX
Console URL:                XXX
Region:                     ca-central-1
Multi-AZ:                   false

Nodes:
 - Control plane:           3
 - Infra:                   2
 - Compute:                 2
Network:
 - Type:                    OVNKubernetes
 - Service CIDR:            XXX
 - Machine CIDR:            XXX
 - Pod CIDR:                XXX
 - Host Prefix:             XXX
Infra ID:                   XXX
EC2 Metadata Http Tokens:   optional
State:                      ready
Private:                    No
Delete Protection:          Disabled
Created:                    Nov 22 2024 18:01:45 UTC
Etcd Encryption:            Disabled
```