### PR TITLE
OCM-19643 | fix: Only list the dns-domain under current organization

### DIFF
--- a/cmd/list/dnsdomains/cmd.go
+++ b/cmd/list/dnsdomains/cmd.go
@@ -71,7 +71,12 @@ func run(_ *cobra.Command, _ []string) {
 	defer r.Cleanup()
 
 	r.Reporter.Debugf("Loading dns domains for current org id")
-	search := "user_defined='true'"
+	orgID, _, err := r.OCMClient.GetCurrentOrganization()
+	if err != nil {
+		_ = r.Reporter.Errorf("Failed to get current organization: %s", err)
+		os.Exit(1)
+	}
+	search := fmt.Sprintf("user_defined='true' AND organization.id='%s'", orgID)
 	if args.all {
 		search = ""
 	}


### PR DESCRIPTION
Before this fix, all the dns-domain shows with `rosa list dns-domain`.
After this fix, only the dns-domain under current organization will be displayed.

Bellow testing has covered:
- List all dns-domain `rosa list dns-domain` and check all shown ones are under current organization
- List hosted-cp dns-domain `rosa list dns-domain --hosted-cp` and check all shown ones are under current organization
`
yuwan@yuwan-mac rosa % ./rosa list dns-domain
ID                    CLUSTER ID  RESERVED TIME         USER DEFINED  ARCHITECTURE
0jyl.s3.devshift.org              0001-01-01T00:00:00Z  Yes           hcp
28z1.s3.devshift.org              0001-01-01T00:00:00Z  Yes           hcp
48k8.s3.devshift.org              0001-01-01T00:00:00Z  Yes           hcp
5ujt.s1.devshift.org              2025-07-31T04:30:40Z  Yes           classic
84ky.s3.devshift.org              0001-01-01T00:00:00Z  Yes           hcp
abyn.s3.devshift.org              0001-01-01T00:00:00Z  Yes           hcp

yuwan@yuwan-mac rosa % ./rosa list dns-domain --hosted-cp
ID                    CLUSTER ID  RESERVED TIME         USER DEFINED  ARCHITECTURE
0jyl.s3.devshift.org              0001-01-01T00:00:00Z  Yes           hcp
28z1.s3.devshift.org              0001-01-01T00:00:00Z  Yes           hcp
48k8.s3.devshift.org              0001-01-01T00:00:00Z  Yes           hcp
84ky.s3.devshift.org              0001-01-01T00:00:00Z  Yes           hcp
abyn.s3.devshift.org              0001-01-01T00:00:00Z  Yes           hcp

`