### PR TITLE
OCM-7670 | fix: Removed optional from subnet selection for HCP

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2342,7 +2342,7 @@ func run(cmd *cobra.Command, _ []string) {
 			subnetIDs, err = interactive.GetMultipleOptions(interactive.Input{
 				Question: "Subnet IDs",
 				Help:     cmd.Flags().Lookup("subnet-ids").Usage,
-				Required: false,
+				Required: isHostedCP,
 				Options:  options,
 				Default:  defaultOptions,
 				Validators: []interactive.Validator{


### PR DESCRIPTION
# Details

This PR improves the UX when creating clusters by ensuring subnet selection is **required** for HCP (Hosted Control Plane) clusters while keeping it **optional** for Classic clusters, preventing deployment issues and providing clearer guidance to users.

The change has been applied to:
- `rosa create cluster` interactive mode for HCP clusters

**Key Change:** 
- Subnet selection prompt now uses `Required: isHostedCP` instead of `Required: false`
- This means subnets are mandatory for HCP clusters but remain optional for Classic clusters
- 
---

## Testing the Change

1. **Build the updated ROSA CLI:**
    ```bash
    go build ./cmd/rosa
    ```

2. **Test HCP cluster creation (subnets required):**
    ```bash
    ./rosa create cluster --hosted-cp --interactive --dry-run
    ```
    - Verify that the subnet prompt does NOT show "(optional)"
    - Verify that you cannot proceed without selecting subnets

3. **Test Classic cluster creation (subnets optional):**
    ```bash
    ./rosa create cluster --interactive --dry-run
    ```
    - Verify that the subnet prompt shows "(optional)"
    - Verify that you can skip subnet selection

---

# Ticket

Closes [OCM-7670](https://issues.redhat.com/browse/OCM-7670)
