### PR TITLE
OCM-17611 | feat: Introduce billing account selection for classic

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1208,14 +1208,22 @@ func run(cmd *cobra.Command, _ []string) {
 
 	// Billing Account
 	billingAccount := args.billingAccount
-	if isHostedCP && !fedramp.Enabled() {
+	if !fedramp.Enabled() {
+		isClassicBillingCapabilityEnabled, err := r.OCMClient.IsCapabilityEnabled(
+			"capability.cluster.rosa_classic_billing_account")
+		if err != nil {
+			_ = r.Reporter.Errorf("Failed to determine if billing account capability is enabled for user "+
+				"organization: %s", err)
+			os.Exit(1)
+		}
+
 		isHcpBillingTechPreview, err := r.OCMClient.IsTechnologyPreview(ocm.HcpBillingAccount, time.Now())
 		if err != nil {
 			r.Reporter.Errorf("%s", err)
 			os.Exit(1)
 		}
 
-		if !isHcpBillingTechPreview {
+		if (isHostedCP && !isHcpBillingTechPreview) || (!isHostedCP && isClassicBillingCapabilityEnabled) {
 
 			if billingAccount != "" && !ocm.IsValidAWSAccount(billingAccount) {
 				r.Reporter.Errorf("Provided billing account number %s is not valid. "+
@@ -1288,14 +1296,14 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 	}
 
-	if !isHostedCP && billingAccount != "" {
-		_ = r.Reporter.Errorf(billingAccountsHcpErrorMsg)
+	if fedramp.Enabled() && billingAccount != "" {
+		_ = r.Reporter.Errorf(billingAccountsGovErrorMsg)
 		os.Exit(1)
 	}
 
 	if isHostedCP && fedramp.Enabled() && billingAccount != "" {
 		if cmd.Flags().Changed(billingAccountFlag) {
-			_ = r.Reporter.Errorf(billingAccountsHcpErrorMsg)
+			_ = r.Reporter.Errorf(billingAccountsGovErrorMsg)
 		} else {
 			r.Reporter.Warnf("Billing accounts when using Govcloud are associated with non-govcloud accounts, " +
 				"using empty ID for billing account to create cluster")
@@ -3689,20 +3697,6 @@ func validateNetworkType(networkType string) error {
 		return fmt.Errorf(fmt.Sprintf("Expected a valid network type. Valid values: %v", ocm.NetworkTypes))
 	}
 	return nil
-}
-
-func GetBillingAccountContracts(cloudAccounts []*accountsv1.CloudAccount,
-	billingAccount string) ([]*accountsv1.Contract, bool) {
-	var contracts []*accountsv1.Contract
-	for _, account := range cloudAccounts {
-		if account.CloudAccountID() == billingAccount {
-			contracts = account.Contracts()
-			if ocm.HasValidContracts(account) {
-				return contracts, true
-			}
-		}
-	}
-	return contracts, false
 }
 
 func GenerateContractDisplay(contract *accountsv1.Contract) string {

--- a/cmd/create/cluster/validation.go
+++ b/cmd/create/cluster/validation.go
@@ -23,7 +23,7 @@ const (
 	isNotGovcloudFeature = "Hosted Control Plane shared VPC clusters are not supported on Govcloud regions; %s"
 	pleaseRemoveFlags    = "Please remove the following flags: %s"
 
-	billingAccountsHcpErrorMsg = "Billing accounts are only supported for non-govcloud Hosted Control Plane clusters"
+	billingAccountsGovErrorMsg = "Billing accounts are only supported for non-govcloud clusters"
 )
 
 func validateHcpSharedVpcArgs(route53RoleArn string, vpcEndpointRoleArn string,

--- a/cmd/edit/cluster/cmd.go
+++ b/cmd/edit/cluster/cmd.go
@@ -252,7 +252,7 @@ func run(cmd *cobra.Command, _ []string) {
 
 	cluster := r.FetchCluster()
 
-	if cluster.Hypershift().Enabled() && cmd.Flags().Changed("disable-workload-monitoring") {
+	if aws.IsHostedCP(cluster) && cmd.Flags().Changed("disable-workload-monitoring") {
 		r.Reporter.Warnf(arguments.UwmDeprecationMessage)
 	}
 
@@ -824,70 +824,81 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 	}
 
-	var billingAccount string
-	if cmd.Flags().Changed("billing-account") {
-		billingAccount = args.billingAccount
-
-		if billingAccount != "" && !aws.IsHostedCP(cluster) {
-			r.Reporter.Errorf("Billing accounts are only supported for Hosted Control Plane clusters")
-			os.Exit(1)
-		}
-		if billingAccount != "" && !ocm.IsValidAWSAccount(billingAccount) {
-			r.Reporter.Errorf("Provided billing account number %s is not valid. "+
-				"Rerun the command with a valid billing account number", billingAccount)
-			os.Exit(1)
-		}
-	} else {
-		billingAccount = cluster.AWS().BillingAccountID()
+	isClassicBillingCapabilityEnabled, err := r.OCMClient.IsCapabilityEnabled(
+		"capability.cluster.rosa_classic_billing_account")
+	if err != nil {
+		_ = r.Reporter.Errorf("Failed to determine if billing account capability is enabled for user "+
+			"organization: %s", err)
+		os.Exit(1)
 	}
 
-	if interactive.Enabled() && aws.IsHostedCP(cluster) && !fedramp.Enabled() {
-		cloudAccounts, err := r.OCMClient.GetBillingAccounts()
-		if err != nil {
-			r.Reporter.Errorf("%s", err)
-			os.Exit(1)
+	var billingAccount string
+	if aws.IsHostedCP(cluster) || (!aws.IsHostedCP(cluster) && isClassicBillingCapabilityEnabled) {
+		if cmd.Flags().Changed("billing-account") {
+			billingAccount = args.billingAccount
+
+			if billingAccount != "" && fedramp.Enabled() {
+				_ = r.Reporter.Errorf("Billing accounts are not supported for govcloud clusters")
+				os.Exit(1)
+			}
+			if billingAccount != "" && !ocm.IsValidAWSAccount(billingAccount) {
+				_ = r.Reporter.Errorf("Provided billing account number %s is not valid. "+
+					"Rerun the command with a valid billing account number", billingAccount)
+				os.Exit(1)
+			}
+		} else {
+			billingAccount = cluster.AWS().BillingAccountID()
 		}
 
-		billingAccounts := ocm.GenerateBillingAccountsList(cloudAccounts)
-		if len(billingAccounts) > 0 {
-			billingAccount, err = interactive.GetOption(interactive.Input{
-				Question:       "Update billing account",
-				Help:           cmd.Flags().Lookup("billing-account").Usage,
-				Default:        billingAccount,
-				DefaultMessage: fmt.Sprintf("current = '%s'", cluster.AWS().BillingAccountID()),
-				Required:       true,
-				Options:        billingAccounts,
-			})
-
+		if interactive.Enabled() && !fedramp.Enabled() &&
+			(aws.IsHostedCP(cluster) && isClassicBillingCapabilityEnabled) {
+			cloudAccounts, err := r.OCMClient.GetBillingAccounts()
 			if err != nil {
-				r.Reporter.Errorf("Expected a valid billing account: '%s'", err)
+				_ = r.Reporter.Errorf("%s", err)
 				os.Exit(1)
 			}
 
-			billingAccount = aws.ParseOption(billingAccount)
-		}
+			billingAccounts := ocm.GenerateBillingAccountsList(cloudAccounts)
+			if len(billingAccounts) > 0 {
+				billingAccount, err = interactive.GetOption(interactive.Input{
+					Question:       "Update billing account",
+					Help:           cmd.Flags().Lookup("billing-account").Usage,
+					Default:        billingAccount,
+					DefaultMessage: fmt.Sprintf("current = '%s'", cluster.AWS().BillingAccountID()),
+					Required:       true,
+					Options:        billingAccounts,
+				})
 
-		err = ocm.ValidateBillingAccount(billingAccount)
-		if err != nil {
-			r.Reporter.Errorf("%v", err)
-			os.Exit(1)
-		}
+				if err != nil {
+					_ = r.Reporter.Errorf("Expected a valid billing account: '%s'", err)
+					os.Exit(1)
+				}
 
-		// Get contract info
-		contracts, isContractEnabled := ocm.GetBillingAccountContracts(cloudAccounts, billingAccount)
+				billingAccount = aws.ParseOption(billingAccount)
+			}
 
-		if billingAccount != r.Creator.AccountID {
-			r.Reporter.Infof(
-				"The AWS billing account you selected is different from your AWS infrastructure account. " +
-					"The AWS billing account will be charged for subscription usage. " +
-					"The AWS infrastructure account contains the ROSA infrastructure.",
-			)
-		}
+			err = ocm.ValidateBillingAccount(billingAccount)
+			if err != nil {
+				_ = r.Reporter.Errorf("%v", err)
+				os.Exit(1)
+			}
 
-		if isContractEnabled && len(contracts) > 0 {
-			//currently, an AWS account will have only one ROSA HCP active contract at a time
-			contractDisplay := ocm.GenerateContractDisplay(contracts[0])
-			r.Reporter.Infof(contractDisplay)
+			// Get contract info
+			contracts, isContractEnabled := ocm.GetBillingAccountContracts(cloudAccounts, billingAccount)
+
+			if billingAccount != r.Creator.AccountID {
+				r.Reporter.Infof(
+					"The AWS billing account you selected is different from your AWS infrastructure account. " +
+						"The AWS billing account will be charged for subscription usage. " +
+						"The AWS infrastructure account contains the ROSA infrastructure.",
+				)
+			}
+
+			if isContractEnabled && len(contracts) > 0 {
+				//currently, an AWS account will have only one ROSA HCP active contract at a time
+				contractDisplay := ocm.GenerateContractDisplay(contracts[0])
+				r.Reporter.Infof(contractDisplay)
+			}
 		}
 	}
 
@@ -913,7 +924,7 @@ func run(cmd *cobra.Command, _ []string) {
 // about how changing cluster visibility may impact them
 func warnUserForOAuthHCPVisibility(r *rosa.Runtime, clusterKey string, cluster *cmv1.Cluster,
 	privateWarning string) (string, error) {
-	if !cluster.Hypershift().Enabled() {
+	if !aws.IsHostedCP(cluster) {
 		return privateWarning, nil
 	}
 	// if ingress visibility public, warning


### PR DESCRIPTION
Introduces day 1 and 2 billing account selection for classic clusters. Simple introduction since it is available for HCP already, the goal here was to replace the `if isHostedCp` gates with `if isHostedCp || (isClassic and isCapabilityEnabledForOrg)` so that billing account selection is available for customers with the correct capability for classic clusters


```swift
❯ ./rosa edit cluster -c hkepley --billing-account 123
I: Updated cluster 'hkepley'
❯ make
go build -ldflags="-X github.com/openshift/rosa/pkg/info.Build=a587d1642" ./cmd/rosa
❯ ./rosa edit cluster -c hkepley --billing-account 123
E: Provided billing account number 123 is not valid. Rerun the command with a valid billing account number
```

^ Example of editing, first command run was with a `false` org capability. Second run is with a `true` capability, but an incorrect billing account number

```swift
❯ ./rosa create cluster --mode auto --sts
hkeI: Enabling interactive mode
? Cluster name: hkepley
? Domain prefix (optional):
? Deploy cluster with Hosted Control Plane: No
? Create cluster admin user: No
? Billing Account:  [Use arrows to move, type to filter, ? for more help]
> ....
....
```

^ Creating (when you do not have capability, it simply skips the prompt, and ignores the flag if passed in. This way, we won't break clients for customers with or without the capability during private preview)

```swift
❯ ./rosa describe cluster -c hkepley

Name:                       hkepley
Domain Prefix:              hkepley
Display Name:               hkepley
ID:                         <CLUSTER_ID>
External ID:                <EXTERNAL_ID>
Control Plane:              Customer Hosted
OpenShift Version:          4.19.12
Channel Group:              stable
DNS:                        <DNS>
AWS Account:                <REAL_BILLING_ACCOUNT_NUMBER>
AWS Billing Account:        <REAL_BILLING_ACCOUNT_NUMBER>
```

^ Describing