### PR TITLE
OCM-18900 | fix: Improve proxy validation error messages for special characters in passwords

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -3047,7 +3047,7 @@ func run(cmd *cobra.Command, _ []string) {
 			Help:     cmd.Flags().Lookup("https-proxy").Usage,
 			Default:  httpsProxy,
 			Validators: []interactive.Validator{
-				interactive.IsURL,
+				ocm.ValidateHTTPSProxy,
 			},
 		})
 		if err != nil {
@@ -3055,7 +3055,7 @@ func run(cmd *cobra.Command, _ []string) {
 			os.Exit(1)
 		}
 	}
-	err = interactive.IsURL(httpsProxy)
+	err = ocm.ValidateHTTPSProxy(httpsProxy)
 	if err != nil {
 		r.Reporter.Errorf("%s", err)
 		os.Exit(1)

--- a/cmd/edit/cluster/cmd.go
+++ b/cmd/edit/cluster/cmd.go
@@ -508,7 +508,7 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 	}
 	if httpsProxy != nil && *httpsProxy != input.DoubleQuotesToRemove {
-		err = interactive.IsURL(*httpsProxy)
+		err = ocm.ValidateHTTPSProxy(*httpsProxy)
 		if err != nil {
 			r.Reporter.Errorf("%s", err)
 			os.Exit(1)

--- a/pkg/helper/url/validation.go
+++ b/pkg/helper/url/validation.go
@@ -1,0 +1,63 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package url
+
+import (
+	"fmt"
+	"strings"
+)
+
+func ValidateURLCredentials(urlString string) error {
+	parts := strings.SplitN(urlString, "://", 2)
+	if len(parts) < 2 {
+		return nil
+	}
+	rest := parts[1]
+
+	if strings.Count(rest, "@") > 1 {
+		return fmt.Errorf("password contains invalid character '@'")
+	}
+
+	userinfo, _, found := strings.Cut(rest, "@")
+	if !found {
+		return nil
+	}
+
+	username, password, hasPassword := strings.Cut(userinfo, ":")
+
+	if err := checkForInvalidChars(username, "username"); err != nil {
+		return err
+	}
+
+	if !hasPassword {
+		return nil
+	}
+
+	return checkForInvalidChars(password, "password")
+}
+
+func checkForInvalidChars(value, field string) error {
+	invalidChars := "/:#?[]@!$&'()*+,;="
+
+	for _, char := range value {
+		if strings.ContainsRune(invalidChars, char) {
+			return fmt.Errorf("%s contains invalid character '%c'", field, char)
+		}
+	}
+
+	return nil
+}

--- a/pkg/helper/url/validation_test.go
+++ b/pkg/helper/url/validation_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package url
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestURLValidation(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "URL Validation Suite")
+}
+
+var _ = Describe("ValidateURLCredentials", func() {
+	Context("when URL has no scheme separator", func() {
+		It("returns nil for URL without scheme", func() {
+			err := ValidateURLCredentials("example.com")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns nil for URL with partial scheme", func() {
+			err := ValidateURLCredentials("http:/example.com")
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("when URL has no credentials", func() {
+		It("returns nil for URL without @", func() {
+			err := ValidateURLCredentials("http://example.com")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns nil for URL with port but no credentials", func() {
+			err := ValidateURLCredentials("http://example.com:8080")
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("when URL has valid credentials", func() {
+		It("returns nil for URL with username only", func() {
+			err := ValidateURLCredentials("http://user@example.com")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns nil for URL with username and password", func() {
+			err := ValidateURLCredentials("http://user:pass@example.com")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns nil for URL with empty password", func() {
+			err := ValidateURLCredentials("http://user:@example.com")
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("when username contains invalid characters", func() {
+		DescribeTable("returns error for invalid username character",
+			func(url string, expectedChar rune) {
+				err := ValidateURLCredentials(url)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("username contains invalid character '" + string(expectedChar) + "'"))
+			},
+			Entry("slash in username", "http://us/er:pass@example.com", '/'),
+			Entry("question mark in username", "http://us?er:pass@example.com", '?'),
+			Entry("hash in username", "http://us#er:pass@example.com", '#'),
+		)
+	})
+
+	Context("when password contains invalid characters", func() {
+		DescribeTable("returns error for invalid password character",
+			func(url string, expectedChar rune) {
+				err := ValidateURLCredentials(url)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("password contains invalid character '" + string(expectedChar) + "'"))
+			},
+			Entry("slash in password", "http://user:pa/ss@example.com", '/'),
+			Entry("question mark in password", "http://user:pa?ss@example.com", '?'),
+			Entry("hash in password", "http://user:pa#ss@example.com", '#'),
+			Entry("bracket in password", "http://user:pa[ss@example.com", '['),
+		)
+	})
+
+	Context("when URL has multiple @ signs", func() {
+		It("returns error indicating @ in password", func() {
+			err := ValidateURLCredentials("http://user:p@ss@example.com")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("password contains invalid character '@'"))
+		})
+	})
+})

--- a/pkg/interactive/validation_test.go
+++ b/pkg/interactive/validation_test.go
@@ -131,7 +131,7 @@ var _ = Describe("SubnetsValidator", func() {
 
 			err := validator(answers)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("The number of subnets for a public hosted " +
+			Expect(err.Error()).To(ContainSubstring("the number of subnets for a public hosted " +
 				"cluster should be at least two"))
 		})
 
@@ -153,7 +153,7 @@ var _ = Describe("SubnetsValidator", func() {
 
 			err := validator(answers)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("Must have at least one public subnet when not using both " +
+			Expect(err.Error()).To(ContainSubstring("must have at least one public subnet when not using both " +
 				"'private API' and 'private ingress'"))
 		})
 
@@ -169,7 +169,7 @@ var _ = Describe("SubnetsValidator", func() {
 
 			err := validator(answers)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("The number of subnets for a 'multi-AZ'"+
+			Expect(err.Error()).To(ContainSubstring("the number of subnets for a 'multi-AZ'"+
 				" 'private link cluster' should be '3', instead received: '%d'", len(answers)))
 		})
 

--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -43,6 +43,7 @@ import (
 
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/helper"
+	urlHelper "github.com/openshift/rosa/pkg/helper/url"
 	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/reporter"
 )
@@ -108,9 +109,9 @@ func ClusterNameValidator(name interface{}) error {
 	if str, ok := name.(string); ok {
 		str := strings.Trim(str, " \t")
 		if !IsValidClusterName(str) {
-			return fmt.Errorf("Cluster name must consist of no more than %d lowercase "+
+			return fmt.Errorf("cluster name must consist of no more than %d lowercase "+
 				"alphanumeric characters or '-', start with a letter, and end with an "+
-				"alphanumeric character.", MaxClusterNameLength)
+				"alphanumeric character", MaxClusterNameLength)
 		}
 		return nil
 	}
@@ -125,13 +126,48 @@ func ClusterDomainPrefixValidator(domainPrefix interface{}) error {
 	if str, ok := domainPrefix.(string); ok {
 		str := strings.Trim(str, " \t")
 		if str != "" && !IsValidClusterDomainPrefix(str) {
-			return fmt.Errorf("Cluster domain prefix must consist of no more than %d lowercase "+
+			return fmt.Errorf("cluster domain prefix must consist of no more than %d lowercase "+
 				"alphanumeric characters or '-', start with a letter, and end with an "+
-				"alphanumeric character.", MaxClusterDomainPrefixLength)
+				"alphanumeric character", MaxClusterDomainPrefixLength)
 		}
 		return nil
 	}
 	return fmt.Errorf("can only validate strings, got '%v'", domainPrefix)
+}
+
+// validateProxyURL validates common proxy URL requirements
+func validateProxyURL(proxyURL string, proxyType string, expectedScheme string) error {
+	if strings.Contains(proxyURL, " ") {
+		return fmt.Errorf("invalid %s value: URL cannot contain spaces", proxyType)
+	}
+
+	if !strings.Contains(proxyURL, "://") {
+		return fmt.Errorf("invalid %s value: URL is missing scheme (expected '://')", proxyType)
+	}
+
+	if err := urlHelper.ValidateURLCredentials(proxyURL); err != nil {
+		return fmt.Errorf("invalid %s value: %s", proxyType, err)
+	}
+
+	parsedURL, err := url.Parse(proxyURL)
+	if err != nil {
+		return fmt.Errorf("invalid %s value: %v", proxyType, err)
+	}
+
+	if parsedURL.Scheme != expectedScheme {
+		return fmt.Errorf("expected '%s' to have an '%s://' scheme", proxyType, expectedScheme)
+	}
+
+	if parsedURL.Host == "" {
+		return fmt.Errorf("invalid %s value: host is missing", proxyType)
+	}
+
+	// Proxy URLs shouldn't have a path
+	if parsedURL.Path != "" && parsedURL.Path != "/" {
+		return fmt.Errorf("invalid %s value: proxy URL should not contain a path '%s'", proxyType, parsedURL.Path)
+	}
+
+	return nil
 }
 
 func ValidateHTTPProxy(val interface{}) error {
@@ -139,14 +175,17 @@ func ValidateHTTPProxy(val interface{}) error {
 		if httpProxy == "" {
 			return nil
 		}
-		url, err := url.ParseRequestURI(httpProxy)
-		if err != nil {
-			return fmt.Errorf("Invalid http-proxy value '%s'", httpProxy)
+		return validateProxyURL(httpProxy, "http-proxy", "http")
+	}
+	return fmt.Errorf("can only validate strings, got '%v'", val)
+}
+
+func ValidateHTTPSProxy(val interface{}) error {
+	if httpsProxy, ok := val.(string); ok {
+		if httpsProxy == "" {
+			return nil
 		}
-		if url.Scheme != "http" {
-			return errors.Errorf("%s", "Expected http-proxy to have an http:// scheme")
-		}
-		return nil
+		return validateProxyURL(httpsProxy, "https-proxy", "https")
 	}
 	return fmt.Errorf("can only validate strings, got '%v'", val)
 }
@@ -174,9 +213,9 @@ func ValidateAllowedRegistriesForImport(input interface{}) error {
 		registries = strings.Split(input.(string), ",")
 		for _, registry := range registries {
 			if !idRE.MatchString(registry) {
-				return fmt.Errorf("invalid identifier '%s' for 'allowed registries for import.' "+
+				return fmt.Errorf("invalid identifier '%s' for 'allowed registries for import'. "+
 					"Should be in a <registry>:<boolean> format. "+
-					"The boolean indicates whether the registry is secure or not.", registry)
+					"The boolean indicates whether the registry is secure or not", registry)
 			}
 		}
 	case reflect.Slice:
@@ -745,7 +784,7 @@ func ValidateSubnetsCount(multiAZ bool, privateLink bool, subnetsInputCount int)
 		if multiAZ {
 			azPrefix = "multi-AZ"
 		}
-		return fmt.Errorf("The number of subnets for a '%s' '%s' should be '%d', "+
+		return fmt.Errorf("the number of subnets for a '%s' '%s' should be '%d', "+
 			"instead received: '%d'", azPrefix, clusterPrefix, expected, subnetsInputCount)
 	}
 	return nil
@@ -755,10 +794,10 @@ func ValidateHostedClusterSubnets(awsClient aws.Client, isPrivate bool, subnetID
 	privateIngress bool) (int, error) {
 
 	if isPrivate && len(subnetIDs) < 1 {
-		return 0, fmt.Errorf("The number of subnets for a private hosted cluster should be at least one")
+		return 0, fmt.Errorf("the number of subnets for a private hosted cluster should be at least one")
 	}
 	if !isPrivate && len(subnetIDs) < 2 {
-		return 0, fmt.Errorf("The number of subnets for a public hosted cluster should be at least two")
+		return 0, fmt.Errorf("the number of subnets for a public hosted cluster should be at least two")
 	}
 	vpcSubnets, vpcSubnetsErr := awsClient.GetVPCSubnets(subnetIDs[0])
 	if vpcSubnetsErr != nil {
@@ -785,11 +824,11 @@ func ValidateHostedClusterSubnets(awsClient aws.Client, isPrivate bool, subnetID
 
 	if isPrivate && privateIngress {
 		if publicSubnetsCount > 0 {
-			return 0, fmt.Errorf("The number of public subnets for a private hosted cluster should be zero")
+			return 0, fmt.Errorf("the number of public subnets for a private hosted cluster should be zero")
 		}
 	} else {
 		if publicSubnetsCount == 0 {
-			return 0, fmt.Errorf("Must have at least one public subnet when not using both " +
+			return 0, fmt.Errorf("must have at least one public subnet when not using both " +
 				"'private API' and 'private ingress'")
 		}
 	}
@@ -1106,8 +1145,8 @@ func ValidateClaimValidationRules(input interface{}) error {
 		inputRules = strings.Split(input.(string), ",")
 		for _, inputRule := range inputRules {
 			if !idRE.MatchString(inputRule) {
-				return fmt.Errorf("invalid identifier '%s' for 'claim validation rule. '"+
-					"Should be in a <claim>:<required_value> format.", inputRule)
+				return fmt.Errorf("invalid identifier '%s' for 'claim validation rule'. "+
+					"Should be in a <claim>:<required_value> format", inputRule)
 			}
 		}
 	case reflect.Slice:

--- a/pkg/ocm/registry_config_test.go
+++ b/pkg/ocm/registry_config_test.go
@@ -111,9 +111,9 @@ var _ = Describe("Registry Config", func() {
 		})
 		It("KO: should fail if the user does not pass the correct regex", func() {
 			_, err := BuildAllowedRegistriesForImport("abc")
-			Expect(err).To(MatchError("invalid identifier 'abc' for 'allowed registries for import.' " +
+			Expect(err).To(MatchError("invalid identifier 'abc' for 'allowed registries for import'. " +
 				"Should be in a <registry>:<boolean> format. " +
-				"The boolean indicates whether the registry is secure or not."))
+				"The boolean indicates whether the registry is secure or not"))
 
 		})
 	})

--- a/tests/e2e/test_rosacli_cluster.go
+++ b/tests/e2e/test_rosacli_cluster.go
@@ -882,8 +882,8 @@ var _ = Describe("Edit cluster validation should", labels.Feature.Cluster, func(
 
 			By("Edit cluster with invalid http_proxy not started with http")
 			invalidHTTPProxy := map[string]string{
-				"invalidvalue":           "ERR: Invalid http-proxy value 'invalidvalue'",
-				"https://test-proxy.com": "ERR: Expected http-proxy to have an http:// scheme",
+				"invalidvalue":           "ERR: invalid http-proxy value: URL is missing scheme",
+				"https://test-proxy.com": "ERR: expected 'http-proxy' to have an 'http://' scheme",
 			}
 			for illegalHttpProxy, errMessage := range invalidHTTPProxy {
 				output, err := clusterService.EditCluster(clusterID,
@@ -898,7 +898,7 @@ var _ = Describe("Edit cluster validation should", labels.Feature.Cluster, func(
 				"--https-proxy", "invalid",
 			)
 			Expect(err).To(HaveOccurred())
-			Expect(output.String()).Should(ContainSubstring(`ERR: parse "invalid": invalid URI for request`))
+			Expect(output.String()).Should(ContainSubstring("ERR: invalid https-proxy value: URL is missing scheme"))
 
 			By("Edit cluster with invalid no_proxy ")
 			output, err = clusterService.EditCluster(clusterID,
@@ -1867,7 +1867,7 @@ var _ = Describe("Create cluster with invalid options will",
 				)
 				Expect(err).To(HaveOccurred())
 				Expect(output.String()).Should(
-					ContainSubstring("The number of subnets for a 'multi-AZ' 'cluster' should be '6'," +
+					ContainSubstring("the number of subnets for a 'multi-AZ' 'cluster' should be '6'," +
 						" instead received: '1'"))
 
 				// Can only test when az number is bigger than 2
@@ -1910,7 +1910,7 @@ var _ = Describe("Create cluster with invalid options will",
 					)
 					Expect(err).To(HaveOccurred())
 					Expect(output.String()).Should(
-						ContainSubstring("The number of subnets for a 'multi-AZ' 'cluster' should be '6', instead received: '%d'",
+						ContainSubstring("the number of subnets for a 'multi-AZ' 'cluster' should be '6', instead received: '%d'",
 							len(fiveSubnetsList)))
 				}
 
@@ -2056,7 +2056,7 @@ var _ = Describe("Create cluster with invalid options will",
 					"--http-proxy", "invalid",
 				)
 				Expect(err).To(HaveOccurred())
-				Expect(output.String()).Should(ContainSubstring("Invalid http-proxy value 'invalid'"))
+				Expect(output.String()).Should(ContainSubstring("invalid http-proxy value: URL is missing scheme"))
 
 				By("Create ccs existing cluster with invalid http_proxy not started with http")
 				output, err = clusterService.CreateDryRun(clusterName,
@@ -2069,7 +2069,7 @@ var _ = Describe("Create cluster with invalid options will",
 				)
 				Expect(err).To(HaveOccurred())
 				Expect(output.String()).Should(
-					ContainSubstring("Invalid http-proxy value 'nohttp.prefix.com'"))
+					ContainSubstring("invalid http-proxy value: URL is missing scheme"))
 
 				By("Create ccs existing cluster with invalid https_proxy set")
 				output, err = clusterService.CreateDryRun(clusterName,
@@ -2082,7 +2082,7 @@ var _ = Describe("Create cluster with invalid options will",
 				)
 				Expect(err).To(HaveOccurred())
 				Expect(output.String()).Should(
-					ContainSubstring(`ERR: parse "invalid": invalid URI for request`))
+					ContainSubstring("ERR: invalid https-proxy value: URL is missing scheme"))
 
 				By("Create wide-proxy cluster with invalid additional_trust_bundle set")
 				tempDir, err := os.MkdirTemp("", "*")


### PR DESCRIPTION
# Details

This PR fixes a usability issue where `rosa create cluster --http-proxy` was displaying unhelpful error messages when proxy passwords contained special characters like forward slashes, making it difficult for users to understand what was wrong with their input.

---

## Problem (Before)

```bash
rosa create cluster --http-proxy "http://proxyuser:QvoZjyy/trkCiY5@10.0.0.161:8080"
```

Output:
```
E: Invalid http-proxy value 'http://proxyuser:QvoZjyy/trkCiY5@10.0.0.161:8080'
```

The user has no idea what's wrong with the URL.

---

## Fixed Behavior (After)

```bash
./rosa create cluster --http-proxy "http://proxyuser:QvoZjyy/trkCiY5@10.0.0.161:8080"
```

Output:
```
ERR: invalid http-proxy value: password contains invalid character '/'
```

Now the user knows exactly what's wrong.

---

## Additional Validations

The implementation validates special characters in both username and password fields:

1. **Forward slash in password**:
    ```bash
    rosa edit cluster --cluster=my-cluster --http-proxy "http://user:pass/word@10.0.0.161:8080"
    ```
    Output:
    ```
    ERR: invalid http-proxy value: password contains invalid character '/'
    ```

2. **@ symbol in password**:
    ```bash
    rosa edit cluster --cluster=my-cluster --http-proxy "http://user:p@ssword@10.0.0.161:8080"
    ```
    Output:
    ```
    ERR: invalid http-proxy value: password contains invalid character '@'
    ```

3. **Question mark in password**:
    ```bash
    rosa edit cluster --cluster=my-cluster --http-proxy "http://user:pass?word@10.0.0.161:8080"
    ```
    Output:
    ```
    ERR: invalid http-proxy value: password contains invalid character '?'
    ```

4. **Hash in password**:
    ```bash
    rosa edit cluster --cluster=my-cluster --http-proxy "http://user:pass#word@10.0.0.161:8080"
    ```
    Output:
    ```
    ERR: invalid http-proxy value: password contains invalid character '#'
    ```

5. **Invalid character in username**:
    ```bash
    rosa edit cluster --cluster=my-cluster --http-proxy "http://us/er:password@10.0.0.161:8080"
    ```
    Output:
    ```
    ERR: invalid http-proxy value: username contains invalid character '/'
    ```

6. **Missing scheme**:
    ```bash
    rosa edit cluster --cluster=my-cluster --http-proxy "user:password@10.0.0.161:8080"
    ```
    Output:
    ```
    ERR: invalid http-proxy value: URL is missing scheme (expected '://')
    ```

7. **HTTPS proxy validation**:
    ```bash
    rosa edit cluster --cluster=my-cluster --https-proxy "https://user:pass/word@10.0.0.161:8080"
    ```
    Output:
    ```
    ERR: invalid https-proxy value: password contains invalid character '/'
    ```

---

# Ticket

Closes [OCM-18900](https://issues.redhat.com/browse/OCM-18900)