### PR TITLE
OCM-18376 | fix: Delete inline policies

### DIFF
--- a/cmd/dlt/iamserviceaccount/cmd.go
+++ b/cmd/dlt/iamserviceaccount/cmd.go
@@ -258,6 +258,13 @@ func DeleteIamServiceAccountRunner(userOptions *iamServiceAccountOpts.DeleteIamS
 				return nil
 			}
 
+			// Delete inline policies
+			if len(inlinePolicies) > 0 {
+				err = r.AWSClient.DeleteInlineRolePolicies(roleName)
+				if err != nil {
+					return fmt.Errorf("failed to delete inline role policies: %s", err)
+				}
+			}
 			// Delete the role
 			err = r.AWSClient.DeleteServiceAccountRole(roleName)
 			if err != nil {


### PR DESCRIPTION
Fixes bug with [XCMSTRAT-1311](http://issues.redhat.com/browse/XCMSTRAT-1311) where inline policies were not deleted
* Bug seems to be that it was never introduced, so inline policies were still attached when the role was attempted to be deleted