### PR TITLE
OCM-17895 | fix: Do not prompt for capacity reservation ID if autoscaling=t

### DIFF
--- a/pkg/machinepool/machinepool.go
+++ b/pkg/machinepool/machinepool.go
@@ -767,7 +767,7 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 	// Capacity reservation ID
 	capacityReservationId := args.CapacityReservationId
 
-	if interactive.Enabled() {
+	if interactive.Enabled() && !autoscaling {
 		capacityReservationId, err = interactive.GetString(interactive.Input{
 			Question: "Capacity Reservation ID",
 			Help:     cmd.Flags().Lookup("capacity-reservation-id").Usage,


### PR DESCRIPTION
```
E: Failed to add machine pool to hosted cluster '2ktf5ln6lmllejp5p8orf40o84u5mop8': status is 400, identifier is '400', code is 'CLUSTERS-MGMT-400', at '2025-08-26T08:33:20Z' and operation identifier is 'd001cc2f-78e2-423f-b750-96c56284db20': Replicas must be specified when using AWS Capacity Reservations
```

This error happens when replying `yes` to the `Enable autoscaling` prompt and supplying a value for the `Capacity Reservation ID` prompt. This is needless, letting the user get through the entire creation of a node pool only to tell them we allowed them to put in conflicting values in interactive mode. This MR makes the prompt for `Capacity Reservation ID` no longer show when the nodepool's `autoscaling` is set to `true`