### PR TITLE
OCM-18536 | ci: Update the aws credential path in the steps scripts of e2e testing

### DIFF
--- a/.tekton/steps/clean-up-step.yaml
+++ b/.tekton/steps/clean-up-step.yaml
@@ -48,7 +48,7 @@ spec:
     cd /rosa
     source ./tests/prow_ci.sh
     configure_aws "${AWS_CREDENTIALS}" "${AWS_REGION}"
-    configure_aws_shared_vpc "${AWS_SHAREDVPC_CREDENTIALS}/.awscred_shared_account"
+    configure_aws_shared_vpc "${AWS_SHAREDVPC_CREDENTIALS}"
 
     rosa login --env ${OCM_LOGIN_ENV} --token ${OCM_TOKEN}
     rosa whoami

--- a/.tekton/steps/run-e2e-day1-step.yaml
+++ b/.tekton/steps/run-e2e-day1-step.yaml
@@ -42,7 +42,7 @@ spec:
     cd /rosa
     source ./tests/prow_ci.sh
     configure_aws "${AWS_CREDENTIALS}" "${AWS_REGION}"
-    configure_aws_shared_vpc "${AWS_SHAREDVPC_CREDENTIALS}/.awscred_shared_account"
+    configure_aws_shared_vpc "${AWS_SHAREDVPC_CREDENTIALS}"
 
     rosa login --env ${OCM_LOGIN_ENV} --token ${OCM_TOKEN}
     rosa whoami

--- a/.tekton/steps/run-e2e-day2-step.yaml
+++ b/.tekton/steps/run-e2e-day2-step.yaml
@@ -42,7 +42,7 @@ spec:
     cd /rosa
     source ./tests/prow_ci.sh
     configure_aws "${AWS_CREDENTIALS}" "${AWS_REGION}"
-    configure_aws_shared_vpc "${AWS_SHAREDVPC_CREDENTIALS}/.awscred_shared_account"
+    configure_aws_shared_vpc "${AWS_SHAREDVPC_CREDENTIALS}"
     rosa login --env ${OCM_LOGIN_ENV} --token ${OCM_TOKEN}
     rosa whoami
 


### PR DESCRIPTION
The Konflux job of hcp-advanced-e2e fails as the aws credential file path is not correct in the step script.

The error is "ERROR: the shared vpc credential file /mnt/secrets/awscred_shared_account/.awscred_shared_account doesn't exist. Please check" https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-terraform-tenant/applications/rh-rosa-cli/taskruns/hcp-advanced-e2e-test-sgdvz-hcp-advance-e2e-test/logs

This fix will correct the aws credential path used in the job step
