### PR TITLE
OCM-16723 | fix: Hardcoded VPC CIDR value in cloudformation template

### DIFF
--- a/cmd/create/network/templates/rosa-quickstart-default-vpc/cloudformation.yaml
+++ b/cmd/create/network/templates/rosa-quickstart-default-vpc/cloudformation.yaml
@@ -507,7 +507,7 @@ Resources:
         - IpProtocol: -1
           FromPort: 0
           ToPort: 0
-          CidrIp: "10.0.0.0/16"
+          CidrIp: !Ref VpcCidr
       SecurityGroupEgress:
         - IpProtocol: -1
           FromPort: 0


### PR DESCRIPTION
There is a hardcoded VPC CIDR value in the cloud formation template which should be a reference to a previously defined var, causing issues if a user needs to use a CIDR which differs from the hardcoded one, specifically for SGs