### PR TITLE
OCM-17465 | fix: created verification to when subnets are not set on proxy

### DIFF
--- a/tests/e2e/test_rosacli_cluster.go
+++ b/tests/e2e/test_rosacli_cluster.go
@@ -693,6 +693,30 @@ var _ = Describe("Edit cluster validation should", labels.Feature.Cluster, func(
 					"ERR: node-drain-grace-period flag is not supported to hosted clusters"))
 		})
 
+	It("should not use existing subnets when proxy set without subnet-ids - [id:45509]", labels.Medium, labels.Runtime.Day1Negative,
+		func() {
+			By("Create a cluster with proxy settings but without subnet-ids")
+			clusterName := "cl-45509"
+			output, err := clusterService.CreateDryRun(clusterName,
+				"--http-proxy", "http://example.com",
+				"--https-proxy", "https://example.com",
+				"--no-proxy", "example.com",
+			)
+
+			By("Should show warning about no subnets found and not error about subnet count")
+			// The error should NOT be about subnet count mismatch
+			Expect(output.String()).ShouldNot(ContainSubstring("The number of subnets for a 'single AZ' 'cluster' should be"))
+			// It should show the proper warning or error about needing subnets for proxy configuration
+			if err != nil {
+				Expect(output.String()).Should(
+					Or(
+						ContainSubstring("No subnets found in current region that are valid for the chosen CIDR ranges"),
+						ContainSubstring("Expected valid subnet IDs"),
+						ContainSubstring("subnet"),
+					))
+			}
+		})
+
 	It("can validate cluster proxy well - [id:46310]", labels.Medium, labels.Runtime.Day2, labels.FedRAMP,
 		func() {
 			By("Load the original cluster config")


### PR DESCRIPTION
# Details

This PR fixes an issue where ROSA incorrectly attempts to use all existing subnets in a region when proxy settings are configured without explicitly providing subnet IDs via the `--subnet-ids` flag.

The implementation includes:
- Modified the subnet initialization logic to only fetch subnets when subnet IDs are explicitly provided
- Prevents automatic listing of all region subnets when proxy is configured without subnets
- Added test case to verify the correct behavior

---

## Reproducing the Issue

1. Run the same command:
    ```bash
    rosa create cluster -c cl-45509 \
      --http-proxy http://example.com \
      --https-proxy https://example.com
    ```

2. **New behavior:**

<img width="1506" height="243" alt="Screenshot From 2025-10-02 15-41-45" src="https://github.com/user-attachments/assets/6b41ecb0-3c66-4e38-b6e7-7f78e7b9b1af" />

---

# Ticket

Closes [ROSA-17465](https://issues.redhat.com/browse/ROSA-17465)
