### PR TITLE
OCM-19810 | feat: Pull versions from CVO instead of CIS for roles

### DIFF
--- a/cmd/upgrade/operatorroles/cmd.go
+++ b/cmd/upgrade/operatorroles/cmd.go
@@ -89,11 +89,7 @@ func run(cmd *cobra.Command, _ []string) {
 	*/
 	if args.upgradeVersion != "" {
 		version := args.upgradeVersion
-		availableUpgrades, err := r.OCMClient.GetAvailableUpgrades(ocm.GetVersionID(cluster))
-		if err != nil {
-			r.Reporter.Errorf("Failed to find available upgrades: %v", err)
-			os.Exit(1)
-		}
+		availableUpgrades := ocm.GetAvailableUpgradesByCluster(cluster)
 		if len(availableUpgrades) == 0 {
 			r.Reporter.Warnf("There are no available upgrades")
 			os.Exit(0)

--- a/cmd/upgrade/roles/cmd.go
+++ b/cmd/upgrade/roles/cmd.go
@@ -136,11 +136,7 @@ func run(cmd *cobra.Command, argv []string) {
 
 	clusterUpgradeVersion := args.clusterUpgradeVersion
 
-	availableUpgrades, err := r.OCMClient.GetAvailableUpgrades(ocm.GetVersionID(cluster))
-	if err != nil {
-		r.Reporter.Errorf("Failed to find available upgrades: %v", err)
-		os.Exit(1)
-	}
+	availableUpgrades := ocm.GetAvailableUpgradesByCluster(cluster)
 	if len(availableUpgrades) == 0 {
 		r.Reporter.Warnf("There are no available upgrades")
 		os.Exit(0)


### PR DESCRIPTION
This MR changes the way we pull available upgrades for `upgrade/account-roles` + `upgrade/operator-roles` to match recent changes to `list/upgrades` + `upgrade/cluster` where we are moving from checking CIS to CVO even for classic architecture

manual testing results when up-to-date:
```
❯ ./rosa upgrade account-roles --prefix hk
I: Ensuring account role policies compatibility for upgrade
I: Account roles with the prefix 'hk' are already up-to-date.
```

manual testing results when not up-to-date:
```
❯ ./rosa upgrade account-roles --prefix hk
I: Ensuring account role policies compatibility for upgrade
? Account role upgrade mode: auto
I: Starting to upgrade the policies
? Upgrade the 'hk-ControlPlane-Role' role policy latest version ? (Y/n)
```
