### PR TITLE
OCM-18575 | fix: It should not report error when create iamserviceaccount without setting '-path' miltiple times

### DIFF
--- a/pkg/options/iamserviceaccount/create.go
+++ b/pkg/options/iamserviceaccount/create.go
@@ -107,7 +107,7 @@ func BuildIamServiceAccountCreateCommandWithOptions() (*cobra.Command, *CreateIa
 	flags.StringVar(
 		&options.Path,
 		"path",
-		"/",
+		"",
 		"IAM path for the role.",
 	)
 


### PR DESCRIPTION
The default path for `rosa create iamserviceaccount` command should be "" rather than "/". this issue can be fixed with updating the default value of 'path'.

Reproduce step and tests:
- Create iamserviceaccount without using path
- Run the same command again
Before this fix, it reports "E: failed to create role: Role with same name but different path exists. Existing role ARN:"; With this fix, the role is created again successfully.

More regression test scenarios have passed:
- Create iamserviceaccount using path multiple times
- Create iamserviceaccount multiple times with different path
