### PR TITLE
OCM-18906 | fix: Handle HTTP errors in rosa download command and improve error messages

### DIFF
--- a/pkg/helper/download/download.go
+++ b/pkg/helper/download/download.go
@@ -3,8 +3,10 @@ package helper
 import (
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -15,27 +17,56 @@ import (
 // write as it downloads and not load the whole file into memory. We pass an io.TeeReader
 // into Copy() to report progress on the download.
 func Download(url string, filename string) error {
-	// Create the file, but give it a tmp file extension, this means we won't overwrite a
-	// file until it's downloaded, but we'll remove the tmp extension once downloaded.
-	out, err := os.Create(filename + ".tmp")
+	// Create a temporary file in the same directory as the target file
+	// This ensures atomic rename and avoids cross-device issues
+	dir := filepath.Dir(filename)
+	base := filepath.Base(filename)
+
+	// Create temp file with pattern "basename.*.tmp"
+	// For example: "rosa-linux.tar.gz" becomes "rosa-linux.tar.gz.123456.tmp"
+	out, err := os.CreateTemp(dir, base+".*.tmp")
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create temporary file: %v", err)
+	}
+	tmpFile := out.Name()
+
+	// Ensure cleanup of temp file on any error
+	cleanupTempFile := func() {
+		out.Close()
+		os.Remove(tmpFile)
 	}
 
 	// Get the data
 	// nolint:gosec
 	resp, err := http.Get(url)
 	if err != nil {
-		out.Close()
-		return err
+		cleanupTempFile()
+		return formatDownloadError(err, url)
 	}
 	defer resp.Body.Close()
+
+	// Check for 2xx success status codes
+	if resp.StatusCode/100 != 2 {
+		cleanupTempFile()
+		switch resp.StatusCode {
+		case http.StatusNotFound:
+			return fmt.Errorf("download failed: file not found (HTTP %d). The requested file may not exist or the URL may be incorrect. URL: %s", resp.StatusCode, url)
+		case http.StatusForbidden:
+			return fmt.Errorf("download failed: access forbidden (HTTP %d). You may not have permission to access this file. URL: %s", resp.StatusCode, url)
+		case http.StatusUnauthorized:
+			return fmt.Errorf("download failed: authentication required (HTTP %d). Please check your credentials. URL: %s", resp.StatusCode, url)
+		case http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable:
+			return fmt.Errorf("download failed: server error (HTTP %d). The server may be temporarily unavailable. Please try again later. URL: %s", resp.StatusCode, url)
+		default:
+			return fmt.Errorf("download failed: HTTP %d %s. URL: %s", resp.StatusCode, resp.Status, url)
+		}
+	}
 
 	// Create our progress reporter and pass it to be used alongside our writer
 	counter := &WriteCounter{}
 	if _, err = io.Copy(out, io.TeeReader(resp.Body, counter)); err != nil {
-		out.Close()
-		return err
+		cleanupTempFile()
+		return fmt.Errorf("failed to save downloaded file: %v", err)
 	}
 
 	// The progress use the same line so print a new line once it's finished downloading
@@ -44,10 +75,55 @@ func Download(url string, filename string) error {
 	// Close the file without defer so it can happen before Rename()
 	out.Close()
 
-	if err = os.Rename(filename+".tmp", filename); err != nil {
-		return err
+	if err = os.Rename(tmpFile, filename); err != nil {
+		os.Remove(tmpFile)
+		return fmt.Errorf("failed to rename downloaded file: %v", err)
 	}
 	return nil
+}
+
+// formatDownloadError formats network and download errors in a user-friendly way
+func formatDownloadError(err error, url string) error {
+	if err == nil {
+		return nil
+	}
+
+	// Check for common network error types
+	errStr := err.Error()
+
+	// DNS resolution errors
+	if strings.Contains(errStr, "lookup") || strings.Contains(errStr, "no such host") {
+		return fmt.Errorf("unable to resolve host for %s\nPlease check your internet connection and DNS settings", url)
+	}
+
+	// Connection refused
+	if strings.Contains(errStr, "connection refused") {
+		return fmt.Errorf("connection refused to %s\nThe server may be down or unreachable", url)
+	}
+
+	// Timeout errors
+	if strings.Contains(errStr, "timeout") || strings.Contains(errStr, "i/o timeout") {
+		return fmt.Errorf("connection timeout while downloading from %s\nPlease check your internet connection and try again", url)
+	}
+
+	// Network unreachable
+	if strings.Contains(errStr, "network is unreachable") {
+		return fmt.Errorf("network is unreachable for %s\nPlease check your internet connection", url)
+	}
+
+	// Certificate errors
+	if strings.Contains(errStr, "certificate") || strings.Contains(errStr, "x509") {
+		return fmt.Errorf("certificate validation failed for %s\nThe server's SSL certificate may be invalid or expired", url)
+	}
+
+	// Check if it's a net.OpError for more specific handling
+	if _, ok := err.(*net.OpError); ok {
+		// Generic network operation error - provide a clean message
+		return fmt.Errorf("network error while downloading from %s\nPlease check your internet connection and try again", url)
+	}
+
+	// Default case - still provide a cleaner message than raw error
+	return fmt.Errorf("download failed: unable to connect to %s\nPlease check your internet connection and try again", url)
 }
 
 // Get the extension used for the compressed oc file

--- a/pkg/helper/download/download_test.go
+++ b/pkg/helper/download/download_test.go
@@ -1,0 +1,126 @@
+package helper_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	helper "github.com/openshift/rosa/pkg/helper/download"
+)
+
+func TestDownload(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Download Helper Suite")
+}
+
+var _ = Describe("Download", func() {
+	var (
+		tmpDir string
+		server *httptest.Server
+	)
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "rosa-download-test-*")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		if server != nil {
+			server.Close()
+		}
+		os.RemoveAll(tmpDir)
+	})
+
+	Context("when downloading files", func() {
+		It("should successfully download a file with 2xx status codes", func() {
+			expectedContent := "test file content"
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, expectedContent)
+			}))
+
+			filename := filepath.Join(tmpDir, "test.txt")
+			err := helper.Download(server.URL, filename)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify file was created and contains expected content
+			content, err := os.ReadFile(filename)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(content)).To(Equal(expectedContent))
+
+			// Verify temp files were cleaned up (pattern: filename.*.tmp)
+			matches, err := filepath.Glob(filepath.Join(tmpDir, filepath.Base(filename)+".*.tmp"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(matches).To(BeEmpty(), "Temporary files should be cleaned up")
+		})
+
+		It("should handle HTTP errors and clean up temp files", func() {
+			testCases := []struct {
+				statusCode   int
+				errorMessage string
+			}{
+				{http.StatusNotFound, "file not found"},
+				{http.StatusForbidden, "access forbidden"},
+				{http.StatusInternalServerError, "server error"},
+			}
+
+			for _, tc := range testCases {
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(tc.statusCode)
+					fmt.Fprint(w, "Error page content")
+				}))
+
+				filename := filepath.Join(tmpDir, fmt.Sprintf("error-%d.txt", tc.statusCode))
+				err := helper.Download(server.URL, filename)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(tc.errorMessage))
+				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("HTTP %d", tc.statusCode)))
+
+				// Verify file was not created and temp files were cleaned up
+				_, err = os.Stat(filename)
+				Expect(os.IsNotExist(err)).To(BeTrue())
+
+				// Check that no temp files remain (pattern: filename.*.tmp)
+				matches, err := filepath.Glob(filepath.Join(tmpDir, filepath.Base(filename)+".*.tmp"))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(matches).To(BeEmpty(), "Temporary files should be cleaned up after error")
+
+				server.Close()
+			}
+		})
+
+		It("should handle network errors", func() {
+			// Use an invalid URL to simulate network error
+			filename := filepath.Join(tmpDir, "network-error.txt")
+			err := helper.Download("http://invalid.test.domain.that.does.not.exist", filename)
+			Expect(err).To(HaveOccurred())
+			// The error should be formatted cleanly without technical details
+			Expect(err.Error()).To(Or(
+				ContainSubstring("unable to resolve host"),
+				ContainSubstring("network error"),
+				ContainSubstring("unable to connect"),
+			))
+			Expect(err.Error()).To(ContainSubstring("check your internet connection"))
+
+			// Verify temp files were cleaned up (pattern: filename.*.tmp)
+			matches, err := filepath.Glob(filepath.Join(tmpDir, filepath.Base(filename)+".*.tmp"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(matches).To(BeEmpty(), "Temporary files should be cleaned up after network error")
+		})
+	})
+
+	Context("when checking file extensions", func() {
+		It("should return 'tar.gz' for non-Windows systems", func() {
+			extension := helper.GetExtension()
+			Expect(extension).To(Or(Equal("tar.gz"), Equal("zip")))
+		})
+	})
+})


### PR DESCRIPTION
# Details

This PR fixes a critical bug where the `rosa download` command would incorrectly report success when receiving HTTP error responses (like 404), downloading error pages instead of failing appropriately. It also improves error message formatting to be more user-friendly.

---

## Fixed Behavior

1. Run the same command after the fix:

    ```bash
    ./rosa download rosa-client
    ```

2. With a 404 response, the command now **properly fails** with a clear error:

    ```
    I: Downloading https://mirror.openshift.com/pub/cgw/rosa/latest/rosa-linux.tar.gz to your current directory
    E: unable to resolve host for https://mirror.openshift.com/pub/cgw/rosa/latest/rosa-linux.tar.gz 
    Please check your internet connection and DNS settings
    ```

---

# Ticket

Closes [OCM-18906](https://issues.redhat.com/browse/OCM-18906)