### PR TITLE
OCM-12612 | fix: Filter DNS domains by organization in list command

### DIFF
--- a/cmd/list/dnsdomains/cmd.go
+++ b/cmd/list/dnsdomains/cmd.go
@@ -71,13 +71,18 @@ func run(_ *cobra.Command, _ []string) {
 	defer r.Cleanup()
 
 	r.Reporter.Debugf("Loading dns domains for current org id")
-	search := "user_defined='true'"
+	orgID, _, err := r.OCMClient.GetCurrentOrganization()
+	if err != nil {
+		_ = r.Reporter.Errorf("Failed to get current organization: %s", err)
+		os.Exit(1)
+	}
+	search := fmt.Sprintf("user_defined='true' AND organization.id='%s'", orgID)
 	if args.all {
 		search = ""
 	}
 	dnsDomains, err := r.OCMClient.ListDNSDomains(search)
 	if err != nil {
-		r.Reporter.Errorf("Failed to list DNS Domains: %v", err)
+		_ = r.Reporter.Errorf("Failed to list DNS Domains: %v", err)
 		os.Exit(1)
 	}
 
@@ -88,7 +93,7 @@ func run(_ *cobra.Command, _ []string) {
 	if output.HasFlag() {
 		err = output.Print(dnsDomains)
 		if err != nil {
-			r.Reporter.Errorf("%s", err)
+			_ = r.Reporter.Errorf("%s", err)
 			os.Exit(1)
 		}
 		os.Exit(0)

--- a/pkg/ocm/dns_domain.go
+++ b/pkg/ocm/dns_domain.go
@@ -22,6 +22,7 @@ func (c *Client) ListDNSDomains(search string) ([]*cmv1.DNSDomain, error) {
 		DNSDomains().
 		List().
 		Parameter("search", search).
+		Parameter("order", "organization.id asc").
 		Page(1).Size(-1).
 		Send()
 	if err != nil {


### PR DESCRIPTION
# Details

This PR fixes a security issue where `rosa list dns-domain` was displaying DNS domains from all organizations instead of filtering by the current logged-in organization, potentially exposing resources from other orgs.

---

## Fixed Behavior (Organization Filtered)

1. Run the same command with the fix:

    ```bash
    ./rosa list dns-domain
    ```

2. Now shows **only DNS domains from the current organization** (3 domains):

    ```
    ID                         CLUSTER ID  RESERVED TIME         USER DEFINED  ARCHITECTURE
    531t.p1.openshiftapps.com              0001-01-01T00:00:00Z  Yes           classic
    rgct.p1.openshiftapps.com              0001-01-01T00:00:00Z  Yes           classic
    ypwi.p4.openshiftapps.com              0001-01-01T00:00:00Z  Yes           
    ```

---

## The --all Flag Behavior

1. The `--all` flag now shows all DNS domains (user-defined + system) but **still filtered by current organization**:

    ```bash
    ./rosa list dns-domain --all
    ```

    Example output (82 domains, all from current org):
    ```
    ID                         CLUSTER ID                        RESERVED TIME         USER DEFINED  ARCHITECTURE
    531t.p1.openshiftapps.com              0001-01-01T00:00:00Z  Yes           classic
    rgct.p1.openshiftapps.com              0001-01-01T00:00:00Z  Yes           classic
    ypwi.p4.openshiftapps.com              0001-01-01T00:00:00Z  Yes           
    auto.p1.openshiftapps.com  2abc3def4...                      2024-01-15T10:30:00Z  No            classic
    ```

---

# Ticket

Closes [OCM-12612](https://issues.redhat.com/browse/OCM-12612)