### PR TITLE
OCM-17858 | fix: Allow nodepool creation without capacity reservation id

### DIFF
--- a/pkg/machinepool/machinepool.go
+++ b/pkg/machinepool/machinepool.go
@@ -773,9 +773,6 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 			Help:     cmd.Flags().Lookup("capacity-reservation-id").Usage,
 			Default:  capacityReservationId,
 			Required: false,
-			Validators: []interactive.Validator{
-				machinepools.ValidateNodeDrainGracePeriod,
-			},
 		})
 		if err != nil {
 			return fmt.Errorf("Expected a valid value for Capacity Reservation ID: %s", err)
@@ -900,13 +897,19 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 		}
 	}
 
-	npBuilder.AWSNodePool(createAwsNodePoolBuilder(
+	awsNodepoolBuilder := createAwsNodePoolBuilder(
 		instanceType,
 		securityGroupIds,
 		httpTokens,
 		awsTags,
 		rootDiskSize,
-	).CapacityReservation(capacityReservation))
+	)
+
+	if capacityReservationId != "" {
+		awsNodepoolBuilder = awsNodepoolBuilder.CapacityReservation(capacityReservation)
+	}
+
+	npBuilder.AWSNodePool(awsNodepoolBuilder)
 
 	nodeDrainGracePeriod := args.NodeDrainGracePeriod
 	if interactive.Enabled() {


### PR DESCRIPTION
Fixes a bug where an empty capacity reservation ID was passed into the API, causing a nil value error

Also fixes a future bug (not found yet) with a validator being leftover from a copied interactive prompt block (whoops)