### PR TITLE
OCM-2610 | fix: changed behavior of sts flag on promoted command

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -4012,7 +4012,10 @@ func buildCommand(spec ocm.Spec, operatorRolesPrefix string,
 	}
 
 	if spec.IsSTS {
-		command += " --sts"
+		// HCP clusters are STS by default, so we only add --sts for non-HCP STS clusters
+		if !spec.Hypershift.Enabled {
+			command += " --sts"
+		}
 		if spec.Mode != "" {
 			command += fmt.Sprintf(" --mode %s", spec.Mode)
 		}

--- a/cmd/create/cluster/cmd_test.go
+++ b/cmd/create/cluster/cmd_test.go
@@ -111,6 +111,43 @@ var _ = Describe("Validate build command", func() {
 						" --external-auth-providers-enabled --properties \"prop1\" --properties \"prop2\""))
 			})
 		})
+
+		// Tests for OCM-2610 fix: HCP clusters should not include --sts flag
+		When("Hypershift is enabled (HCP cluster)", func() {
+			It("should include --hosted-cp but not --sts", func() {
+				clusterConfig.IsSTS = true
+				clusterConfig.Hypershift.Enabled = true
+				command := buildCommand(clusterConfig, operatorRolesPrefix,
+					expectedOperatorRolePath, userSelectedAvailabilityZones,
+					defaultMachinePoolLabels, argsDotProperties)
+				Expect(command).To(ContainSubstring("--hosted-cp"))
+				Expect(command).NotTo(ContainSubstring("--sts"))
+			})
+
+			It("should include --mode when specified for HCP", func() {
+				clusterConfig.IsSTS = true
+				clusterConfig.Hypershift.Enabled = true
+				clusterConfig.Mode = "auto"
+				command := buildCommand(clusterConfig, operatorRolesPrefix,
+					expectedOperatorRolePath, userSelectedAvailabilityZones,
+					defaultMachinePoolLabels, argsDotProperties)
+				Expect(command).To(ContainSubstring("--mode auto"))
+				Expect(command).To(ContainSubstring("--hosted-cp"))
+				Expect(command).NotTo(ContainSubstring("--sts"))
+			})
+		})
+
+		When("Regular STS cluster (non-HCP)", func() {
+			It("should include --sts but not --hosted-cp", func() {
+				clusterConfig.IsSTS = true
+				clusterConfig.Hypershift.Enabled = false
+				command := buildCommand(clusterConfig, operatorRolesPrefix,
+					expectedOperatorRolePath, userSelectedAvailabilityZones,
+					defaultMachinePoolLabels, argsDotProperties)
+				Expect(command).To(ContainSubstring("--sts"))
+				Expect(command).NotTo(ContainSubstring("--hosted-cp"))
+			})
+		})
 	})
 	Context("build tags command", func() {
 		When("tag key or values DO contain a colon", func() {

--- a/cmd/create/operatorroles/by_prefix.go
+++ b/cmd/create/operatorroles/by_prefix.go
@@ -201,16 +201,19 @@ func HandleOperatorRoleCreationByPrefix(r *rosa.Runtime, env string,
 		}
 		if r.Reporter.IsTerminal() {
 			hostedCpOutputParam := ""
+			stsParam := " --sts"
 			if args.hostedCp {
 				hostedCpOutputParam = fmt.Sprintf(" --%s", HostedCpFlag)
+				// HCP clusters are STS by default, so we don't need the --sts flag
+				stsParam = ""
 			}
 			installerRoleArnParam := ""
 			if args.installerRoleArn != "" && path != "" {
 				installerRoleArnParam = fmt.Sprintf(" --role-arn %s", args.installerRoleArn)
 			}
 			r.Reporter.Infof(fmt.Sprintf("To create a cluster with these roles, run the following command:\n"+
-				"\trosa create cluster --sts --oidc-config-id %s --operator-roles-prefix %s%s%s",
-				args.oidcConfigId, args.prefix, hostedCpOutputParam, installerRoleArnParam))
+				"\trosa create cluster%s --oidc-config-id %s --operator-roles-prefix %s%s%s",
+				stsParam, args.oidcConfigId, args.prefix, hostedCpOutputParam, installerRoleArnParam))
 		}
 		r.OCMClient.LogEvent("ROSACreateOperatorRolesModeAuto", map[string]string{
 			ocm.OperatorRolesPrefix: operatorRolesPrefix,


### PR DESCRIPTION
# Details

This PR fixes a UX issue where the `--sts` flag was incorrectly included in the promoted command when creating operator roles for Hosted Control Plane (HCP) clusters. 

---

## Testing the Fix

### Test Case 1: HCP Operator Roles

```bash

# Create HCP operator roles
./rosa create operator-roles \
    --prefix test-hcp-fix \
    --hosted-cp \
    --oidc-config-id <your-oidc-config-id> \
    --role-arn <hcp-installer-role-arn> \
    --mode auto
```

**Expected:** Promoted command should NOT contain `--sts` flag

### Test Case 2: Regular STS Operator Roles

```bash
# Create regular STS operator roles
./rosa create operator-roles \
    --prefix test-sts-fix \
    --oidc-config-id <your-oidc-config-id> \
    --role-arn <installer-role-arn> \
    --mode auto
```

**Expected:** Promoted command SHOULD contain `--sts` flag

---

# Ticket

Closes [[OCM-2610](https://issues.redhat.com/browse/OCM-2610)]