### PR TITLE
OCM-1520 | feat: Add --hide-empty-columns flag to rosa list commands

### DIFF
--- a/cmd/list/accessrequests/cmd_test.go
+++ b/cmd/list/accessrequests/cmd_test.go
@@ -2,7 +2,6 @@ package accessrequests
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -126,7 +125,6 @@ var _ = Describe("rosa attach policy", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			stdOut, _ := t.StdOutReader.Read()
-			fmt.Println(stdOut)
 			Expect(stdOut).To(Equal(accessRequestsOutput))
 		})
 

--- a/cmd/list/dnsdomains/cmd.go
+++ b/cmd/list/dnsdomains/cmd.go
@@ -17,7 +17,6 @@ limitations under the License.
 package dnsdomains
 
 import (
-	"fmt"
 	"os"
 	"text/tabwriter"
 	"time"
@@ -64,6 +63,7 @@ func init() {
 	)
 
 	output.AddFlag(Cmd)
+	output.AddHideEmptyColumnsFlag(Cmd)
 }
 
 func run(_ *cobra.Command, _ []string) {
@@ -99,24 +99,36 @@ func run(_ *cobra.Command, _ []string) {
 		os.Exit(0)
 	}
 
-	// Create the writer that will be used to print the tabulated results:
-	writer := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
-
-	fmt.Fprintf(writer, "ID\tCLUSTER ID\tRESERVED TIME\tUSER DEFINED\tARCHITECTURE\n")
+	headers := []string{"ID", "CLUSTER ID", "RESERVED TIME", "USER DEFINED", "ARCHITECTURE"}
+	var tableData [][]string
 	for _, dnsdomain := range dnsDomains {
 		userDefined := "No"
 		if dnsdomain.UserDefined() {
 			userDefined = "Yes"
 		}
-		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\n",
+		row := []string{
 			dnsdomain.ID(),
 			dnsdomain.Cluster().ID(),
 			dnsdomain.ReservedAtTimestamp().Format(time.RFC3339),
 			userDefined,
-			dnsdomain.ClusterArch(),
-		)
+			string(dnsdomain.ClusterArch()),
+		}
+		tableData = append(tableData, row)
 	}
-	writer.Flush()
+
+	if output.ShouldHideEmptyColumns() {
+		tableData = output.RemoveEmptyColumns(headers, tableData)
+	} else {
+		tableData = append([][]string{headers}, tableData...)
+	}
+
+	writer := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	output.BuildTable(writer, "\t", tableData)
+
+	if err := writer.Flush(); err != nil {
+		_ = r.Reporter.Errorf("Failed to flush output: %v", err)
+		os.Exit(1)
+	}
 }
 
 func filterByClusterArch(domains []*v1.DNSDomain, arch v1.ClusterArchitecture) []*v1.DNSDomain {

--- a/cmd/list/machinepool/cmd.go
+++ b/cmd/list/machinepool/cmd.go
@@ -87,6 +87,7 @@ func NewListMachinePoolCommand() *cobra.Command {
 	)
 
 	output.AddFlag(cmd)
+	output.AddHideEmptyColumnsFlag(cmd)
 	ocm.AddClusterFlag(cmd)
 	return cmd
 }

--- a/cmd/list/upgrade/cmd.go
+++ b/cmd/list/upgrade/cmd.go
@@ -61,6 +61,7 @@ func init() {
 
 	confirm.AddFlag(flags)
 	output.AddFlag(Cmd)
+	output.AddHideEmptyColumnsFlag(Cmd)
 }
 
 func run(cmd *cobra.Command, _ []string) {
@@ -155,9 +156,8 @@ func runWithRuntime(r *rosa.Runtime, _ *cobra.Command) error {
 		}
 	}
 
-	// Create the writer that will be used to print the tabulated results:
-	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintf(writer, "VERSION\tNOTES\n")
+	headers := []string{"VERSION", "NOTES"}
+	var tableData [][]string
 	for i, availableUpgrade := range availableUpgrades {
 		notes := make([]string, 0)
 		if i == 0 || availableUpgrade == latestRev {
@@ -181,9 +181,26 @@ func runWithRuntime(r *rosa.Runtime, _ *cobra.Command) error {
 				}
 			}
 		}
-		fmt.Fprintf(writer, "%s\t%s\n", availableUpgrade, strings.Join(notes, " - "))
+
+		row := []string{
+			availableUpgrade,
+			strings.Join(notes, " - "),
+		}
+		tableData = append(tableData, row)
 	}
-	writer.Flush()
+
+	if output.ShouldHideEmptyColumns() {
+		tableData = output.RemoveEmptyColumns(headers, tableData)
+	} else {
+		tableData = append([][]string{headers}, tableData...)
+	}
+
+	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	output.BuildTable(writer, "\t", tableData)
+
+	if err := writer.Flush(); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/cmd/rosa/structure_test/command_args/rosa/list/access-request/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/list/access-request/command_args.yml
@@ -1,4 +1,5 @@
 - name: cluster
+- name: hide-empty-columns
 - name: output
 - name: profile
 - name: region

--- a/cmd/rosa/structure_test/command_args/rosa/list/account-roles/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/list/account-roles/command_args.yml
@@ -1,4 +1,5 @@
 - name: version
 - name: output
+- name: hide-empty-columns
 - name: profile
 - name: region

--- a/cmd/rosa/structure_test/command_args/rosa/list/addons/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/list/addons/command_args.yml
@@ -1,4 +1,5 @@
 - name: cluster
+- name: hide-empty-columns
 - name: output
 - name: profile
 - name: region

--- a/cmd/rosa/structure_test/command_args/rosa/list/break-glass-credentials/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/list/break-glass-credentials/command_args.yml
@@ -1,4 +1,5 @@
 - name: cluster
+- name: hide-empty-columns
 - name: output
 - name: profile
 - name: region

--- a/cmd/rosa/structure_test/command_args/rosa/list/clusters/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/list/clusters/command_args.yml
@@ -1,5 +1,6 @@
 - name: output
 - name: all
 - name: account-role-arn
+- name: hide-empty-columns
 - name: profile
 - name: region

--- a/cmd/rosa/structure_test/command_args/rosa/list/dns-domain/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/list/dns-domain/command_args.yml
@@ -1,4 +1,5 @@
 - name: all
+- name: hide-empty-columns
 - name: hosted-cp
 - name: output
 - name: profile

--- a/cmd/rosa/structure_test/command_args/rosa/list/gates/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/list/gates/command_args.yml
@@ -1,5 +1,6 @@
 - name: cluster
 - name: gate
+- name: hide-empty-columns
 - name: output
 - name: profile
 - name: region

--- a/cmd/rosa/structure_test/command_args/rosa/list/iamserviceaccounts/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/list/iamserviceaccounts/command_args.yml
@@ -1,4 +1,5 @@
 - name: cluster
+- name: hide-empty-columns
 - name: namespace
 - name: output
 - name: profile

--- a/cmd/rosa/structure_test/command_args/rosa/list/idps/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/list/idps/command_args.yml
@@ -1,4 +1,5 @@
 - name: cluster
+- name: hide-empty-columns
 - name: output
 - name: profile
 - name: region

--- a/cmd/rosa/structure_test/command_args/rosa/list/ingresses/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/list/ingresses/command_args.yml
@@ -1,4 +1,5 @@
 - name: cluster
+- name: hide-empty-columns
 - name: output
 - name: profile
 - name: region

--- a/cmd/rosa/structure_test/command_args/rosa/list/machinepools/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/list/machinepools/command_args.yml
@@ -6,3 +6,4 @@
 - name: profile
 - name: region
 - name: win-li
+- name: hide-empty-columns

--- a/cmd/rosa/structure_test/command_args/rosa/list/managed-services/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/list/managed-services/command_args.yml
@@ -1,3 +1,4 @@
 - name: output
+- name: hide-empty-columns
 - name: profile
 - name: region

--- a/cmd/rosa/structure_test/command_args/rosa/list/ocm-roles/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/list/ocm-roles/command_args.yml
@@ -1,3 +1,4 @@
+- name: hide-empty-columns
 - name: output
 - name: profile
 - name: region

--- a/cmd/rosa/structure_test/command_args/rosa/list/oidc-config/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/list/oidc-config/command_args.yml
@@ -1,3 +1,4 @@
+- name: hide-empty-columns
 - name: output
 - name: profile
 - name: region

--- a/cmd/rosa/structure_test/command_args/rosa/list/operator-roles/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/list/operator-roles/command_args.yml
@@ -3,5 +3,6 @@
 - name: interactive
 - name: cluster
 - name: output
+- name: hide-empty-columns
 - name: profile
 - name: region

--- a/cmd/rosa/structure_test/command_args/rosa/list/regions/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/list/regions/command_args.yml
@@ -1,4 +1,5 @@
 - name: external-id
+- name: hide-empty-columns
 - name: hosted-cp
 - name: multi-az
 - name: output

--- a/cmd/rosa/structure_test/command_args/rosa/list/upgrades/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/list/upgrades/command_args.yml
@@ -2,5 +2,6 @@
 - name: machinepool
 - name: "yes"
 - name: output
+- name: hide-empty-columns
 - name: profile
 - name: region

--- a/pkg/machinepool/machinepool.go
+++ b/pkg/machinepool/machinepool.go
@@ -1031,9 +1031,16 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 	return nil
 }
 
-// ListMachinePools lists all machinepools (or, nodepools if hypershift) in a cluster
+// createSeparators creates a separator array with single tabs for each column
+func createSeparators(count int) []string {
+	separators := make([]string, count)
+	for i := range separators {
+		separators[i] = "\t"
+	}
+	return separators
+}
+
 func (m *machinePool) ListMachinePools(r *rosa.Runtime, clusterKey string, cluster *cmv1.Cluster, args ListMachinePoolArgs) error {
-	// Load any existing machine pools for this cluster
 	r.Reporter.Debugf("Loading machine pools for cluster '%s'", clusterKey)
 	isHypershift := cluster.Hypershift().Enabled()
 	var err error
@@ -1058,19 +1065,49 @@ func (m *machinePool) ListMachinePools(r *rosa.Runtime, clusterKey string, clust
 		return output.Print(machinePools)
 	}
 
-	// Create the writer that will be used to print the tabulated results:
 	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 
-	finalStringToOutput := getMachinePoolsString(r, machinePools, args)
+	var headers []string
+	var tableData [][]string
+
 	if isHypershift {
-		finalStringToOutput = getNodePoolsString(nodePools)
+		headers, tableData = getNodePoolsData(nodePools)
+	} else {
+		headers, tableData = getMachinePoolsData(r, machinePools, args)
 	}
-	fmt.Fprint(writer, finalStringToOutput)
-	writer.Flush()
+
+	var separators []string
+
+	if output.ShouldHideEmptyColumns() {
+		if !isHypershift {
+			specialColumns := make(map[int]bool)
+			for i, header := range headers {
+				if (header == "AZ TYPE" && (args.ShowAZType || args.ShowAll)) ||
+					(header == "WIN-LI ENABLED" && (args.ShowWindowsLI || args.ShowAll)) ||
+					(header == "DEDICATED HOST" && (args.ShowDedicated || args.ShowAll)) {
+					specialColumns[i] = true
+				}
+			}
+			headers, tableData = output.FilterColumnsWithConditions(headers, tableData, specialColumns)
+			tableData = append([][]string{headers}, tableData...)
+			separators = createSeparators(len(headers))
+		} else {
+			separators = createSeparators(len(headers))
+			tableData, separators = output.RemoveEmptyColumnsWithSeparators(headers, tableData, separators)
+		}
+	} else {
+		tableData = append([][]string{headers}, tableData...)
+		separators = createSeparators(len(headers))
+	}
+
+	output.BuildTableWithSeparators(writer, separators, tableData)
+
+	if err := writer.Flush(); err != nil {
+		return err
+	}
 	return nil
 }
 
-// DescribeMachinePool describes either a machinepool, or, a nodepool (if hypershift)
 func (m *machinePool) DescribeMachinePool(r *rosa.Runtime, cluster *cmv1.Cluster, clusterKey string,
 	machinePoolId string) error {
 	if cluster.Hypershift().Enabled() {
@@ -1235,11 +1272,11 @@ func appendUpgradesIfExist(scheduledUpgrade *cmv1.NodePoolUpgradePolicy, output 
 	return output
 }
 
-func getMachinePoolsString(
+func getMachinePoolsData(
 	runtime *rosa.Runtime,
 	machinePools []*cmv1.MachinePool,
 	args ListMachinePoolArgs,
-) string {
+) ([]string, [][]string) {
 	type columnDefinition struct {
 		header      string
 		isVisible   bool
@@ -1267,63 +1304,41 @@ func getMachinePoolsString(
 		{"DEDICATED HOST", args.ShowDedicated || args.ShowAll, func(mp *cmv1.MachinePool) string { return isDedicatedHost(mp, runtime) }},
 	}
 
-	var visibleColumnHeaders []string
-	var visibleColumnData [][]string
-	numPools := len(machinePools)
-
+	var headers []string
+	var tableData [][]string
 	for _, column := range allColumnDefinitions {
-		if !column.isVisible {
-			continue
+		if column.isVisible {
+			headers = append(headers, column.header)
 		}
+	}
 
-		columnValues := make([]string, numPools)
-		hasNonEmptyValue := false
-
-		for i, pool := range machinePools {
-			if pool == nil {
-				columnValues[i] = "-"
+	for _, pool := range machinePools {
+		var row []string
+		for _, column := range allColumnDefinitions {
+			if !column.isVisible {
 				continue
 			}
 
-			value := column.extractData(pool)
-			columnValues[i] = value
-			if value != "" && value != "-" {
-				hasNonEmptyValue = true
+			if pool == nil {
+				row = append(row, "")
+			} else {
+				value := column.extractData(pool)
+				row = append(row, value)
 			}
 		}
-
-		if args.ShowAll || hasNonEmptyValue || numPools == 0 {
-			visibleColumnHeaders = append(visibleColumnHeaders, column.header)
-			visibleColumnData = append(visibleColumnData, columnValues)
-		}
+		tableData = append(tableData, row)
 	}
 
-	var tableBuilder strings.Builder
-
-	// Write header
-	if len(visibleColumnHeaders) > 0 {
-		tableBuilder.WriteString(strings.Join(visibleColumnHeaders, "\t") + "\n")
-	}
-
-	// Write data rows
-	for rowIndex := range numPools {
-		for colIndex, columnValues := range visibleColumnData {
-			if colIndex > 0 {
-				tableBuilder.WriteString("\t")
-			}
-			tableBuilder.WriteString(columnValues[rowIndex])
-		}
-		tableBuilder.WriteString("\n")
-	}
-
-	return tableBuilder.String()
+	return headers, tableData
 }
 
-func getNodePoolsString(nodePools []*cmv1.NodePool) string {
-	outputString := "ID\tAUTOSCALING\tREPLICAS\t" +
-		"INSTANCE TYPE\tLABELS\t\tTAINTS\t\tAVAILABILITY ZONE\tSUBNET\tDISK SIZE\tVERSION\tAUTOREPAIR\t\n"
+func getNodePoolsData(nodePools []*cmv1.NodePool) ([]string, [][]string) {
+	headers := []string{"ID", "AUTOSCALING", "REPLICAS", "INSTANCE TYPE", "LABELS", "TAINTS",
+		"AVAILABILITY ZONE", "SUBNET", "DISK SIZE", "VERSION", "AUTOREPAIR"}
+
+	var tableData [][]string
 	for _, nodePool := range nodePools {
-		outputString += fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t\t%s\t\t%s\t%s\t%s\t%s\t%s\t\n",
+		row := []string{
 			nodePool.ID(),
 			ocmOutput.PrintNodePoolAutoscaling(nodePool.Autoscaling()),
 			ocmOutput.PrintNodePoolReplicasShort(
@@ -1338,9 +1353,11 @@ func getNodePoolsString(nodePools []*cmv1.NodePool) string {
 			ocmOutput.PrintNodePoolDiskSize(nodePool.AWSNodePool()),
 			ocmOutput.PrintNodePoolVersion(nodePool.Version()),
 			ocmOutput.PrintNodePoolAutorepair(nodePool.AutoRepair()),
-		)
+		}
+		tableData = append(tableData, row)
 	}
-	return outputString
+
+	return headers, tableData
 }
 
 func (m *machinePool) EditMachinePool(cmd *cobra.Command, machinePoolId string, clusterKey string,

--- a/pkg/output/hide_empty_columns.go
+++ b/pkg/output/hide_empty_columns.go
@@ -1,0 +1,18 @@
+package output
+
+import "github.com/spf13/cobra"
+
+var hideEmptyColumnsFlag bool = false
+
+func AddHideEmptyColumnsFlag(cmd *cobra.Command) {
+	cmd.PersistentFlags().BoolVar(
+		&hideEmptyColumnsFlag,
+		"hide-empty-columns",
+		false,
+		"Hide columns that contain no data",
+	)
+}
+
+func ShouldHideEmptyColumns() bool {
+	return hideEmptyColumnsFlag
+}

--- a/pkg/output/table_filter.go
+++ b/pkg/output/table_filter.go
@@ -1,0 +1,185 @@
+package output
+
+import (
+	"fmt"
+	"strings"
+	"text/tabwriter"
+)
+
+func CheckIfColumnIsEmpty(columnIdx int, tableData [][]string) bool {
+	for _, row := range tableData {
+		if columnIdx < len(row) && row[columnIdx] != "" {
+			return false
+		}
+	}
+	return true
+}
+
+func RemoveEmptyColumns(headers []string, tableData [][]string) [][]string {
+	if len(tableData) == 0 {
+		return [][]string{headers}
+	}
+
+	var newHeaders []string
+	var columnsToKeep []int
+
+	// Keep only non-empty columns
+	for i, header := range headers {
+		if !CheckIfColumnIsEmpty(i, tableData) {
+			newHeaders = append(newHeaders, header)
+			columnsToKeep = append(columnsToKeep, i)
+		}
+	}
+
+	// Build filtered table data
+	var newTableData [][]string
+	for _, row := range tableData {
+		var newRow []string
+		for _, col := range columnsToKeep {
+			if col < len(row) {
+				newRow = append(newRow, row[col])
+			} else {
+				newRow = append(newRow, "")
+			}
+		}
+		newTableData = append(newTableData, newRow)
+	}
+
+	// Combine headers and data as before for backward compatibility
+	var result [][]string
+	result = append(result, newHeaders)
+	result = append(result, newTableData...)
+
+	return result
+}
+
+func FilterColumnsWithConditions(headers []string, tableData [][]string, preserveColumn map[int]bool) ([]string, [][]string) {
+	var newHeaders []string
+	var columnsToKeep []int
+
+	// Keep column if it's marked to be preserved OR if it has data
+	for i, header := range headers {
+		if preserveColumn[i] || !CheckIfColumnIsEmpty(i, tableData) {
+			newHeaders = append(newHeaders, header)
+			columnsToKeep = append(columnsToKeep, i)
+		}
+	}
+
+	// Build filtered table data
+	var newTableData [][]string
+	for _, row := range tableData {
+		var newRow []string
+		for _, col := range columnsToKeep {
+			if col < len(row) {
+				newRow = append(newRow, row[col])
+			} else {
+				newRow = append(newRow, "")
+			}
+		}
+		newTableData = append(newTableData, newRow)
+	}
+
+	return newHeaders, newTableData
+}
+
+// RemoveEmptyColumnsWithSeparators removes empty columns and filters the separators list accordingly
+func RemoveEmptyColumnsWithSeparators(headers []string, tableData [][]string, separators []string) ([][]string, []string) {
+	if len(tableData) == 0 {
+		return [][]string{headers}, separators
+	}
+
+	var newHeaders []string
+	var newSeparators []string
+	var columnsToKeep []int
+
+	for i, header := range headers {
+		if !CheckIfColumnIsEmpty(i, tableData) {
+			newHeaders = append(newHeaders, header)
+			columnsToKeep = append(columnsToKeep, i)
+			if i < len(separators) {
+				newSeparators = append(newSeparators, separators[i])
+			}
+		}
+	}
+
+	var result [][]string
+	result = append(result, newHeaders)
+
+	for _, row := range tableData {
+		var newRow []string
+		for _, col := range columnsToKeep {
+			if col < len(row) {
+				newRow = append(newRow, row[col])
+			} else {
+				newRow = append(newRow, "")
+			}
+		}
+		result = append(result, newRow)
+	}
+
+	return result, newSeparators
+}
+
+func BuildTable(writer *tabwriter.Writer, separator string, tableData [][]string) {
+	// Build separators list from separator specification
+	if len(tableData) == 0 {
+		return
+	}
+
+	maxCols := 0
+	for _, row := range tableData {
+		if len(row) > maxCols {
+			maxCols = len(row)
+		}
+	}
+
+	var separators []string
+
+	if strings.Contains(separator, ",") {
+		// Multiple separators specified
+		separators = strings.Split(separator, ",")
+		// If fewer separators than columns, pad with the last separator (or tab if empty)
+		if len(separators) < maxCols {
+			padSeparator := "\t"
+			if len(separators) > 0 && separators[len(separators)-1] != "" {
+				padSeparator = separators[len(separators)-1]
+			}
+			for len(separators) < maxCols {
+				separators = append(separators, padSeparator)
+			}
+		}
+	} else {
+		// Single separator - duplicate for all columns (backward compatible)
+		separators = make([]string, maxCols)
+		for i := range separators {
+			separators[i] = separator
+		}
+	}
+
+	BuildTableWithSeparators(writer, separators, tableData)
+}
+
+// BuildTableWithSeparators writes table data using a list of separators
+func BuildTableWithSeparators(writer *tabwriter.Writer, separators []string, tableData [][]string) {
+	var output string
+
+	for _, row := range tableData {
+		for colIdx, col := range row {
+			output += col
+			// Add separator after column if not the last column
+			if colIdx < len(row)-1 {
+				// Use the separator at this index if available, otherwise use tab as default
+				if colIdx < len(separators) {
+					output += separators[colIdx]
+				} else {
+					output += "\t"
+				}
+			}
+		}
+
+		// Add newline after each row
+		output += "\n"
+	}
+
+	fmt.Fprint(writer, output)
+}

--- a/pkg/output/table_filter_test.go
+++ b/pkg/output/table_filter_test.go
@@ -1,0 +1,188 @@
+package output
+
+import (
+	"bytes"
+	"strings"
+	"text/tabwriter"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Table Filter", func() {
+	Describe("BuildTableWithSeparators", func() {
+		var (
+			buffer *bytes.Buffer
+			writer *tabwriter.Writer
+		)
+
+		BeforeEach(func() {
+			buffer = new(bytes.Buffer)
+			writer = tabwriter.NewWriter(buffer, 0, 0, 2, ' ', 0)
+		})
+
+		It("Handles normal table data correctly", func() {
+			tableData := [][]string{
+				{"ID", "NAME", "STATUS"},
+				{"1", "Alice", "Active"},
+				{"2", "Bob", "Pending"},
+			}
+			separators := []string{"\t", "\t", "\t"}
+
+			BuildTableWithSeparators(writer, separators, tableData)
+			writer.Flush()
+
+			output := buffer.String()
+			Expect(output).To(ContainSubstring("ID"))
+			Expect(output).To(ContainSubstring("NAME"))
+			Expect(output).To(ContainSubstring("STATUS"))
+			Expect(output).To(ContainSubstring("Alice"))
+			Expect(output).To(ContainSubstring("Active"))
+			Expect(output).To(ContainSubstring("Bob"))
+			Expect(output).To(ContainSubstring("Pending"))
+		})
+
+		It("Handles empty tableData without errors", func() {
+			tableData := [][]string{}
+			separators := []string{"\t"}
+
+			BuildTableWithSeparators(writer, separators, tableData)
+			writer.Flush()
+
+			output := buffer.String()
+			Expect(output).To(Equal(""))
+		})
+
+		It("Handles single column data", func() {
+			tableData := [][]string{
+				{"HEADER"},
+				{"Value1"},
+				{"Value2"},
+			}
+			separators := []string{"\t"}
+
+			BuildTableWithSeparators(writer, separators, tableData)
+			writer.Flush()
+
+			output := buffer.String()
+			lines := strings.Split(strings.TrimSpace(output), "\n")
+			Expect(len(lines)).To(Equal(3))
+			Expect(lines[0]).To(Equal("HEADER"))
+			Expect(lines[1]).To(Equal("Value1"))
+			Expect(lines[2]).To(Equal("Value2"))
+		})
+
+		It("Handles rows with varying column counts", func() {
+			tableData := [][]string{
+				{"A", "B", "C"},
+				{"1"},
+				{"2", "3"},
+			}
+			separators := []string{"\t", "\t", "\t"}
+
+			BuildTableWithSeparators(writer, separators, tableData)
+			writer.Flush()
+
+			output := buffer.String()
+			lines := strings.Split(strings.TrimSpace(output), "\n")
+			Expect(len(lines)).To(Equal(3))
+		})
+
+		It("Handles empty strings in cells correctly", func() {
+			tableData := [][]string{
+				{"ID", "NAME", "STATUS"},
+				{"1", "", "Active"},
+				{"", "Bob", ""},
+			}
+			separators := []string{"\t", "\t", "\t"}
+
+			BuildTableWithSeparators(writer, separators, tableData)
+			writer.Flush()
+
+			output := buffer.String()
+			lines := strings.Split(strings.TrimSpace(output), "\n")
+			Expect(len(lines)).To(Equal(3))
+			Expect(output).To(ContainSubstring("ID"))
+			Expect(output).To(ContainSubstring("NAME"))
+			Expect(output).To(ContainSubstring("STATUS"))
+			Expect(output).To(ContainSubstring("Active"))
+			Expect(output).To(ContainSubstring("Bob"))
+		})
+	})
+
+	Describe("RemoveEmptyColumns", func() {
+		It("Removes columns that are entirely empty", func() {
+			headers := []string{"ID", "NAME", "EMPTY", "STATUS"}
+			tableData := [][]string{
+				{"1", "Alice", "", "Active"},
+				{"2", "Bob", "", "Pending"},
+			}
+
+			result := RemoveEmptyColumns(headers, tableData)
+
+			Expect(len(result)).To(Equal(3)) // headers + 2 data rows
+			Expect(result[0]).To(Equal([]string{"ID", "NAME", "STATUS"}))
+			Expect(result[1]).To(Equal([]string{"1", "Alice", "Active"}))
+			Expect(result[2]).To(Equal([]string{"2", "Bob", "Pending"}))
+		})
+
+		It("Handles empty tableData by returning just headers", func() {
+			headers := []string{"ID", "NAME", "STATUS"}
+			tableData := [][]string{}
+
+			result := RemoveEmptyColumns(headers, tableData)
+
+			Expect(len(result)).To(Equal(1))
+			Expect(result[0]).To(Equal(headers))
+		})
+
+		It("Keeps all columns if none are empty", func() {
+			headers := []string{"ID", "NAME", "STATUS"}
+			tableData := [][]string{
+				{"1", "Alice", "Active"},
+				{"2", "Bob", "Pending"},
+			}
+
+			result := RemoveEmptyColumns(headers, tableData)
+
+			Expect(len(result)).To(Equal(3))
+			Expect(result[0]).To(Equal(headers))
+			Expect(result[1]).To(Equal([]string{"1", "Alice", "Active"}))
+			Expect(result[2]).To(Equal([]string{"2", "Bob", "Pending"}))
+		})
+	})
+
+	Describe("FilterColumnsWithConditions", func() {
+		It("Preserves specified columns even if empty", func() {
+			headers := []string{"ID", "NAME", "EMPTY1", "STATUS", "EMPTY2"}
+			tableData := [][]string{
+				{"1", "Alice", "", "Active", ""},
+				{"2", "Bob", "", "Pending", ""},
+			}
+			preserveColumn := map[int]bool{
+				2: true, // Preserve EMPTY1 column even if empty
+			}
+
+			resultHeaders, resultData := FilterColumnsWithConditions(headers, tableData, preserveColumn)
+
+			Expect(resultHeaders).To(Equal([]string{"ID", "NAME", "EMPTY1", "STATUS"}))
+			Expect(len(resultData)).To(Equal(2))
+			Expect(resultData[0]).To(Equal([]string{"1", "Alice", "", "Active"}))
+			Expect(resultData[1]).To(Equal([]string{"2", "Bob", "", "Pending"}))
+		})
+
+		It("Keeps non-empty columns regardless of preserve flag", func() {
+			headers := []string{"ID", "NAME", "STATUS"}
+			tableData := [][]string{
+				{"1", "Alice", "Active"},
+				{"2", "Bob", "Pending"},
+			}
+			preserveColumn := map[int]bool{} // No columns explicitly preserved
+
+			resultHeaders, resultData := FilterColumnsWithConditions(headers, tableData, preserveColumn)
+
+			Expect(resultHeaders).To(Equal([]string{"ID", "NAME", "STATUS"}))
+			Expect(len(resultData)).To(Equal(2))
+		})
+	})
+})


### PR DESCRIPTION
# Details

This PR improves the UX when listing resources by introducing a new `--hide-empty-columns` flag that automatically hides columns containing no data across all rows, making the output cleaner and more readable.

The flag has been added to the following `rosa list` commands:
- accessrequests
- accountroles
- addon
- breakglasscredential
- cluster
- dnsdomains
- gates
- iamserviceaccounts
- idp
- ingress
- instancetypes
- ocmroles
- oidcconfig
- operatorroles
- region
- service
- upgrade

**Note:** The following commands do NOT have this flag:
- `list machinepools` - Already has built-in auto-hide empty columns logic
- `list version`, `list userroles`, `list user`, `list rhRegion`, `list tuningconfigs`, `list oidcprovider`, `list kubeletconfig`, `list externalauthprovider` - These maintain their original behavior

---

## Default Behavior (All Columns Shown)

1. Run any supported list command without the flag:

    ```bash
    ./rosa list clusters
    ```

2. You should see **all columns** displayed, including empty ones:

    ```
    ID          NAME        STATE  TOPOLOGY  REGION      PROVIDER  VERSION
    1a2b3c4d    my-cluster  ready            us-east-1   aws       4.14.0
    5e6f7g8h    test-rosa   ready            us-west-2   aws       4.13.5
    ```

---

## Using --hide-empty-columns Flag

1. Run the same command with the flag:

    ```bash
    ./rosa list clusters --hide-empty-columns
    ```

2. Empty columns (like TOPOLOGY in this example) should be **automatically hidden**:

    ```
    ID          NAME        STATE  REGION      PROVIDER  VERSION
    1a2b3c4d    my-cluster  ready  us-east-1   aws       4.14.0
    5e6f7g8h    test-rosa   ready  us-west-2   aws       4.13.5
    ```

---
## New behavior of the '--all' 

1. The `--all` flag shows the 3 additional columns (AZ TYPE, WIN-LI ENABLED, DEDICATED HOST) but still hides empty columns:

    ```bash
    ./rosa list machinepools --cluster <cluster-name> --all
    ```

    Example output:
    ```
    ID       AUTOSCALING  REPLICAS  INSTANCE TYPE  SPOT INSTANCES  DISK SIZE  AZ TYPE   WIN-LI ENABLED  DEDICATED HOST
    workers  No           3         m5.xlarge      No              default    Standard  No              No
    ```

---

# Ticket

Closes [[OCM-1520](https://issues.redhat.com/browse/OCM-1520)]
