### PR TITLE
OCM-17695 | Remove attaching ec2 policy to worker role for zero egress

### DIFF
--- a/cmd/create/accountroles/creators.go
+++ b/cmd/create/accountroles/creators.go
@@ -356,12 +356,6 @@ func (hcp *hcpManagedPoliciesCreator) createRoles(r *rosa.Runtime, input *accoun
 		for _, policyKey := range policyKeys {
 			policyARN, err := aws.GetManagedPolicyARN(input.policies, policyKey)
 			if err != nil {
-				// EC2 policy is only available to orgs for zero-egress feature toggle enabled
-				if policyKey == aws.WorkerEC2RegistryKey {
-					r.Reporter.Infof("Skip attaching policy '%s' to role '%s' (zero egress feature toggle is not enabled)",
-						policyKey, accRoleName)
-					continue
-				}
 				return err
 			}
 
@@ -391,12 +385,6 @@ func (hcp *hcpManagedPoliciesCreator) printCommands(r *rosa.Runtime, input *acco
 		for _, policyKey := range policyKeys {
 			policyARN, err := aws.GetManagedPolicyARN(input.policies, policyKey)
 			if err != nil {
-				// EC2 policy is only available to orgs for zero-egress feature toggle enabled
-				if policyKey == aws.WorkerEC2RegistryKey {
-					r.Reporter.Infof("Skip attaching policy '%s' to role '%s' (zero egress feature toggle is not enabled)",
-						policyKey, accRoleName)
-					continue
-				}
 				return err
 			}
 

--- a/cmd/create/accountroles/creators_test.go
+++ b/cmd/create/accountroles/creators_test.go
@@ -53,10 +53,10 @@ var _ = Describe("Accountroles", Ordered, func() {
 			err := (&hcpManagedPoliciesCreator{}).createRoles(r, accountRolesCreationInput)
 			Expect(err).ToNot(HaveOccurred())
 		})
-		It("createRole succeeds with ec2 policy", func() {
+		It("createRole succeeds when ec2 policy is available but not attached", func() {
 			mockCtrl := gomock.NewController(GinkgoT())
 			mockClient := mock.NewMockClient(mockCtrl)
-			mockClient.EXPECT().AttachRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(4)
+			mockClient.EXPECT().AttachRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(3)
 			mockClient.EXPECT().EnsureRole(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 				gomock.Any(), gomock.Any(), gomock.Any()).Return("role-123", nil).AnyTimes()
 
@@ -82,7 +82,7 @@ var _ = Describe("Accountroles", Ordered, func() {
 		It("createRole succeeds with hosted-cp and shared-vpc roles", func() {
 			mockCtrl := gomock.NewController(GinkgoT())
 			mockClient := mock.NewMockClient(mockCtrl)
-			mockClient.EXPECT().AttachRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(6)
+			mockClient.EXPECT().AttachRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(5)
 			mockClient.EXPECT().EnsureRole(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 				gomock.Any(), gomock.Any(), gomock.Any()).Return("arn::role:role-123", nil).AnyTimes()
 			mockClient.EXPECT().EnsurePolicy(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),

--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -980,9 +980,6 @@ func GetAccountRolePolicyKeys(roleType string) []string {
 // GetAccountRolePolicyKeys returns the policy key for fetching the managed policy ARN
 func GetHcpAccountRolePolicyKeys(roleType string) []string {
 	policyKeys := []string{fmt.Sprintf("sts_hcp_%s_permission_policy", roleType)}
-	if roleType == HCPWorkerRole {
-		policyKeys = append(policyKeys, WorkerEC2RegistryKey)
-	}
 
 	return policyKeys
 }

--- a/pkg/aws/helpers_test.go
+++ b/pkg/aws/helpers_test.go
@@ -254,9 +254,8 @@ var _ = Describe("GetHcpAccountRolePolicyKeys", func() {
 	When("role_type contains instance_worker", func() {
 		It("should return correct policy keys", func() {
 			policyKeys := GetHcpAccountRolePolicyKeys("instance_worker")
-			Expect(len(policyKeys)).To(Equal(2))
+			Expect(len(policyKeys)).To(Equal(1))
 			Expect(policyKeys[0]).To(Equal("sts_hcp_instance_worker_permission_policy"))
-			Expect(policyKeys[1]).To(Equal("sts_hcp_ec2_registry_permission_policy"))
 		})
 	})
 	When("role_type contains installer", func() {

--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -2184,11 +2184,6 @@ func (c *awsClient) validateManagedPolicy(policies map[string]*cmv1.AWSSTSPolicy
 	roleName string) error {
 	managedPolicyARN, err := GetManagedPolicyARN(policies, policyKey)
 	if err != nil {
-		// EC2 policy is only available to orgs for zero-egress feature toggle enabled
-		if policyKey == WorkerEC2RegistryKey {
-			c.logger.Info(fmt.Sprintf("Ignored check for policy key '%s' (zero egress feature toggle is not enabled)", policyKey))
-			return nil
-		}
 		return err
 	}
 

--- a/pkg/aws/policies_test.go
+++ b/pkg/aws/policies_test.go
@@ -853,9 +853,9 @@ var _ = Describe("validateManagedPolicy", func() {
 			Expect(err.Error()).To(ContainSubstring(expectedErr))
 		}
 	},
-		Entry("succeeds if ECR policy does not exist", map[string]*cmv1.AWSSTSPolicy{
+		Entry("fails if ECR policy does not exist", map[string]*cmv1.AWSSTSPolicy{
 			"sts_hcp_instance_worker_permission_policy": workerPolicy},
-			"sts_hcp_ec2_registry_permission_policy", "worker", ""),
+			"sts_hcp_ec2_registry_permission_policy", "worker", "failed to find policy ARN for 'sts_hcp_ec2_registry_permission_policy'"),
 		Entry("fails to find worker policy", map[string]*cmv1.AWSSTSPolicy{
 			"sts_hcp_ec2_registry_permission_policy": ec2ContainerPolicy},
 			"sts_hcp_instance_worker_permission_policy", "worker",


### PR DESCRIPTION
Rosa CLI should not attach the EC2 policy to the worker role. This removes the warning message.

https://issues.redhat.com/browse/OCM-17695