### PR TITLE
OCM-16969 | ci: Add a new HCP profile with proxy that is set username/password

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/nathan-fiscaletti/consolesize-go v0.0.0-20210105204122-a87d9f614b9d
 	github.com/onsi/ginkgo/v2 v2.17.1
 	github.com/onsi/gomega v1.30.0
-	github.com/openshift-online/ocm-common v0.0.29
+	github.com/openshift-online/ocm-common v0.0.31
 	github.com/openshift-online/ocm-sdk-go v0.1.476
 	github.com/pkg/errors v0.9.1
 	github.com/robfig/cron/v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -278,8 +278,8 @@ github.com/openshift-online/ocm-api-model/clientapi v0.0.431 h1:oGyJaX7ERZZVqVQB
 github.com/openshift-online/ocm-api-model/clientapi v0.0.431/go.mod h1:fZwy5HY2URG9nrExvQeXrDU/08TGqZ16f8oymVEN5lo=
 github.com/openshift-online/ocm-api-model/model v0.0.431 h1:vIuELb0uH2AkN5LMQLYbLrdYIULMEK6ctQkbdoNbEZQ=
 github.com/openshift-online/ocm-api-model/model v0.0.431/go.mod h1:PQIoq6P8Vlb7goOdRMLK8nJY+B7HH0RTqYAa4kyidTE=
-github.com/openshift-online/ocm-common v0.0.29 h1:EyKoLvQXKOa3UpoWHT3cMyNHBbhSZURC8Ws/cxTaT1U=
-github.com/openshift-online/ocm-common v0.0.29/go.mod h1:VEkuZp9aqbXtetZ5ycND6QpvhykvTuBF3oPsVM1X3vI=
+github.com/openshift-online/ocm-common v0.0.31 h1:csxB4UQAUhwhDOVBmOzUKgtemuwV9rhCkzMoeFX8zCQ=
+github.com/openshift-online/ocm-common v0.0.31/go.mod h1:VEkuZp9aqbXtetZ5ycND6QpvhykvTuBF3oPsVM1X3vI=
 github.com/openshift-online/ocm-sdk-go v0.1.476 h1:l5gp/QEqnocqM02m7pDeS9ndXcCTBamewVSGaymd88Y=
 github.com/openshift-online/ocm-sdk-go v0.1.476/go.mod h1:ds+aOAlQbiK0ubZP3CwXkzd7m48v6fMQ1ef9UCrjzBY=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/tests/ci/config/config.go
+++ b/tests/ci/config/config.go
@@ -40,6 +40,7 @@ type TestConfig struct {
 	ClusterDetailFile               string
 	ClusterInstallLogArtifactFile   string
 	ClusterAdminFile                string
+	ProxyAuthFile                   string
 	ClusterIDPAdminUsernamePassword string
 	TestFocusFile                   string
 	TestLabelFilterFile             string
@@ -121,6 +122,7 @@ func init() {
 	Test.ClusterDetailFile = path.Join(Test.OutputDir, "cluster-detail.json")
 	Test.ClusterInstallLogArtifactFile = path.Join(Test.ArtifactDir, ".install.log")
 	Test.ClusterAdminFile = path.Join(Test.ArtifactDir, ".admin")
+	Test.ProxyAuthFile = path.Join(Test.ArtifactDir, ".proxy-auth")
 	Test.ClusterIDPAdminUsernamePassword = path.Join(Test.ArtifactDir, ".idp-admin-username-password")
 	Test.TestFocusFile = path.Join(Test.RootDir, "tests", "ci", "data", "commit-focus")
 	Test.TestLabelFilterFile = path.Join(Test.RootDir, "tests", "ci", "data", "label-filter")

--- a/tests/ci/data/profiles/external.yaml
+++ b/tests/ci/data/profiles/external.yaml
@@ -216,6 +216,7 @@ profiles:
     kms_key: true
     networking: true
     proxy_enabled: true
+    proxy_type: "auth"
     label_enabled: false
     zones: ""
     tag_enabled: true

--- a/tests/utils/handler/cluster_handler.go
+++ b/tests/utils/handler/cluster_handler.go
@@ -736,8 +736,22 @@ func (ch *clusterHandler) GenerateClusterCreateFlags() ([]string, error) {
 			if proxyName == "" {
 				proxyName = clusterName
 			}
-			proxy, err := resourcesHandler.
-				PrepareProxy(ch.profile.Region, proxyName, config.Test.OutputDir, config.Test.ProxyCABundleFile)
+			proxy := &ProxyDetail{}
+			if ch.profile.ClusterConfig.ProxyType == "auth" {
+				log.Logger.Infof("Proxy auth is enabled. Going to generate the user and password and record in %s",
+					config.Test.ProxyAuthFile)
+				username := "proxyuser"
+				_, password := resourcesHandler.PrepareAdminUser()
+				_, err = helper.CreateFileWithContent(config.Test.ProxyAuthFile, fmt.Sprintf("%s:%s", username, password))
+				if err != nil {
+					return flags, err
+				}
+				proxy, err = resourcesHandler.
+					PrepareProxyWithAuth(ch.profile.Region, proxyName, config.Test.OutputDir, config.Test.ProxyCABundleFile, username, password)
+			} else {
+				proxy, err = resourcesHandler.
+					PrepareProxy(ch.profile.Region, proxyName, config.Test.OutputDir, config.Test.ProxyCABundleFile)
+			}
 			if err != nil {
 				return flags, err
 			}

--- a/tests/utils/handler/interface.go
+++ b/tests/utils/handler/interface.go
@@ -63,6 +63,7 @@ type ClusterConfig struct {
 	DefaultIngressPrivate         bool   `yaml:"default_ingress_private,omitempty"`
 	Private                       bool   `yaml:"private,omitempty" json:"private,omitempty"`
 	ProxyEnabled                  bool   `yaml:"proxy_enabled,omitempty" json:"proxy_enabled,omitempty"`
+	ProxyType                     string `yaml:"proxy_type,omitempty" json:"proxy_type,omitempty"`
 	STS                           bool   `yaml:"sts,omitempty" json:"sts,omitempty"`
 	SharedVPC                     bool   `yaml:"shared_vpc,omitempty" json:"shared_vpc,omitempty"`
 	TagEnabled                    bool   `yaml:"tag_enabled,omitempty" json:"tag_enabled,omitempty"`
@@ -123,5 +124,7 @@ type ProxyDetail struct {
 	HTTPProxy        string
 	CABundleFilePath string
 	NoProxy          string
+	Username         string
+	Password         string
 	InstanceID       string
 }

--- a/vendor/github.com/openshift-online/ocm-common/pkg/deprecation/transport_wrapper.go
+++ b/vendor/github.com/openshift-online/ocm-common/pkg/deprecation/transport_wrapper.go
@@ -1,5 +1,7 @@
 package deprecation
 
+//go:generate mockgen -destination=test/mock_roundtripper.go -package=test net/http RoundTripper
+
 import (
 	"fmt"
 	"net/http"

--- a/vendor/github.com/openshift-online/ocm-common/pkg/test/vpc_client/proxy.go
+++ b/vendor/github.com/openshift-online/ocm-common/pkg/test/vpc_client/proxy.go
@@ -10,7 +10,38 @@ import (
 	CON "github.com/openshift-online/ocm-common/pkg/aws/consts"
 	"github.com/openshift-online/ocm-common/pkg/file"
 	"github.com/openshift-online/ocm-common/pkg/log"
+	"github.com/openshift-online/ocm-common/pkg/utils"
 )
+
+/*
+MITM Proxy Authentication Support
+
+This package now supports username and password authentication for MITM proxy servers.
+Users can connect to the proxy using either format:
+
+1. Without authentication (backward compatible):
+   http_proxy=http://10.0.0.183:8080
+
+2. With authentication:
+   http_proxy=http://username:password@10.0.0.183:8080
+
+To use authentication, call LaunchProxyInstanceWithAuth() with username and password parameters.
+To maintain backward compatibility, use the original LaunchProxyInstance() function.
+
+Security Note: Passwords are never logged in plain text. All logging operations
+are designed to protect sensitive credential information.
+
+Example usage:
+    // Without authentication (original behavior)
+    instance, privateIP, caContent, err := vpc.LaunchProxyInstance(zone, keypairName, privateKeyPath)
+
+    // With authentication
+    instance, privateIP, caContent, err := vpc.LaunchProxyInstanceWithAuth(zone, keypairName, privateKeyPath, "myuser", "mypass")
+
+    // Get proxy URLs
+    httpProxy := vpc.GetProxyURL(privateIP, "myuser", "mypass")
+    httpsProxy := vpc.GetHTTPSProxyURL(privateIP, "myuser", "mypass")
+*/
 
 // FindProxyLaunchImage will try to find a proper image based on the filters to launch the proxy instance
 // No parameter needed here
@@ -69,6 +100,15 @@ func (vpc *VPC) FindProxyLaunchImage() (string, error) {
 // If set imageID to empty, it will find the proxy image in the ProxyImageMap map
 // LaunchProxyInstance will return proxyInstance detail, privateIPAddress,CAcontent and error
 func (vpc *VPC) LaunchProxyInstance(zone string, keypairName string, privateKeyPath string) (inst types.Instance, privateIP string, proxyServerCA string, err error) {
+	return vpc.LaunchProxyInstanceWithAuth(zone, keypairName, privateKeyPath, "", "")
+}
+
+// LaunchProxyInstanceWithAuth will launch a proxy instance on the indicated zone with optional authentication.
+// If username and password are provided, the proxy will require authentication
+// If set imageID to empty, it will find the proxy image in the ProxyImageMap map
+// LaunchProxyInstanceWithAuth will return proxyInstance detail, privateIPAddress,CAcontent and error
+func (vpc *VPC) LaunchProxyInstanceWithAuth(zone string, keypairName string, privateKeyPath string, username string, password string) (
+	inst types.Instance, privateIP string, proxyServerCA string, err error) {
 	imageID, err := vpc.FindProxyLaunchImage()
 	if err != nil {
 		return inst, "", "", err
@@ -83,8 +123,8 @@ func (vpc *VPC) LaunchProxyInstance(zone string, keypairName string, privateKeyP
 		log.LogError("Prepare SG failed for the proxy preparation %s", err)
 		return inst, "", "", err
 	}
-
-	keyName := fmt.Sprintf("%s-%s", CON.InstanceKeyNamePrefix, keypairName)
+	randomStr := utils.RandomLabel(2)
+	keyName := fmt.Sprintf("%s-%s-%s", CON.InstanceKeyNamePrefix, randomStr, keypairName)
 	key, err := vpc.CreateKeyPair(keyName)
 	if err != nil {
 		log.LogError("Create key pair %s failed %s", keyName, err)
@@ -130,7 +170,7 @@ func (vpc *VPC) LaunchProxyInstance(zone string, keypairName string, privateKeyP
 
 	time.Sleep(2 * time.Minute)
 	hostname := fmt.Sprintf("%s:22", publicIP)
-	err = setupMITMProxyServer(sshKey, hostname)
+	err = setupMITMProxyServer(sshKey, hostname, username, password)
 	if err != nil {
 		log.LogError("Setup MITM proxy server failed  %s", err)
 		return inst, "", "", err
@@ -145,16 +185,53 @@ func (vpc *VPC) LaunchProxyInstance(zone string, keypairName string, privateKeyP
 	return instOut.Instances[0], *instOut.Instances[0].PrivateIpAddress, caContent, err
 }
 
-func setupMITMProxyServer(sshKey string, hostname string) (err error) {
+func setupMITMProxyServer(sshKey string, hostname string, username string, password string) (err error) {
 	setupProxyCMDs := []string{
 		"sudo yum install -y wget",
 		"wget https://snapshots.mitmproxy.org/7.0.2/mitmproxy-7.0.2-linux.tar.gz",
 		"mkdir mitm",
 		"tar zxvf mitmproxy-7.0.2-linux.tar.gz -C mitm",
-		"nohup ./mitm/mitmdump --showhost --ssl-insecure > mitm.log 2>&1 &",
-		"sleep 5",
-		"http_proxy=127.0.0.1:8080 curl http://mitm.it/cert/pem -s > ~/mitm-ca.pem",
 	}
+
+	// If username and password are provided, set up authentication
+	if username != "" && password != "" {
+		// Create a simple authentication script
+		authScript := fmt.Sprintf(`cat > ~/proxy_auth.py << 'EOF'
+import mitmproxy.http
+import mitmproxy.addons.core
+
+class ProxyAuth:
+    def __init__(self, username, password):
+        self.username = username
+        self.password = password
+    
+    def request(self, flow: mitmproxy.http.HTTPFlow) -> None:
+        if flow.request.headers.get("Proxy-Authorization"):
+            return
+        
+        # Add basic authentication header
+        import base64
+        auth = base64.b64encode(f"{self.username}:{self.password}".encode()).decode()
+        flow.request.headers["Proxy-Authorization"] = f"Basic {auth}"
+
+addons = [
+    ProxyAuth("%s", "%s"),
+    mitmproxy.addons.core.Core()
+]
+EOF`, username, password)
+
+		setupProxyCMDs = append(setupProxyCMDs, authScript)
+		setupProxyCMDs = append(setupProxyCMDs,
+			"nohup ./mitm/mitmdump --showhost --ssl-insecure --script ~/proxy_auth.py > mitm.log 2>&1 &")
+	} else {
+		// No authentication - use standard setup
+		setupProxyCMDs = append(setupProxyCMDs,
+			"nohup ./mitm/mitmdump --showhost --ssl-insecure > mitm.log 2>&1 &")
+	}
+
+	setupProxyCMDs = append(setupProxyCMDs, "sleep 5")
+	setupProxyCMDs = append(setupProxyCMDs, "http_proxy=127.0.0.1:8080 curl http://mitm.it/cert/pem -s > ~/mitm-ca.pem")
+
 	for _, cmd := range setupProxyCMDs {
 		_, err = Exec_CMD(CON.AWSInstanceUser, sshKey, hostname, cmd)
 		if err != nil {
@@ -163,4 +240,22 @@ func setupMITMProxyServer(sshKey string, hostname string) (err error) {
 		log.LogDebug("Run the cmd successfully: %s", cmd)
 	}
 	return
+}
+
+// GetProxyURL returns the HTTP proxy URL with optional authentication
+// If username and password are provided, they will be included in the URL
+func (vpc *VPC) GetProxyURL(privateIP string, username string, password string) string {
+	if username != "" && password != "" {
+		return fmt.Sprintf("http://%s:%s@%s:8080", username, password, privateIP)
+	}
+	return fmt.Sprintf("http://%s:8080", privateIP)
+}
+
+// GetHTTPSProxyURL returns the HTTPS proxy URL with optional authentication
+// If username and password are provided, they will be included in the URL
+func (vpc *VPC) GetHTTPSProxyURL(privateIP string, username string, password string) string {
+	if username != "" && password != "" {
+		return fmt.Sprintf("https://%s:%s@%s:8080", username, password, privateIP)
+	}
+	return fmt.Sprintf("https://%s:8080", privateIP)
 }

--- a/vendor/github.com/openshift-online/ocm-common/pkg/utils/pointers.go
+++ b/vendor/github.com/openshift-online/ocm-common/pkg/utils/pointers.go
@@ -1,0 +1,45 @@
+package utils
+
+import (
+	"fmt"
+	"time"
+)
+
+// time.Time isn't really a primitive, but it's only pointer is to Location which would be the same one after the copy
+type primitive interface {
+	~int | ~int32 | ~int64 | ~float32 | ~float64 | ~string | ~bool | time.Time
+}
+
+// New takes any type of primitive and returns a pointer to a copy that is allocated in the heap.
+// This is needed to allow setting values (hard coded or struct members) by reference to the api structs.
+func New[T primitive](value T) *T {
+	return &value
+}
+
+// NewFormat is equivalent to Sprintf, but it returns a pointer to a string allocated in the heap.
+func NewFormat(format string, a ...interface{}) *string {
+	value := fmt.Sprintf(format, a...)
+	return &value
+}
+
+// NewByteArray takes the given byte array and returns a pointer to a copy that is allocated in the heap.
+func NewByteArray(value []byte) []byte {
+	if len(value) > 0 {
+		ret := make([]byte, len(value))
+		copy(ret, value)
+		return ret
+	}
+	return nil
+}
+
+// NewStringArray takes a string array and returns an array whose string elements are allocated in the heap.
+func NewStringArray(array []string) []*string {
+	if len(array) > 0 {
+		ret := make([]*string, len(array))
+		for idx, str := range array {
+			ret[idx] = New(str)
+		}
+		return ret
+	}
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -447,7 +447,7 @@ github.com/openshift-online/ocm-api-model/model/service_logs/v1
 github.com/openshift-online/ocm-api-model/model/service_mgmt/v1
 github.com/openshift-online/ocm-api-model/model/status_board/v1
 github.com/openshift-online/ocm-api-model/model/web_rca/v1
-# github.com/openshift-online/ocm-common v0.0.29
+# github.com/openshift-online/ocm-common v0.0.31
 ## explicit; go 1.21
 github.com/openshift-online/ocm-common/pkg/aws/aws_client
 github.com/openshift-online/ocm-common/pkg/aws/consts


### PR DESCRIPTION
[OCM-16969](https://issues.redhat.com//browse/OCM-16969) ：It support setup proxy with username/password way.Enable it in a new HCP profile
rosa describe cluster -c ying-proxy-0wby

```
Name:                       ying-proxy-0wby
Domain Prefix:              ying-proxy-0wby
Display Name:               ying-proxy-0wby
ID:                         2l40q27dvhbp0mhrr61799v2gl9ea4ik
External ID:                3e550e4f-999d-4af8-888b-0eafaf242046
Control Plane:              ROSA Service Hosted
OpenShift Version:          4.19.9
Channel Group:              stable
DNS:                        ying-proxy-0wby.961f.s3.devshift.org
AWS Account:                989064034108
AWS Billing Account:        301721915996
API URL:                    https://api.ying-proxy-0wby.961f.s3.devshift.org:443
Console URL:                https://console-openshift-console.apps.rosa.ying-proxy-0wby.961f.s3.devshift.org
Region:                     us-west-2
Availability:
 - Control Plane:           MultiAZ
 - Data Plane:              MultiAZ

Nodes:
 - Compute (desired):       3
 - Compute (current):       3
Network:
 - Type:                    OVNKubernetes
 - Service CIDR:            172.30.0.0/16
 - Machine CIDR:            10.0.0.0/16
 - Pod CIDR:                10.128.0.0/14
 - Host Prefix:             /23
 - Subnets:                 subnet-07602dcdd8f33c58d, subnet-0261fd61dfb6d7242, subnet-00752686e33854292
Proxy:
 - HTTPProxy:               http://proxyuser:WsRNbkkR2XYikt@10.0.0.27:8080
 - HTTPSProxy:              https://proxyuser:WsRNbkkR2XYikt@10.0.0.27:8080
 - NoProxy:                 quay.io
Additional trust bundle:    REDACTED
EC2 Metadata Http Tokens:   optional
Role (STS) ARN:             arn:aws:iam::989064034108:role/ying-proxy-0wby-HCP-ROSA-Installer-Role
Support Role ARN:           arn:aws:iam::989064034108:role/ying-proxy-0wby-HCP-ROSA-Support-Role
Instance IAM Roles:
 - Worker:                  arn:aws:iam::989064034108:role/ying-proxy-0wby-HCP-ROSA-Worker-Role
Operator IAM Roles:
 - arn:aws:iam::989064034108:role/ying-proxy-0wby-openshift-cloud-network-config-controller-cloud-
 - arn:aws:iam::989064034108:role/ying-proxy-0wby-kube-system-control-plane-operator
 - arn:aws:iam::989064034108:role/ying-proxy-0wby-kube-system-kms-provider
 - arn:aws:iam::989064034108:role/ying-proxy-0wby-kube-system-kube-controller-manager
 - arn:aws:iam::989064034108:role/ying-proxy-0wby-kube-system-capa-controller-manager
 - arn:aws:iam::989064034108:role/ying-proxy-0wby-openshift-image-registry-installer-cloud-credent
 - arn:aws:iam::989064034108:role/ying-proxy-0wby-openshift-ingress-operator-cloud-credentials
 - arn:aws:iam::989064034108:role/tying-proxy-0wby-openshift-cluster-csi-drivers-ebs-cloud-credenti
Managed Policies:           Yes
State:                      ready
Private:                    Yes
Delete Protection:          Disabled
Created:                    Sep  5 2025 03:37:47 UTC
[DEPRECATED] User Workload Monitoring:   Enabled
Details Page:               https://console.dev.redhat.com/openshift/details/s/32GOVebfUCnAfi1YEYytwMzvl4s
OIDC Endpoint URL:          https://oidc.os1.devshift.org/2l40mopoqs20ib54b3pbdoqan1u2g1ht (Managed)
Etcd Encryption:            Disabled
Audit Log Forwarding:       Disabled
External Authentication:    Disabled
Additional Principals:      arn:aws:iam::767397922229:role/ying-proxy-0wby-additional-principal-role
Zero Egress:                Disabled
./oc get co -A  --kubeconfig=kubeconfig
NAME                                       VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
console                                    4.19.9    True        False         False      85m     
csi-snapshot-controller                    4.19.9    True        False         False      100m    
dns                                        4.19.9    True        False         False      86m     
image-registry                             4.19.9    True        False         False      87m     
ingress                                    4.19.9    True        False         False      83m     
insights                                   4.19.9    True        False         False      88m     
kube-apiserver                             4.19.9    True        False         False      100m    
kube-controller-manager                    4.19.9    True        False         False      100m    
kube-scheduler                             4.19.9    True        False         False      100m    
kube-storage-version-migrator              4.19.9    True        False         False      88m     
monitoring                                 4.19.9    True        False         False      82m     
network                                    4.19.9    True        False         False      100m    
node-tuning                                4.19.9    True        False         False      82m     
openshift-apiserver                        4.19.9    True        False         False      100m    
openshift-controller-manager               4.19.9    True        False         False      100m    
openshift-samples                          4.19.9    True        False         False      88m     
operator-lifecycle-manager                 4.19.9    True        False         False      100m    
operator-lifecycle-manager-catalog         4.19.9    True        False         False      100m    
operator-lifecycle-manager-packageserver   4.19.9    True        False         False      100m    
service-ca                                 4.19.9    True        False         False      88m     
storage                                    4.19.9    True        False         False      89m     
```