### PR TITLE
OCM-16535 | chore: Update warning around upgrade dry runs

### DIFF
--- a/cmd/upgrade/cluster/cmd.go
+++ b/cmd/upgrade/cluster/cmd.go
@@ -635,7 +635,7 @@ func checkGates(r *rosa.Runtime, cluster *cmv1.Cluster, gates []*cmv1.VersionGat
 	isWarningDisplayed := false
 	if !args.dryRun {
 		r.Reporter.Warnf("To check and acknowledge gates prior to scheduling an upgrade, run this command with " +
-			"'--dry-run'")
+			"'--dry-run', particularly if you encounter an upgrade failure related to acknowledged agreements.")
 	}
 	for _, gate := range gates {
 		if !gate.STSOnly() {

--- a/cmd/upgrade/cluster/cmd_test.go
+++ b/cmd/upgrade/cluster/cmd_test.go
@@ -208,8 +208,9 @@ var _ = Describe("Upgrade", Ordered, func() {
 		stdout, stderr, err := test.RunWithOutputCapture(runWithRuntime, testRuntime.RosaRuntime, Cmd)
 		Expect(err).To(BeNil())
 		Expect(stdout).To(ContainSubstring("INFO: Upgrade successfully scheduled for cluster 'cluster1'"))
-		Expect(stderr).To(Equal("WARN: To check and acknowledge gates prior to scheduling an upgrade, run this" +
-			" command with '--dry-run'\n"))
+		Expect(stderr).To(Equal("WARN: To check and acknowledge gates prior to scheduling an upgrade, run" +
+			" this command with '--dry-run', particularly if you encounter an upgrade failure related to " +
+			"acknowledged agreements.\n"))
 	})
 	It("Cluster is ready and with automatic scheduling, dry run flag doesn't allow cluster upgrade", func() {
 		args.schedule = "20 5 * * *"


### PR DESCRIPTION
Updates the warning message which spits out when `--dry-run` is not used