### PR TITLE
OCM-19567 | feat: Use Cluster.Versions for classic list/upgrades

### DIFF
--- a/cmd/list/upgrade/cmd.go
+++ b/cmd/list/upgrade/cmd.go
@@ -113,14 +113,7 @@ func runWithRuntime(r *rosa.Runtime, _ *cobra.Command) error {
 	} else {
 		// Control plane or cluster updates
 		r.Reporter.Debugf("Loading available upgrades for cluster '%s'", clusterKey)
-		if isHypershift {
-			availableUpgrades = ocm.GetAvailableUpgradesByCluster(cluster)
-		} else {
-			availableUpgrades, err = r.OCMClient.GetAvailableUpgrades(ocm.GetVersionID(cluster))
-			if err != nil {
-				return fmt.Errorf("Failed to get available upgrades for cluster '%s': %v", clusterKey, err)
-			}
-		}
+		availableUpgrades = ocm.GetAvailableUpgradesByCluster(cluster)
 
 		if len(availableUpgrades) == 0 {
 			r.Reporter.Infof("There are no available upgrades for cluster '%s'", clusterKey)

--- a/cmd/upgrade/cluster/cmd.go
+++ b/cmd/upgrade/cluster/cmd.go
@@ -464,14 +464,9 @@ func buildVersion(r *rosa.Runtime, cmd *cobra.Command, cluster *cmv1.Cluster,
 	version string, isAutomaticUpgrade bool) ([]string, string, error) {
 	var availableUpgrades []string
 	var err error
-	if ocm.IsHyperShiftCluster(cluster) {
-		availableUpgrades = ocm.GetAvailableUpgradesByCluster(cluster)
-	} else {
-		availableUpgrades, err = r.OCMClient.GetAvailableUpgrades(ocm.GetVersionID(cluster))
-		if err != nil {
-			return availableUpgrades, version, fmt.Errorf("Failed to find available upgrades: %v", err)
-		}
-	}
+
+	availableUpgrades = ocm.GetAvailableUpgradesByCluster(cluster)
+
 	if len(availableUpgrades) == 0 {
 		return availableUpgrades, version, nil
 	}


### PR DESCRIPTION
Removes the old logic for classic cluster listing, which used `v1.Versions.ClusterId(...)` in favor of how HCP is handled: `v1.Clusters(...).Versions()`

This way clusters will always receive the proper recommended upgrades when running `rosa list upgrades` - even if it's a classic cluster