### PR TITLE
OCM-17876 | feat: IDMS support for ROSA-HCP

### DIFF
--- a/cmd/create/cmd.go
+++ b/cmd/create/cmd.go
@@ -29,6 +29,7 @@ import (
 	"github.com/openshift/rosa/cmd/create/externalauthprovider"
 	"github.com/openshift/rosa/cmd/create/iamserviceaccount"
 	"github.com/openshift/rosa/cmd/create/idp"
+	"github.com/openshift/rosa/cmd/create/imagemirror"
 	"github.com/openshift/rosa/cmd/create/kubeletconfig"
 	"github.com/openshift/rosa/cmd/create/machinepool"
 	"github.com/openshift/rosa/cmd/create/network"
@@ -71,6 +72,8 @@ func init() {
 	Cmd.AddCommand(autoscalerCommand)
 	kubeletConfig := kubeletconfig.NewCreateKubeletConfigCommand()
 	Cmd.AddCommand(kubeletConfig)
+	imageMirrorCommand := imagemirror.NewCreateImageMirrorCommand()
+	Cmd.AddCommand(imageMirrorCommand)
 	Cmd.AddCommand(externalauthprovider.Cmd)
 	Cmd.AddCommand(breakglasscredential.Cmd)
 	decisionCommand := decision.NewCreateDecisionCommand()

--- a/cmd/create/imagemirror/cmd.go
+++ b/cmd/create/imagemirror/cmd.go
@@ -1,0 +1,127 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package imagemirror
+
+import (
+	"context"
+	"fmt"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/arguments"
+	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+const (
+	use     = "image-mirror"
+	short   = "Create image mirror for a cluster"
+	long    = "Create an image mirror configuration for a Hosted Control Plane cluster. The image mirror ID will be auto-generated."
+	example = `  # Create an image mirror for cluster "mycluster"
+  rosa create image-mirror --cluster=mycluster \
+    --source=registry.example.com/team \
+    --mirrors=mirror.corp.com/team,backup.corp.com/team
+
+  # Create with a specific type (digest is default and only supported type)
+  rosa create image-mirror --cluster=mycluster \
+    --type=digest --source=docker.io/library \
+    --mirrors=internal-registry.company.com/dockerhub`
+)
+
+var (
+	aliases = []string{"image-mirrors"}
+)
+
+func NewCreateImageMirrorCommand() *cobra.Command {
+	options := NewCreateImageMirrorOptions()
+	cmd := &cobra.Command{
+		Use:     use,
+		Short:   short,
+		Long:    long,
+		Aliases: aliases,
+		Example: example,
+		Args:    cobra.NoArgs,
+		Run:     rosa.DefaultRunner(rosa.RuntimeWithOCM(), CreateImageMirrorRunner(options)),
+	}
+
+	flags := cmd.Flags()
+
+	flags.StringVar(
+		&options.Args().Type,
+		"type",
+		"digest",
+		"Type of image mirror (default: digest)",
+	)
+
+	flags.StringVar(
+		&options.Args().Source,
+		"source",
+		"",
+		"Source registry that will be mirrored (required)",
+	)
+
+	flags.StringSliceVar(
+		&options.Args().Mirrors,
+		"mirrors",
+		[]string{},
+		"List of mirror registries (comma-separated, required)",
+	)
+
+	_ = cmd.MarkFlagRequired("source")
+	_ = cmd.MarkFlagRequired("mirrors")
+
+	ocm.AddClusterFlag(cmd)
+	arguments.AddProfileFlag(cmd.Flags())
+	arguments.AddRegionFlag(cmd.Flags())
+	return cmd
+}
+
+func CreateImageMirrorRunner(options *CreateImageMirrorOptions) rosa.CommandRunner {
+	return func(_ context.Context, runtime *rosa.Runtime, cmd *cobra.Command, _ []string) error {
+		clusterKey := runtime.GetClusterKey()
+		args := options.Args()
+
+		cluster, err := runtime.OCMClient.GetCluster(clusterKey, runtime.Creator)
+		if err != nil {
+			return err
+		}
+		if cluster.State() != cmv1.ClusterStateReady {
+			return fmt.Errorf("Cluster '%s' is not ready. Image mirrors can only be created on ready clusters", clusterKey)
+		}
+
+		if !cluster.Hypershift().Enabled() {
+			return fmt.Errorf("Image mirrors are only supported on Hosted Control Plane clusters")
+		}
+
+		if len(args.Mirrors) == 0 {
+			return fmt.Errorf("At least one mirror registry must be specified")
+		}
+
+		createdMirror, err := runtime.OCMClient.CreateImageMirror(
+			cluster.ID(), args.Type, args.Source, args.Mirrors)
+		if err != nil {
+			return fmt.Errorf("Failed to create image mirror: %v", err)
+		}
+		runtime.Reporter.Infof("Image mirror with ID '%s' has been created on cluster '%s'",
+			createdMirror.ID(), clusterKey)
+		runtime.Reporter.Infof("Source: %s", createdMirror.Source())
+		runtime.Reporter.Infof("Mirrors: %v", createdMirror.Mirrors())
+
+		return nil
+	}
+}

--- a/cmd/create/imagemirror/cmd_test.go
+++ b/cmd/create/imagemirror/cmd_test.go
@@ -1,0 +1,217 @@
+package imagemirror
+
+import (
+	"context"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+
+	"github.com/openshift/rosa/pkg/test"
+)
+
+const (
+	clusterId = "24vf9iitg3p6tlml88iml6j6mu095mh8"
+)
+
+var _ = Describe("Create image mirror", func() {
+	Context("Create image mirror command", func() {
+		mockHCPClusterReady := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+			c.AWS(cmv1.NewAWS().SubnetIDs("subnet-0b761d44d3d9a4663", "subnet-0f87f640e56934cbc"))
+			c.Region(cmv1.NewCloudRegion().ID("us-east-1"))
+			c.State(cmv1.ClusterStateReady)
+			c.Hypershift(cmv1.NewHypershift().Enabled(true))
+		})
+
+		mockClassicCluster := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+			c.AWS(cmv1.NewAWS().SubnetIDs("subnet-0b761d44d3d9a4663", "subnet-0f87f640e56934cbc"))
+			c.Region(cmv1.NewCloudRegion().ID("us-east-1"))
+			c.State(cmv1.ClusterStateReady)
+			c.Hypershift(cmv1.NewHypershift().Enabled(false))
+		})
+
+		mockClusterNotReady := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+			c.AWS(cmv1.NewAWS().SubnetIDs("subnet-0b761d44d3d9a4663", "subnet-0f87f640e56934cbc"))
+			c.Region(cmv1.NewCloudRegion().ID("us-east-1"))
+			c.State(cmv1.ClusterStateInstalling)
+			c.Hypershift(cmv1.NewHypershift().Enabled(true))
+		})
+
+		hcpClusterReady := test.FormatClusterList([]*cmv1.Cluster{mockHCPClusterReady})
+		classicClusterReady := test.FormatClusterList([]*cmv1.Cluster{mockClassicCluster})
+		clusterNotReady := test.FormatClusterList([]*cmv1.Cluster{mockClusterNotReady})
+
+		var t *test.TestingRuntime
+
+		BeforeEach(func() {
+			t = test.NewTestRuntime()
+		})
+
+		Context("Success scenarios", func() {
+			It("Creates image mirror successfully with all required parameters", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hcpClusterReady))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusCreated, formatCreatedImageMirror()))
+				options := NewCreateImageMirrorOptions()
+				options.Args().Source = "registry.redhat.io"
+				options.Args().Mirrors = []string{"mirror.example.com", "backup.example.com"}
+				runner := CreateImageMirrorRunner(options)
+				err := t.StdOutReader.Record()
+				Expect(err).ToNot(HaveOccurred())
+				cmd := NewCreateImageMirrorCommand()
+				err = cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).ToNot(HaveOccurred())
+				stdout, err := t.StdOutReader.Read()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stdout).To(ContainSubstring("Image mirror with ID 'test-mirror-123' has been created on cluster"))
+				Expect(stdout).To(ContainSubstring("Source: registry.redhat.io"))
+				Expect(stdout).To(ContainSubstring("Mirrors: [mirror.example.com backup.example.com]"))
+			})
+
+			It("Creates image mirror with custom type", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hcpClusterReady))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusCreated, formatCreatedImageMirror()))
+				options := NewCreateImageMirrorOptions()
+				options.Args().Type = "digest"
+				options.Args().Source = "quay.io/openshift"
+				options.Args().Mirrors = []string{"internal.corp.com/openshift"}
+				runner := CreateImageMirrorRunner(options)
+				cmd := NewCreateImageMirrorCommand()
+				err := cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("Creates image mirror with single mirror", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hcpClusterReady))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusCreated, formatCreatedImageMirror()))
+				options := NewCreateImageMirrorOptions()
+				options.Args().Source = "docker.io/library"
+				options.Args().Mirrors = []string{"mirror.company.com/dockerhub"}
+				runner := CreateImageMirrorRunner(options)
+				cmd := NewCreateImageMirrorCommand()
+				err := cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("Validation error scenarios", func() {
+			It("Returns error when cluster is not ready", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, clusterNotReady))
+				options := NewCreateImageMirrorOptions()
+				options.Args().Source = "registry.redhat.io"
+				options.Args().Mirrors = []string{"mirror.example.com"}
+				runner := CreateImageMirrorRunner(options)
+				cmd := NewCreateImageMirrorCommand()
+				err := cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("is not ready. Image mirrors can only be created on ready clusters"))
+			})
+
+			It("Returns error when cluster is not Hosted Control Plane", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, classicClusterReady))
+				options := NewCreateImageMirrorOptions()
+				options.Args().Source = "registry.redhat.io"
+				options.Args().Mirrors = []string{"mirror.example.com"}
+				runner := CreateImageMirrorRunner(options)
+				cmd := NewCreateImageMirrorCommand()
+				err := cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Image mirrors are only supported on Hosted Control Plane clusters"))
+			})
+
+			It("Returns error when cluster fetch fails", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusNotFound, "{}"))
+				options := NewCreateImageMirrorOptions()
+				options.Args().Source = "registry.redhat.io"
+				options.Args().Mirrors = []string{"mirror.example.com"}
+				runner := CreateImageMirrorRunner(options)
+				cmd := NewCreateImageMirrorCommand()
+				err := cmd.Flag("cluster").Value.Set("nonexistent-cluster")
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("status is 404"))
+			})
+
+			It("Returns error when CreateImageMirror API call fails", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hcpClusterReady))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusInternalServerError, "{}"))
+				options := NewCreateImageMirrorOptions()
+				options.Args().Source = "registry.redhat.io"
+				options.Args().Mirrors = []string{"mirror.example.com"}
+				runner := CreateImageMirrorRunner(options)
+				cmd := NewCreateImageMirrorCommand()
+				err := cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Failed to create image mirror"))
+			})
+		})
+
+		Context("Runtime validation", func() {
+			It("Returns error when mirrors array is empty", func() {
+				// Test the runtime validation that checks if mirrors slice is empty
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hcpClusterReady))
+				options := NewCreateImageMirrorOptions()
+				options.Args().Source = "registry.redhat.io"
+				options.Args().Mirrors = []string{} // Empty array
+				runner := CreateImageMirrorRunner(options)
+				cmd := NewCreateImageMirrorCommand()
+				err := cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("At least one mirror registry must be specified"))
+			})
+
+			It("Has default type as digest", func() {
+				cmd := NewCreateImageMirrorCommand()
+				typeFlag := cmd.Flag("type")
+				Expect(typeFlag.DefValue).To(Equal("digest"))
+			})
+		})
+
+		Context("Command structure", func() {
+			It("Has correct command properties", func() {
+				cmd := NewCreateImageMirrorCommand()
+				Expect(cmd.Use).To(Equal("image-mirror"))
+				Expect(cmd.Short).To(Equal("Create image mirror for a cluster"))
+				Expect(cmd.Aliases).To(ContainElement("image-mirrors"))
+				Expect(cmd.Args).ToNot(BeNil())
+			})
+
+			It("Has expected flags", func() {
+				cmd := NewCreateImageMirrorCommand()
+				flags := []string{"cluster", "type", "source", "mirrors", "profile", "region"}
+				for _, flagName := range flags {
+					flag := cmd.Flag(flagName)
+					Expect(flag).ToNot(BeNil(), "Flag %s should exist", flagName)
+				}
+			})
+		})
+	})
+})
+
+// formatCreatedImageMirror simulates the response from creating an image mirror
+func formatCreatedImageMirror() string {
+	imageMirror, err := cmv1.NewImageMirror().
+		ID("test-mirror-123").
+		Type("digest").
+		Source("registry.redhat.io").
+		Mirrors("mirror.example.com", "backup.example.com").
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+	return test.FormatResource(imageMirror)
+}

--- a/cmd/create/imagemirror/imagemirror_suite_test.go
+++ b/cmd/create/imagemirror/imagemirror_suite_test.go
@@ -1,0 +1,13 @@
+package imagemirror
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestImageMirror(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Create ImageMirror suite")
+}

--- a/cmd/create/imagemirror/options.go
+++ b/cmd/create/imagemirror/options.go
@@ -1,0 +1,51 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package imagemirror
+
+import (
+	"github.com/openshift/rosa/pkg/reporter"
+)
+
+type CreateImageMirrorUserOptions struct {
+	Type    string
+	Source  string
+	Mirrors []string
+}
+
+type CreateImageMirrorOptions struct {
+	reporter reporter.Logger
+	args     *CreateImageMirrorUserOptions
+}
+
+func NewCreateImageMirrorUserOptions() *CreateImageMirrorUserOptions {
+	return &CreateImageMirrorUserOptions{
+		Type:    "digest",
+		Source:  "",
+		Mirrors: []string{},
+	}
+}
+
+func NewCreateImageMirrorOptions() *CreateImageMirrorOptions {
+	return &CreateImageMirrorOptions{
+		reporter: reporter.CreateReporter(),
+		args:     NewCreateImageMirrorUserOptions(),
+	}
+}
+
+func (o *CreateImageMirrorOptions) Args() *CreateImageMirrorUserOptions {
+	return o.args
+}

--- a/cmd/create/imagemirror/options_test.go
+++ b/cmd/create/imagemirror/options_test.go
@@ -1,0 +1,59 @@
+package imagemirror
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/rosa/pkg/reporter"
+)
+
+var _ = Describe("CreateImageMirrorOptions", func() {
+	var (
+		imageMirrorOptions *CreateImageMirrorOptions
+		userOptions        *CreateImageMirrorUserOptions
+	)
+
+	BeforeEach(func() {
+		imageMirrorOptions = NewCreateImageMirrorOptions()
+		userOptions = NewCreateImageMirrorUserOptions()
+	})
+
+	Context("NewCreateImageMirrorUserOptions", func() {
+		It("should create default user options", func() {
+			Expect(userOptions.Type).To(Equal("digest"))
+			Expect(userOptions.Source).To(Equal(""))
+			Expect(userOptions.Mirrors).To(BeEmpty())
+		})
+	})
+
+	Context("NewCreateImageMirrorOptions", func() {
+		It("should create default image mirror options", func() {
+			Expect(imageMirrorOptions.reporter).To(BeAssignableToTypeOf(&reporter.Object{}))
+			Expect(imageMirrorOptions.args).To(BeAssignableToTypeOf(&CreateImageMirrorUserOptions{}))
+		})
+
+		It("should initialize args with default values", func() {
+			Expect(imageMirrorOptions.args.Type).To(Equal("digest"))
+			Expect(imageMirrorOptions.args.Source).To(Equal(""))
+			Expect(imageMirrorOptions.args.Mirrors).To(BeEmpty())
+		})
+	})
+
+	Context("Args", func() {
+		It("should return the args field", func() {
+			imageMirrorOptions.args = userOptions
+			Expect(imageMirrorOptions.Args()).To(Equal(userOptions))
+		})
+
+		It("should allow modification of args", func() {
+			args := imageMirrorOptions.Args()
+			args.Type = "tag"
+			args.Source = "registry.example.com/team"
+			args.Mirrors = []string{"mirror1.com", "mirror2.com"}
+
+			Expect(imageMirrorOptions.args.Type).To(Equal("tag"))
+			Expect(imageMirrorOptions.args.Source).To(Equal("registry.example.com/team"))
+			Expect(imageMirrorOptions.args.Mirrors).To(Equal([]string{"mirror1.com", "mirror2.com"}))
+		})
+	})
+})

--- a/cmd/dlt/cmd.go
+++ b/cmd/dlt/cmd.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openshift/rosa/cmd/dlt/externalauthprovider"
 	"github.com/openshift/rosa/cmd/dlt/iamserviceaccount"
 	"github.com/openshift/rosa/cmd/dlt/idp"
+	"github.com/openshift/rosa/cmd/dlt/imagemirror"
 	"github.com/openshift/rosa/cmd/dlt/ingress"
 	"github.com/openshift/rosa/cmd/dlt/kubeletconfig"
 	"github.com/openshift/rosa/cmd/dlt/machinepool"
@@ -72,6 +73,8 @@ func init() {
 	Cmd.AddCommand(autoscalerCommand)
 	kubeletconfig := kubeletconfig.NewDeleteKubeletConfigCommand()
 	Cmd.AddCommand(kubeletconfig)
+	imageMirrorCommand := imagemirror.NewDeleteImageMirrorCommand()
+	Cmd.AddCommand(imageMirrorCommand)
 	Cmd.AddCommand(externalauthprovider.Cmd)
 
 	flags := Cmd.PersistentFlags()
@@ -84,7 +87,7 @@ func init() {
 		userrole.Cmd, ocmrole.Cmd,
 		oidcprovider.Cmd, upgrade.Cmd, admin.Cmd,
 		service.Cmd, autoscalerCommand, iamserviceaccount.Cmd, idp.Cmd,
-		cluster.Cmd, dnsdomains.Cmd, externalauthprovider.Cmd,
+		imageMirrorCommand, cluster.Cmd, dnsdomains.Cmd, externalauthprovider.Cmd,
 		kubeletconfig, machinepoolCommand, tuningconfigs.Cmd,
 	}
 	arguments.MarkRegionDeprecated(Cmd, globallyAvailableCommands)

--- a/cmd/dlt/imagemirror/cmd.go
+++ b/cmd/dlt/imagemirror/cmd.go
@@ -1,0 +1,143 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package imagemirror
+
+import (
+	"context"
+	"fmt"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/arguments"
+	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+const (
+	use     = "image-mirror"
+	short   = "Delete image mirror from a cluster"
+	long    = "Delete an image mirror configuration from a Hosted Control Plane cluster by ID."
+	example = `  # Delete image mirror with ID "abc123" from cluster "mycluster"
+  rosa delete image-mirror --cluster=mycluster abc123
+
+  # Delete without confirmation prompt
+  rosa delete image-mirror --cluster=mycluster abc123 --yes
+
+  # Alternative: using the --id flag
+  rosa delete image-mirror --cluster=mycluster --id=abc123`
+)
+
+var (
+	aliases = []string{"image-mirrors"}
+)
+
+func NewDeleteImageMirrorCommand() *cobra.Command {
+	options := NewDeleteImageMirrorOptions()
+	cmd := &cobra.Command{
+		Use:     use,
+		Short:   short,
+		Long:    long,
+		Aliases: aliases,
+		Example: example,
+		Args:    cobra.MaximumNArgs(1),
+		Run:     rosa.DefaultRunner(rosa.RuntimeWithOCM(), DeleteImageMirrorRunner(options)),
+	}
+
+	flags := cmd.Flags()
+
+	flags.StringVar(
+		&options.Args().Id,
+		"id",
+		"",
+		"ID of the image mirror configuration to delete",
+	)
+
+	flags.BoolVarP(
+		&options.Args().Yes,
+		"yes",
+		"y",
+		false,
+		"Automatically answer yes to confirm deletion",
+	)
+
+	ocm.AddClusterFlag(cmd)
+	arguments.AddProfileFlag(cmd.Flags())
+	arguments.AddRegionFlag(cmd.Flags())
+	return cmd
+}
+
+func DeleteImageMirrorRunner(options *DeleteImageMirrorOptions) rosa.CommandRunner {
+	return func(_ context.Context, runtime *rosa.Runtime, cmd *cobra.Command, argv []string) error {
+		clusterKey := runtime.GetClusterKey()
+		args := options.Args()
+
+		// Get image mirror ID from positional argument or flag
+		if len(argv) == 1 && !cmd.Flag("id").Changed {
+			args.Id = argv[0]
+		}
+
+		if args.Id == "" {
+			return fmt.Errorf("Image mirror ID is required. Specify it as an argument or use the --id flag")
+		}
+
+		cluster, err := runtime.OCMClient.GetCluster(clusterKey, runtime.Creator)
+		if err != nil {
+			return err
+		}
+		if cluster.State() != cmv1.ClusterStateReady {
+			return fmt.Errorf("Cluster '%s' is not ready. Image mirrors can only be deleted on ready clusters", clusterKey)
+		}
+
+		if !cluster.Hypershift().Enabled() {
+			return fmt.Errorf("Image mirrors are only supported on Hosted Control Plane clusters")
+		}
+
+		// First, verify the image mirror exists
+		imageMirror, err := runtime.OCMClient.GetImageMirror(cluster.ID(), args.Id)
+		if err != nil {
+			return fmt.Errorf("Failed to get image mirror '%s': %v", args.Id, err)
+		}
+
+		if !args.Yes {
+			prompt := fmt.Sprintf("Are you sure you want to delete image mirror '%s' on cluster '%s'?",
+				args.Id, clusterKey)
+			confirmed, err := interactive.GetBool(interactive.Input{
+				Question: prompt,
+				Default:  false,
+				Required: false,
+			})
+			if err != nil {
+				return err
+			}
+			if !confirmed {
+				return nil
+			}
+		}
+
+		err = runtime.OCMClient.DeleteImageMirror(cluster.ID(), args.Id)
+		if err != nil {
+			return fmt.Errorf("Failed to delete image mirror: %v", err)
+		}
+
+		runtime.Reporter.Infof("Image mirror '%s' has been deleted from cluster '%s'",
+			imageMirror.ID(), clusterKey)
+
+		return nil
+	}
+}

--- a/cmd/dlt/imagemirror/cmd_test.go
+++ b/cmd/dlt/imagemirror/cmd_test.go
@@ -1,0 +1,293 @@
+package imagemirror
+
+import (
+	"context"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+
+	"github.com/openshift/rosa/pkg/test"
+)
+
+const (
+	clusterId     = "24vf9iitg3p6tlml88iml6j6mu095mh8"
+	imageMirrorId = "test-mirror-123"
+)
+
+var _ = Describe("Delete image mirror", func() {
+	Context("Delete image mirror command", func() {
+		mockHCPClusterReady := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+			c.AWS(cmv1.NewAWS().SubnetIDs("subnet-0b761d44d3d9a4663", "subnet-0f87f640e56934cbc"))
+			c.Region(cmv1.NewCloudRegion().ID("us-east-1"))
+			c.State(cmv1.ClusterStateReady)
+			c.Hypershift(cmv1.NewHypershift().Enabled(true))
+		})
+
+		mockClassicCluster := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+			c.AWS(cmv1.NewAWS().SubnetIDs("subnet-0b761d44d3d9a4663", "subnet-0f87f640e56934cbc"))
+			c.Region(cmv1.NewCloudRegion().ID("us-east-1"))
+			c.State(cmv1.ClusterStateReady)
+			c.Hypershift(cmv1.NewHypershift().Enabled(false))
+		})
+
+		mockClusterNotReady := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+			c.AWS(cmv1.NewAWS().SubnetIDs("subnet-0b761d44d3d9a4663", "subnet-0f87f640e56934cbc"))
+			c.Region(cmv1.NewCloudRegion().ID("us-east-1"))
+			c.State(cmv1.ClusterStateInstalling)
+			c.Hypershift(cmv1.NewHypershift().Enabled(true))
+		})
+
+		hcpClusterReady := test.FormatClusterList([]*cmv1.Cluster{mockHCPClusterReady})
+		classicClusterReady := test.FormatClusterList([]*cmv1.Cluster{mockClassicCluster})
+		clusterNotReady := test.FormatClusterList([]*cmv1.Cluster{mockClusterNotReady})
+
+		var t *test.TestingRuntime
+
+		BeforeEach(func() {
+			t = test.NewTestRuntime()
+		})
+
+		Context("Input validation", func() {
+			It("Returns error when no image mirror ID is provided", func() {
+				options := NewDeleteImageMirrorOptions()
+				runner := DeleteImageMirrorRunner(options)
+				cmd := NewDeleteImageMirrorCommand()
+				err := cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Image mirror ID is required. Specify it as an argument or use the --id flag"))
+			})
+
+			It("Uses positional argument for image mirror ID", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hcpClusterReady))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, formatExistingImageMirror()))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, ""))
+				options := NewDeleteImageMirrorOptions()
+				options.Args().Yes = true // Skip confirmation
+				runner := DeleteImageMirrorRunner(options)
+				err := t.StdOutReader.Record()
+				Expect(err).ToNot(HaveOccurred())
+				cmd := NewDeleteImageMirrorCommand()
+				err = cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{imageMirrorId})
+				Expect(err).ToNot(HaveOccurred())
+				stdout, err := t.StdOutReader.Read()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stdout).To(ContainSubstring("Image mirror 'test-mirror-123' has been deleted from cluster"))
+			})
+
+			It("Uses --id flag for image mirror ID", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hcpClusterReady))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, formatExistingImageMirror()))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, ""))
+				options := NewDeleteImageMirrorOptions()
+				options.Args().Id = imageMirrorId
+				options.Args().Yes = true // Skip confirmation
+				runner := DeleteImageMirrorRunner(options)
+				err := t.StdOutReader.Record()
+				Expect(err).ToNot(HaveOccurred())
+				cmd := NewDeleteImageMirrorCommand()
+				err = cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).ToNot(HaveOccurred())
+				stdout, err := t.StdOutReader.Read()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stdout).To(ContainSubstring("Image mirror 'test-mirror-123' has been deleted from cluster"))
+			})
+
+			It("Prefers positional argument over --id flag", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hcpClusterReady))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, formatExistingImageMirror()))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, ""))
+				options := NewDeleteImageMirrorOptions()
+				options.Args().Id = "different-id"
+				options.Args().Yes = true // Skip confirmation
+				runner := DeleteImageMirrorRunner(options)
+				err := t.StdOutReader.Record()
+				Expect(err).ToNot(HaveOccurred())
+				cmd := NewDeleteImageMirrorCommand()
+				err = cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				// Should use positional argument (imageMirrorId) instead of options.Args().Id
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{imageMirrorId})
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("Success scenarios", func() {
+			It("Deletes image mirror successfully with --yes flag", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hcpClusterReady))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, formatExistingImageMirror()))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, ""))
+				options := NewDeleteImageMirrorOptions()
+				options.Args().Id = imageMirrorId
+				options.Args().Yes = true
+				runner := DeleteImageMirrorRunner(options)
+				err := t.StdOutReader.Record()
+				Expect(err).ToNot(HaveOccurred())
+				cmd := NewDeleteImageMirrorCommand()
+				err = cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).ToNot(HaveOccurred())
+				stdout, err := t.StdOutReader.Read()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stdout).To(ContainSubstring("Image mirror 'test-mirror-123' has been deleted from cluster"))
+			})
+		})
+
+		Context("Validation error scenarios", func() {
+			It("Returns error when cluster is not ready", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, clusterNotReady))
+				options := NewDeleteImageMirrorOptions()
+				options.Args().Id = imageMirrorId
+				options.Args().Yes = true
+				runner := DeleteImageMirrorRunner(options)
+				cmd := NewDeleteImageMirrorCommand()
+				err := cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("is not ready. Image mirrors can only be deleted on ready clusters"))
+			})
+
+			It("Returns error when cluster is not Hosted Control Plane", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, classicClusterReady))
+				options := NewDeleteImageMirrorOptions()
+				options.Args().Id = imageMirrorId
+				options.Args().Yes = true
+				runner := DeleteImageMirrorRunner(options)
+				cmd := NewDeleteImageMirrorCommand()
+				err := cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Image mirrors are only supported on Hosted Control Plane clusters"))
+			})
+
+			It("Returns error when cluster fetch fails", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusNotFound, "{}"))
+				options := NewDeleteImageMirrorOptions()
+				options.Args().Id = imageMirrorId
+				options.Args().Yes = true
+				runner := DeleteImageMirrorRunner(options)
+				cmd := NewDeleteImageMirrorCommand()
+				err := cmd.Flag("cluster").Value.Set("nonexistent-cluster")
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("status is 404"))
+			})
+
+			It("Returns error when image mirror does not exist", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hcpClusterReady))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusNotFound, "{}"))
+				options := NewDeleteImageMirrorOptions()
+				options.Args().Id = "nonexistent-mirror"
+				options.Args().Yes = true
+				runner := DeleteImageMirrorRunner(options)
+				cmd := NewDeleteImageMirrorCommand()
+				err := cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Failed to get image mirror 'nonexistent-mirror'"))
+			})
+
+			It("Returns error when delete API call fails", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hcpClusterReady))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, formatExistingImageMirror()))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusInternalServerError, "{}"))
+				options := NewDeleteImageMirrorOptions()
+				options.Args().Id = imageMirrorId
+				options.Args().Yes = true
+				runner := DeleteImageMirrorRunner(options)
+				cmd := NewDeleteImageMirrorCommand()
+				err := cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Failed to delete image mirror"))
+			})
+		})
+
+		Context("Interactive confirmation", func() {
+			It("Skips confirmation when --yes flag is used", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hcpClusterReady))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, formatExistingImageMirror()))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, ""))
+				options := NewDeleteImageMirrorOptions()
+				options.Args().Id = imageMirrorId
+				options.Args().Yes = true
+				runner := DeleteImageMirrorRunner(options)
+				err := t.StdOutReader.Record()
+				Expect(err).ToNot(HaveOccurred())
+				cmd := NewDeleteImageMirrorCommand()
+				err = cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).ToNot(HaveOccurred())
+				// Should not prompt for confirmation
+				stdout, err := t.StdOutReader.Read()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stdout).To(ContainSubstring("Image mirror 'test-mirror-123' has been deleted"))
+			})
+		})
+
+		Context("Command structure", func() {
+			It("Has correct command properties", func() {
+				cmd := NewDeleteImageMirrorCommand()
+				Expect(cmd.Use).To(Equal("image-mirror"))
+				Expect(cmd.Short).To(Equal("Delete image mirror from a cluster"))
+				Expect(cmd.Aliases).To(ContainElement("image-mirrors"))
+				Expect(cmd.Args).ToNot(BeNil())
+			})
+
+			It("Has expected flags", func() {
+				cmd := NewDeleteImageMirrorCommand()
+				flags := []string{"cluster", "id", "yes", "profile", "region"}
+				for _, flagName := range flags {
+					flag := cmd.Flag(flagName)
+					Expect(flag).ToNot(BeNil(), "Flag %s should exist", flagName)
+				}
+			})
+
+			It("Accepts maximum of 1 positional argument", func() {
+				cmd := NewDeleteImageMirrorCommand()
+				// MaximumNArgs(1) means it should accept 0 or 1 arguments
+				Expect(cmd.Args).ToNot(BeNil())
+			})
+
+			It("Has correct flag properties", func() {
+				cmd := NewDeleteImageMirrorCommand()
+
+				// Check --yes flag has short form -y
+				yesFlag := cmd.Flag("yes")
+				Expect(yesFlag).ToNot(BeNil())
+				Expect(yesFlag.Shorthand).To(Equal("y"))
+
+				// Check --id flag exists
+				idFlag := cmd.Flag("id")
+				Expect(idFlag).ToNot(BeNil())
+			})
+		})
+	})
+})
+
+// formatExistingImageMirror simulates the response from getting an existing image mirror
+func formatExistingImageMirror() string {
+	imageMirror, err := cmv1.NewImageMirror().
+		ID("test-mirror-123").
+		Type("digest").
+		Source("registry.redhat.io").
+		Mirrors("mirror.example.com", "backup.example.com").
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+	return test.FormatResource(imageMirror)
+}

--- a/cmd/dlt/imagemirror/imagemirror_suite_test.go
+++ b/cmd/dlt/imagemirror/imagemirror_suite_test.go
@@ -1,0 +1,13 @@
+package imagemirror
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestImageMirror(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Delete ImageMirror suite")
+}

--- a/cmd/dlt/imagemirror/options.go
+++ b/cmd/dlt/imagemirror/options.go
@@ -1,0 +1,49 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package imagemirror
+
+import (
+	"github.com/openshift/rosa/pkg/reporter"
+)
+
+type DeleteImageMirrorUserOptions struct {
+	Id  string
+	Yes bool
+}
+
+type DeleteImageMirrorOptions struct {
+	reporter reporter.Logger
+	args     *DeleteImageMirrorUserOptions
+}
+
+func NewDeleteImageMirrorUserOptions() *DeleteImageMirrorUserOptions {
+	return &DeleteImageMirrorUserOptions{
+		Id:  "",
+		Yes: false,
+	}
+}
+
+func NewDeleteImageMirrorOptions() *DeleteImageMirrorOptions {
+	return &DeleteImageMirrorOptions{
+		reporter: reporter.CreateReporter(),
+		args:     NewDeleteImageMirrorUserOptions(),
+	}
+}
+
+func (o *DeleteImageMirrorOptions) Args() *DeleteImageMirrorUserOptions {
+	return o.args
+}

--- a/cmd/dlt/imagemirror/options_test.go
+++ b/cmd/dlt/imagemirror/options_test.go
@@ -1,0 +1,55 @@
+package imagemirror
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/rosa/pkg/reporter"
+)
+
+var _ = Describe("DeleteImageMirrorOptions", func() {
+	var (
+		imageMirrorOptions *DeleteImageMirrorOptions
+		userOptions        *DeleteImageMirrorUserOptions
+	)
+
+	BeforeEach(func() {
+		imageMirrorOptions = NewDeleteImageMirrorOptions()
+		userOptions = NewDeleteImageMirrorUserOptions()
+	})
+
+	Context("NewDeleteImageMirrorUserOptions", func() {
+		It("should create default user options", func() {
+			Expect(userOptions.Id).To(Equal(""))
+			Expect(userOptions.Yes).To(BeFalse())
+		})
+	})
+
+	Context("NewDeleteImageMirrorOptions", func() {
+		It("should create default image mirror options", func() {
+			Expect(imageMirrorOptions.reporter).To(BeAssignableToTypeOf(&reporter.Object{}))
+			Expect(imageMirrorOptions.args).To(BeAssignableToTypeOf(&DeleteImageMirrorUserOptions{}))
+		})
+
+		It("should initialize args with default values", func() {
+			Expect(imageMirrorOptions.args.Id).To(Equal(""))
+			Expect(imageMirrorOptions.args.Yes).To(BeFalse())
+		})
+	})
+
+	Context("Args", func() {
+		It("should return the args field", func() {
+			imageMirrorOptions.args = userOptions
+			Expect(imageMirrorOptions.Args()).To(Equal(userOptions))
+		})
+
+		It("should allow modification of args", func() {
+			args := imageMirrorOptions.Args()
+			args.Id = "test-mirror-id"
+			args.Yes = true
+
+			Expect(imageMirrorOptions.args.Id).To(Equal("test-mirror-id"))
+			Expect(imageMirrorOptions.args.Yes).To(BeTrue())
+		})
+	})
+})

--- a/cmd/edit/cmd.go
+++ b/cmd/edit/cmd.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openshift/rosa/cmd/edit/addon"
 	"github.com/openshift/rosa/cmd/edit/autoscaler"
 	"github.com/openshift/rosa/cmd/edit/cluster"
+	"github.com/openshift/rosa/cmd/edit/imagemirror"
 	"github.com/openshift/rosa/cmd/edit/ingress"
 	"github.com/openshift/rosa/cmd/edit/kubeletconfig"
 	"github.com/openshift/rosa/cmd/edit/machinepool"
@@ -50,6 +51,8 @@ func init() {
 	Cmd.AddCommand(autoscalerCommand)
 	kubeletConfig := kubeletconfig.NewEditKubeletConfigCommand()
 	Cmd.AddCommand(kubeletConfig)
+	imageMirrorCommand := imagemirror.NewEditImageMirrorCommand()
+	Cmd.AddCommand(imageMirrorCommand)
 
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)
@@ -62,7 +65,7 @@ func init() {
 	globallyAvailableCommands := []*cobra.Command{
 		autoscalerCommand, addon.Cmd,
 		service.Cmd, cluster.Cmd,
-		ingress.Cmd, kubeletConfig,
+		imageMirrorCommand, ingress.Cmd, kubeletConfig,
 		machinepoolCommand, tuningconfigs.Cmd,
 	}
 	arguments.MarkRegionDeprecated(Cmd, globallyAvailableCommands)

--- a/cmd/edit/imagemirror/cmd.go
+++ b/cmd/edit/imagemirror/cmd.go
@@ -1,0 +1,126 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package imagemirror
+
+import (
+	"context"
+	"fmt"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/arguments"
+	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+const (
+	use     = "image-mirror"
+	short   = "Edit image mirror for a cluster"
+	long    = "Edit an existing image mirror configuration for a Hosted Control Plane cluster by ID. Only the mirrors list can be updated."
+	example = `  # Update mirrors for image mirror with ID "abc123" on cluster "mycluster"
+  rosa edit image-mirror --cluster=mycluster abc123 \
+    --mirrors=mirror.corp.com/team,backup.corp.com/team,new-mirror.corp.com/team
+
+  # Alternative: using the --id flag
+  rosa edit image-mirror --cluster=mycluster --id=abc123 \
+    --mirrors=mirror.corp.com/team,backup.corp.com/team,new-mirror.corp.com/team`
+)
+
+var (
+	aliases = []string{"image-mirrors"}
+)
+
+func NewEditImageMirrorCommand() *cobra.Command {
+	options := NewEditImageMirrorOptions()
+	cmd := &cobra.Command{
+		Use:     use,
+		Short:   short,
+		Long:    long,
+		Aliases: aliases,
+		Example: example,
+		Args:    cobra.MaximumNArgs(1),
+		Run:     rosa.DefaultRunner(rosa.RuntimeWithOCM(), EditImageMirrorRunner(options)),
+	}
+
+	flags := cmd.Flags()
+
+	flags.StringVar(
+		&options.Args().Id,
+		"id",
+		"",
+		"ID of the image mirror configuration to edit",
+	)
+
+	flags.StringSliceVar(
+		&options.Args().Mirrors,
+		"mirrors",
+		[]string{},
+		"New list of mirror registries (comma-separated, required). This will replace the existing mirrors.",
+	)
+
+	_ = cmd.MarkFlagRequired("mirrors")
+
+	ocm.AddClusterFlag(cmd)
+	arguments.AddProfileFlag(cmd.Flags())
+	arguments.AddRegionFlag(cmd.Flags())
+	return cmd
+}
+
+func EditImageMirrorRunner(options *EditImageMirrorOptions) rosa.CommandRunner {
+	return func(_ context.Context, runtime *rosa.Runtime, cmd *cobra.Command, argv []string) error {
+		clusterKey := runtime.GetClusterKey()
+		args := options.Args()
+
+		// Get image mirror ID from positional argument or flag
+		if len(argv) == 1 && !cmd.Flag("id").Changed {
+			args.Id = argv[0]
+		}
+
+		if args.Id == "" {
+			return fmt.Errorf("Image mirror ID is required. Specify it as an argument or use the --id flag")
+		}
+
+		cluster, err := runtime.OCMClient.GetCluster(clusterKey, runtime.Creator)
+		if err != nil {
+			return err
+		}
+		if cluster.State() != cmv1.ClusterStateReady {
+			return fmt.Errorf("Cluster '%s' is not ready. Image mirrors can only be edited on ready clusters", clusterKey)
+		}
+
+		if !cluster.Hypershift().Enabled() {
+			return fmt.Errorf("Image mirrors are only supported on Hosted Control Plane clusters")
+		}
+
+		if len(args.Mirrors) == 0 {
+			return fmt.Errorf("At least one mirror registry must be specified")
+		}
+
+		updatedMirror, err := runtime.OCMClient.UpdateImageMirror(
+			cluster.ID(), args.Id, args.Mirrors)
+		if err != nil {
+			return fmt.Errorf("Failed to edit image mirror: %v", err)
+		}
+		runtime.Reporter.Infof("Image mirror '%s' has been updated on cluster '%s'",
+			updatedMirror.ID(), clusterKey)
+		runtime.Reporter.Infof("Source: %s", updatedMirror.Source())
+		runtime.Reporter.Infof("Updated mirrors: %v", updatedMirror.Mirrors())
+
+		return nil
+	}
+}

--- a/cmd/edit/imagemirror/cmd_test.go
+++ b/cmd/edit/imagemirror/cmd_test.go
@@ -1,0 +1,298 @@
+package imagemirror
+
+import (
+	"context"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+
+	"github.com/openshift/rosa/pkg/test"
+)
+
+const (
+	clusterId     = "24vf9iitg3p6tlml88iml6j6mu095mh8"
+	imageMirrorId = "test-mirror-123"
+)
+
+var _ = Describe("Edit image mirror", func() {
+	Context("Edit image mirror command", func() {
+		mockHCPClusterReady := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+			c.AWS(cmv1.NewAWS().SubnetIDs("subnet-0b761d44d3d9a4663", "subnet-0f87f640e56934cbc"))
+			c.Region(cmv1.NewCloudRegion().ID("us-east-1"))
+			c.State(cmv1.ClusterStateReady)
+			c.Hypershift(cmv1.NewHypershift().Enabled(true))
+		})
+
+		mockClassicCluster := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+			c.AWS(cmv1.NewAWS().SubnetIDs("subnet-0b761d44d3d9a4663", "subnet-0f87f640e56934cbc"))
+			c.Region(cmv1.NewCloudRegion().ID("us-east-1"))
+			c.State(cmv1.ClusterStateReady)
+			c.Hypershift(cmv1.NewHypershift().Enabled(false))
+		})
+
+		mockClusterNotReady := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+			c.AWS(cmv1.NewAWS().SubnetIDs("subnet-0b761d44d3d9a4663", "subnet-0f87f640e56934cbc"))
+			c.Region(cmv1.NewCloudRegion().ID("us-east-1"))
+			c.State(cmv1.ClusterStateInstalling)
+			c.Hypershift(cmv1.NewHypershift().Enabled(true))
+		})
+
+		hcpClusterReady := test.FormatClusterList([]*cmv1.Cluster{mockHCPClusterReady})
+		classicClusterReady := test.FormatClusterList([]*cmv1.Cluster{mockClassicCluster})
+		clusterNotReady := test.FormatClusterList([]*cmv1.Cluster{mockClusterNotReady})
+
+		var t *test.TestingRuntime
+
+		BeforeEach(func() {
+			t = test.NewTestRuntime()
+		})
+
+		Context("Input validation", func() {
+			It("Returns error when no image mirror ID is provided", func() {
+				options := NewEditImageMirrorOptions()
+				options.Args().Mirrors = []string{"mirror.example.com"}
+				runner := EditImageMirrorRunner(options)
+				cmd := NewEditImageMirrorCommand()
+				err := cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Image mirror ID is required. Specify it as an argument or use the --id flag"))
+			})
+
+			It("Returns error when no mirrors are provided", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hcpClusterReady))
+				options := NewEditImageMirrorOptions()
+				options.Args().Id = imageMirrorId
+				options.Args().Mirrors = []string{}
+				runner := EditImageMirrorRunner(options)
+				cmd := NewEditImageMirrorCommand()
+				err := cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("At least one mirror registry must be specified"))
+			})
+
+			It("Uses positional argument for image mirror ID", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hcpClusterReady))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, formatUpdatedImageMirror()))
+				options := NewEditImageMirrorOptions()
+				options.Args().Mirrors = []string{"mirror.example.com", "backup.example.com"}
+				runner := EditImageMirrorRunner(options)
+				err := t.StdOutReader.Record()
+				Expect(err).ToNot(HaveOccurred())
+				cmd := NewEditImageMirrorCommand()
+				err = cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{imageMirrorId})
+				Expect(err).ToNot(HaveOccurred())
+				stdout, err := t.StdOutReader.Read()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stdout).To(ContainSubstring("Image mirror 'test-mirror-123' has been updated on cluster"))
+				Expect(stdout).To(ContainSubstring("Source: registry.redhat.io"))
+				Expect(stdout).To(ContainSubstring("Updated mirrors: [mirror.example.com backup.example.com]"))
+			})
+
+			It("Uses --id flag for image mirror ID", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hcpClusterReady))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, formatUpdatedImageMirror()))
+				options := NewEditImageMirrorOptions()
+				options.Args().Id = imageMirrorId
+				options.Args().Mirrors = []string{"mirror.example.com", "backup.example.com"}
+				runner := EditImageMirrorRunner(options)
+				err := t.StdOutReader.Record()
+				Expect(err).ToNot(HaveOccurred())
+				cmd := NewEditImageMirrorCommand()
+				err = cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).ToNot(HaveOccurred())
+				stdout, err := t.StdOutReader.Read()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stdout).To(ContainSubstring("Image mirror 'test-mirror-123' has been updated on cluster"))
+				Expect(stdout).To(ContainSubstring("Source: registry.redhat.io"))
+				Expect(stdout).To(ContainSubstring("Updated mirrors: [mirror.example.com backup.example.com]"))
+			})
+
+			It("Prefers positional argument over --id flag", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hcpClusterReady))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, formatUpdatedImageMirror()))
+				options := NewEditImageMirrorOptions()
+				options.Args().Id = "different-id"
+				options.Args().Mirrors = []string{"mirror.example.com"}
+				runner := EditImageMirrorRunner(options)
+				err := t.StdOutReader.Record()
+				Expect(err).ToNot(HaveOccurred())
+				cmd := NewEditImageMirrorCommand()
+				err = cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				// Should use positional argument (imageMirrorId) instead of options.Args().Id
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{imageMirrorId})
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("Success scenarios", func() {
+			It("Edits image mirror successfully with multiple mirrors", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hcpClusterReady))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, formatUpdatedImageMirror()))
+				options := NewEditImageMirrorOptions()
+				options.Args().Id = imageMirrorId
+				options.Args().Mirrors = []string{"mirror.example.com", "backup.example.com", "third.example.com"}
+				runner := EditImageMirrorRunner(options)
+				err := t.StdOutReader.Record()
+				Expect(err).ToNot(HaveOccurred())
+				cmd := NewEditImageMirrorCommand()
+				err = cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).ToNot(HaveOccurred())
+				stdout, err := t.StdOutReader.Read()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stdout).To(ContainSubstring("Image mirror 'test-mirror-123' has been updated on cluster"))
+				Expect(stdout).To(ContainSubstring("Source: registry.redhat.io"))
+				Expect(stdout).To(ContainSubstring("Updated mirrors: [mirror.example.com backup.example.com]"))
+			})
+
+			It("Edits image mirror successfully with single mirror", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hcpClusterReady))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, formatSingleMirrorUpdate()))
+				options := NewEditImageMirrorOptions()
+				options.Args().Id = imageMirrorId
+				options.Args().Mirrors = []string{"single-mirror.example.com"}
+				runner := EditImageMirrorRunner(options)
+				err := t.StdOutReader.Record()
+				Expect(err).ToNot(HaveOccurred())
+				cmd := NewEditImageMirrorCommand()
+				err = cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).ToNot(HaveOccurred())
+				stdout, err := t.StdOutReader.Read()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stdout).To(ContainSubstring("Image mirror 'test-mirror-123' has been updated on cluster"))
+				Expect(stdout).To(ContainSubstring("Source: registry.redhat.io"))
+				Expect(stdout).To(ContainSubstring("Updated mirrors: [single-mirror.example.com]"))
+			})
+		})
+
+		Context("Validation error scenarios", func() {
+			It("Returns error when cluster is not ready", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, clusterNotReady))
+				options := NewEditImageMirrorOptions()
+				options.Args().Id = imageMirrorId
+				options.Args().Mirrors = []string{"mirror.example.com"}
+				runner := EditImageMirrorRunner(options)
+				cmd := NewEditImageMirrorCommand()
+				err := cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("is not ready. Image mirrors can only be edited on ready clusters"))
+			})
+
+			It("Returns error when cluster is not Hosted Control Plane", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, classicClusterReady))
+				options := NewEditImageMirrorOptions()
+				options.Args().Id = imageMirrorId
+				options.Args().Mirrors = []string{"mirror.example.com"}
+				runner := EditImageMirrorRunner(options)
+				cmd := NewEditImageMirrorCommand()
+				err := cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Image mirrors are only supported on Hosted Control Plane clusters"))
+			})
+		})
+
+		Context("Command structure", func() {
+			It("Has correct command properties", func() {
+				cmd := NewEditImageMirrorCommand()
+				Expect(cmd.Use).To(Equal("image-mirror"))
+				Expect(cmd.Short).To(Equal("Edit image mirror for a cluster"))
+				Expect(cmd.Aliases).To(ContainElement("image-mirrors"))
+				Expect(cmd.Args).ToNot(BeNil())
+			})
+
+			It("Has expected flags", func() {
+				cmd := NewEditImageMirrorCommand()
+				flags := []string{"cluster", "id", "mirrors", "profile", "region"}
+				for _, flagName := range flags {
+					flag := cmd.Flag(flagName)
+					Expect(flag).ToNot(BeNil(), "Flag %s should exist", flagName)
+				}
+			})
+
+			It("Accepts maximum of 1 positional argument", func() {
+				cmd := NewEditImageMirrorCommand()
+				// MaximumNArgs(1) means it should accept 0 or 1 arguments
+				Expect(cmd.Args).ToNot(BeNil())
+			})
+
+			It("Has correct flag properties", func() {
+				cmd := NewEditImageMirrorCommand()
+
+				// Check --mirrors flag exists and is a string slice
+				mirrorsFlag := cmd.Flag("mirrors")
+				Expect(mirrorsFlag).ToNot(BeNil())
+
+				// Check --id flag exists
+				idFlag := cmd.Flag("id")
+				Expect(idFlag).ToNot(BeNil())
+			})
+		})
+
+		Context("Mirror validation", func() {
+			It("Validates mirrors flag is required through command setup", func() {
+				cmd := NewEditImageMirrorCommand()
+				// The command sets mirrors as required in cmd.MarkFlagRequired("mirrors")
+				// This would be validated by cobra before reaching our runner
+				mirrorsFlag := cmd.Flag("mirrors")
+				Expect(mirrorsFlag).ToNot(BeNil())
+			})
+
+			It("Accepts empty mirrors slice in options but validates in runner", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hcpClusterReady))
+				options := NewEditImageMirrorOptions()
+				options.Args().Id = imageMirrorId
+				options.Args().Mirrors = []string{} // Empty mirrors
+				runner := EditImageMirrorRunner(options)
+				cmd := NewEditImageMirrorCommand()
+				err := cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("At least one mirror registry must be specified"))
+			})
+		})
+	})
+})
+
+// formatUpdatedImageMirror simulates the response from updating an image mirror
+func formatUpdatedImageMirror() string {
+	imageMirror, err := cmv1.NewImageMirror().
+		ID("test-mirror-123").
+		Type("digest").
+		Source("registry.redhat.io").
+		Mirrors("mirror.example.com", "backup.example.com").
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+	return test.FormatResource(imageMirror)
+}
+
+// formatSingleMirrorUpdate simulates the response from updating an image mirror with a single mirror
+func formatSingleMirrorUpdate() string {
+	imageMirror, err := cmv1.NewImageMirror().
+		ID("test-mirror-123").
+		Type("digest").
+		Source("registry.redhat.io").
+		Mirrors("single-mirror.example.com").
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+	return test.FormatResource(imageMirror)
+}

--- a/cmd/edit/imagemirror/imagemirror_suite_test.go
+++ b/cmd/edit/imagemirror/imagemirror_suite_test.go
@@ -1,0 +1,13 @@
+package imagemirror
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestImageMirror(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Edit ImageMirror suite")
+}

--- a/cmd/edit/imagemirror/options.go
+++ b/cmd/edit/imagemirror/options.go
@@ -1,0 +1,49 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package imagemirror
+
+import (
+	"github.com/openshift/rosa/pkg/reporter"
+)
+
+type EditImageMirrorUserOptions struct {
+	Id      string
+	Mirrors []string
+}
+
+type EditImageMirrorOptions struct {
+	reporter reporter.Logger
+	args     *EditImageMirrorUserOptions
+}
+
+func NewEditImageMirrorUserOptions() *EditImageMirrorUserOptions {
+	return &EditImageMirrorUserOptions{
+		Id:      "",
+		Mirrors: []string{},
+	}
+}
+
+func NewEditImageMirrorOptions() *EditImageMirrorOptions {
+	return &EditImageMirrorOptions{
+		reporter: reporter.CreateReporter(),
+		args:     NewEditImageMirrorUserOptions(),
+	}
+}
+
+func (o *EditImageMirrorOptions) Args() *EditImageMirrorUserOptions {
+	return o.args
+}

--- a/cmd/edit/imagemirror/options_test.go
+++ b/cmd/edit/imagemirror/options_test.go
@@ -1,0 +1,55 @@
+package imagemirror
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/rosa/pkg/reporter"
+)
+
+var _ = Describe("EditImageMirrorOptions", func() {
+	var (
+		imageMirrorOptions *EditImageMirrorOptions
+		userOptions        *EditImageMirrorUserOptions
+	)
+
+	BeforeEach(func() {
+		imageMirrorOptions = NewEditImageMirrorOptions()
+		userOptions = NewEditImageMirrorUserOptions()
+	})
+
+	Context("NewEditImageMirrorUserOptions", func() {
+		It("should create default user options", func() {
+			Expect(userOptions.Id).To(Equal(""))
+			Expect(userOptions.Mirrors).To(BeEmpty())
+		})
+	})
+
+	Context("NewEditImageMirrorOptions", func() {
+		It("should create default image mirror options", func() {
+			Expect(imageMirrorOptions.reporter).To(BeAssignableToTypeOf(&reporter.Object{}))
+			Expect(imageMirrorOptions.args).To(BeAssignableToTypeOf(&EditImageMirrorUserOptions{}))
+		})
+
+		It("should initialize args with default values", func() {
+			Expect(imageMirrorOptions.args.Id).To(Equal(""))
+			Expect(imageMirrorOptions.args.Mirrors).To(BeEmpty())
+		})
+	})
+
+	Context("Args", func() {
+		It("should return the args field", func() {
+			imageMirrorOptions.args = userOptions
+			Expect(imageMirrorOptions.Args()).To(Equal(userOptions))
+		})
+
+		It("should allow modification of args", func() {
+			args := imageMirrorOptions.Args()
+			args.Id = "test-mirror-id"
+			args.Mirrors = []string{"new-mirror1.com", "new-mirror2.com"}
+
+			Expect(imageMirrorOptions.args.Id).To(Equal("test-mirror-id"))
+			Expect(imageMirrorOptions.args.Mirrors).To(Equal([]string{"new-mirror1.com", "new-mirror2.com"}))
+		})
+	})
+})

--- a/cmd/list/cmd.go
+++ b/cmd/list/cmd.go
@@ -29,6 +29,7 @@ import (
 	"github.com/openshift/rosa/cmd/list/gates"
 	"github.com/openshift/rosa/cmd/list/iamserviceaccounts"
 	"github.com/openshift/rosa/cmd/list/idp"
+	"github.com/openshift/rosa/cmd/list/imagemirrors"
 	"github.com/openshift/rosa/cmd/list/ingress"
 	"github.com/openshift/rosa/cmd/list/instancetypes"
 	"github.com/openshift/rosa/cmd/list/kubeletconfig"
@@ -61,6 +62,8 @@ func init() {
 	Cmd.AddCommand(gates.Cmd)
 	Cmd.AddCommand(iamserviceaccounts.Cmd)
 	Cmd.AddCommand(idp.Cmd)
+	imageMirrorsCommand := imagemirrors.NewListImageMirrorsCommand()
+	Cmd.AddCommand(imageMirrorsCommand)
 	Cmd.AddCommand(ingress.Cmd)
 	machinePoolCommand := machinepool.NewListMachinePoolCommand()
 	Cmd.AddCommand(machinePoolCommand)

--- a/cmd/list/imagemirrors/cmd.go
+++ b/cmd/list/imagemirrors/cmd.go
@@ -1,0 +1,112 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package imagemirrors
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/arguments"
+	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/output"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+const (
+	use     = "image-mirrors"
+	short   = "List cluster image mirrors"
+	long    = "List image mirror configurations for a Hosted Control Plane cluster."
+	example = `  # List all image mirrors on a cluster named "mycluster"
+  rosa list image-mirrors --cluster=mycluster`
+)
+
+var (
+	aliases = []string{"image-mirror"}
+)
+
+func NewListImageMirrorsCommand() *cobra.Command {
+	options := NewListImageMirrorsOptions()
+	cmd := &cobra.Command{
+		Use:     use,
+		Short:   short,
+		Long:    long,
+		Aliases: aliases,
+		Example: example,
+		Args:    cobra.NoArgs,
+		Run:     rosa.DefaultRunner(rosa.RuntimeWithOCM(), ListImageMirrorsRunner(options)),
+	}
+
+	output.AddFlag(cmd)
+	ocm.AddClusterFlag(cmd)
+	arguments.AddProfileFlag(cmd.Flags())
+	arguments.AddRegionFlag(cmd.Flags())
+	return cmd
+}
+
+func ListImageMirrorsRunner(options *ListImageMirrorsOptions) rosa.CommandRunner {
+	return func(_ context.Context, runtime *rosa.Runtime, cmd *cobra.Command, _ []string) error {
+		clusterKey := runtime.GetClusterKey()
+
+		cluster, err := runtime.OCMClient.GetCluster(clusterKey, runtime.Creator)
+		if err != nil {
+			return err
+		}
+		imageMirrors, err := runtime.OCMClient.ListImageMirrors(cluster.ID())
+		if err != nil {
+			return fmt.Errorf("Failed to list image mirrors: %v", err)
+		}
+
+		if output.HasFlag() {
+			return output.Print(imageMirrors)
+		}
+
+		if len(imageMirrors) == 0 {
+			runtime.Reporter.Infof("No image mirrors found for cluster '%s'", clusterKey)
+			return nil
+		}
+
+		// Create tabwriter for formatted output
+		writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintf(writer, "ID\tTYPE\tSOURCE\tMIRRORS\n")
+
+		for _, mirror := range imageMirrors {
+			mirrors := ""
+			if len(mirror.Mirrors()) > 0 {
+				for i, m := range mirror.Mirrors() {
+					if i > 0 {
+						mirrors += ", "
+					}
+					mirrors += m
+				}
+			}
+
+			fmt.Fprintf(writer, "%s\t%s\t%s\t%s\n",
+				mirror.ID(),
+				mirror.Type(),
+				mirror.Source(),
+				mirrors,
+			)
+		}
+
+		writer.Flush()
+		return nil
+	}
+}

--- a/cmd/list/imagemirrors/cmd_test.go
+++ b/cmd/list/imagemirrors/cmd_test.go
@@ -1,0 +1,252 @@
+package imagemirrors
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+
+	. "github.com/openshift/rosa/pkg/output"
+	"github.com/openshift/rosa/pkg/test"
+)
+
+const (
+	clusterId               = "24vf9iitg3p6tlml88iml6j6mu095mh8"
+	singleImageMirrorOutput = "ID       TYPE    SOURCE              MIRRORS\n" +
+		"mirror1  digest  registry.redhat.io  mirror.example.com\n"
+	multipleImageMirrorsOutput = "ID       TYPE    SOURCE              MIRRORS\n" +
+		"mirror1  digest  registry.redhat.io  mirror.example.com\n" +
+		"mirror2  tag     quay.io/openshift   mirror1.com, mirror2.com\n"
+	emptyImageMirrorsMessage = "INFO: No image mirrors found for cluster '24vf9iitg3p6tlml88iml6j6mu095mh8'\n"
+)
+
+var _ = Describe("List image mirrors", func() {
+	Context("List image mirrors command", func() {
+		// Full diff for long string to help debugging
+		format.TruncatedDiff = false
+
+		mockClusterReady := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+			c.AWS(cmv1.NewAWS().SubnetIDs("subnet-0b761d44d3d9a4663", "subnet-0f87f640e56934cbc"))
+			c.Region(cmv1.NewCloudRegion().ID("us-east-1"))
+			c.State(cmv1.ClusterStateReady)
+			c.Hypershift(cmv1.NewHypershift().Enabled(true))
+		})
+
+		hypershiftClusterReady := test.FormatClusterList([]*cmv1.Cluster{mockClusterReady})
+
+		singleImageMirrorResponse := formatSingleImageMirror()
+		multipleImageMirrorsResponse := formatMultipleImageMirrors()
+		emptyImageMirrorsResponse := formatEmptyImageMirrors()
+
+		var t *test.TestingRuntime
+
+		BeforeEach(func() {
+			t = test.NewTestRuntime()
+			SetOutput("")
+		})
+
+		Context("Success scenarios", func() {
+			It("Lists single image mirror", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, singleImageMirrorResponse))
+				runner := ListImageMirrorsRunner(NewListImageMirrorsOptions())
+				err := t.StdOutReader.Record()
+				Expect(err).ToNot(HaveOccurred())
+				cmd := NewListImageMirrorsCommand()
+				err = cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).ToNot(HaveOccurred())
+				stdout, err := t.StdOutReader.Read()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stdout).To(Equal(singleImageMirrorOutput))
+			})
+
+			It("Lists multiple image mirrors", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, multipleImageMirrorsResponse))
+				runner := ListImageMirrorsRunner(NewListImageMirrorsOptions())
+				err := t.StdOutReader.Record()
+				Expect(err).ToNot(HaveOccurred())
+				cmd := NewListImageMirrorsCommand()
+				err = cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).ToNot(HaveOccurred())
+				stdout, err := t.StdOutReader.Read()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stdout).To(Equal(multipleImageMirrorsOutput))
+			})
+
+			It("Shows info message when no image mirrors found", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, emptyImageMirrorsResponse))
+				runner := ListImageMirrorsRunner(NewListImageMirrorsOptions())
+				err := t.StdOutReader.Record()
+				Expect(err).ToNot(HaveOccurred())
+				cmd := NewListImageMirrorsCommand()
+				err = cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).ToNot(HaveOccurred())
+				stdout, err := t.StdOutReader.Read()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stdout).To(Equal(emptyImageMirrorsMessage))
+			})
+
+			It("Outputs JSON when output flag is set", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, singleImageMirrorResponse))
+				runner := ListImageMirrorsRunner(NewListImageMirrorsOptions())
+				err := t.StdOutReader.Record()
+				Expect(err).ToNot(HaveOccurred())
+				cmd := NewListImageMirrorsCommand()
+				err = cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = cmd.Flag("output").Value.Set("json")
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).ToNot(HaveOccurred())
+				stdout, err := t.StdOutReader.Read()
+				Expect(err).ToNot(HaveOccurred())
+				// Verify JSON contains all the image mirror data
+				Expect(stdout).To(ContainSubstring("\"id\": \"mirror1\""))
+				Expect(stdout).To(ContainSubstring("\"type\": \"digest\""))
+				Expect(stdout).To(ContainSubstring("\"source\": \"registry.redhat.io\""))
+				Expect(stdout).To(ContainSubstring("\"mirrors\": ["))
+				Expect(stdout).To(ContainSubstring("\"mirror.example.com\""))
+				// Ensure it's valid JSON array format
+				Expect(stdout).To(ContainSubstring("["))
+				Expect(stdout).To(ContainSubstring("]"))
+			})
+		})
+
+		Context("Error scenarios", func() {
+			It("Returns error when cluster fetch fails", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusNotFound, "{}"))
+				runner := ListImageMirrorsRunner(NewListImageMirrorsOptions())
+				cmd := NewListImageMirrorsCommand()
+				err := cmd.Flag("cluster").Value.Set("nonexistent-cluster")
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("status is 404"))
+			})
+
+			It("Returns error when ListImageMirrors API call fails", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusInternalServerError, "{}"))
+				runner := ListImageMirrorsRunner(NewListImageMirrorsOptions())
+				cmd := NewListImageMirrorsCommand()
+				err := cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Failed to list image mirrors"))
+			})
+		})
+
+		Context("Edge cases", func() {
+			It("Handles image mirror with no mirrors array", func() {
+				imageMirror, err := cmv1.NewImageMirror().
+					ID("mirror-no-mirrors").
+					Type("digest").
+					Source("registry.example.com").
+					Mirrors().
+					Build()
+				Expect(err).ToNot(HaveOccurred())
+				response := fmt.Sprintf("{\n  \"items\": [\n    %s\n  ],\n  \"page\": 0,\n  \"size\": 1,\n  \"total\": 1\n}",
+					test.FormatResource(imageMirror))
+
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, response))
+				runner := ListImageMirrorsRunner(NewListImageMirrorsOptions())
+				err = t.StdOutReader.Record()
+				Expect(err).ToNot(HaveOccurred())
+				cmd := NewListImageMirrorsCommand()
+				err = cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).ToNot(HaveOccurred())
+				stdout, err := t.StdOutReader.Read()
+				Expect(err).ToNot(HaveOccurred())
+				expectedOutput := "ID                 TYPE    SOURCE                MIRRORS\n" +
+					"mirror-no-mirrors  digest  registry.example.com  \n"
+				Expect(stdout).To(Equal(expectedOutput))
+			})
+
+			It("Handles image mirror with empty mirrors array", func() {
+				imageMirror, err := cmv1.NewImageMirror().
+					ID("mirror-empty-mirrors").
+					Type("tag").
+					Source("quay.io/test").
+					Mirrors().
+					Build()
+				Expect(err).ToNot(HaveOccurred())
+				response := fmt.Sprintf("{\n  \"items\": [\n    %s\n  ],\n  \"page\": 0,\n  \"size\": 1,\n  \"total\": 1\n}",
+					test.FormatResource(imageMirror))
+
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, response))
+				runner := ListImageMirrorsRunner(NewListImageMirrorsOptions())
+				err = t.StdOutReader.Record()
+				Expect(err).ToNot(HaveOccurred())
+				cmd := NewListImageMirrorsCommand()
+				err = cmd.Flag("cluster").Value.Set(clusterId)
+				Expect(err).ToNot(HaveOccurred())
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).ToNot(HaveOccurred())
+				stdout, err := t.StdOutReader.Read()
+				Expect(err).ToNot(HaveOccurred())
+				expectedOutput := "ID                    TYPE  SOURCE        MIRRORS\n" +
+					"mirror-empty-mirrors  tag   quay.io/test  \n"
+				Expect(stdout).To(Equal(expectedOutput))
+			})
+		})
+	})
+})
+
+// formatSingleImageMirror simulates the output of APIs for a fake image mirror list with one item
+func formatSingleImageMirror() string {
+	imageMirror, err := cmv1.NewImageMirror().
+		ID("mirror1").
+		Type("digest").
+		Source("registry.redhat.io").
+		Mirrors("mirror.example.com").
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+	return fmt.Sprintf("{\n  \"items\": [\n    %s\n  ],\n  \"page\": 0,\n  \"size\": 1,\n  \"total\": 1\n}",
+		test.FormatResource(imageMirror))
+}
+
+// formatMultipleImageMirrors simulates the output of APIs for a fake image mirror list with multiple items
+func formatMultipleImageMirrors() string {
+	imageMirror1, err := cmv1.NewImageMirror().
+		ID("mirror1").
+		Type("digest").
+		Source("registry.redhat.io").
+		Mirrors("mirror.example.com").
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+
+	imageMirror2, err := cmv1.NewImageMirror().
+		ID("mirror2").
+		Type("tag").
+		Source("quay.io/openshift").
+		Mirrors("mirror1.com", "mirror2.com").
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+
+	return fmt.Sprintf("{\n  \"items\": [\n    %s,\n    %s\n  ],\n  \"page\": 0,\n  \"size\": 2,\n  \"total\": 2\n}",
+		test.FormatResource(imageMirror1), test.FormatResource(imageMirror2))
+}
+
+// formatEmptyImageMirrors simulates the output of APIs for an empty image mirror list
+func formatEmptyImageMirrors() string {
+	return "{\n  \"items\": [],\n  \"page\": 0,\n  \"size\": 0,\n  \"total\": 0\n}"
+}

--- a/cmd/list/imagemirrors/imagemirror_suite_test.go
+++ b/cmd/list/imagemirrors/imagemirror_suite_test.go
@@ -1,0 +1,13 @@
+package imagemirrors
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestImageMirrors(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "List ImageMirrors suite")
+}

--- a/cmd/list/imagemirrors/options.go
+++ b/cmd/list/imagemirrors/options.go
@@ -1,0 +1,44 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package imagemirrors
+
+import (
+	"github.com/openshift/rosa/pkg/reporter"
+)
+
+type ListImageMirrorsUserOptions struct {
+}
+
+type ListImageMirrorsOptions struct {
+	reporter reporter.Logger
+	args     *ListImageMirrorsUserOptions
+}
+
+func NewListImageMirrorsUserOptions() *ListImageMirrorsUserOptions {
+	return &ListImageMirrorsUserOptions{}
+}
+
+func NewListImageMirrorsOptions() *ListImageMirrorsOptions {
+	return &ListImageMirrorsOptions{
+		reporter: reporter.CreateReporter(),
+		args:     NewListImageMirrorsUserOptions(),
+	}
+}
+
+func (o *ListImageMirrorsOptions) Args() *ListImageMirrorsUserOptions {
+	return o.args
+}

--- a/cmd/list/imagemirrors/options_test.go
+++ b/cmd/list/imagemirrors/options_test.go
@@ -1,0 +1,40 @@
+package imagemirrors
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/rosa/pkg/reporter"
+)
+
+var _ = Describe("ListImageMirrorsOptions", func() {
+	var (
+		imageMirrorsOptions *ListImageMirrorsOptions
+		userOptions         *ListImageMirrorsUserOptions
+	)
+
+	BeforeEach(func() {
+		imageMirrorsOptions = NewListImageMirrorsOptions()
+		userOptions = NewListImageMirrorsUserOptions()
+	})
+
+	Context("NewListImageMirrorsUserOptions", func() {
+		It("should create default user options", func() {
+			Expect(userOptions).To(BeAssignableToTypeOf(&ListImageMirrorsUserOptions{}))
+		})
+	})
+
+	Context("NewListImageMirrorsOptions", func() {
+		It("should create default image mirrors options", func() {
+			Expect(imageMirrorsOptions.reporter).To(BeAssignableToTypeOf(&reporter.Object{}))
+			Expect(imageMirrorsOptions.args).To(BeAssignableToTypeOf(&ListImageMirrorsUserOptions{}))
+		})
+	})
+
+	Context("Args", func() {
+		It("should return the args field", func() {
+			imageMirrorsOptions.args = userOptions
+			Expect(imageMirrorsOptions.Args()).To(Equal(userOptions))
+		})
+	})
+})

--- a/cmd/rosa/structure_test/command_args/rosa/create/image-mirror/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/create/image-mirror/command_args.yml
@@ -1,0 +1,6 @@
+- name: cluster
+- name: type
+- name: source
+- name: mirrors
+- name: profile
+- name: region

--- a/cmd/rosa/structure_test/command_args/rosa/delete/image-mirror/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/delete/image-mirror/command_args.yml
@@ -1,0 +1,5 @@
+- name: cluster
+- name: id
+- name: "yes"
+- name: profile
+- name: region

--- a/cmd/rosa/structure_test/command_args/rosa/edit/image-mirror/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/edit/image-mirror/command_args.yml
@@ -1,0 +1,7 @@
+- name: cluster
+- name: id
+- name: interactive
+- name: mirrors
+- name: profile
+- name: region
+- name: yes

--- a/cmd/rosa/structure_test/command_args/rosa/list/image-mirrors/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/list/image-mirrors/command_args.yml
@@ -1,0 +1,4 @@
+- name: cluster
+- name: output
+- name: profile
+- name: region

--- a/cmd/rosa/structure_test/command_structure.yml
+++ b/cmd/rosa/structure_test/command_structure.yml
@@ -22,6 +22,7 @@ children:
     - name: idp
     - name: external-auth-provider
     - name: iamserviceaccount
+    - name: image-mirror
     - name: kubeletconfig
     - name: machinepool
     - name: ocm-role
@@ -43,6 +44,7 @@ children:
     - name: external-auth-provider
     - name: iamserviceaccount
     - name: idp
+    - name: image-mirror
     - name: ingress
     - name: kubeletconfig
     - name: machinepool
@@ -84,6 +86,7 @@ children:
     - name: addon
     - name: autoscaler
     - name: cluster
+    - name: image-mirror
     - name: ingress
     - name: kubeletconfig
     - name: machinepool
@@ -117,6 +120,7 @@ children:
     - name: gates
     - name: iamserviceaccounts
     - name: idps
+    - name: image-mirrors
     - name: ingresses
     - name: instance-types
     - name: kubeletconfigs

--- a/pkg/ocm/imagemirrors.go
+++ b/pkg/ocm/imagemirrors.go
@@ -1,0 +1,119 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ocm
+
+import (
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+)
+
+// CreateImageMirror creates a new image mirror for the given cluster
+func (c *Client) CreateImageMirror(clusterID, mirrorType, source string, mirrors []string) (*cmv1.ImageMirror, error) {
+	imageMirror, err := cmv1.NewImageMirror().
+		Type(mirrorType).
+		Source(source).
+		Mirrors(mirrors...).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := c.ocm.ClustersMgmt().V1().
+		Clusters().
+		Cluster(clusterID).
+		ImageMirrors().
+		Add().
+		Body(imageMirror).
+		Send()
+	if err != nil {
+		return nil, handleErr(response.Error(), err)
+	}
+
+	return response.Body(), nil
+}
+
+// ListImageMirrors lists image mirrors for the given cluster
+func (c *Client) ListImageMirrors(clusterID string) ([]*cmv1.ImageMirror, error) {
+	response, err := c.ocm.ClustersMgmt().V1().
+		Clusters().
+		Cluster(clusterID).
+		ImageMirrors().
+		List().
+		Page(1).
+		Size(-1).
+		Send()
+	if err != nil {
+		return nil, handleErr(response.Error(), err)
+	}
+
+	return response.Items().Slice(), nil
+}
+
+// GetImageMirror gets a specific image mirror by ID for the given cluster
+func (c *Client) GetImageMirror(clusterID, id string) (*cmv1.ImageMirror, error) {
+	response, err := c.ocm.ClustersMgmt().V1().
+		Clusters().
+		Cluster(clusterID).
+		ImageMirrors().
+		ImageMirror(id).
+		Get().
+		Send()
+	if err != nil {
+		return nil, handleErr(response.Error(), err)
+	}
+
+	return response.Body(), nil
+}
+
+// UpdateImageMirror updates an existing image mirror
+func (c *Client) UpdateImageMirror(clusterID, id string, mirrors []string) (*cmv1.ImageMirror, error) {
+	imageMirrorPatch, err := cmv1.NewImageMirror().
+		Mirrors(mirrors...).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := c.ocm.ClustersMgmt().V1().
+		Clusters().
+		Cluster(clusterID).
+		ImageMirrors().
+		ImageMirror(id).
+		Update().
+		Body(imageMirrorPatch).
+		Send()
+	if err != nil {
+		return nil, handleErr(response.Error(), err)
+	}
+
+	return response.Body(), nil
+}
+
+// DeleteImageMirror deletes an image mirror
+func (c *Client) DeleteImageMirror(clusterID, id string) error {
+	response, err := c.ocm.ClustersMgmt().V1().
+		Clusters().
+		Cluster(clusterID).
+		ImageMirrors().
+		ImageMirror(id).
+		Delete().
+		Send()
+	if err != nil {
+		return handleErr(response.Error(), err)
+	}
+
+	return nil
+}

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -158,6 +158,20 @@ func Print(resource interface{}) error {
 		if subnetNetworkVerification, ok := resource.(*cmv1.SubnetNetworkVerification); ok {
 			cmv1.MarshalSubnetNetworkVerification(subnetNetworkVerification, &b)
 		}
+	case "*v1.ImageMirror":
+		if imageMirror, ok := resource.(*cmv1.ImageMirror); ok {
+			err := cmv1.MarshalImageMirror(imageMirror, &b)
+			if err != nil {
+				return err
+			}
+		}
+	case "[]*v1.ImageMirror":
+		if imageMirrors, ok := resource.([]*cmv1.ImageMirror); ok {
+			err := cmv1.MarshalImageMirrorList(imageMirrors, &b)
+			if err != nil {
+				return err
+			}
+		}
 	case "[]aws.Role", "[]aws.OidcProviderOutput":
 		{
 			err := defaultEncode(resource, &b)

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -297,6 +297,10 @@ func FormatResource(resource interface{}) string {
 		if res, ok := resource.(*accessv1.AccessRequest); ok {
 			err = accessv1.MarshalAccessRequest(res, &outputJson)
 		}
+	case "*v1.ImageMirror":
+		if res, ok := resource.(*v1.ImageMirror); ok {
+			err = v1.MarshalImageMirror(res, &outputJson)
+		}
 	default:
 		{
 			return "NOTIMPLEMENTED"


### PR DESCRIPTION
Sample interaction and output for image mirrors (IDMS)
```
[davidlee@fedora rosa]$ rosa create image-mirror -c dle-test-fix --source docker.io/nginx --mirrors my.registry.com/nginx,testing.org/nginx
I: Image mirror with ID 'ec936cd7-8c04-4938-b1ab-341b1ddd3d0f' has been created on cluster 'dle-test-fix'
I: Source: docker.io/nginx
I: Mirrors: [my.registry.com/nginx testing.org/nginx]

[davidlee@fedora rosa]$ rosa create image-mirror -c dle-test-fix --source docker.io/hw --mirrors my.registry.com/hw
I: Image mirror with ID '0a66f83f-c63b-4c55-86c5-f48dbc946e7d' has been created on cluster 'dle-test-fix'
I: Source: docker.io/hw
I: Mirrors: [my.registry.com/hw]

[davidlee@fedora rosa]$ rosa list image-mirrors -c dle-test-fix
ID                                    TYPE    SOURCE           MIRRORS
0a66f83f-c63b-4c55-86c5-f48dbc946e7d  digest  docker.io/hw     my.registry.com/hw
ec936cd7-8c04-4938-b1ab-341b1ddd3d0f  digest  docker.io/nginx  my.registry.com/nginx, testing.org/nginx

[davidlee@fedora rosa]$ rosa edit image-mirror -c dle-test-fix 0a66f83f-c63b-4c55-86c5-f48dbc946e7d --mirrors what.abc/hw,fire.abc/hw
I: Image mirror '0a66f83f-c63b-4c55-86c5-f48dbc946e7d' has been updated on cluster 'dle-test-fix'
I: Source: docker.io/hw
I: Updated mirrors: [what.abc/hw fire.abc/hw]

[davidlee@fedora rosa]$ rosa list image-mirrors -c dle-test-fix
ID                                    TYPE    SOURCE           MIRRORS
0a66f83f-c63b-4c55-86c5-f48dbc946e7d  digest  docker.io/hw     what.abc/hw, fire.abc/hw
ec936cd7-8c04-4938-b1ab-341b1ddd3d0f  digest  docker.io/nginx  my.registry.com/nginx, testing.org/nginx

[davidlee@fedora rosa]$ rosa delete image-mirror -c dle-test-fix 0a66f83f-c63b-4c55-86c5-f48dbc946e7d
? Are you sure you want to delete image mirror '0a66f83f-c63b-4c55-86c5-f48dbc946e7d' on cluster 'dle-test-fix'?: Yes
I: Image mirror '0a66f83f-c63b-4c55-86c5-f48dbc946e7d' has been deleted from cluster 'dle-test-fix'

[davidlee@fedora rosa]$ rosa delete image-mirror -c dle-test-fix 0a66f83f-c63b-4c55-86c5-f48dbc946e7d
? Are you sure you want to delete image mirror '0a66f83f-c63b-4c55-86c5-f48dbc946e7d' on cluster 'dle-test-fix'?: Yes
I: Image mirror '0a66f83f-c63b-4c55-86c5-f48dbc946e7d' has been deleted from cluster 'dle-test-fix'

```