### PR TITLE
OCM-18557 | ci: Flags should precede the package name in the ginkgo commands in the steps scripts of e2e testing

### DIFF
--- a/.tekton/steps/clean-up-step.yaml
+++ b/.tekton/steps/clean-up-step.yaml
@@ -54,7 +54,5 @@ spec:
     rosa whoami
 
     # run destroy case to clean up all testing resources
-    ginkgo ./tests/e2e --ginkgo.v --ginkgo.no-color \
-      --ginkgo.timeout "1h" \
-      --ginkgo.label-filter "destroy"
+    ginkgo --label-filter destroy --v --no-color --timeout 1h ./tests/e2e
 

--- a/.tekton/steps/run-e2e-day1-step.yaml
+++ b/.tekton/steps/run-e2e-day1-step.yaml
@@ -49,21 +49,14 @@ spec:
     rosa version
 
     # day1: prepare testing cluster
-    ginkgo ./tests/e2e --ginkgo.v --ginkgo.no-color \
-      --ginkgo.timeout "100m" \
-      --ginkgo.label-filter "day1"
+    ginkgo --label-filter day1 --v --no-color --timeout 60m ./tests/e2e
     rc1=$?
-
     # cluster setup readiness step
-    ginkgo ./tests/e2e --ginkgo.v --ginkgo.no-color \
-      --ginkgo.timeout "60m" \
-      --ginkgo.label-filter "day1-readiness"
+    ginkgo --label-filter day1-readiness --v --no-color --timeout 60m ./tests/e2e
     rc2=$?
 
     # day1-post check
-    ginkgo ./tests/e2e --ginkgo.v --ginkgo.no-color \
-      --ginkgo.timeout "60m" \
-      --ginkgo.label-filter "day1-post"
+    ginkgo --label-filter day1-post --v --no-color --timeout 60m ./tests/e2e
     rc3=$?
     if [ $rc1 -ne 0 ] || [ $rc2 -ne 0 ] || [ $rc3 -ne 0 ]; then
       exit 1

--- a/.tekton/steps/run-e2e-day2-step.yaml
+++ b/.tekton/steps/run-e2e-day2-step.yaml
@@ -47,15 +47,11 @@ spec:
     rosa whoami
 
     # run day2 cases
-    ginkgo ./tests/e2e --ginkgo.v --ginkgo.no-color \
-      --ginkgo.timeout "4h" \
-      --ginkgo.label-filter "day2"
+    ginkgo --label-filter day2 --v --no-color --timeout 4h ./tests/e2e
     rc1=$?
 
     # run day2 destructive cases
-    ginkgo ./tests/e2e --ginkgo.v --ginkgo.no-color \
-      --ginkgo.timeout "2h" \
-      --ginkgo.label-filter "destructive"
+    ginkgo --label-filter destructive --v --no-color --timeout 2h ./tests/e2e
     rc2=$?
     if [ $rc1 -ne 0 ] || [ $rc2 -ne 0 ]; then
       exit 1


### PR DESCRIPTION
In konflux hcp-advance-e2e-test job, fix the ginkgo command in the step scripts, flags should precede the package name to avoid all cases selected to run