### PR TITLE
OCM-18528 | fix: Discontinue UWM for ROSA HCP clusters

### DIFF
--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -457,16 +457,12 @@ func run(cmd *cobra.Command, argv []string) {
 		deleteProtection,
 		cluster.CreationTimestamp().Format("Jan _2 2006 15:04:05 MST"))
 
-	uwmString := "%s" +
-		"User Workload Monitoring:   %s\n"
-	if isHypershift {
-		uwmString = "%s" +
-			"[DEPRECATED] User Workload Monitoring:   %s\n"
+	if !isHypershift {
+		str = fmt.Sprintf("%s"+
+			"User Workload Monitoring:   %s\n",
+			str,
+			getUseworkloadMonitoring(cluster.DisableUserWorkloadMonitoring()))
 	}
-
-	str = fmt.Sprintf(uwmString,
-		str,
-		getUseworkloadMonitoring(cluster.DisableUserWorkloadMonitoring()))
 
 	if cluster.FIPS() {
 		str = fmt.Sprintf("%s"+
@@ -1046,7 +1042,7 @@ func getRolePolicyBindings(roleARN string, rolePolicyDetails map[string][]aws.Po
 	prefix string) (string, error) {
 	roleName, err := aws.GetResourceIdFromARN(roleARN)
 	if err != nil {
-		return "", fmt.Errorf("Failed to get role name from arn %s: %v", roleARN, err)
+		return "", fmt.Errorf("failed to get role name from arn %s: %v", roleARN, err)
 	}
 	str := ""
 	if rolePolicyDetails[roleName] != nil {
@@ -1061,7 +1057,7 @@ func getRolePolicyBindings(roleARN string, rolePolicyDetails map[string][]aws.Po
 func getZeroEgressStatus(r *rosa.Runtime, cluster *cmv1.Cluster) (string, error) {
 	techPreviewMsg, err := r.OCMClient.GetTechnologyPreviewMessage("hcp-zero-egress", time.Now())
 	if err != nil {
-		return "", fmt.Errorf("Failed to get technology preview message for zero egress: %v", err)
+		return "", fmt.Errorf("failed to get technology preview message for zero egress: %v", err)
 	}
 	if techPreviewMsg != "" {
 		zeroEgressOutput := DisabledOutput

--- a/cmd/edit/cluster/cmd_test.go
+++ b/cmd/edit/cluster/cmd_test.go
@@ -108,7 +108,7 @@ var _ = Describe("Edit cluster", func() {
 		})
 		It("KO: should fail with error if ca file does not exist", func() {
 			_, err := BuildClusterConfigWithRegistry(clusterConfig, allowedRegistries, nil, nil, "not-exist", "", "")
-			Expect(err).To(MatchError("Failed to build the additional trusted ca from file not-exist, " +
+			Expect(err).To(MatchError("failed to build the additional trusted ca from file not-exist, " +
 				"got error: expected a valid additional trusted certificate spec file:" +
 				" open not-exist: no such file or directory"))
 		})

--- a/pkg/arguments/arguments.go
+++ b/pkg/arguments/arguments.go
@@ -44,9 +44,7 @@ var hasUnknownFlags bool
 var DisableRegionDeprecationFlagName = "disable-region-deprecation" // Temporary for region deprecation
 var DisableRegionDeprecationWarning = false                         // Temporary for region deprecation
 
-var UwmDeprecationMessage = "[DEPRECATED FOR ROSA HCP] User workload monitoring (--disable-workload-monitoring)" +
-	" has been deprecated for Hosted Control Plane clusters, and will be removed in a future version of ROSA CLI. " +
-	"Please remove from your workflows to avoid future issues"
+var UwmNotSupportedMessage = "User Workload Monitoring configuration is not supported for Hosted Control Plane clusters"
 
 // ParseUnknownFlags parses all flags from the CLI, including
 // unknown ones, and adds them to the current command tree
@@ -122,7 +120,7 @@ func ParseUnknownFlags(cmd *cobra.Command, argv []string) error {
 func ParseKnownFlags(cmd *cobra.Command, argv []string, failOnUnknown bool) error {
 	flags := cmd.Flags()
 
-	var validArgs []string = []string{}
+	var validArgs = []string{}
 	var upcomingValue bool
 	unknownFlags := ""
 
@@ -176,7 +174,7 @@ func ParseKnownFlags(cmd *cobra.Command, argv []string, failOnUnknown bool) erro
 	}
 
 	if failOnUnknown && unknownFlags != "" {
-		return fmt.Errorf("Unknown flags passed: %s", unknownFlags[:len(unknownFlags)-2])
+		return fmt.Errorf("unknown flags passed: %s", unknownFlags[:len(unknownFlags)-2])
 	}
 
 	err := flags.Parse(validArgs)
@@ -226,7 +224,7 @@ func PreprocessUnknownFlagsWithId(cmd *cobra.Command, argv []string) error {
 		// Upcoming value from a space-separated value
 		case upcomingValue:
 			if strings.HasPrefix(arg, "-") {
-				return fmt.Errorf("No value given for flag '%s'", argv[i-1])
+				return fmt.Errorf("no value given for flag '%s'", argv[i-1])
 			}
 			validArgs = append(validArgs, arg)
 			upcomingValue = false
@@ -286,7 +284,7 @@ func PreprocessUnknownFlagsWithId(cmd *cobra.Command, argv []string) error {
 
 func AddStringFlag(cmd *cobra.Command, flagName string) {
 	flags := cmd.Flags()
-	var pStrVal *string = new(string)
+	var pStrVal = new(string)
 	flags.StringVar(pStrVal, flagName, "", "")
 }
 

--- a/pkg/arguments/arguments_test.go
+++ b/pkg/arguments/arguments_test.go
@@ -147,7 +147,7 @@ var _ = Describe("Client", func() {
 		It("Returns error with flag that has no value", func() {
 			err := PreprocessUnknownFlagsWithId(cmd, []string{"test", "-c", "-c", "-c", "-c"})
 			Expect(err).To(HaveOccurred())
-			Expect(fmt.Sprint(err)).To(Equal("No value given for flag '-c'"))
+			Expect(fmt.Sprint(err)).To(Equal("no value given for flag '-c'"))
 		})
 	})
 })


### PR DESCRIPTION
# Details

This PR discontinues User Workload Monitoring (UWM) configuration for ROSA HCP clusters as part of the effort to offer self-service CMO on ROSA HCP clusters, while maintaining full functionality for Classic clusters.

---

## Fixed Behavior

1. Run the command with UWM flag on HCP cluster:

    ```bash
    ./rosa create cluster --hosted-cp --disable-workload-monitoring
    ```

2. Now shows **clear error message**:

    ```
    E: User Workload Monitoring configuration is not supported for Hosted Control Plane clusters
    ```

---

## Additional Validations Added

1. **Edit Cluster Blocking** - Prevents UWM configuration on existing HCP clusters:

    ```bash
    ./rosa edit cluster -c my-hcp-cluster --disable-workload-monitoring
    ```

    Output:

    ```
    E: User Workload Monitoring configuration is not supported for Hosted Control Plane clusters
    ```

2. **Interactive Mode** - UWM prompt no longer appears for HCP clusters:

    ```bash
    ./rosa create cluster --hosted-cp --interactive
    ```

    Output:

    ```
    [UWM prompt is skipped entirely for HCP clusters]
    ```

3. **Describe Output** - UWM status hidden for HCP clusters:

    ```bash
    ./rosa describe cluster -c my-hcp-cluster
    ```

    Output:

    ```
    [User Workload Monitoring line is completely absent from output]
    ```

---

## The Classic Cluster Behavior

Using UWM with Classic clusters continues to work normally:

```bash
./rosa create cluster --disable-workload-monitoring
```

Output:

```
[Cluster creation proceeds with UWM disabled as before]
```

---

# Ticket

Closes [OCM-18528](https://issues.redhat.com/browse/OCM-18528)