### PR TITLE
feat(SLSRE-371): add hidden options for setting master/infra machine types with rosa create cluster

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -257,6 +257,10 @@ var args struct {
 	allowedRegistriesForImport string
 	platformAllowlist          string
 	additionalTrustedCa        string
+
+	// Master / Infra Machine Config
+	masterMachineType string
+	infraMachineType  string
 }
 
 var clusterRegistryConfigArgs *clusterregistryconfig.ClusterRegistryConfigArgs
@@ -928,6 +932,22 @@ func initFlags(cmd *cobra.Command) {
 		"The additional Security Group IDs to be added to the control plane nodes. "+
 			listInputMessage,
 	)
+
+	flags.StringVar(
+		&args.masterMachineType,
+		"master-machine-type",
+		"",
+		"Instance type for the Master nodes",
+	)
+	_ = flags.MarkHidden("master-machine-type")
+
+	flags.StringVar(
+		&args.infraMachineType,
+		"infra-machine-type",
+		"",
+		"Instance type for the Infra nodes",
+	)
+	_ = flags.MarkHidden("infra-machine-type")
 
 	interactive.AddModeFlag(cmd)
 	interactive.AddFlag(flags)
@@ -3389,6 +3409,8 @@ func run(cmd *cobra.Command, _ []string) {
 		AdditionalInfraSecurityGroupIds:        additionalInfraSecurityGroupIds,
 		AdditionalControlPlaneSecurityGroupIds: additionalControlPlaneSecurityGroupIds,
 		AdditionalAllowedPrincipals:            additionalAllowedPrincipals,
+		MasterMachineType:                      args.masterMachineType,
+		InfraMachineType:                       args.infraMachineType,
 	}
 
 	if httpTokens != "" {

--- a/cmd/rosa/structure_test/command_args/rosa/create/cluster/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/create/cluster/command_args.yml
@@ -111,3 +111,5 @@
 - name: interactive
 - name: output
 - name: "yes"
+- name: master-machine-type
+- name: infra-machine-type

--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -191,6 +191,10 @@ type Spec struct {
 	PlatformAllowlist          string
 	AdditionalTrustedCaFile    string
 	AdditionalTrustedCa        map[string]string
+
+	// Master/Infra Machine Config
+	MasterMachineType string
+	InfraMachineType  string
 }
 
 // Volume represents a volume property for a disk
@@ -924,6 +928,12 @@ func (c *Client) createClusterSpec(config Spec) (*cmv1.Cluster, error) {
 		}
 		if len(config.ComputeLabels) > 0 {
 			clusterNodesBuilder = clusterNodesBuilder.ComputeLabels(config.ComputeLabels)
+		}
+		if config.MasterMachineType != "" {
+			clusterNodesBuilder.MasterMachineType(cmv1.NewMachineType().ID(config.MasterMachineType))
+		}
+		if config.InfraMachineType != "" {
+			clusterNodesBuilder.InfraMachineType(cmv1.NewMachineType().ID(config.InfraMachineType))
 		}
 		clusterBuilder = clusterBuilder.Nodes(clusterNodesBuilder)
 	}


### PR DESCRIPTION
### Summary

Adds hidden options to set both Master and Infra node types for Classic clusters to enable testing of regions where `[m|r]5` instances are not available and provisioning would normally fail.

Closes [SLSRE-371](https://issues.redhat.com//browse/SLSRE-371)