### PR TITLE
OCM-13376 | fix: Fix a couple tests that are failing in fedramp

### DIFF
--- a/tests/e2e/test_rosacli_cluster_post.go
+++ b/tests/e2e/test_rosacli_cluster_post.go
@@ -301,7 +301,7 @@ var _ = Describe("Healthy check",
 					if clusterConfig.Private {
 						private = constants.Yes
 					}
-					if clusterConfig.DefaultIngressPrivate {
+					if clusterConfig.DefaultIngressPrivate || clusterConfig.PrivateLink {
 						ingressPrivate = "true"
 					}
 					By("Describe the cluster the cluster should be private")

--- a/tests/e2e/test_rosacli_machine_pool.go
+++ b/tests/e2e/test_rosacli_machine_pool.go
@@ -242,7 +242,6 @@ var _ = Describe("Create machinepool",
 		It("List newly added instance-types - [id:73308]",
 			labels.Runtime.Day2,
 			labels.Medium,
-			labels.FedRAMP,
 			func() {
 				By("List the available instance-types and verify the presence of newly added instance-types")
 				newlyAddedTypes := []string{


### PR DESCRIPTION
OCP-41549 seems to not work with classic clusters since they don't set the `DefaultIngressPrivate` flag, but they do have a private ingress when they use private link
OCP-73308 seems like fedramp doesn't currently support those machine types even though I'm fairly certain I tested this earlier and it worked fine

Local logs:
```
TEST_PROFILE=rosa-fedramp ginkgo run --timeout 2h --focus 41549 tests/e2e
Running Suite: ROSA CLI e2e tests suite - /home/jkeyne/work/repos/rosa/tests/e2e
================================================================================
Random Seed: 1755294781

Will run 1 of 268 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 268 Specs in 25.083 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 267 Skipped
PASS

Ginkgo ran 1 suite in 26.648659384s
Test Suite Passed
```