### PR TITLE
OCM-16903 | fix: changed messaging for validation error in HCP cluster

### DIFF
--- a/pkg/interactive/validation_test.go
+++ b/pkg/interactive/validation_test.go
@@ -153,8 +153,8 @@ var _ = Describe("SubnetsValidator", func() {
 
 			err := validator(answers)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("The number of public subnets for a public hosted " +
-				"cluster should be at least one"))
+			Expect(err.Error()).To(ContainSubstring("Must have at least one public subnet when not using both " +
+				"'private API' and 'private ingress'"))
 		})
 
 	})

--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -789,8 +789,8 @@ func ValidateHostedClusterSubnets(awsClient aws.Client, isPrivate bool, subnetID
 		}
 	} else {
 		if publicSubnetsCount == 0 {
-			return 0, fmt.Errorf("The number of public subnets for a public hosted " +
-				"cluster should be at least one")
+			return 0, fmt.Errorf("Must have at least one public subnet when not using both " +
+				"'private API' and 'private ingress'")
 		}
 	}
 	return privateSubnetCount, nil


### PR DESCRIPTION
# Details

This PR improves the validation error message for subnet configuration in ROSA Hosted Control Plane clusters, providing clearer guidance when clusters require public subnets.

The implementation includes:
- Updated error message in `ValidateHostedClusterSubnets` function to accurately describe subnet requirements
- Clarified that public subnets are required unless **both** API and ingress are private
- Updated test cases to match the new error message

---

## Reproducing the Issue

### Interactive Mode

1. Create a ROSA HCP cluster in interactive mode:
    ```bash
    rosa create cluster --hosted-cp --interactive
    ```

2. Choose:
    - Private API: **Yes**
    - Private ingress: **No**
    - Select only private subnets in "Subnet IDs"

3. **Old behavior:** Confusing error about "public hosted cluster"
4. **New behavior:** Clear error explaining subnets needed for clusters not fully private

### Command Line Mode

1. Create a ROSA HCP cluster with private API but public ingress:
    ```bash
    rosa create cluster --cluster-name mycluster \
      --sts --mode auto \
      --hosted-cp \
      --private \
      --subnet-ids subnet-private1,subnet-private2,subnet-private3
    ```
    (Note: `--private` flag without `--default-ingress-private`)

2. **Old error:**
    ```
    E: The number of public subnets for a public hosted cluster should be at least one
    ```

3. **New error:**
    ```
    E: The number of public subnets for a hosted cluster which is not both API and ingress private should be at least one
    ```

---

# Ticket

Closes [ROSA-16903](https://issues.redhat.com/browse/ROSA-16903)