### PR TITLE
OCM-20111 | test: fix ids: 75922 to update the expected billing account with the cluster config

### DIFF
--- a/tests/e2e/test_rosacli_cluster.go
+++ b/tests/e2e/test_rosacli_cluster.go
@@ -620,11 +620,15 @@ var _ = Describe("Edit cluster",
 						"not valid. Rerun the command with a valid billing account number"))
 
 				By("Check the billing account is NOT changed")
+				clusterConfig, err := config.ParseClusterProfile()
+				Expect(err).ToNot(HaveOccurred())
 				output, err = clusterService.DescribeCluster(clusterID)
 				Expect(err).To(BeNil())
 				CD, err := clusterService.ReflectClusterDescription(output)
 				Expect(err).To(BeNil())
-				Expect(CD.AWSBillingAccount).To(Equal(constants.BillingAccount))
+				if clusterConfig.BillingAccount != "" {
+					Expect(CD.AWSBillingAccount).To(Equal(clusterConfig.BillingAccount))
+				}
 			})
 	})
 var _ = Describe("Edit cluster validation should", labels.Feature.Cluster, func() {


### PR DESCRIPTION
OCP-75922 to update the expected billing account with the cluster config.

Before this fix, the test case used the fixed value to check if the billing account is changed, that would fail if custom billing account is set for the testing cluster.

logs:https://privatebin.corp.redhat.com/?5edd5fc6077987ca#E4ejywaPpdCnbusyrmw1q6KSaFPeChzFQHoB67qjUheQ