### PR TITLE
OCM-18569 | feat: Unhide CapRes flag for m2

### DIFF
--- a/pkg/options/machinepool/create.go
+++ b/pkg/options/machinepool/create.go
@@ -283,9 +283,6 @@ func BuildMachinePoolCreateCommandWithOptions() (*cobra.Command, *CreateMachinep
 		"",
 		"The ID of an AWS On-Demand Capacity Reservation. The 'capacity-reservation-id' must be pre-created "+
 			"in advance, before creating a NodePool.")
-
-	_ = flags.MarkHidden("capacity-reservation-id") // Mark hidden for m1
-
 	output.AddFlag(cmd)
 	interactive.AddFlag(flags)
 	return cmd, options


### PR DESCRIPTION
M2 requires only to unhide this flag for the ROSA CLI