### PR TITLE
OCM-17223 | fix: Exclude public subnets for privatelink classic

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2257,7 +2257,7 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 
 		var excludedPublicSubnets []string
-		if privateLink && privateIngress {
+		if (isHostedCP && private && privateIngress) || (!isHostedCP && privateLink) {
 			subnets, excludedPublicSubnets = filterPrivateSubnets(subnets, r)
 		}
 


### PR DESCRIPTION
Excludes public subnets when creating a private link classic cluster (regression from private API changes for HCP)