### PR TITLE
OCM-18684 | fix: enhance the format to support proxy value with special characters

### DIFF
--- a/tests/utils/handler/cluster_handler.go
+++ b/tests/utils/handler/cluster_handler.go
@@ -764,9 +764,9 @@ func (ch *clusterHandler) GenerateClusterCreateFlags() ([]string, error) {
 				TrustBundleFile: proxy.CABundleFilePath,
 			}
 			flags = append(flags,
-				"--http-proxy", proxy.HTTPProxy,
-				"--https-proxy", proxy.HTTPsProxy,
-				"--no-proxy", proxy.NoProxy,
+				fmt.Sprintf("--http-proxy '%s'", proxy.HTTPProxy),
+				fmt.Sprintf("--https-proxy '%s'", proxy.HTTPsProxy),
+				fmt.Sprintf("--no-proxy '%s'", proxy.NoProxy),
 				"--additional-trust-bundle-file", proxy.CABundleFilePath,
 			)
 		}


### PR DESCRIPTION
Fix this error:
```
rosa create cluster -c ocpe2e-z5annkwx -y --version 4.19.13 --channel-group candidate --region us-west-2 --role-arn arn:aws:iam::*************:role/ocpe2e-z5annkwx-HCP-ROSA-Installer-Role --support-role-arn arn:aws:iam::*************:role/ocpe2e-z5annkwx-HCP-ROSA-Support-Role --worker-iam-role arn:aws:iam::*************:role/ocpe2e-z5annkwx-HCP-ROSA-Worker-Role --oidc-config-id 2lfud6k0l8i37g1h8v17fk9cg8l0hafp --operator-roles-prefix ocpe2e-z5annkwx --private --default-ingress-private --enable-autoscaling --min-replicas 3 --max-replicas 6 --machine-cidr 10.0.0.0/16 --service-cidr 172.31.0.0/24 --pod-cidr 10.128.0.0/14 --host-prefix 23 --subnet-ids subnet-01d10f09338bd2bf5,subnet-0bb3f42ad049af141,subnet-0321e96a144e94857 --additional-compute-security-group-ids sg-0abd6ac621cdf6fde,sg-061da2cb92a450882,sg-03cae86c6975c9fd9 --http-proxy http://proxyuser:Xp5T/GxEneT3R3@10.0.0.192:8080 --https-proxy https://proxyuser:Xp5T/GxEneT3R3@10.0.0.192:8080 --no-proxy quay.io --additional-trust-bundle-file /tmp/secret/proxy-bundle.ca --disable-workload-monitoring --etcd-encryption-kms-arn arn:aws:kms:us-west-2:*************:key/7075ce65-dc54-4d6a-9abd-11a1fdac8bae --ec2-metadata-http-tokens required --etcd-encryption --hosted-cp --compute-machine-type m5.xlarge --kms-key-arn arn:aws:kms:us-west-2:*************:key/645384f8-8e3b-4554-bceb-ff114210a3fc --enable-customer-managed-key --multi-az --tags test-tag:tagvalue,qe-managed:true --worker-disk-size 75GiB --properties zero_egress:true
  time=2025-09-23T05:54:05Z level=info msg=Get Combining Stdout and Stderr is :
  WARN: [DEPRECATED FOR ROSA HCP] User workload monitoring (--disable-workload-monitoring) has been deprecated for Hosted Control Plane clusters, and will be removed in a future version of ROSA CLI. Please remove from your workflows to avoid future issues
  INFO: Using '3017***' as billing account
  INFO: To use a different billing account, add --billing-account ************* to previous command
  WARN: Hosted clusters deprecate the --multi-az flag. The hosted control plane will be MultiAZ, machinepools will be created in the different private subnets provided under --subnet-ids flag.
  ERR: Invalid http-proxy value 'http://proxyuser:Xp5T/GxEneT3R3@10.0.0.192:8080'
```