### PR TITLE
OCM-18946 | test: automate id: 73141 post check for billing account setting

### DIFF
--- a/tests/ci/data/profiles/rosa-classic.yaml
+++ b/tests/ci/data/profiles/rosa-classic.yaml
@@ -31,6 +31,7 @@ profiles:
     name_length: 54
     domain_prefix_enabled: true
     additional_sg_number: 3
+    billing_account: "487962084830"
   account-role:
     path: "/test/"
     permission_boundary: "arn:aws:iam::aws:policy/AdministratorAccess"

--- a/tests/ci/data/profiles/rosa-hcp.yaml
+++ b/tests/ci/data/profiles/rosa-hcp.yaml
@@ -32,6 +32,7 @@ profiles:
     additional_sg_number: 3
     registries_config: true
     allowed_registries: true
+    billing_account: "487962084830"
   account-role:
     customized_prefix: true
     path: ""

--- a/tests/e2e/test_rosacli_cluster_post.go
+++ b/tests/e2e/test_rosacli_cluster_post.go
@@ -1041,6 +1041,26 @@ var _ = Describe("Post-Check testing for cluster creation",
 				Expect(err).ToNot(HaveOccurred())
 				Expect(clusterDescription.AdditionalPrincipals).To(ContainSubstring(fakeAP))
 			})
+		It("to verify billing account settings- [id:73141]",
+			labels.Critical, labels.Runtime.Day1Post,
+			func() {
+				profile := handler.LoadProfileYamlFileByENV()
+
+				By("Retrieve oidc config from cluster config")
+				clusterID = config.GetClusterID()
+
+				By("Describe cluster")
+				output, err := clusterService.DescribeCluster(clusterID)
+				Expect(err).ToNot(HaveOccurred())
+				clusterDescription, err := clusterService.ReflectClusterDescription(output)
+				Expect(err).ToNot(HaveOccurred())
+				if profile.ClusterConfig.BillingAccount != "" {
+					Expect(clusterDescription.AWSBillingAccount).To(Equal(profile.ClusterConfig.BillingAccount))
+				} else {
+					// If --billing-account is not set when creating cluster, it will use the default one
+					Expect(clusterDescription.AWSBillingAccount).To(Equal(constants.BillingAccount))
+				}
+			})
 	})
 
 var _ = Describe("Post-Check testing for cluster clusters with the --disable-scp-checks flag",


### PR DESCRIPTION
post check for billing account setting.

below log includes the local testing for both hosted-cp and classic profiles,https://privatebin.corp.redhat.com/?481d96e9b829b086#DTziAtjPo4rbiHJdyg4sgx8jirFqfoD2tteqbq5yvqxA