### PR TITLE
OCM-18058 | ci: Fix the cluster desciption parsing of '[DEPRECATED] User Workload Monitoring'

### DIFF
--- a/tests/utils/exec/rosacli/cluster_service.go
+++ b/tests/utils/exec/rosacli/cluster_service.go
@@ -206,6 +206,7 @@ func (c *clusterService) ReflectClusterDescription(result bytes.Buffer) (res *Cl
 			newStr = strings.ReplaceAll(newStr, "not found: Role name", "not found:Role name")
 			//Until https://issues.redhat.com/browse/OCM-11830 fixed
 			newStr = strings.Replace(newStr, "Platform Allowlist:", "Platform Allowlist: \n    - ID:", 1)
+			newStr = strings.Replace(newStr, "[DEPRECATED] User Workload Monitoring:", "User Workload Monitoring:", 1)
 			return
 		}).
 		YamlToMap()


### PR DESCRIPTION
Fix the cluster desciption parsing of "[DEPRECATED] User Workload Monitoring"

 After https://issues.redhat.com/browse/OCM-17719, as M1 stage,  "[DEPRECATED] User Workload Monitoring" is added in the cluster description of hosted-cp cluster, this change makes DescribeClusterAndReflect failure, this function is using in some automated cases and also the cluster setup step, will cause bellow error,

`[FAILED] Unexpected error: <*errors.errorString | 0xc000e47e90>: yaml: line 1: did not find expected key { s: "yaml: line 1: did not find expected key", } occurred`

The log of rerun with this fix on local has passed, without above error anymore.
