### PR TITLE
OCM-18230 | ci: Use env to avoid failure that param substitution in scripts is not allowed

### DIFF
--- a/.tekton/steps/clean-up-step.yaml
+++ b/.tekton/steps/clean-up-step.yaml
@@ -16,6 +16,7 @@ spec:
     - name: aws-region
     - name: cluster-profile
     - name: ocm-login-env
+    - name: konflux-resources-json
   volumeMounts:
     - name: $(params.secret-volume)
       mountPath: /mnt/secrets
@@ -37,10 +38,12 @@ spec:
       value: $(params.aws-region)
     - name: TEST_PROFILE
       value: $(params.cluster-profile)
+    - name: KonfluxResourcesJson
+      value: $(params.konflux-resources-json)
   script: |
     #!/bin/bash
-    mkdir -p /rosa/tests/output/$(params.cluster-profile)
-    echo '$(params.konflux-resources-json)' > /rosa/tests/output/$(params.cluster-profile)/konflux_resources.json
+    mkdir -p /rosa/tests/output/$(TEST_PROFILE)
+    echo '$(KonfluxResourcesJson)' > /rosa/tests/output/$(TEST_PROFILE)/konflux_resources.json
     
     cd /rosa
     source ./tests/prow_ci.sh

--- a/.tekton/steps/export-resources-record-step.yaml
+++ b/.tekton/steps/export-resources-record-step.yaml
@@ -11,9 +11,15 @@ spec:
     - name: container-image
     - name: output-volume
     - name: cluster-profile
+    - name: konflux-resources-json
   volumeMounts:
     - name: $(params.output-volume)
       mountPath: /tests/output
+  env:
+    - name: KonfluxResourcesJson
+      value: $(params.konflux-resources-json)
+    - name: TEST_PROFILE
+      value: $(params.cluster-profile)
   script: |
     #!/bin/bash
-    cat /rosa/tests/output/$(params.cluster-profile)/konflux_resources.json > $(results.konflux-resources-json.path)
+    cat /rosa/tests/output/$(TEST_PROFILE)/konflux_resources.json > $(KonfluxResourcesJson)

--- a/.tekton/tasks/e2e-clean-up-task.yaml
+++ b/.tekton/tasks/e2e-clean-up-task.yaml
@@ -68,7 +68,7 @@ spec:
         - name: ocm-login-env
           value: "$(params.ocm-login-env)"
         - name: konflux-resources-json
-          value: "$(params.konflux-resources-json)"
+          value: $(tasks.hcp-advance-e2e-test.results.konflux-resources-json)
   volumes:
     - name: output-volume
       emptyDir: {}

--- a/.tekton/tasks/e2e-task.yaml
+++ b/.tekton/tasks/e2e-task.yaml
@@ -110,6 +110,8 @@ spec:
           value: output-volume
         - name: cluster-profile
           value: "$(params.cluster-profile)"
+        - name: konflux-resources-json
+          value: $(results.konflux-resources-json.path)
   volumes:
     - name: output-volume
       emptyDir: {}


### PR DESCRIPTION
Use env to avoid failure that param substitution in scripts is not allowed.

The Konflux hcp-advanced-e2e-test met bellow erorr: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-terraform-tenant/applications/rh-rosa-cli/pipelineruns/hcp-advanced-e2e-test-jl62v/logs?task=hcp-advance-e2e-test

```
// code placeholder
validation failed for referenced object export-resources-record: admission webhook "validation.webhook.pipeline.tekton.dev" denied the request: validation failed: non-existent variable in "#!/bin/bash\ncat /rosa/tests/output/$(params.cluster-profile)/konflux_resources.json > $(results.konflux-resources-json.path)\n": spec.script param substitution in scripts is not allowed.: spec.script 
```

