### PR TITLE
OCM-19067 | refactor: add tool to generate docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,10 @@ e2e_test: install
         --focus-file tests/e2e/.* \
 		$(NULL)
 
+.PHONY: generate-docs
+generate-docs:
+	go run ./tools/gendocs
+
 # verifies changes to .goreleaser.yaml
 .PHONY: check-release-config
 check-release-config:

--- a/cmd/rosa/main.go
+++ b/cmd/rosa/main.go
@@ -23,37 +23,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/openshift/rosa/cmd/attach"
-	"github.com/openshift/rosa/cmd/completion"
-	"github.com/openshift/rosa/cmd/config"
-	"github.com/openshift/rosa/cmd/create"
-	"github.com/openshift/rosa/cmd/describe"
-	"github.com/openshift/rosa/cmd/detach"
-	"github.com/openshift/rosa/cmd/dlt"
-	"github.com/openshift/rosa/cmd/docs"
-	"github.com/openshift/rosa/cmd/download"
-	"github.com/openshift/rosa/cmd/edit"
-	"github.com/openshift/rosa/cmd/grant"
-	"github.com/openshift/rosa/cmd/hibernate"
-	"github.com/openshift/rosa/cmd/initialize"
-	"github.com/openshift/rosa/cmd/install"
-	"github.com/openshift/rosa/cmd/link"
-	"github.com/openshift/rosa/cmd/list"
-	"github.com/openshift/rosa/cmd/login"
-	"github.com/openshift/rosa/cmd/logout"
-	"github.com/openshift/rosa/cmd/logs"
-	"github.com/openshift/rosa/cmd/register"
-	"github.com/openshift/rosa/cmd/resume"
-	"github.com/openshift/rosa/cmd/revoke"
-	"github.com/openshift/rosa/cmd/token"
-	"github.com/openshift/rosa/cmd/uninstall"
-	"github.com/openshift/rosa/cmd/unlink"
-	"github.com/openshift/rosa/cmd/upgrade"
-	"github.com/openshift/rosa/cmd/verify"
-	"github.com/openshift/rosa/cmd/version"
-	"github.com/openshift/rosa/cmd/whoami"
 	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/color"
+	"github.com/openshift/rosa/pkg/commands"
 	"github.com/openshift/rosa/pkg/info"
 	"github.com/openshift/rosa/pkg/reporter"
 	versionUtils "github.com/openshift/rosa/pkg/version"
@@ -76,35 +48,7 @@ func init() {
 	arguments.AddDebugFlag(fs)
 
 	// Register the subcommands:
-	root.AddCommand(completion.Cmd)
-	root.AddCommand(create.Cmd)
-	root.AddCommand(describe.Cmd)
-	root.AddCommand(dlt.Cmd)
-	root.AddCommand(docs.Cmd)
-	root.AddCommand(download.Cmd)
-	root.AddCommand(edit.Cmd)
-	root.AddCommand(grant.Cmd)
-	root.AddCommand(list.Cmd)
-	root.AddCommand(initialize.Cmd)
-	root.AddCommand(install.Cmd)
-	root.AddCommand(login.Cmd)
-	root.AddCommand(logout.Cmd)
-	root.AddCommand(logs.Cmd)
-	root.AddCommand(register.Cmd)
-	root.AddCommand(revoke.Cmd)
-	root.AddCommand(uninstall.Cmd)
-	root.AddCommand(upgrade.Cmd)
-	root.AddCommand(verify.Cmd)
-	root.AddCommand(version.NewRosaVersionCommand())
-	root.AddCommand(whoami.Cmd)
-	root.AddCommand(hibernate.GenerateCommand())
-	root.AddCommand(resume.GenerateCommand())
-	root.AddCommand(link.Cmd)
-	root.AddCommand(unlink.Cmd)
-	root.AddCommand(token.Cmd)
-	root.AddCommand(config.Cmd)
-	root.AddCommand(attach.NewRosaAttachCommand())
-	root.AddCommand(detach.NewRosaDetachCommand())
+	commands.RegisterCommands(root)
 }
 
 func main() {

--- a/codecov.yml
+++ b/codecov.yml
@@ -18,4 +18,5 @@ ignore:
   - "assets"
   - "hack"
   - "templates"
+  - "tools"
   - "vendor"

--- a/pkg/commands/commands_suite_test.go
+++ b/pkg/commands/commands_suite_test.go
@@ -1,0 +1,13 @@
+package commands
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCommands(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Commands Suite")
+}

--- a/pkg/commands/registry.go
+++ b/pkg/commands/registry.go
@@ -1,0 +1,87 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/cmd/attach"
+	"github.com/openshift/rosa/cmd/completion"
+	"github.com/openshift/rosa/cmd/config"
+	"github.com/openshift/rosa/cmd/create"
+	"github.com/openshift/rosa/cmd/describe"
+	"github.com/openshift/rosa/cmd/detach"
+	"github.com/openshift/rosa/cmd/dlt"
+	"github.com/openshift/rosa/cmd/docs"
+	"github.com/openshift/rosa/cmd/download"
+	"github.com/openshift/rosa/cmd/edit"
+	"github.com/openshift/rosa/cmd/grant"
+	"github.com/openshift/rosa/cmd/hibernate"
+	"github.com/openshift/rosa/cmd/initialize"
+	"github.com/openshift/rosa/cmd/install"
+	"github.com/openshift/rosa/cmd/link"
+	"github.com/openshift/rosa/cmd/list"
+	"github.com/openshift/rosa/cmd/login"
+	"github.com/openshift/rosa/cmd/logout"
+	"github.com/openshift/rosa/cmd/logs"
+	"github.com/openshift/rosa/cmd/register"
+	"github.com/openshift/rosa/cmd/resume"
+	"github.com/openshift/rosa/cmd/revoke"
+	"github.com/openshift/rosa/cmd/token"
+	"github.com/openshift/rosa/cmd/uninstall"
+	"github.com/openshift/rosa/cmd/unlink"
+	"github.com/openshift/rosa/cmd/upgrade"
+	"github.com/openshift/rosa/cmd/verify"
+	"github.com/openshift/rosa/cmd/version"
+	"github.com/openshift/rosa/cmd/whoami"
+)
+
+// RegisterCommands registers all ROSA CLI subcommands to the provided root command.
+// This function provides a single source of truth for command registration, used by both
+// the main ROSA CLI (cmd/rosa/main.go) and the documentation generation tool
+// (tools/gendocs/gen_rosa_docs.go), ensuring docs stay in sync with the actual CLI.
+func RegisterCommands(root *cobra.Command) {
+	root.AddCommand(completion.Cmd)
+	root.AddCommand(create.Cmd)
+	root.AddCommand(describe.Cmd)
+	root.AddCommand(dlt.Cmd)
+	root.AddCommand(docs.Cmd)
+	root.AddCommand(download.Cmd)
+	root.AddCommand(edit.Cmd)
+	root.AddCommand(grant.Cmd)
+	root.AddCommand(list.Cmd)
+	root.AddCommand(initialize.Cmd)
+	root.AddCommand(install.Cmd)
+	root.AddCommand(login.Cmd)
+	root.AddCommand(logout.Cmd)
+	root.AddCommand(logs.Cmd)
+	root.AddCommand(register.Cmd)
+	root.AddCommand(revoke.Cmd)
+	root.AddCommand(uninstall.Cmd)
+	root.AddCommand(upgrade.Cmd)
+	root.AddCommand(verify.Cmd)
+	root.AddCommand(version.NewRosaVersionCommand())
+	root.AddCommand(whoami.Cmd)
+	root.AddCommand(hibernate.GenerateCommand())
+	root.AddCommand(resume.GenerateCommand())
+	root.AddCommand(link.Cmd)
+	root.AddCommand(unlink.Cmd)
+	root.AddCommand(token.Cmd)
+	root.AddCommand(config.Cmd)
+	root.AddCommand(attach.NewRosaAttachCommand())
+	root.AddCommand(detach.NewRosaDetachCommand())
+}

--- a/pkg/commands/registry_test.go
+++ b/pkg/commands/registry_test.go
@@ -1,0 +1,112 @@
+package commands
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+)
+
+var _ = Describe("RegisterCommands", func() {
+	var rootCmd *cobra.Command
+
+	BeforeEach(func() {
+		// Create a fresh root command for each test
+		rootCmd = &cobra.Command{
+			Use:   "test",
+			Short: "Test command",
+			Long:  "Test command for verifying command registration",
+		}
+	})
+
+	Context("when registering all ROSA CLI commands", func() {
+		It("successfully registers all expected commands", func() {
+			// Call the function under test
+			RegisterCommands(rootCmd)
+
+			// Verify commands were registered
+			commands := rootCmd.Commands()
+			Expect(commands).ToNot(BeEmpty())
+
+			// Verify the expected number of commands are registered
+			// As of this test, there should be 29 top-level commands
+			Expect(len(commands)).To(Equal(29))
+
+			// Verify specific critical commands are present
+			commandNames := make(map[string]bool)
+			for _, cmd := range commands {
+				commandNames[cmd.Name()] = true
+			}
+
+			// Check for essential commands
+			expectedCommands := []string{
+				"completion",
+				"create",
+				"describe",
+				"delete",
+				"docs",
+				"download",
+				"edit",
+				"grant",
+				"list",
+				"init",
+				"install",
+				"login",
+				"logout",
+				"logs",
+				"register",
+				"revoke",
+				"uninstall",
+				"upgrade",
+				"verify",
+				"version",
+				"whoami",
+				"hibernate",
+				"resume",
+				"link",
+				"unlink",
+				"token",
+				"config",
+				"attach",
+				"detach",
+			}
+
+			for _, cmdName := range expectedCommands {
+				Expect(commandNames[cmdName]).To(BeTrue(), "Expected command '%s' to be registered", cmdName)
+			}
+		})
+
+		It("does not modify the root command's basic properties", func() {
+			originalUse := rootCmd.Use
+			originalShort := rootCmd.Short
+			originalLong := rootCmd.Long
+
+			RegisterCommands(rootCmd)
+
+			// Verify root command properties remain unchanged
+			Expect(rootCmd.Use).To(Equal(originalUse))
+			Expect(rootCmd.Short).To(Equal(originalShort))
+			Expect(rootCmd.Long).To(Equal(originalLong))
+		})
+
+		It("can be called multiple times without error", func() {
+			// First registration
+			RegisterCommands(rootCmd)
+			firstCount := len(rootCmd.Commands())
+
+			// Create a new root command for second registration
+			rootCmd2 := &cobra.Command{
+				Use:   "test2",
+				Short: "Test command 2",
+				Long:  "Test command 2 for verifying command registration",
+			}
+
+			// Second registration on different root
+			RegisterCommands(rootCmd2)
+			secondCount := len(rootCmd2.Commands())
+
+			// Both should have the same number of commands
+			Expect(firstCount).To(Equal(secondCount))
+			Expect(firstCount).To(Equal(29))
+		})
+	})
+})

--- a/templates/clibyexample/template
+++ b/templates/clibyexample/template
@@ -1,0 +1,17 @@
+// NOTE: The contents of this file are auto-generated
+:_mod-docs-content-type: REFERENCE
+[id="rosa-cli-commands_{context}"]
+= ROSA CLI commands
+
+{{range .Items}}
+
+== {{.FullName}}
+{{.Description}}
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+{{.Examples}}
+----
+
+{{end}}

--- a/tools/gendocs/gen_rosa_docs.go
+++ b/tools/gendocs/gen_rosa_docs.go
@@ -1,0 +1,50 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/commands"
+	"github.com/openshift/rosa/tools/gendocs/gendocs"
+)
+
+func main() {
+	// Initialize the root command with all subcommands
+	root := &cobra.Command{
+		Use:   "rosa",
+		Short: "Command line tool for ROSA.",
+		Long: "Command line tool for Red Hat OpenShift Service on AWS.\n" +
+			"For further documentation visit " +
+			"https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws\n",
+	}
+
+	// Register all subcommands using shared function from pkg/commands
+	commands.RegisterCommands(root)
+
+	// Generate the documentation
+	outputFile := "docs/generated/rosa-by-example-content.adoc"
+	if err := gendocs.GenDocs(root, outputFile); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to generate documentation: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Documentation generated successfully: %s\n", outputFile)
+}

--- a/tools/gendocs/gendocs/gendocs.go
+++ b/tools/gendocs/gendocs/gendocs.go
@@ -1,0 +1,101 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gendocs
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/spf13/cobra"
+)
+
+type Examples struct {
+	Items []Example `json:"items"`
+}
+
+type Example struct {
+	Name        string `json:"name"`
+	FullName    string `json:"fullName"`
+	Description string `json:"description"`
+	Examples    string `json:"examples"`
+}
+
+// GenDocs generates Asciidoc documentation for ROSA CLI commands
+func GenDocs(cmd *cobra.Command, filename string) error {
+	examples := extractExamples(cmd)
+
+	templateContent, err := os.ReadFile("templates/clibyexample/template")
+	if err != nil {
+		return fmt.Errorf("failed to read template file: %w", err)
+	}
+
+	tmpl, err := template.New("docs").Parse(string(templateContent))
+	if err != nil {
+		return fmt.Errorf("failed to parse template: %w", err)
+	}
+
+	buf := &bytes.Buffer{}
+	if err := tmpl.Execute(buf, examples); err != nil {
+		return fmt.Errorf("failed to execute template: %w", err)
+	}
+
+	// Ensure output directory exists
+	if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	if err := os.WriteFile(filename, buf.Bytes(), 0644); err != nil {
+		return fmt.Errorf("failed to write output file: %w", err)
+	}
+
+	return nil
+}
+
+// extractExamples recursively walks the command tree and extracts examples
+func extractExamples(cmd *cobra.Command) Examples {
+	examples := Examples{
+		Items: []Example{},
+	}
+
+	// Skip hidden commands
+	if cmd.Hidden {
+		return examples
+	}
+
+	// Add current command if it has examples
+	if cmd.Example != "" {
+		example := Example{
+			Name:        cmd.Name(),
+			FullName:    cmd.CommandPath(),
+			Description: cmd.Short,
+			Examples:    strings.TrimSpace(cmd.Example),
+		}
+		examples.Items = append(examples.Items, example)
+	}
+
+	// Recursively process subcommands
+	for _, subCmd := range cmd.Commands() {
+		subExamples := extractExamples(subCmd)
+		examples.Items = append(examples.Items, subExamples.Items...)
+	}
+
+	return examples
+}

--- a/tools/gendocs/gendocs/gendocs_suite_test.go
+++ b/tools/gendocs/gendocs/gendocs_suite_test.go
@@ -1,0 +1,13 @@
+package gendocs_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestGendocs(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Gendocs Suite")
+}

--- a/tools/gendocs/gendocs/gendocs_test.go
+++ b/tools/gendocs/gendocs/gendocs_test.go
@@ -1,0 +1,293 @@
+package gendocs_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+
+	. "github.com/openshift/rosa/tools/gendocs/gendocs"
+)
+
+var _ = Describe("Gendocs", func() {
+	var tmpDir string
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "gendocs-test-*")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(tmpDir)
+	})
+
+	Describe("GenDocs", func() {
+		Context("when generating documentation", func() {
+			It("generates documentation for a command with examples", func() {
+				// Create a simple template
+				templatePath := filepath.Join(tmpDir, "template")
+				templateContent := `{{range .Items}}{{.FullName}}: {{.Description}}
+{{end}}`
+				err := os.WriteFile(templatePath, []byte(templateContent), 0644)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Create test command
+				rootCmd := &cobra.Command{
+					Use:     "test",
+					Short:   "Test command",
+					Example: "test example",
+				}
+
+				// Generate docs
+				outputPath := filepath.Join(tmpDir, "output.adoc")
+
+				// Change directory to tmpDir so template path works
+				oldDir, err := os.Getwd()
+				Expect(err).ToNot(HaveOccurred())
+				defer os.Chdir(oldDir)
+
+				err = os.Chdir(tmpDir)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Create templates/clibyexample directory structure
+				err = os.MkdirAll("templates/clibyexample", 0755)
+				Expect(err).ToNot(HaveOccurred())
+				err = os.WriteFile("templates/clibyexample/template", []byte(templateContent), 0644)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = GenDocs(rootCmd, outputPath)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Verify output file exists
+				_, err = os.Stat(outputPath)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Verify content
+				content, err := os.ReadFile(outputPath)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(content)).To(ContainSubstring("test: Test command"))
+			})
+
+			It("generates documentation for commands with subcommands", func() {
+				// Create template
+				templatePath := filepath.Join(tmpDir, "template")
+				templateContent := `{{range .Items}}{{.FullName}}
+{{end}}`
+				err := os.WriteFile(templatePath, []byte(templateContent), 0644)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Create test command with subcommands
+				rootCmd := &cobra.Command{
+					Use:     "test",
+					Short:   "Test command",
+					Example: "test example",
+				}
+				subCmd := &cobra.Command{
+					Use:     "sub",
+					Short:   "Sub command",
+					Example: "test sub example",
+				}
+				rootCmd.AddCommand(subCmd)
+
+				// Generate docs
+				outputPath := filepath.Join(tmpDir, "output.adoc")
+
+				oldDir, err := os.Getwd()
+				Expect(err).ToNot(HaveOccurred())
+				defer os.Chdir(oldDir)
+
+				err = os.Chdir(tmpDir)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = os.MkdirAll("templates/clibyexample", 0755)
+				Expect(err).ToNot(HaveOccurred())
+				err = os.WriteFile("templates/clibyexample/template", []byte(templateContent), 0644)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = GenDocs(rootCmd, outputPath)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Verify content includes both commands
+				content, err := os.ReadFile(outputPath)
+				Expect(err).ToNot(HaveOccurred())
+				contentStr := string(content)
+				Expect(contentStr).To(ContainSubstring("test"))
+				Expect(contentStr).To(ContainSubstring("test sub"))
+			})
+
+			It("skips hidden commands", func() {
+				templatePath := filepath.Join(tmpDir, "template")
+				templateContent := `{{range .Items}}{{.FullName}}
+{{end}}`
+				err := os.WriteFile(templatePath, []byte(templateContent), 0644)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Create command with hidden subcommand
+				rootCmd := &cobra.Command{
+					Use:     "test",
+					Short:   "Test command",
+					Example: "test example",
+				}
+				hiddenCmd := &cobra.Command{
+					Use:     "hidden",
+					Short:   "Hidden command",
+					Example: "test hidden example",
+					Hidden:  true,
+				}
+				rootCmd.AddCommand(hiddenCmd)
+
+				outputPath := filepath.Join(tmpDir, "output.adoc")
+
+				oldDir, err := os.Getwd()
+				Expect(err).ToNot(HaveOccurred())
+				defer os.Chdir(oldDir)
+
+				err = os.Chdir(tmpDir)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = os.MkdirAll("templates/clibyexample", 0755)
+				Expect(err).ToNot(HaveOccurred())
+				err = os.WriteFile("templates/clibyexample/template", []byte(templateContent), 0644)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = GenDocs(rootCmd, outputPath)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Verify hidden command is not in output
+				content, err := os.ReadFile(outputPath)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(content)).ToNot(ContainSubstring("hidden"))
+			})
+
+			It("skips commands without examples", func() {
+				templatePath := filepath.Join(tmpDir, "template")
+				templateContent := `{{range .Items}}{{.FullName}}
+{{end}}`
+				err := os.WriteFile(templatePath, []byte(templateContent), 0644)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Create command without examples
+				rootCmd := &cobra.Command{
+					Use:     "test",
+					Short:   "Test command",
+					Example: "", // No example
+				}
+
+				outputPath := filepath.Join(tmpDir, "output.adoc")
+
+				oldDir, err := os.Getwd()
+				Expect(err).ToNot(HaveOccurred())
+				defer os.Chdir(oldDir)
+
+				err = os.Chdir(tmpDir)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = os.MkdirAll("templates/clibyexample", 0755)
+				Expect(err).ToNot(HaveOccurred())
+				err = os.WriteFile("templates/clibyexample/template", []byte(templateContent), 0644)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = GenDocs(rootCmd, outputPath)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Verify output is essentially empty (just template header)
+				content, err := os.ReadFile(outputPath)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(strings.TrimSpace(string(content))).To(BeEmpty())
+			})
+
+			It("returns error when template file does not exist", func() {
+				rootCmd := &cobra.Command{
+					Use:     "test",
+					Short:   "Test command",
+					Example: "test example",
+				}
+
+				outputPath := filepath.Join(tmpDir, "output.adoc")
+
+				oldDir, err := os.Getwd()
+				Expect(err).ToNot(HaveOccurred())
+				defer os.Chdir(oldDir)
+
+				err = os.Chdir(tmpDir)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = GenDocs(rootCmd, outputPath)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to read template file"))
+			})
+
+			It("returns error when template is invalid", func() {
+				templatePath := filepath.Join(tmpDir, "template")
+				// Invalid template syntax
+				templateContent := `{{range .Items}{{.FullName}}`
+				err := os.WriteFile(templatePath, []byte(templateContent), 0644)
+				Expect(err).ToNot(HaveOccurred())
+
+				rootCmd := &cobra.Command{
+					Use:     "test",
+					Short:   "Test command",
+					Example: "test example",
+				}
+
+				outputPath := filepath.Join(tmpDir, "output.adoc")
+
+				oldDir, err := os.Getwd()
+				Expect(err).ToNot(HaveOccurred())
+				defer os.Chdir(oldDir)
+
+				err = os.Chdir(tmpDir)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = os.MkdirAll("templates/clibyexample", 0755)
+				Expect(err).ToNot(HaveOccurred())
+				err = os.WriteFile("templates/clibyexample/template", []byte(templateContent), 0644)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = GenDocs(rootCmd, outputPath)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to parse template"))
+			})
+
+			It("trims whitespace from examples", func() {
+				templatePath := filepath.Join(tmpDir, "template")
+				templateContent := `{{range .Items}}Examples: {{.Examples}}
+{{end}}`
+				err := os.WriteFile(templatePath, []byte(templateContent), 0644)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Create command with whitespace in examples
+				rootCmd := &cobra.Command{
+					Use:     "test",
+					Short:   "Test command",
+					Example: "  \n  test example  \n  ",
+				}
+
+				outputPath := filepath.Join(tmpDir, "output.adoc")
+
+				oldDir, err := os.Getwd()
+				Expect(err).ToNot(HaveOccurred())
+				defer os.Chdir(oldDir)
+
+				err = os.Chdir(tmpDir)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = os.MkdirAll("templates/clibyexample", 0755)
+				Expect(err).ToNot(HaveOccurred())
+				err = os.WriteFile("templates/clibyexample/template", []byte(templateContent), 0644)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = GenDocs(rootCmd, outputPath)
+				Expect(err).ToNot(HaveOccurred())
+
+				content, err := os.ReadFile(outputPath)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(content)).To(Equal("Examples: test example\n"))
+			})
+		})
+	})
+})


### PR DESCRIPTION
This tool generates a "command-by-example" style command ref for the ROSA docs. It follows the same pattern as the gendocs tool for the OpenShift (oc) CLI (https://github.com/openshift/oc/tree/main/tools/gendocs).

Assisted by: Claude Code