### PR TITLE
OCM-20196 | chore: Bump Go version to 1.24.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ Example: `OCM-6141 | feat: Allow longer cluster names up to 54 chars`
 5. Use similar architecture to the create machinepool command, with the user options files and separate logic in `pkg/`. Do not always make a new service, `machine pool service` is a special case
 
 ### Dependencies and Modules
-- Go 1.23.1 minimum version
+- Go 1.24.0 minimum version
 - Major dependencies: AWS SDK v2, Cobra, Ginkgo v2, OCM SDK
 - Use `go mod tidy` and `go mod vendor` as part of verification
 - Mock generation using `go.uber.org/mock/gomock`. 

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -60,7 +60,6 @@ import (
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/interactive/consts"
 	interactiveOidc "github.com/openshift/rosa/pkg/interactive/oidc"
-	"github.com/openshift/rosa/pkg/interactive/securitygroups"
 	interactiveSgs "github.com/openshift/rosa/pkg/interactive/securitygroups"
 	"github.com/openshift/rosa/pkg/machinepool"
 	"github.com/openshift/rosa/pkg/ocm"
@@ -911,7 +910,7 @@ func initFlags(cmd *cobra.Command) {
 
 	flags.StringSliceVar(
 		&args.additionalComputeSecurityGroupIds,
-		securitygroups.ComputeSecurityGroupFlag,
+		interactiveSgs.ComputeSecurityGroupFlag,
 		nil,
 		"The additional Security Group IDs to be added to the default worker machine pool. "+
 			listInputMessage,
@@ -919,7 +918,7 @@ func initFlags(cmd *cobra.Command) {
 
 	flags.StringSliceVar(
 		&args.additionalInfraSecurityGroupIds,
-		securitygroups.InfraSecurityGroupFlag,
+		interactiveSgs.InfraSecurityGroupFlag,
 		nil,
 		"The additional Security Group IDs to be added to the infra worker nodes. "+
 			listInputMessage,
@@ -927,7 +926,7 @@ func initFlags(cmd *cobra.Command) {
 
 	flags.StringSliceVar(
 		&args.additionalControlPlaneSecurityGroupIds,
-		securitygroups.ControlPlaneSecurityGroupFlag,
+		interactiveSgs.ControlPlaneSecurityGroupFlag,
 		nil,
 		"The additional Security Group IDs to be added to the control plane nodes. "+
 			listInputMessage,
@@ -2829,18 +2828,18 @@ func run(cmd *cobra.Command, _ []string) {
 
 	additionalComputeSecurityGroupIds := args.additionalComputeSecurityGroupIds
 	getSecurityGroups(r, cmd, isVersionCompatibleComputeSgIds,
-		securitygroups.ComputeKind, useExistingVPC, subnets,
+		interactiveSgs.ComputeKind, useExistingVPC, subnets,
 		subnetIDs, &additionalComputeSecurityGroupIds)
 
 	additionalInfraSecurityGroupIds := args.additionalInfraSecurityGroupIds
 	additionalControlPlaneSecurityGroupIds := args.additionalControlPlaneSecurityGroupIds
 	if !isHostedCP {
 		getSecurityGroups(r, cmd, isVersionCompatibleComputeSgIds,
-			securitygroups.InfraKind, useExistingVPC, subnets,
+			interactiveSgs.InfraKind, useExistingVPC, subnets,
 			subnetIDs, &additionalInfraSecurityGroupIds)
 
 		getSecurityGroups(r, cmd, isVersionCompatibleComputeSgIds,
-			securitygroups.ControlPlaneKind, useExistingVPC, subnets,
+			interactiveSgs.ControlPlaneKind, useExistingVPC, subnets,
 			subnetIDs, &additionalControlPlaneSecurityGroupIds)
 	}
 
@@ -2952,7 +2951,7 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 	}
 
-	if interactive.Enabled() && !(fips || etcdEncryptionKmsARN != "") {
+	if interactive.Enabled() && !fips && etcdEncryptionKmsARN == "" {
 		etcdEncryption, err = interactive.GetBool(interactive.Input{
 			Question: "Encrypt etcd data",
 			Help:     cmd.Flags().Lookup("etcd-encryption").Usage,
@@ -3667,14 +3666,14 @@ func clusterConfigFor(
 		var err error
 		clusterConfig.AWSAccessKey, err = awsCredentialsGetter.GetLocalAWSAccessKeys()
 		if err != nil {
-			return clusterConfig, fmt.Errorf("Failed to get local AWS credentials: %w", err)
+			return clusterConfig, fmt.Errorf("failed to get local AWS credentials: %w", err)
 		}
 	} else if clusterConfig.RoleARN == "" {
 		// Create the access key for the AWS user:
 		var err error
 		clusterConfig.AWSAccessKey, err = awsCredentialsGetter.GetAWSAccessKeys()
 		if err != nil {
-			return clusterConfig, fmt.Errorf("Failed to get access keys for user '%s': %w",
+			return clusterConfig, fmt.Errorf("failed to get access keys for user '%s': %w",
 				aws.AdminUserName, err)
 		}
 	}
@@ -3683,7 +3682,7 @@ func clusterConfigFor(
 
 func provideBillingAccount(billingAccounts []string, accountID string, r *rosa.Runtime) (string, error) {
 	if !helper.ContainsPrefix(billingAccounts, accountID) {
-		return "", fmt.Errorf("A billing account is required for Hosted Control Plane clusters. %s",
+		return "", fmt.Errorf("a billing account is required for Hosted Control Plane clusters. %s",
 			listBillingAccountMessage)
 	}
 
@@ -3703,7 +3702,7 @@ func validateNetworkType(networkType string) error {
 		return nil
 	}
 	if !helper.Contains(ocm.NetworkTypes, networkType) {
-		return fmt.Errorf(fmt.Sprintf("Expected a valid network type. Valid values: %v", ocm.NetworkTypes))
+		return fmt.Errorf("%s", fmt.Sprintf("expected a valid network type. Valid values: %v", ocm.NetworkTypes))
 	}
 	return nil
 }
@@ -3845,7 +3844,7 @@ func filterCidrRangeSubnets(
 		skip := false
 		subnetIP, subnetNetwork, err := net.ParseCIDR(*subnet.CidrBlock)
 		if err != nil {
-			return nil, fmt.Errorf("Unable to parse subnet CIDR: %w", err)
+			return nil, fmt.Errorf("unable to parse subnet CIDR: %w", err)
 		}
 
 		if !isValidCidrRange(subnetIP, subnetNetwork, machineNetwork, serviceNetwork) {
@@ -3890,7 +3889,7 @@ func hostPrefixValidator(val interface{}) error {
 	}
 	if hostPrefix < HostPrefixMin || hostPrefix > HostPrefixMax {
 		return fmt.Errorf(
-			"Invalid Network Host Prefix /%d: Subnet length should be between %d and %d",
+			"invalid Network Host Prefix /%d: Subnet length should be between %d and %d",
 			hostPrefix, HostPrefixMin, HostPrefixMax)
 	}
 	return nil
@@ -3920,7 +3919,7 @@ func evaluateDuration(duration time.Duration) time.Time {
 func validateExpiration() (expiration time.Time, err error) {
 	// Validate options
 	if len(args.expirationTime) > 0 && args.expirationDuration != 0 {
-		err = errors.New("At most one of 'expiration-time' or 'expiration' may be specified")
+		err = errors.New("at most one of 'expiration-time' or 'expiration' may be specified")
 		return
 	}
 
@@ -3928,7 +3927,7 @@ func validateExpiration() (expiration time.Time, err error) {
 	if len(args.expirationTime) > 0 {
 		t, err := parseRFC3339(args.expirationTime)
 		if err != nil {
-			err = fmt.Errorf("Failed to parse expiration-time: %s", err)
+			err = fmt.Errorf("failed to parse expiration-time: %s", err)
 			return expiration, err
 		}
 
@@ -3957,7 +3956,7 @@ func selectAvailabilityZonesInteractively(cmd *cobra.Command, optionsAvailabilit
 			},
 		})
 		if err != nil {
-			return availabilityZones, fmt.Errorf("Expected valid availability zones: %s", err)
+			return availabilityZones, fmt.Errorf("expected valid availability zones: %s", err)
 		}
 	} else {
 		var availabilityZone string
@@ -3968,7 +3967,7 @@ func selectAvailabilityZonesInteractively(cmd *cobra.Command, optionsAvailabilit
 			Options:  optionsAvailabilityZones,
 		})
 		if err != nil {
-			return availabilityZones, fmt.Errorf("Expected valid availability zone: %s", err)
+			return availabilityZones, fmt.Errorf("expected valid availability zone: %s", err)
 		}
 		availabilityZones = append(availabilityZones, availabilityZone)
 	}
@@ -3984,11 +3983,11 @@ func validateAvailabilityZones(multiAZ bool, availabilityZones []string, awsClie
 
 	regionAvailabilityZones, err := awsClient.DescribeAvailabilityZones()
 	if err != nil {
-		return fmt.Errorf("Failed to get the list of the availability zone: %s", err)
+		return fmt.Errorf("failed to get the list of the availability zone: %s", err)
 	}
 	for _, az := range availabilityZones {
 		if !helper.Contains(regionAvailabilityZones, az) {
-			return fmt.Errorf("Expected a valid availability zone, "+
+			return fmt.Errorf("expected a valid availability zone, "+
 				"'%s' doesn't belong to region '%s' availability zones", az, awsClient.GetRegion())
 		}
 	}
@@ -4226,19 +4225,19 @@ func buildCommand(spec ocm.Spec, operatorRolesPrefix string,
 
 	if len(spec.AdditionalComputeSecurityGroupIds) > 0 {
 		command += fmt.Sprintf(" --%s %s",
-			securitygroups.ComputeSecurityGroupFlag,
+			interactiveSgs.ComputeSecurityGroupFlag,
 			strings.Join(spec.AdditionalComputeSecurityGroupIds, ","))
 	}
 
 	if len(spec.AdditionalInfraSecurityGroupIds) > 0 {
 		command += fmt.Sprintf(" --%s %s",
-			securitygroups.InfraSecurityGroupFlag,
+			interactiveSgs.InfraSecurityGroupFlag,
 			strings.Join(spec.AdditionalInfraSecurityGroupIds, ","))
 	}
 
 	if len(spec.AdditionalControlPlaneSecurityGroupIds) > 0 {
 		command += fmt.Sprintf(" --%s %s",
-			securitygroups.ControlPlaneSecurityGroupFlag,
+			interactiveSgs.ControlPlaneSecurityGroupFlag,
 			strings.Join(spec.AdditionalControlPlaneSecurityGroupIds, ","))
 	}
 
@@ -4374,11 +4373,11 @@ func outputClusterAdminDetails(r *rosa.Runtime, isClusterAdmin bool, createAdmin
 func getSecurityGroups(r *rosa.Runtime, cmd *cobra.Command, isVersionCompatibleComputeSgIds bool,
 	kind string, useExistingVpc bool, currentSubnets []ec2types.Subnet, subnetIds []string,
 	additionalSgIds *[]string) {
-	hasChangedSgIdsFlag := cmd.Flags().Changed(securitygroups.SgKindFlagMap[kind])
+	hasChangedSgIdsFlag := cmd.Flags().Changed(interactiveSgs.SgKindFlagMap[kind])
 	if hasChangedSgIdsFlag {
 		if !useExistingVpc {
 			r.Reporter.Errorf("Setting the `%s` flag is only allowed for BYO VPC clusters",
-				securitygroups.SgKindFlagMap[kind])
+				interactiveSgs.SgKindFlagMap[kind])
 			os.Exit(1)
 		}
 		if !isVersionCompatibleComputeSgIds {
@@ -4390,7 +4389,7 @@ func getSecurityGroups(r *rosa.Runtime, cmd *cobra.Command, isVersionCompatibleC
 				os.Exit(1)
 			}
 			r.Reporter.Errorf("Parameter '%s' is not supported prior to version '%s'",
-				securitygroups.SgKindFlagMap[kind], formattedVersion)
+				interactiveSgs.SgKindFlagMap[kind], formattedVersion)
 			os.Exit(1)
 		}
 	} else if interactive.Enabled() && isVersionCompatibleComputeSgIds && useExistingVpc {
@@ -4419,7 +4418,7 @@ func getMachinePoolRootDisk(r *rosa.Runtime, cmd *cobra.Command, version string,
 		isVersionCompatibleMachinePoolRootDisk, err = versions.IsGreaterThanOrEqual(
 			version, ocm.MinVersionForMachinePoolRootDisk)
 		if err != nil {
-			return nil, fmt.Errorf("There was a problem checking version compatibility: %v", err)
+			return nil, fmt.Errorf("there was a problem checking version compatibility: %v", err)
 		}
 		if !isVersionCompatibleMachinePoolRootDisk && cmd.Flags().Changed(workerDiskSizeFlag) {
 			formattedVersion, err := versions.FormatMajorMinorPatch(ocm.MinVersionForMachinePoolRootDisk)
@@ -4428,7 +4427,7 @@ func getMachinePoolRootDisk(r *rosa.Runtime, cmd *cobra.Command, version string,
 				os.Exit(1)
 			}
 			return nil, fmt.Errorf(
-				"Updating Worker disk size is not supported for versions prior to '%s'",
+				"updating Worker disk size is not supported for versions prior to '%s'",
 				formattedVersion,
 			)
 		}
@@ -4470,14 +4469,14 @@ func getMachinePoolRootDisk(r *rosa.Runtime, cmd *cobra.Command, version string,
 				})
 			}
 			if err != nil {
-				return nil, fmt.Errorf("Expected a valid machine pool root disk size value: %v", err)
+				return nil, fmt.Errorf("expected a valid machine pool root disk size value: %v", err)
 			}
 		}
 
 		// Parse the value given by either CLI or interactive mode and return it in GigiBytes
 		machinePoolRootDiskSize, err := ocm.ParseDiskSizeToGigibyte(machinePoolRootDiskSizeStr)
 		if err != nil {
-			return nil, fmt.Errorf("Expected a valid machine pool root disk size value '%s': %v",
+			return nil, fmt.Errorf("expected a valid machine pool root disk size value '%s': %v",
 				machinePoolRootDiskSizeStr, err)
 
 		}

--- a/cmd/create/oidcprovider/cmd.go
+++ b/cmd/create/oidcprovider/cmd.go
@@ -186,7 +186,7 @@ func run(cmd *cobra.Command, argv []string) {
 		if clusterKey != "" {
 			confirmPromptMessage = fmt.Sprintf("Create the OIDC provider for cluster '%s'?", clusterKey)
 		}
-		if !confirm.Prompt(true, confirmPromptMessage) {
+		if !confirm.Prompt(true, "%s", confirmPromptMessage) {
 			os.Exit(0)
 		}
 		if clusterId == "" && clusterKey != "" {
@@ -232,7 +232,7 @@ func CreateOIDCProvider(r *rosa.Runtime, oidcConfigId string, clusterId string, 
 	args.oidcConfigId = oidcConfigId
 	oidcConfig, err := r.OCMClient.GetOidcConfig(oidcConfigId)
 	if err != nil {
-		return fmt.Errorf("There was a problem retrieving OIDC Config '%s': %v", oidcConfigId, err)
+		return fmt.Errorf("there was a problem retrieving OIDC Config '%s': %v", oidcConfigId, err)
 	}
 	oidcEndpointURL := oidcConfig.IssuerUrl()
 	return createProvider(r, oidcEndpointURL, clusterId, isProgrammaticallyCalled)

--- a/cmd/detach/policy/cmd.go
+++ b/cmd/detach/policy/cmd.go
@@ -104,13 +104,13 @@ func DetachPolicyRunner(userOptions *RosaDetachPolicyOptions) rosa.CommandRunner
 		if interactive.Enabled() {
 			mode, err = interactive.GetOptionMode(cmd, mode, "Detach policy mode")
 			if err != nil {
-				return fmt.Errorf("Expected a valid detach policy mode: %s", err)
+				return fmt.Errorf("expected a valid detach policy mode: %s", err)
 			}
 		}
 
 		orgID, _, err := r.OCMClient.GetCurrentOrganization()
 		if err != nil {
-			return fmt.Errorf("Failed to get current organization: %s", err)
+			return fmt.Errorf("failed to get current organization: %s", err)
 		}
 		switch mode {
 		case interactive.ModeAuto:
@@ -134,7 +134,7 @@ func DetachPolicyRunner(userOptions *RosaDetachPolicyOptions) rosa.CommandRunner
 				fmt.Print(output)
 			}
 		default:
-			return fmt.Errorf("Invalid mode. Allowed values are %s", interactive.Modes)
+			return fmt.Errorf("invalid mode. Allowed values are %s", interactive.Modes)
 		}
 		return nil
 	}

--- a/cmd/dlt/accountroles/cmd.go
+++ b/cmd/dlt/accountroles/cmd.go
@@ -235,7 +235,7 @@ func deleteAccountRoles(r *rosa.Runtime, cmd *cobra.Command, env string, prefix 
 		r.OCMClient.LogEvent("ROSADeleteAccountRoleModeManual", nil)
 		policyMap, arbitraryPolicyMap, err := r.AWSClient.GetAccountRolePolicies(finalRoleList, prefix)
 		if err != nil {
-			return fmt.Errorf("There was an error getting the policy: %v", err)
+			return fmt.Errorf("there was an error getting the policy: %v", err)
 		}
 
 		// Get HCP shared vpc policy details if the user is deleting roles related to HCP shared vpc
@@ -269,7 +269,7 @@ func getRoleListForDeletion(r *rosa.Runtime, env string, prefix string, clusters
 	finalRoleList := []string{}
 	roles, err := r.AWSClient.GetAccountRoleForCurrentEnvWithPrefix(env, prefix, accountRolesMap)
 	if err != nil {
-		return finalRoleList, false, fmt.Errorf("Error getting role: %s", err)
+		return finalRoleList, false, fmt.Errorf("error getting role: %s", err)
 	}
 	if len(roles) == 0 {
 		return finalRoleList, false, nil
@@ -281,7 +281,7 @@ func getRoleListForDeletion(r *rosa.Runtime, env string, prefix string, clusters
 		}
 		clusterID := checkIfRoleAssociated(clusters, role)
 		if clusterID != "" {
-			return finalRoleList, false, fmt.Errorf("Role %s is associated with the cluster %s", role.RoleName, clusterID)
+			return finalRoleList, false, fmt.Errorf("role %s is associated with the cluster %s", role.RoleName, clusterID)
 		}
 		finalRoleList = append(finalRoleList, role.RoleName)
 	}
@@ -292,18 +292,18 @@ func getRoleListForDeletion(r *rosa.Runtime, env string, prefix string, clusters
 	for _, role := range finalRoleList {
 		instanceProfiles, err := r.AWSClient.GetInstanceProfilesForRole(role)
 		if err != nil {
-			return finalRoleList, false, fmt.Errorf("Error checking for instance roles: %s", err)
+			return finalRoleList, false, fmt.Errorf("error checking for instance roles: %s", err)
 		}
 		if len(instanceProfiles) > 0 {
 			return finalRoleList, false, fmt.Errorf(
-				"Instance Profiles are attached to the role. Please make sure it is deleted: %s",
+				"instance Profiles are attached to the role. Please make sure it is deleted: %s",
 				strings.Join(instanceProfiles, ","))
 		}
 	}
 
 	managedPolicies, err := r.AWSClient.HasManagedPolicies(roles[0].RoleARN)
 	if err != nil {
-		return finalRoleList, false, fmt.Errorf("Failed to determine if cluster has managed policies: %v", err)
+		return finalRoleList, false, fmt.Errorf("failed to determine if cluster has managed policies: %v", err)
 	}
 
 	return finalRoleList, managedPolicies, nil
@@ -377,9 +377,10 @@ func buildCommand(roleNames []string, policyMap map[string][]aws.PolicyDetail,
 			hasRhManagedTag := false
 			hasHcpSharedVpcTag := false
 			for _, tag := range hcpSharedVpcPolicy.Policy.Tags {
-				if *tag.Key == tags.RedHatManaged {
+				switch *tag.Key {
+				case tags.RedHatManaged:
 					hasRhManagedTag = true
-				} else if *tag.Key == tags.HcpSharedVpc {
+				case tags.HcpSharedVpc:
 					hasHcpSharedVpcTag = true
 				}
 			}

--- a/cmd/dlt/upgrade/cmd.go
+++ b/cmd/dlt/upgrade/cmd.go
@@ -73,11 +73,11 @@ func runWithRuntime(r *rosa.Runtime) error {
 
 	cluster := r.FetchCluster()
 	if cluster.State() != cmv1.ClusterStateReady {
-		return fmt.Errorf("Cluster '%s' is not yet ready", clusterKey)
+		return fmt.Errorf("cluster '%s' is not yet ready", clusterKey)
 	}
 
 	if args.nodePool != "" && !ocm.IsHyperShiftCluster(cluster) {
-		return fmt.Errorf("The '--machinepool' option is only supported for Hosted Control Planes")
+		return fmt.Errorf("the '--machinepool' option is only supported for Hosted Control Planes")
 	}
 
 	if args.nodePool != "" {
@@ -94,7 +94,7 @@ func runWithRuntime(r *rosa.Runtime) error {
 func deleteClassicUpgrade(r *rosa.Runtime, clusterID, clusterKey string) error {
 	scheduledUpgrade, _, err := r.OCMClient.GetScheduledUpgrade(clusterID)
 	if err != nil {
-		return fmt.Errorf("Failed to get scheduled upgrades for cluster '%s': %v", clusterKey, err)
+		return fmt.Errorf("failed to get scheduled upgrades for cluster '%s': %v", clusterKey, err)
 	}
 	if scheduledUpgrade == nil {
 		r.Reporter.Infof("There are no scheduled upgrades on cluster '%s'", clusterKey)
@@ -105,7 +105,7 @@ func deleteClassicUpgrade(r *rosa.Runtime, clusterID, clusterKey string) error {
 		r.Reporter.Debugf("Deleting scheduled upgrade for cluster '%s'", clusterKey)
 		canceled, err := r.OCMClient.CancelUpgrade(clusterID)
 		if err != nil {
-			return fmt.Errorf("Failed to cancel scheduled upgrade on cluster '%s': %v", clusterKey, err)
+			return fmt.Errorf("failed to cancel scheduled upgrade on cluster '%s': %v", clusterKey, err)
 		}
 
 		if !canceled {
@@ -121,7 +121,7 @@ func deleteClassicUpgrade(r *rosa.Runtime, clusterID, clusterKey string) error {
 func deleteHypershiftUpgrade(r *rosa.Runtime, clusterID, clusterKey string) error {
 	scheduledUpgrade, err := r.OCMClient.GetControlPlaneScheduledUpgrade(clusterID)
 	if err != nil {
-		return fmt.Errorf("Failed to get scheduled upgrades for cluster '%s': %v", clusterKey, err)
+		return fmt.Errorf("failed to get scheduled upgrades for cluster '%s': %v", clusterKey, err)
 	}
 
 	if scheduledUpgrade == nil {
@@ -133,7 +133,7 @@ func deleteHypershiftUpgrade(r *rosa.Runtime, clusterID, clusterKey string) erro
 		r.Reporter.Debugf("Deleting scheduled upgrade for cluster '%s'", clusterKey)
 		canceled, err := r.OCMClient.CancelControlPlaneUpgrade(clusterID, scheduledUpgrade.ID())
 		if err != nil {
-			return fmt.Errorf("Failed to cancel scheduled upgrade on cluster '%s': %v", clusterKey, err)
+			return fmt.Errorf("failed to cancel scheduled upgrade on cluster '%s': %v", clusterKey, err)
 		}
 
 		if !canceled {
@@ -162,7 +162,7 @@ func deleteHypershiftNodePoolUpgrade(r *rosa.Runtime, clusterID, clusterKey, nod
 		r.Reporter.Debugf("Deleting scheduled upgrade for machine pool '%s'", nodePoolID)
 		canceled, err := r.OCMClient.CancelNodePoolUpgrade(clusterID, nodePoolID, scheduledUpgrade.ID())
 		if err != nil {
-			return fmt.Errorf("Failed to cancel scheduled upgrades for machine pool '%s': %v", nodePoolID, err)
+			return fmt.Errorf("failed to cancel scheduled upgrades for machine pool '%s': %v", nodePoolID, err)
 		}
 
 		if !canceled {

--- a/cmd/install/addon/cmd.go
+++ b/cmd/install/addon/cmd.go
@@ -66,7 +66,7 @@ var Cmd = &cobra.Command{
 		}
 
 		if len(cmd.Flags().Args()) != 1 {
-			return fmt.Errorf("Expected exactly one command line parameter containing the id of the add-on")
+			return fmt.Errorf("expected exactly one command line parameter containing the id of the add-on")
 		}
 		return nil
 	},

--- a/cmd/token/cmd.go
+++ b/cmd/token/cmd.go
@@ -100,12 +100,12 @@ func CreateToken(r *rosa.Runtime) error {
 	}
 
 	if count > 1 {
-		return fmt.Errorf("Options '--payload', '--header', '--signature', and '--generate' are mutually exclusive")
+		return fmt.Errorf("options '--payload', '--header', '--signature', and '--generate' are mutually exclusive")
 	}
 
 	accessToken, refreshToken, err = getAccessTokens(r, args.generate)
 	if err != nil {
-		return fmt.Errorf("Can't get token: %v", err)
+		return fmt.Errorf("can't get token: %v", err)
 	}
 
 	// Select the token according to the options:
@@ -118,20 +118,20 @@ func CreateToken(r *rosa.Runtime) error {
 	parser := new(jwt.Parser)
 	_, parts, err := parser.ParseUnverified(selectedToken, jwt.MapClaims{})
 	if err != nil {
-		return fmt.Errorf("Can't parse token: %v", err)
+		return fmt.Errorf("can't parse token: %v", err)
 	}
 	encoding := base64.RawURLEncoding
 	header, err := encoding.DecodeString(parts[0])
 	if err != nil {
-		return fmt.Errorf("Can't decode header: %v", err)
+		return fmt.Errorf("can't decode header: %v", err)
 	}
 	payload, err := encoding.DecodeString(parts[1])
 	if err != nil {
-		return fmt.Errorf("Can't decode payload: %v", err)
+		return fmt.Errorf("can't decode payload: %v", err)
 	}
 	signature, err := encoding.DecodeString(parts[2])
 	if err != nil {
-		return fmt.Errorf("Can't decode signature: %v", err)
+		return fmt.Errorf("can't decode signature: %v", err)
 	}
 
 	// Print the data:
@@ -148,14 +148,14 @@ func CreateToken(r *rosa.Runtime) error {
 	// Load the configuration file:
 	cfg, err := config.Load()
 	if err != nil {
-		return fmt.Errorf("Can't load config file: %v", err)
+		return fmt.Errorf("can't load config file: %v", err)
 	}
 
 	// Save the configuration:
 	cfg.AccessToken = accessToken
 	cfg.RefreshToken = refreshToken
 	if err = config.Save(cfg); err != nil {
-		return fmt.Errorf("Can't save config file: %v", err)
+		return fmt.Errorf("can't save config file: %v", err)
 	}
 	return nil
 }
@@ -167,13 +167,13 @@ func getAccessTokens(r *rosa.Runtime, generate bool) (string, string, error) {
 		// Get new tokens:
 		accessToken, refreshToken, err = r.OCMClient.GetConnectionTokens(15 * time.Minute)
 		if err != nil {
-			return "", "", fmt.Errorf("Can't get new tokens: %v", err)
+			return "", "", fmt.Errorf("can't get new tokens: %v", err)
 		}
 	} else {
 		// Get the tokens:
 		accessToken, refreshToken, err = r.OCMClient.GetConnectionTokens()
 		if err != nil {
-			return "", "", fmt.Errorf("Can't get token: %v", err)
+			return "", "", fmt.Errorf("can't get token: %v", err)
 		}
 	}
 	return accessToken, refreshToken, nil

--- a/cmd/upgrade/accountroles/cmd.go
+++ b/cmd/upgrade/accountroles/cmd.go
@@ -287,7 +287,7 @@ func upgradeAccountRolePolicies(reporter reporter.Logger, awsClient aws.Client, 
 		if isVersionChosen {
 			promptString = fmt.Sprintf("Upgrade the '%s' role policy to version '%s' ?", roleName, policyVersion)
 		}
-		if !confirm.Prompt(true, promptString) {
+		if !confirm.Prompt(true, "%s", promptString) {
 			continue
 		}
 		filename := fmt.Sprintf("sts_%s_permission_policy", file)
@@ -380,6 +380,6 @@ func getAccountPolicyPath(awsClient aws.Client, prefix string) (string, error) {
 			return awsClient.GetRoleARNPath(prefix)
 		}
 	}
-	return "", fmt.Errorf("Could not find account policies that are attached to account roles." +
+	return "", fmt.Errorf("could not find account policies that are attached to account roles." +
 		"We need at least one in order to detect account policies path")
 }

--- a/cmd/upgrade/cluster/cmd.go
+++ b/cmd/upgrade/cluster/cmd.go
@@ -177,21 +177,21 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 	isHypershift := cluster.Hypershift().Enabled()
 
 	if currentUpgradeScheduling.Schedule == "" && currentUpgradeScheduling.AllowMinorVersionUpdates {
-		return fmt.Errorf("The '--allow-minor-version-upgrades' option needs to be used with --schedule")
+		return fmt.Errorf("the '--allow-minor-version-upgrades' option needs to be used with --schedule")
 	}
 
 	if currentUpgradeScheduling.Schedule != "" && !isHypershift {
-		return fmt.Errorf("The '--schedule' option is only supported for Hosted Control Planes")
+		return fmt.Errorf("the '--schedule' option is only supported for Hosted Control Planes")
 	}
 
 	if (currentUpgradeScheduling.ScheduleDate != "" || currentUpgradeScheduling.ScheduleTime != "") &&
 		currentUpgradeScheduling.Schedule != "" {
-		return fmt.Errorf("The '--schedule-date' and '--schedule-time' options are mutually exclusive with" +
+		return fmt.Errorf("the '--schedule-date' and '--schedule-time' options are mutually exclusive with" +
 			" '--schedule'")
 	}
 
 	if currentUpgradeScheduling.Schedule != "" && args.version != "" {
-		return fmt.Errorf("The '--schedule' option is mutually exclusive with '--version'")
+		return fmt.Errorf("the '--schedule' option is mutually exclusive with '--version'")
 	}
 
 	if args.dryRun {
@@ -200,7 +200,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 
 	// Check cluster preconditions
 	if cluster.State() != cmv1.ClusterStateReady {
-		return fmt.Errorf("Cluster '%s' is not yet ready", clusterKey)
+		return fmt.Errorf("cluster '%s' is not yet ready", clusterKey)
 	}
 	if isHypershift {
 		scheduledUpgrade, err := checkExistingScheduledUpgradeHypershift(r, cluster, clusterKey)
@@ -250,7 +250,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 	}
 	_, isSTS := cluster.AWS().STS().GetRoleARN()
 	if !isSTS && mode != "" {
-		return fmt.Errorf("The 'mode' option is only supported for STS clusters")
+		return fmt.Errorf("the 'mode' option is only supported for STS clusters")
 	}
 	if isSTS && mode == "" {
 		mode, err = interactive.GetOptionMode(cmd, mode, "IAM Roles/Policies upgrade mode")
@@ -275,7 +275,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 				Required: true,
 			})
 			if err != nil {
-				return fmt.Errorf("Expected an upgrade type: %s", err)
+				return fmt.Errorf("expected an upgrade type: %s", err)
 			}
 
 			if currentUpgradeScheduling.AutomaticUpgrades {
@@ -286,7 +286,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 					Required: false,
 				})
 				if err != nil {
-					return fmt.Errorf("Expected a choice on the versions to target: %s", err)
+					return fmt.Errorf("expected a choice on the versions to target: %s", err)
 				}
 			}
 		}
@@ -353,7 +353,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 	if !currentUpgradeScheduling.AutomaticUpgrades {
 		version, err = ocm.CheckAndParseVersion(availableUpgrades, version, cluster)
 		if err != nil {
-			return fmt.Errorf("Error parsing version to upgrade to")
+			return fmt.Errorf("error parsing version to upgrade to")
 		}
 
 		if r.Reporter.IsTerminal() && !args.dryRun && !confirm.Confirm("upgrade cluster to version '%s'", version) {
@@ -374,7 +374,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 			currentUpgradeScheduling.ScheduleTime)
 	}
 	if err != nil {
-		return fmt.Errorf("Failed to schedule upgrade for cluster '%s': %v", clusterKey, err)
+		return fmt.Errorf("failed to schedule upgrade for cluster '%s': %v", clusterKey, err)
 	}
 
 	if args.dryRun {
@@ -388,7 +388,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 	// Update cluster with grace period configuration
 	err = r.OCMClient.UpdateCluster(cluster.ID(), r.Creator, clusterSpec)
 	if err != nil {
-		return fmt.Errorf("Failed to update cluster '%s': %v", clusterKey, err)
+		return fmt.Errorf("failed to update cluster '%s': %v", clusterKey, err)
 	}
 
 	r.Reporter.Infof("Upgrade successfully scheduled for cluster '%s'", clusterKey)
@@ -482,7 +482,7 @@ func buildVersion(r *rosa.Runtime, cmd *cobra.Command, cluster *cmv1.Cluster,
 			Required: true,
 		})
 		if err != nil {
-			return availableUpgrades, version, fmt.Errorf("Expected a valid version to upgrade to: %s", err)
+			return availableUpgrades, version, fmt.Errorf("expected a valid version to upgrade to: %s", err)
 		}
 	}
 	return availableUpgrades, version, nil
@@ -492,7 +492,7 @@ func checkExistingScheduledUpgrade(r *rosa.Runtime, cluster *cmv1.Cluster,
 	clusterKey string) (*cmv1.UpgradePolicy, *cmv1.UpgradePolicyState, error) {
 	scheduledUpgrade, upgradeState, err := r.OCMClient.GetScheduledUpgrade(cluster.ID())
 	if err != nil {
-		return nil, nil, fmt.Errorf("Failed to get scheduled upgrades for cluster '%s': %v", clusterKey, err)
+		return nil, nil, fmt.Errorf("failed to get scheduled upgrades for cluster '%s': %v", clusterKey, err)
 	}
 
 	return scheduledUpgrade, upgradeState, nil
@@ -502,7 +502,7 @@ func checkExistingScheduledUpgradeHypershift(r *rosa.Runtime, cluster *cmv1.Clus
 	clusterKey string) (*cmv1.ControlPlaneUpgradePolicy, error) {
 	scheduledUpgrade, err := r.OCMClient.GetControlPlaneScheduledUpgrade(cluster.ID())
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get scheduled control plane upgrades for cluster '%s': %v", clusterKey, err)
+		return nil, fmt.Errorf("failed to get scheduled control plane upgrades for cluster '%s': %v", clusterKey, err)
 	}
 	return scheduledUpgrade, nil
 }
@@ -525,12 +525,12 @@ func checkRolesManagedPolicies(r *rosa.Runtime, cluster *cmv1.Cluster, mode stri
 
 	credRequests, err := ocmClient.GetCredRequests(cluster.Hypershift().Enabled())
 	if err != nil {
-		return fmt.Errorf("Error getting operator credential request from OCM %v", err)
+		return fmt.Errorf("error getting operator credential request from OCM %v", err)
 	}
 
 	unifiedPath, err := aws.GetPathFromAccountRole(cluster, aws.AccountRoles[aws.InstallerAccountRole].Name)
 	if err != nil {
-		return fmt.Errorf("Expected a valid path for '%s': %v", cluster.AWS().STS().RoleARN(), err)
+		return fmt.Errorf("expected a valid path for '%s': %v", cluster.AWS().STS().RoleARN(), err)
 	}
 
 	err = rolesHelper.ValidateAccountAndOperatorRolesManagedPolicies(r, cluster, credRequests, unifiedPath,

--- a/cmd/upgrade/machinepool/cmd.go
+++ b/cmd/upgrade/machinepool/cmd.go
@@ -130,34 +130,34 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command, argv []string) error {
 
 	// Check parameters preconditions
 	if currentUpgradeScheduling.Schedule == "" && currentUpgradeScheduling.AllowMinorVersionUpdates {
-		return fmt.Errorf("The '--allow-minor-version-upgrades' option needs to be used with --schedule")
+		return fmt.Errorf("the '--allow-minor-version-upgrades' option needs to be used with --schedule")
 	}
 
 	if (currentUpgradeScheduling.ScheduleDate != "" || currentUpgradeScheduling.ScheduleTime != "") &&
 		currentUpgradeScheduling.Schedule != "" {
-		return fmt.Errorf("The '--schedule-date' and '--schedule-time' options are mutually exclusive with" +
+		return fmt.Errorf("the '--schedule-date' and '--schedule-time' options are mutually exclusive with" +
 			" '--schedule'")
 	}
 
 	if currentUpgradeScheduling.Schedule != "" && args.version != "" {
-		return fmt.Errorf("The '--schedule' option is mutually exclusive with '--version'")
+		return fmt.Errorf("the '--schedule' option is mutually exclusive with '--version'")
 	}
 
 	// Validate cluster state
 	input.CheckIfHypershiftClusterOrExit(r, cluster)
 	if cluster.State() != cmv1.ClusterStateReady {
-		return fmt.Errorf("Cluster '%s' is not yet ready", clusterKey)
+		return fmt.Errorf("cluster '%s' is not yet ready", clusterKey)
 	}
 
 	if !machinepool.MachinePoolKeyRE.MatchString(machinePoolID) {
-		return fmt.Errorf("Expected a valid identifier for the machine pool")
+		return fmt.Errorf("expected a valid identifier for the machine pool")
 	}
 	_, exists, err := r.OCMClient.GetNodePool(cluster.ID(), machinePoolID)
 	if err != nil {
-		return fmt.Errorf("Failed to get machine pools for hosted cluster '%s': %v", clusterKey, err)
+		return fmt.Errorf("failed to get machine pools for hosted cluster '%s': %v", clusterKey, err)
 	}
 	if !exists {
-		return fmt.Errorf("Machine pool '%s' does not exist for hosted cluster '%s'", machinePoolID, clusterKey)
+		return fmt.Errorf("machine pool '%s' does not exist for hosted cluster '%s'", machinePoolID, clusterKey)
 	}
 
 	// Enable interactive mode if needed
@@ -184,7 +184,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command, argv []string) error {
 			Required: true,
 		})
 		if err != nil {
-			return fmt.Errorf("Expected an upgrade type: %s", err)
+			return fmt.Errorf("expected an upgrade type: %s", err)
 		}
 
 		if currentUpgradeScheduling.AutomaticUpgrades {
@@ -195,7 +195,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command, argv []string) error {
 				Required: false,
 			})
 			if err != nil {
-				return fmt.Errorf("Expected an choice on the versions to target: %s", err)
+				return fmt.Errorf("expected an choice on the versions to target: %s", err)
 			}
 		}
 	}
@@ -360,14 +360,14 @@ func ComputeNodePoolVersion(r *rosa.Runtime, cmd *cobra.Command, cluster *cmv1.C
 			Required: true,
 		})
 		if err != nil {
-			return "", fmt.Errorf("Expected a valid machine pool version from interactive prompt: %s", err)
+			return "", fmt.Errorf("expected a valid machine pool version from interactive prompt: %s", err)
 		}
 	}
 	// This is called in HyperShift, but we don't want to exclude version which are HCP disabled for node pools
 	// so we pass the relative parameter as false
 	version, err = r.OCMClient.ValidateVersion(version, filteredVersionList, channelGroup, true, false)
 	if err != nil {
-		return "", fmt.Errorf("Expected a valid machine pool version: %s", err)
+		return "", fmt.Errorf("expected a valid machine pool version: %s", err)
 	}
 	return version, nil
 }

--- a/cmd/upgrade/roles/cmd.go
+++ b/cmd/upgrade/roles/cmd.go
@@ -573,7 +573,7 @@ func upgradeAccountRolePoliciesFromCluster(
 		if isVersionChosen {
 			promptString = fmt.Sprintf("Upgrade the '%s' role policy to version '%s' ?", roleName, policyVersion)
 		}
-		if !confirm.Prompt(true, promptString) {
+		if !confirm.Prompt(true, "%s", promptString) {
 			if args.isInvokedFromClusterUpgrade {
 				return reporter.Errorf("Account roles need to be upgraded to proceed")
 			}

--- a/cmd/verify/network/cmd.go
+++ b/cmd/verify/network/cmd.go
@@ -161,12 +161,12 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 		if cluster != nil {
 			if !helper.IsBYOVPC(cluster) {
 				return fmt.Errorf(
-					"Running the network verifier is only supported for BYO VPC clusters")
+					"running the network verifier is only supported for BYO VPC clusters")
 			}
 
 			args.subnetIDs = cluster.AWS().SubnetIDs()
 		} else {
-			return fmt.Errorf("At least one subnet IDs is required")
+			return fmt.Errorf("at least one subnet IDs is required")
 		}
 	}
 
@@ -177,7 +177,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 	if cmd.Flags().Changed(roleArnFlag) {
 		err := aws.ARNValidator(args.roleArn)
 		if err != nil {
-			return fmt.Errorf("Expected a valid ARN: %s", err)
+			return fmt.Errorf("expected a valid ARN: %s", err)
 		}
 	} else if !cmd.Flags().Changed(statusOnlyFlag) {
 		if cmd.Flags().Changed(clusterFlag) {
@@ -223,7 +223,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 			}
 			_, err := r.OCMClient.VerifyNetworkSubnetsByCluster(cluster.ID(), tagsList)
 			if err != nil {
-				return fmt.Errorf("Error verifying subnets by cluster: %s", err)
+				return fmt.Errorf("error verifying subnets by cluster: %s", err)
 			}
 		} else {
 			// Default platform type set to 'aws-classic'
@@ -233,7 +233,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 			}
 			_, err := r.OCMClient.VerifyNetworkSubnets(args.roleArn, args.region, args.subnetIDs, tagsList, platform)
 			if err != nil {
-				return fmt.Errorf("Error verifying subnets: %s", err)
+				return fmt.Errorf("error verifying subnets: %s", err)
 			}
 		}
 	}
@@ -271,7 +271,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 			spin.Stop()
 		}
 	} else {
-		var pending bool = false
+		pending := false
 		for i := 0; i < len(args.subnetIDs); i++ {
 			subnet := args.subnetIDs[i]
 			status, err := r.OCMClient.GetVerifyNetworkSubnet(subnet)
@@ -331,7 +331,7 @@ func getRegion(cmd *cobra.Command, cluster *cmv1.Cluster) (region string, err er
 	if cmd.Flags().Changed("region") {
 		region, err = aws.GetRegion(arguments.GetRegion())
 		if err != nil {
-			return "", fmt.Errorf("Error getting region: %v", err)
+			return "", fmt.Errorf("error getting region: %v", err)
 		}
 		return region, nil
 	}
@@ -339,5 +339,5 @@ func getRegion(cmd *cobra.Command, cluster *cmv1.Cluster) (region string, err er
 		return cluster.Region().ID(), nil
 	}
 
-	return "", fmt.Errorf("Region is required")
+	return "", fmt.Errorf("region is required")
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/rosa
 
-go 1.23.1
+go 1.24.0
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.15

--- a/pkg/aws/client_test.go
+++ b/pkg/aws/client_test.go
@@ -522,7 +522,7 @@ var _ = Describe("Client", func() {
 		It("Does not wrap other errors and returns false", func() {
 			fakeError := "Fake AWS creds failure"
 
-			err := fmt.Errorf(fakeError)
+			err := fmt.Errorf("%s", fakeError)
 			mockSTSApi.EXPECT().GetCallerIdentity(gomock.Any(), &sts.GetCallerIdentityInput{}).Return(nil, err)
 
 			valid, err := client.ValidateCredentials()

--- a/pkg/helper/versions/helpers.go
+++ b/pkg/helper/versions/helpers.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/go-version"
 	ver "github.com/hashicorp/go-version"
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 
@@ -14,7 +13,7 @@ import (
 
 const (
 	MinorVersionsSupported              = 2
-	MajorMinorPatchFormattedErrorOutput = "An error occurred formatting the version for output: %v"
+	MajorMinorPatchFormattedErrorOutput = "an error occurred formatting the version for output: %v"
 )
 
 func GetVersionList(r *rosa.Runtime, channelGroup string, isSTS bool, isHostedCP bool, filterHostedCP bool,
@@ -27,18 +26,18 @@ func GetVersionList(r *rosa.Runtime, channelGroup string, isSTS bool, isHostedCP
 	// Product can be empty. In this case, no filter will be applied
 	vs, err = r.OCMClient.GetVersionsWithProduct(product, channelGroup, defaultFirst)
 	if err != nil {
-		err = fmt.Errorf("Failed to retrieve versions: %s", err)
+		err = fmt.Errorf("failed to retrieve versions: %s", err)
 		return
 	}
 
 	defaultVersion, versionList, err = computeVersionListAndDefault(vs, isHostedCP, isSTS, filterHostedCP)
 	if err != nil {
-		err = fmt.Errorf("Failed to retrieve versions: %s", err)
+		err = fmt.Errorf("failed to retrieve versions: %s", err)
 		return
 	}
 
 	if len(versionList) == 0 {
-		err = fmt.Errorf("Could not find versions for the provided channel-group: '%s'", channelGroup)
+		err = fmt.Errorf("could not find versions for the provided channel-group: '%s'", channelGroup)
 		return
 	}
 
@@ -142,11 +141,11 @@ func GetMinimalHostedMachinePoolVersion(controlPlaneVersion string) (string, err
 }
 
 func IsGreaterThanOrEqual(version1, version2 string) (bool, error) {
-	v1, err := version.NewVersion(strings.TrimPrefix(version1, ocm.VersionPrefix))
+	v1, err := ver.NewVersion(strings.TrimPrefix(version1, ocm.VersionPrefix))
 	if err != nil {
 		return false, err
 	}
-	v2, err := version.NewVersion(strings.TrimPrefix(version2, ocm.VersionPrefix))
+	v2, err := ver.NewVersion(strings.TrimPrefix(version2, ocm.VersionPrefix))
 	if err != nil {
 		return false, err
 	}

--- a/pkg/interactive/addon.go
+++ b/pkg/interactive/addon.go
@@ -44,7 +44,7 @@ func GetAddonArgument(param asv1.AddonParameter, dflt string) (string, error) {
 				}
 				if isValid, err := regexp.MatchString(param.Validation(), strAns); err != nil || !isValid {
 					if param.ValidationErrMsg() != "" {
-						return fmt.Errorf(param.ValidationErrMsg())
+						return fmt.Errorf("%s", param.ValidationErrMsg())
 					}
 					return fmt.Errorf("expected %q to match /%s/", strAns, param.Validation())
 				}
@@ -106,7 +106,7 @@ func GetAddonArgument(param asv1.AddonParameter, dflt string) (string, error) {
 
 	// If the parameter type wasn't handled in the above switch statement
 	// then this parameter type is not supported by interactive mode yet.
-	return "", fmt.Errorf("The parameter '%s' does not support interactive mode", param.ID())
+	return "", fmt.Errorf("the parameter '%s' does not support interactive mode", param.ID())
 }
 
 func getOptionNames(param asv1.AddonParameter) []string {

--- a/pkg/interactive/confirm/confirm.go
+++ b/pkg/interactive/confirm/confirm.go
@@ -42,7 +42,7 @@ func Yes() bool {
 
 // Asks the user to confirm the operation, using the specified string as the message
 func ConfirmRaw(q string) bool {
-	return Prompt(false, q)
+	return Prompt(false, "%s", q)
 }
 
 func Confirm(q string, v ...interface{}) bool {

--- a/pkg/interactive/validation.go
+++ b/pkg/interactive/validation.go
@@ -76,10 +76,10 @@ func IsValidHostname(val interface{}) error {
 		return nil
 	}
 	if hostname == "github.com" || strings.HasSuffix(hostname, ".github.com") {
-		return fmt.Errorf(fmt.Sprintf("'%s' hostname cannot be equal to [*.]github.com", hostname))
+		return fmt.Errorf("%v", fmt.Sprintf("'%s' hostname cannot be equal to [*.]github.com", hostname))
 	}
 	if !(len(validation.IsDNS1123Subdomain(hostname)) == 0 || netutils.ParseIPSloppy(hostname) != nil) {
-		return fmt.Errorf(fmt.Sprintf("'%s' hostname must be a valid DNS subdomain or IP address", hostname))
+		return fmt.Errorf("%v", fmt.Sprintf("'%s' hostname must be a valid DNS subdomain or IP address", hostname))
 	}
 	return nil
 }
@@ -90,7 +90,7 @@ func IsURLHttps(val interface{}) error {
 		return err
 	}
 	if parsedUri.Scheme != helper.ProtocolHttps {
-		return fmt.Errorf("Expect URL '%s' to use an 'https://' scheme", val.(string))
+		return fmt.Errorf("expect URL '%s' to use an 'https://' scheme", val.(string))
 	}
 	return nil
 }

--- a/pkg/machinepool/helper.go
+++ b/pkg/machinepool/helper.go
@@ -62,7 +62,7 @@ func ValidateLabels(cmd *cobra.Command, args *mpOpts.CreateMachinepoolUserOption
 // Validate the cluster's state is ready
 func ValidateClusterState(cluster *cmv1.Cluster, clusterKey string) error {
 	if cluster.State() != cmv1.ClusterStateReady {
-		return fmt.Errorf("Cluster '%s' is not yet ready", clusterKey)
+		return fmt.Errorf("cluster '%s' is not yet ready", clusterKey)
 	}
 	return nil
 }
@@ -89,7 +89,7 @@ func getSubnetFromUser(cmd *cobra.Command, r *rosa.Runtime, isSubnetSet bool,
 			Required: false,
 		})
 		if err != nil {
-			return "", fmt.Errorf(questionError)
+			return "", fmt.Errorf("%s", questionError)
 		}
 	} else {
 		subnet = args.Subnet
@@ -109,7 +109,7 @@ func getSubnetFromUser(cmd *cobra.Command, r *rosa.Runtime, isSubnetSet bool,
 			Required: true,
 		})
 		if err != nil {
-			return "", fmt.Errorf("Expected a valid AWS subnet: %s", err)
+			return "", fmt.Errorf("expected a valid AWS subnet: %s", err)
 		}
 		subnet = aws.ParseOption(subnetOption)
 	}
@@ -136,12 +136,12 @@ func getSubnetOptions(r *rosa.Runtime, cluster *cmv1.Cluster) ([]string, error) 
 
 func getSecurityGroupsOption(r *rosa.Runtime, cmd *cobra.Command, cluster *cmv1.Cluster) ([]string, error) {
 	if len(cluster.AWS().SubnetIDs()) == 0 {
-		return []string{}, fmt.Errorf("Expected cluster's subnets to contain subnets IDs, but got an empty list")
+		return []string{}, fmt.Errorf("expected cluster's subnets to contain subnets IDs, but got an empty list")
 	}
 
 	availableSubnets, err := r.AWSClient.GetVPCSubnets(cluster.AWS().SubnetIDs()[0])
 	if err != nil {
-		return []string{}, fmt.Errorf("Failed to retrieve available subnets: %v", err)
+		return []string{}, fmt.Errorf("failed to retrieve available subnets: %v", err)
 	}
 	firstSubnet := availableSubnets[0]
 	vpcId, err := getVpcIdFromSubnet(firstSubnet)
@@ -188,7 +188,7 @@ func createAwsNodePoolBuilder(
 func getVpcIdFromSubnet(subnet ec2types.Subnet) (string, error) {
 	vpcId := awssdk.ToString(subnet.VpcId)
 	if vpcId == "" {
-		return "", fmt.Errorf("Unexpected situation a VPC ID should have been selected based on chosen subnets")
+		return "", fmt.Errorf("unexpected situation a VPC ID should have been selected based on chosen subnets")
 	}
 
 	return vpcId, nil
@@ -230,7 +230,7 @@ func (r *ReplicaSizeValidation) MaxReplicaValidator() interactive.Validator {
 			return fmt.Errorf("max-replicas must be greater or equal to min-replicas")
 		}
 		if r.MultiAz && maxReplicas%3 != 0 {
-			return fmt.Errorf("Multi AZ clusters require that the replicas be a multiple of 3")
+			return fmt.Errorf("multi AZ clusters require that the replicas be a multiple of 3")
 		}
 		return validateClusterVersionWithMaxNodesLimit(
 			r.ClusterVersion, maxReplicas, r.IsHostedCp)
@@ -251,10 +251,10 @@ func (r *ReplicaSizeValidation) MinReplicaValidator() interactive.Validator {
 				" enabled")
 		}
 		if !r.Autoscaling && minReplicas < 0 {
-			return fmt.Errorf("Replicas must be a non-negative integer")
+			return fmt.Errorf("replicas must be a non-negative integer")
 		}
 		if r.MultiAz && minReplicas%3 != 0 {
-			return fmt.Errorf("Multi AZ clusters require that the replicas be a multiple of 3")
+			return fmt.Errorf("multi AZ clusters require that the replicas be a multiple of 3")
 		}
 		return validateClusterVersionWithMaxNodesLimit(
 			r.ClusterVersion, minReplicas, r.IsHostedCp)
@@ -268,11 +268,11 @@ func spotMaxPriceValidator(val interface{}) error {
 	}
 	price, err := strconv.ParseFloat(spotMaxPrice, commonUtils.MaxByteSize)
 	if err != nil {
-		return fmt.Errorf("Expected a numeric value for spot max price")
+		return fmt.Errorf("expected a numeric value for spot max price")
 	}
 
 	if price <= 0 {
-		return fmt.Errorf("Spot max price must be positive")
+		return fmt.Errorf("spot max price must be positive")
 	}
 	return nil
 }
@@ -311,7 +311,7 @@ func getSubnetFromAvailabilityZone(cmd *cobra.Command, r *rosa.Runtime, isAvaila
 			Required: true,
 		})
 		if err != nil {
-			return "", fmt.Errorf("Expected a valid AWS availability zone: %s", err)
+			return "", fmt.Errorf("expected a valid AWS availability zone: %s", err)
 		}
 	} else if isAvailabilityZoneSet {
 		availabilityZone = args.AvailabilityZone
@@ -330,7 +330,7 @@ func getSubnetFromAvailabilityZone(cmd *cobra.Command, r *rosa.Runtime, isAvaila
 		return subnet, nil
 	}
 
-	return "", fmt.Errorf("Failed to find a private subnet for '%s' availability zone", availabilityZone)
+	return "", fmt.Errorf("failed to find a private subnet for '%s' availability zone", availabilityZone)
 }
 
 // temporary fn until calculated default values can be retrieved from single source of truth

--- a/pkg/machinepool/machinepool.go
+++ b/pkg/machinepool/machinepool.go
@@ -22,7 +22,6 @@ import (
 	"github.com/openshift/rosa/pkg/fedramp"
 	"github.com/openshift/rosa/pkg/helper"
 	"github.com/openshift/rosa/pkg/helper/features"
-	"github.com/openshift/rosa/pkg/helper/machinepools"
 	mpHelpers "github.com/openshift/rosa/pkg/helper/machinepools"
 	"github.com/openshift/rosa/pkg/helper/versions"
 	"github.com/openshift/rosa/pkg/interactive"
@@ -90,29 +89,29 @@ func (m *machinePool) CreateMachinePool(r *rosa.Runtime, cmd *cobra.Command, clu
 	// Validate flags that are only allowed for multi-AZ clusters
 	isMultiAvailabilityZoneSet := cmd.Flags().Changed("multi-availability-zone")
 	if isMultiAvailabilityZoneSet && !cluster.MultiAZ() {
-		return fmt.Errorf("Setting the `multi-availability-zone` flag is only allowed for multi-AZ clusters")
+		return fmt.Errorf("setting the `multi-availability-zone` flag is only allowed for multi-AZ clusters")
 	}
 	isAvailabilityZoneSet := cmd.Flags().Changed("availability-zone")
 	if isAvailabilityZoneSet && !cluster.MultiAZ() {
-		return fmt.Errorf("Setting the `availability-zone` flag is only allowed for multi-AZ clusters")
+		return fmt.Errorf("setting the `availability-zone` flag is only allowed for multi-AZ clusters")
 	}
 
 	// Validate flags that are only allowed for BYOVPC cluster
 	isSubnetSet := cmd.Flags().Changed("subnet")
 	isByoVpc := helper.IsBYOVPC(cluster)
 	if !isByoVpc && isSubnetSet {
-		return fmt.Errorf("Setting the `subnet` flag is only allowed for BYO VPC clusters")
+		return fmt.Errorf("setting the `subnet` flag is only allowed for BYO VPC clusters")
 	}
 
 	isSecurityGroupIdsSet := cmd.Flags().Changed(securitygroups.MachinePoolSecurityGroupFlag)
 	isVersionCompatibleComputeSgIds, err := versions.IsGreaterThanOrEqual(
 		cluster.Version().RawID(), ocm.MinVersionForAdditionalComputeSecurityGroupIdsDay2)
 	if err != nil {
-		return fmt.Errorf("There was a problem checking version compatibility: %v", err)
+		return fmt.Errorf("there was a problem checking version compatibility: %v", err)
 	}
 	if isSecurityGroupIdsSet {
 		if !isByoVpc {
-			return fmt.Errorf("Setting the `%s` flag is only allowed for BYOVPC clusters",
+			return fmt.Errorf("setting the `%s` flag is only allowed for BYOVPC clusters",
 				securitygroups.MachinePoolSecurityGroupFlag)
 		}
 		if !isVersionCompatibleComputeSgIds {
@@ -122,23 +121,23 @@ func (m *machinePool) CreateMachinePool(r *rosa.Runtime, cmd *cobra.Command, clu
 			if err != nil {
 				return fmt.Errorf(versions.MajorMinorPatchFormattedErrorOutput, err)
 			}
-			return fmt.Errorf("Parameter '%s' is not supported prior to version '%s'",
+			return fmt.Errorf("parameter '%s' is not supported prior to version '%s'",
 				securitygroups.MachinePoolSecurityGroupFlag, formattedVersion)
 		}
 	}
 
 	if isSubnetSet && isAvailabilityZoneSet {
-		return fmt.Errorf("Setting both `subnet` and `availability-zone` flag is not supported." +
+		return fmt.Errorf("setting both `subnet` and `availability-zone` flag is not supported." +
 			" Please select `subnet` or `availability-zone` to create a single availability zone machine pool")
 	}
 
 	// Validate `subnet` or `availability-zone` flags are set for a single AZ machine pool
 	if isAvailabilityZoneSet && isMultiAvailabilityZoneSet && args.MultiAvailabilityZone {
-		return fmt.Errorf("Setting the `availability-zone` flag is only supported for creating a single AZ " +
+		return fmt.Errorf("setting the `availability-zone` flag is only supported for creating a single AZ " +
 			"machine pool in a multi-AZ cluster")
 	}
 	if isSubnetSet && isMultiAvailabilityZoneSet && args.MultiAvailabilityZone {
-		return fmt.Errorf("Setting the `subnet` flag is only supported for creating a single AZ machine pool")
+		return fmt.Errorf("setting the `subnet` flag is only supported for creating a single AZ machine pool")
 	}
 
 	rosa.HostedClusterOnlyFlag(r, cmd, "version")
@@ -163,12 +162,12 @@ func (m *machinePool) CreateMachinePool(r *rosa.Runtime, cmd *cobra.Command, clu
 			},
 		})
 		if err != nil {
-			return fmt.Errorf("Expected a valid name for the machine pool: %s", err)
+			return fmt.Errorf("expected a valid name for the machine pool: %s", err)
 		}
 	}
 	name = strings.Trim(name, " \t")
 	if !machinePoolKeyRE.MatchString(name) {
-		return fmt.Errorf("Expected a valid name for the machine pool")
+		return fmt.Errorf("expected a valid name for the machine pool")
 	}
 
 	// Allow the user to select subnet for a single AZ BYOVPC cluster
@@ -198,7 +197,7 @@ func (m *machinePool) CreateMachinePool(r *rosa.Runtime, cmd *cobra.Command, clu
 				Required: false,
 			})
 			if err != nil {
-				return fmt.Errorf("Expected a valid value for create multi-AZ machine pool")
+				return fmt.Errorf("expected a valid value for create multi-AZ machine pool")
 			}
 		} else {
 			multiAZMachinePool = args.MultiAvailabilityZone
@@ -225,14 +224,14 @@ func (m *machinePool) CreateMachinePool(r *rosa.Runtime, cmd *cobra.Command, clu
 						Required: true,
 					})
 					if err != nil {
-						return fmt.Errorf("Expected a valid AWS availability zone: %s", err)
+						return fmt.Errorf("expected a valid AWS availability zone: %s", err)
 					}
 				} else if isAvailabilityZoneSet {
 					availabilityZone = args.AvailabilityZone
 				}
 
 				if !helper.Contains(cluster.Nodes().AvailabilityZones(), availabilityZone) {
-					return fmt.Errorf("Availability zone '%s' doesn't belong to the cluster's availability zones",
+					return fmt.Errorf("availability zone '%s' doesn't belong to the cluster's availability zones",
 						availabilityZone)
 				}
 			}
@@ -264,7 +263,7 @@ func (m *machinePool) CreateMachinePool(r *rosa.Runtime, cmd *cobra.Command, clu
 	// Machine pool instance type:
 	instanceType := args.InstanceType
 	if instanceType == "" && !interactive.Enabled() {
-		return fmt.Errorf("You must supply a valid instance type")
+		return fmt.Errorf("you must supply a valid instance type")
 	}
 
 	var spin *spinner.Spinner
@@ -291,7 +290,7 @@ func (m *machinePool) CreateMachinePool(r *rosa.Runtime, cmd *cobra.Command, clu
 		cluster.AWS().STS().ExternalID(),
 	)
 	if err != nil {
-		return fmt.Errorf(fmt.Sprintf("%s", err))
+		return fmt.Errorf("%s", err.Error())
 	}
 
 	if spin != nil {
@@ -310,13 +309,13 @@ func (m *machinePool) CreateMachinePool(r *rosa.Runtime, cmd *cobra.Command, clu
 			Required: true,
 		})
 		if err != nil {
-			return fmt.Errorf("Expected a valid instance type: %s", err)
+			return fmt.Errorf("expected a valid instance type: %s", err)
 		}
 	}
 
 	err = instanceTypeList.ValidateMachineType(instanceType, cluster.MultiAZ())
 	if err != nil {
-		return fmt.Errorf("Expected a valid instance type: %s", err)
+		return fmt.Errorf("expected a valid instance type: %s", err)
 	}
 
 	existingLabels := make(map[string]string, 0)
@@ -332,7 +331,7 @@ func (m *machinePool) CreateMachinePool(r *rosa.Runtime, cmd *cobra.Command, clu
 	useSpotInstances := args.UseSpotInstances
 	spotMaxPrice := args.SpotMaxPrice
 	if isSpotMaxPriceSet && isSpotSet && !useSpotInstances {
-		return fmt.Errorf("Can't set max price when not using spot instances")
+		return fmt.Errorf("can't set max price when not using spot instances")
 	}
 
 	// Validate spot instance are supported
@@ -344,7 +343,7 @@ func (m *machinePool) CreateMachinePool(r *rosa.Runtime, cmd *cobra.Command, clu
 		}
 	}
 	if isLocalZone && useSpotInstances {
-		return fmt.Errorf("Spot instances are not supported for local zones")
+		return fmt.Errorf("spot instances are not supported for local zones")
 	}
 
 	if !isSpotSet && !isSpotMaxPriceSet && !isLocalZone && interactive.Enabled() {
@@ -355,7 +354,7 @@ func (m *machinePool) CreateMachinePool(r *rosa.Runtime, cmd *cobra.Command, clu
 			Required: false,
 		})
 		if err != nil {
-			return fmt.Errorf("Expected a valid value for use spot instances: %s", err)
+			return fmt.Errorf("expected a valid value for use spot instances: %s", err)
 		}
 	}
 
@@ -370,7 +369,7 @@ func (m *machinePool) CreateMachinePool(r *rosa.Runtime, cmd *cobra.Command, clu
 			},
 		})
 		if err != nil {
-			return fmt.Errorf("Expected a valid value for spot max price: %s", err)
+			return fmt.Errorf("expected a valid value for spot max price: %s", err)
 		}
 	}
 
@@ -385,7 +384,7 @@ func (m *machinePool) CreateMachinePool(r *rosa.Runtime, cmd *cobra.Command, clu
 		maxPrice = &price
 	}
 
-	awsTags := machinepools.GetAwsTags(cmd, r, args.Tags)
+	awsTags := mpHelpers.GetAwsTags(cmd, r, args.Tags)
 
 	mpBuilder := cmv1.NewMachinePool().
 		ID(name).
@@ -455,14 +454,14 @@ func (m *machinePool) CreateMachinePool(r *rosa.Runtime, cmd *cobra.Command, clu
 				},
 			})
 			if err != nil {
-				return fmt.Errorf("Expected a valid machine pool root disk size value: %v", err)
+				return fmt.Errorf("expected a valid machine pool root disk size value: %v", err)
 			}
 		}
 
 		// Parse the value given by either CLI or interactive mode and return it in GigiBytes
 		rootDiskSize, err := ocm.ParseDiskSizeToGigibyte(rootDiskSizeStr)
 		if err != nil {
-			return fmt.Errorf("Expected a valid machine pool root disk size value '%s': %v", rootDiskSizeStr, err)
+			return fmt.Errorf("expected a valid machine pool root disk size value '%s': %v", rootDiskSizeStr, err)
 		}
 
 		err = diskValidator.ValidateMachinePoolRootDiskSize(cluster.Version().RawID(), rootDiskSize)
@@ -479,17 +478,17 @@ func (m *machinePool) CreateMachinePool(r *rosa.Runtime, cmd *cobra.Command, clu
 
 	machinePool, err := mpBuilder.Build()
 	if err != nil {
-		return fmt.Errorf("Failed to create machine pool for cluster '%s': %v", clusterKey, err)
+		return fmt.Errorf("failed to create machine pool for cluster '%s': %v", clusterKey, err)
 	}
 
 	createdMachinePool, err := r.OCMClient.CreateMachinePool(cluster.ID(), machinePool)
 	if err != nil {
-		return fmt.Errorf("Failed to add machine pool to cluster '%s': %v", clusterKey, err)
+		return fmt.Errorf("failed to add machine pool to cluster '%s': %v", clusterKey, err)
 	}
 
 	if output.HasFlag() {
 		if err = output.Print(createdMachinePool); err != nil {
-			return fmt.Errorf("Unable to print machine pool: %v", err)
+			return fmt.Errorf("unable to print machine pool: %v", err)
 		}
 	} else {
 		r.Reporter.Infof("Machine pool '%s' created successfully on cluster '%s'", name, clusterKey)
@@ -507,13 +506,13 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 	var err error
 	isMultiAvailabilityZoneSet := cmd.Flags().Changed("multi-availability-zone")
 	if isMultiAvailabilityZoneSet {
-		return fmt.Errorf("Setting `multi-availability-zone` flag is not supported for HCP clusters.")
+		return fmt.Errorf("setting `multi-availability-zone` flag is not supported for HCP clusters")
 	}
 
 	isAvailabilityZoneSet := cmd.Flags().Changed("availability-zone")
 	isSubnetSet := cmd.Flags().Changed("subnet")
 	if isSubnetSet && isAvailabilityZoneSet {
-		return fmt.Errorf("Setting both `subnet` and `availability-zone` flag is not supported." +
+		return fmt.Errorf("setting both `subnet` and `availability-zone` flag is not supported." +
 			" Please select `subnet` or `availability-zone` to create a single availability zone machine pool")
 	}
 
@@ -533,12 +532,12 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 			},
 		})
 		if err != nil {
-			return fmt.Errorf("Expected a valid name for the machine pool: %s", err)
+			return fmt.Errorf("expected a valid name for the machine pool: %s", err)
 		}
 	}
 	name = strings.Trim(name, " \t")
 	if !machinePoolKeyRE.MatchString(name) {
-		return fmt.Errorf("Expected a valid name for the machine pool")
+		return fmt.Errorf("expected a valid name for the machine pool")
 	}
 
 	// OpenShift version:
@@ -576,14 +575,14 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 				Required: true,
 			})
 			if err != nil {
-				return fmt.Errorf("Expected a valid OpenShift version: %s", err)
+				return fmt.Errorf("expected a valid OpenShift version: %s", err)
 			}
 		}
 		// This is called in HyperShift, but we don't want to exclude version which are HCP disabled for node pools
 		// so we pass the relative parameter as false
 		version, err = r.OCMClient.ValidateVersion(version, filteredVersionList, channelGroup, true, false)
 		if err != nil {
-			return fmt.Errorf("Expected a valid OpenShift version: %s", err)
+			return fmt.Errorf("expected a valid OpenShift version: %s", err)
 		}
 	}
 
@@ -613,10 +612,10 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 	}
 
 	existingLabels := make(map[string]string, 0)
-	labelMap := machinepools.GetLabelMap(cmd, r, existingLabels, args.Labels)
+	labelMap := mpHelpers.GetLabelMap(cmd, r, existingLabels, args.Labels)
 
 	existingTaints := make([]*cmv1.Taint, 0)
-	taintBuilders := machinepools.GetTaints(cmd, r, existingTaints, args.Taints)
+	taintBuilders := mpHelpers.GetTaints(cmd, r, existingTaints, args.Taints)
 
 	isSecurityGroupIdsSet := cmd.Flags().Changed(securitygroups.MachinePoolSecurityGroupFlag)
 	securityGroupIds := args.SecurityGroupIds
@@ -635,7 +634,7 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 		securityGroupIds[i] = strings.TrimSpace(sg)
 	}
 
-	awsTags := machinepools.GetAwsTags(cmd, r, args.Tags)
+	awsTags := mpHelpers.GetAwsTags(cmd, r, args.Tags)
 
 	npBuilder := cmv1.NewNodePool()
 	npBuilder.ID(name).Labels(labelMap).
@@ -658,7 +657,7 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 	// NodePools don't support MultiAZ yet, so the availabilityZonesFilters is calculated from the cluster
 	instanceType := args.InstanceType
 	if instanceType == "" && !interactive.Enabled() {
-		return fmt.Errorf("You must supply a valid instance type")
+		return fmt.Errorf("you must supply a valid instance type")
 	}
 
 	var spin *spinner.Spinner
@@ -677,7 +676,7 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 	if subnet != "" {
 		availabilityZone, err := r.AWSClient.GetSubnetAvailabilityZone(subnet)
 		if err != nil {
-			return fmt.Errorf(fmt.Sprintf("%s", err))
+			return fmt.Errorf("%s", err)
 		}
 		availabilityZonesFilter = []string{availabilityZone}
 	}
@@ -685,7 +684,7 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 	instanceTypeList, err := r.OCMClient.GetAvailableMachineTypesInRegion(cluster.Region().ID(),
 		availabilityZonesFilter, cluster.AWS().STS().RoleARN(), r.AWSClient, cluster.AWS().STS().ExternalID())
 	if err != nil {
-		return fmt.Errorf(fmt.Sprintf("%s", err))
+		return fmt.Errorf("%s", err)
 	}
 
 	if spin != nil {
@@ -704,13 +703,13 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 			Required: true,
 		})
 		if err != nil {
-			return fmt.Errorf("Expected a valid instance type: %s", err)
+			return fmt.Errorf("expected a valid instance type: %s", err)
 		}
 	}
 
 	err = instanceTypeList.ValidateMachineType(instanceType, cluster.MultiAZ())
 	if err != nil {
-		return fmt.Errorf("Expected a valid instance type: %s", err)
+		return fmt.Errorf("expected a valid instance type: %s", err)
 	}
 
 	autorepair := args.Autorepair
@@ -722,7 +721,7 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 			Required: false,
 		})
 		if err != nil {
-			return fmt.Errorf("Expected a valid value for autorepair: %s", err)
+			return fmt.Errorf("expected a valid value for autorepair: %s", err)
 		}
 	}
 
@@ -755,7 +754,7 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 				Required: false,
 			})
 			if err != nil {
-				return fmt.Errorf("Expected a valid value for tuning configs: %s", err)
+				return fmt.Errorf("expected a valid value for tuning configs: %s", err)
 			}
 		}
 	}
@@ -775,7 +774,7 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 			Required: false,
 		})
 		if err != nil {
-			return fmt.Errorf("Expected a valid value for Capacity Reservation ID: %s", err)
+			return fmt.Errorf("expected a valid value for Capacity Reservation ID: %s", err)
 		}
 	}
 
@@ -813,14 +812,14 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 					},
 				})
 				if err != nil {
-					return fmt.Errorf("Expected a valid value for kubelet config: %s", err)
+					return fmt.Errorf("expected a valid value for kubelet config: %s", err)
 				}
 			}
 		}
 
 		err = ValidateKubeletConfig(inputKubeletConfigs)
 		if err != nil {
-			return fmt.Errorf(err.Error())
+			return fmt.Errorf("%s", err.Error())
 		}
 
 		if len(inputKubeletConfigs) != 0 {
@@ -841,12 +840,12 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 			Default:  httpTokens,
 		})
 		if err != nil {
-			return fmt.Errorf("Expected a valid http tokens value : %v", err)
+			return fmt.Errorf("expected a valid http tokens value : %v", err)
 		}
 	}
 
 	if err = ocm.ValidateHttpTokensValue(httpTokens); err != nil {
-		return fmt.Errorf("Expected a valid http tokens value : %v", err)
+		return fmt.Errorf("expected a valid http tokens value : %v", err)
 	}
 
 	var rootDiskSize *int
@@ -877,14 +876,14 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 				},
 			})
 			if err != nil {
-				return fmt.Errorf("Expected a valid node pool root disk size value: %v", err)
+				return fmt.Errorf("expected a valid node pool root disk size value: %v", err)
 			}
 		}
 
 		// Parse the value given by either CLI or interactive mode and return it in GigiBytes
 		parsedRootDiskSize, err := ocm.ParseDiskSizeToGigibyte(rootDiskSizeStr)
 		if err != nil {
-			return fmt.Errorf("Expected a valid node pool root disk size value '%s': %v", rootDiskSizeStr, err)
+			return fmt.Errorf("expected a valid node pool root disk size value '%s': %v", rootDiskSizeStr, err)
 		}
 
 		err = diskValidator.ValidateNodePoolRootDiskSize(parsedRootDiskSize)
@@ -919,17 +918,17 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 			Default:  nodeDrainGracePeriod,
 			Required: false,
 			Validators: []interactive.Validator{
-				machinepools.ValidateNodeDrainGracePeriod,
+				mpHelpers.ValidateNodeDrainGracePeriod,
 			},
 		})
 		if err != nil {
-			return fmt.Errorf("Expected a valid value for Node drain grace period: %s", err)
+			return fmt.Errorf("expected a valid value for Node drain grace period: %s", err)
 		}
 	}
 	if nodeDrainGracePeriod != "" {
-		nodeDrainBuilder, err := machinepools.CreateNodeDrainGracePeriodBuilder(nodeDrainGracePeriod)
+		nodeDrainBuilder, err := mpHelpers.CreateNodeDrainGracePeriodBuilder(nodeDrainGracePeriod)
 		if err != nil {
-			return fmt.Errorf(err.Error())
+			return fmt.Errorf("%s", err.Error())
 		}
 		npBuilder.NodeDrainGracePeriod(nodeDrainBuilder)
 	}
@@ -945,11 +944,11 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 				Default:  maxSurge,
 				Required: false,
 				Validators: []interactive.Validator{
-					machinepools.ValidateUpgradeMaxSurgeUnavailable,
+					mpHelpers.ValidateUpgradeMaxSurgeUnavailable,
 				},
 			})
 			if err != nil {
-				return fmt.Errorf("Expected a valid value for max surge: %s", err)
+				return fmt.Errorf("expected a valid value for max surge: %s", err)
 			}
 		}
 
@@ -961,11 +960,11 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 				Default:  maxUnavailable,
 				Required: false,
 				Validators: []interactive.Validator{
-					machinepools.ValidateUpgradeMaxSurgeUnavailable,
+					mpHelpers.ValidateUpgradeMaxSurgeUnavailable,
 				},
 			})
 			if err != nil {
-				return fmt.Errorf("Expected a valid value for max unavailable: %s", err)
+				return fmt.Errorf("expected a valid value for max unavailable: %s", err)
 			}
 		}
 		if maxSurge != "" || maxUnavailable != "" {
@@ -1032,17 +1031,17 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 
 	nodePool, err := npBuilder.Build()
 	if err != nil {
-		return fmt.Errorf("Failed to create machine pool for hosted cluster '%s': %v", clusterKey, err)
+		return fmt.Errorf("failed to create machine pool for hosted cluster '%s': %v", clusterKey, err)
 	}
 
 	createdNodePool, err := r.OCMClient.CreateNodePool(cluster.ID(), nodePool)
 	if err != nil {
-		return fmt.Errorf("Failed to add machine pool to hosted cluster '%s': %v", clusterKey, err)
+		return fmt.Errorf("failed to add machine pool to hosted cluster '%s': %v", clusterKey, err)
 	}
 
 	if output.HasFlag() {
 		if err = output.Print(createdNodePool); err != nil {
-			return fmt.Errorf("Unable to print machine pool: %v", err)
+			return fmt.Errorf("unable to print machine pool: %v", err)
 		}
 	} else {
 		r.Reporter.Infof("Machine pool '%s' created successfully on hosted cluster '%s'", createdNodePool.ID(), clusterKey)
@@ -1055,7 +1054,8 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 }
 
 // ListMachinePools lists all machinepools (or, nodepools if hypershift) in a cluster
-func (m *machinePool) ListMachinePools(r *rosa.Runtime, clusterKey string, cluster *cmv1.Cluster, args ListMachinePoolArgs) error {
+func (m *machinePool) ListMachinePools(r *rosa.Runtime, clusterKey string, cluster *cmv1.Cluster,
+	args ListMachinePoolArgs) error {
 	// Load any existing machine pools for this cluster
 	r.Reporter.Debugf("Loading machine pools for cluster '%s'", clusterKey)
 	isHypershift := cluster.Hypershift().Enabled()
@@ -1165,7 +1165,7 @@ func (m *machinePool) DeleteMachinePool(r *rosa.Runtime, machinePoolId string, c
 	r.Reporter.Debugf("Loading machine pools for cluster '%s'", clusterKey)
 	machinePools, err := r.OCMClient.GetMachinePools(cluster.ID())
 	if err != nil {
-		return fmt.Errorf("Failed to get machine pools for cluster '%s': %v", clusterKey, err)
+		return fmt.Errorf("failed to get machine pools for cluster '%s': %v", clusterKey, err)
 	}
 
 	var machinePool *cmv1.MachinePool
@@ -1175,14 +1175,14 @@ func (m *machinePool) DeleteMachinePool(r *rosa.Runtime, machinePoolId string, c
 		}
 	}
 	if machinePool == nil {
-		return fmt.Errorf("Failed to get machine pool '%s' for cluster '%s'", machinePoolId, clusterKey)
+		return fmt.Errorf("failed to get machine pool '%s' for cluster '%s'", machinePoolId, clusterKey)
 	}
 
 	if confirm.Confirm("delete machine pool '%s' on cluster '%s'", machinePoolId, clusterKey) {
 		r.Reporter.Debugf("Deleting machine pool '%s' on cluster '%s'", machinePool.ID(), clusterKey)
 		err = r.OCMClient.DeleteMachinePool(cluster.ID(), machinePool.ID())
 		if err != nil {
-			return fmt.Errorf("Failed to delete machine pool '%s' on cluster '%s': %s",
+			return fmt.Errorf("failed to delete machine pool '%s' on cluster '%s': %s",
 				machinePool.ID(), clusterKey, err)
 		}
 		r.Reporter.Infof("Successfully deleted machine pool '%s' from cluster '%s'", machinePoolId, clusterKey)
@@ -1197,11 +1197,11 @@ func deleteNodePool(r *rosa.Runtime, nodePoolID string, clusterKey string, clust
 	r.Reporter.Debugf("Loading machine pools for hosted cluster '%s'", clusterKey)
 	nodePool, exists, err := r.OCMClient.GetNodePool(cluster.ID(), nodePoolID)
 	if err != nil {
-		return fmt.Errorf("Failed to get machine pools for hosted cluster '%s': %v", clusterKey,
+		return fmt.Errorf("failed to get machine pools for hosted cluster '%s': %v", clusterKey,
 			err)
 	}
 	if !exists {
-		return fmt.Errorf("Machine pool '%s' does not exist for hosted cluster '%s'", nodePoolID,
+		return fmt.Errorf("machine pool '%s' does not exist for hosted cluster '%s'", nodePoolID,
 			clusterKey)
 	}
 
@@ -1209,7 +1209,7 @@ func deleteNodePool(r *rosa.Runtime, nodePoolID string, clusterKey string, clust
 		r.Reporter.Debugf("Deleting machine pool '%s' on hosted cluster '%s'", nodePool.ID(), clusterKey)
 		err = r.OCMClient.DeleteNodePool(cluster.ID(), nodePool.ID())
 		if err != nil {
-			return fmt.Errorf("Failed to delete machine pool '%s' on hosted cluster '%s': %s",
+			return fmt.Errorf("failed to delete machine pool '%s' on hosted cluster '%s': %s",
 				nodePool.ID(), clusterKey, err)
 		}
 		r.Reporter.Infof("Successfully deleted machine pool '%s' from hosted cluster '%s'", nodePoolID,
@@ -1271,23 +1271,43 @@ func getMachinePoolsString(
 
 	allColumnDefinitions := []columnDefinition{
 		{"ID", true, func(mp *cmv1.MachinePool) string { return mp.ID() }},
-		{"AUTOSCALING", true, func(mp *cmv1.MachinePool) string { return ocmOutput.PrintMachinePoolAutoscaling(mp.Autoscaling()) }},
+		{"AUTOSCALING", true, func(mp *cmv1.MachinePool) string {
+			return ocmOutput.PrintMachinePoolAutoscaling(mp.Autoscaling())
+		}},
 		{"REPLICAS", true, func(mp *cmv1.MachinePool) string {
 			return ocmOutput.PrintMachinePoolReplicas(mp.Autoscaling(), mp.Replicas())
 		}},
-		{"INSTANCE TYPE", true, func(mp *cmv1.MachinePool) string { return mp.InstanceType() }},
-		{"LABELS", true, func(mp *cmv1.MachinePool) string { return ocmOutput.PrintLabels(mp.Labels()) }},
-		{"TAINTS", true, func(mp *cmv1.MachinePool) string { return ocmOutput.PrintTaints(mp.Taints()) }},
-		{"AVAILABILITY ZONES", true, func(mp *cmv1.MachinePool) string { return output.PrintStringSlice(mp.AvailabilityZones()) }},
-		{"SUBNETS", true, func(mp *cmv1.MachinePool) string { return output.PrintStringSlice(mp.Subnets()) }},
-		{"SPOT INSTANCES", true, func(mp *cmv1.MachinePool) string { return ocmOutput.PrintMachinePoolSpot(mp) }},
-		{"DISK SIZE", true, func(mp *cmv1.MachinePool) string { return ocmOutput.PrintMachinePoolDiskSize(mp) }},
+		{"INSTANCE TYPE", true, func(mp *cmv1.MachinePool) string {
+			return mp.InstanceType()
+		}},
+		{"LABELS", true, func(mp *cmv1.MachinePool) string {
+			return ocmOutput.PrintLabels(mp.Labels())
+		}},
+		{"TAINTS", true, func(mp *cmv1.MachinePool) string {
+			return ocmOutput.PrintTaints(mp.Taints())
+		}},
+		{"AVAILABILITY ZONES", true, func(mp *cmv1.MachinePool) string {
+			return output.PrintStringSlice(mp.AvailabilityZones())
+		}},
+		{"SUBNETS", true, func(mp *cmv1.MachinePool) string {
+			return output.PrintStringSlice(mp.Subnets())
+		}},
+		{"SPOT INSTANCES", true, func(mp *cmv1.MachinePool) string {
+			return ocmOutput.PrintMachinePoolSpot(mp)
+		}},
+		{"DISK SIZE", true, func(mp *cmv1.MachinePool) string {
+			return ocmOutput.PrintMachinePoolDiskSize(mp)
+		}},
 		{"SG IDS", true, func(mp *cmv1.MachinePool) string {
 			return output.PrintStringSlice(mp.AWS().AdditionalSecurityGroupIds())
 		}},
-		{"AZ TYPE", args.ShowAZType || args.ShowAll, func(mp *cmv1.MachinePool) string { return getZoneType(mp) }},
-		{"WIN-LI ENABLED", args.ShowWindowsLI || args.ShowAll, func(mp *cmv1.MachinePool) string { return isWinLIEnabled(mp.Labels()) }},
-		{"DEDICATED HOST", args.ShowDedicated || args.ShowAll, func(mp *cmv1.MachinePool) string { return isDedicatedHost(mp, runtime) }},
+		{"AZ TYPE", args.ShowAZType || args.ShowAll, func(mp *cmv1.MachinePool) string {
+			return getZoneType(mp)
+		}},
+		{"WIN-LI ENABLED", args.ShowWindowsLI || args.ShowAll,
+			func(mp *cmv1.MachinePool) string { return isWinLIEnabled(mp.Labels()) }},
+		{"DEDICATED HOST", args.ShowDedicated || args.ShowAll,
+			func(mp *cmv1.MachinePool) string { return isDedicatedHost(mp, runtime) }},
 	}
 
 	var visibleColumnHeaders []string
@@ -1369,16 +1389,16 @@ func getNodePoolsString(nodePools []*cmv1.NodePool) string {
 func (m *machinePool) EditMachinePool(cmd *cobra.Command, machinePoolId string, clusterKey string,
 	cluster *cmv1.Cluster, r *rosa.Runtime) error {
 	if cluster.State() != cmv1.ClusterStateReady {
-		return fmt.Errorf("Cluster '%s' is not yet ready", clusterKey)
+		return fmt.Errorf("cluster '%s' is not yet ready", clusterKey)
 	}
 
 	if !MachinePoolKeyRE.MatchString(machinePoolId) {
-		return fmt.Errorf("Expected a valid identifier for the machine pool")
+		return fmt.Errorf("expected a valid identifier for the machine pool")
 	}
 	if cluster.Hypershift().Enabled() {
 		clusterAutoscaler, err := r.OCMClient.GetClusterAutoscaler(cluster.ID())
 		if err != nil {
-			return errors.UserErrorf("Failed to fetch cluster autoscaler for cluster '%s'", cluster.ID())
+			return errors.UserErrorf("failed to fetch cluster autoscaler for cluster '%s'", cluster.ID())
 		}
 		return editNodePool(cmd, machinePoolId, clusterKey, cluster, clusterAutoscaler, r)
 	}
@@ -1411,36 +1431,36 @@ func getMachinePoolReplicas(cmd *cobra.Command,
 
 	replicas, err = cmd.Flags().GetInt("replicas")
 	if err != nil {
-		err = fmt.Errorf("Failed to get inputted replicas: %s", err)
+		err = fmt.Errorf("failed to get inputted replicas: %s", err)
 		return
 	}
 	minReplicas, err = cmd.Flags().GetInt("min-replicas")
 	if err != nil {
-		err = fmt.Errorf("Failed to get inputted min replicas: %s", err)
+		err = fmt.Errorf("failed to get inputted min replicas: %s", err)
 		return
 	}
 	maxReplicas, err = cmd.Flags().GetInt("max-replicas")
 	if err != nil {
-		err = fmt.Errorf("Failed to get inputted max replicas: %s", err)
+		err = fmt.Errorf("failed to get inputted max replicas: %s", err)
 		return
 	}
 	autoscaling, err = cmd.Flags().GetBool("enable-autoscaling")
 	if err != nil {
-		err = fmt.Errorf("Failed to get inputted autoscaling: %s", err)
+		err = fmt.Errorf("failed to get inputted autoscaling: %s", err)
 		return
 	}
 	replicasRequired := existingAutoscaling == nil
 
 	// if the user set min/max replicas and hasn't enabled autoscaling, or existing is disabled
 	if (isMinReplicasSet || isMaxReplicasSet) && !autoscaling && existingAutoscaling == nil {
-		err = fmt.Errorf("Autoscaling is not enabled on machine pool '%s'. can't set min or max replicas",
+		err = fmt.Errorf("autoscaling is not enabled on machine pool '%s'. can't set min or max replicas",
 			machinePoolID)
 		return
 	}
 
 	// if the user set replicas but enabled autoscaling or hasn't disabled existing autoscaling
 	if isReplicasSet && existingAutoscaling != nil && (!isAutoscalingSet || autoscaling) {
-		err = fmt.Errorf("Autoscaling enabled on machine pool '%s'. can't set replicas",
+		err = fmt.Errorf("autoscaling enabled on machine pool '%s'. can't set replicas",
 			machinePoolID)
 		return
 	}
@@ -1455,7 +1475,7 @@ func getMachinePoolReplicas(cmd *cobra.Command,
 				Required: false,
 			})
 			if err != nil {
-				err = fmt.Errorf("Expected a valid value for enable-autoscaling: %s", err)
+				err = fmt.Errorf("expected a valid value for enable-autoscaling: %s", err)
 				return
 			}
 		}
@@ -1491,7 +1511,7 @@ func getMachinePoolReplicas(cmd *cobra.Command,
 				},
 			})
 			if err != nil {
-				err = fmt.Errorf("Expected a valid number of min replicas: %s", err)
+				err = fmt.Errorf("expected a valid number of min replicas: %s", err)
 				return
 			}
 			replicaSizeValidation.MinReplicas = minReplicas
@@ -1510,7 +1530,7 @@ func getMachinePoolReplicas(cmd *cobra.Command,
 				},
 			})
 			if err != nil {
-				err = fmt.Errorf("Expected a valid number of max replicas: %s", err)
+				err = fmt.Errorf("expected a valid number of max replicas: %s", err)
 				return
 			}
 		}
@@ -1529,7 +1549,7 @@ func getMachinePoolReplicas(cmd *cobra.Command,
 				},
 			})
 			if err != nil {
-				err = fmt.Errorf("Expected a valid number of replicas: %s", err)
+				err = fmt.Errorf("expected a valid number of replicas: %s", err)
 				return
 			}
 		}
@@ -1551,11 +1571,10 @@ func editMachinePoolAutoscaling(machinePool *cmv1.MachinePool,
 	asBuilder := cmv1.NewMachinePoolAutoscaling()
 	changed := false
 
-	if machinePool.Autoscaling().MinReplicas() != minReplicas && minReplicas >= 0 {
-		changed = true
-	}
-	if machinePool.Autoscaling().MaxReplicas() != maxReplicas && maxReplicas >= 0 {
-		changed = true
+	changed = machinePool.Autoscaling().MinReplicas() != minReplicas && minReplicas >= 0
+
+	if !changed {
+		changed = machinePool.Autoscaling().MaxReplicas() != maxReplicas && maxReplicas >= 0
 	}
 
 	if changed {
@@ -1579,6 +1598,7 @@ func editMachinePool(cmd *cobra.Command, machinePoolId string,
 	isTaintsSet := cmd.Flags().Changed("taints")
 
 	// if no value set enter interactive mode
+	//nolint:staticcheck
 	if !(isMinReplicasSet || isMaxReplicasSet || isReplicasSet || isAutoscalingSet || isLabelsSet || isTaintsSet) {
 		interactive.Enable()
 	}
@@ -1587,7 +1607,7 @@ func editMachinePool(cmd *cobra.Command, machinePoolId string,
 	r.Reporter.Debugf("Loading machine pools for cluster '%s'", clusterKey)
 	machinePools, err := r.OCMClient.GetMachinePools(cluster.ID())
 	if err != nil {
-		return fmt.Errorf("Failed to get machine pools for cluster '%s': %v", clusterKey, err)
+		return fmt.Errorf("failed to get machine pools for cluster '%s': %v", clusterKey, err)
 	}
 
 	var machinePool *cmv1.MachinePool
@@ -1597,7 +1617,7 @@ func editMachinePool(cmd *cobra.Command, machinePoolId string,
 		}
 	}
 	if machinePool == nil {
-		return fmt.Errorf("Failed to get machine pool '%s' for cluster '%s'", machinePoolId, clusterKey)
+		return fmt.Errorf("failed to get machine pool '%s' for cluster '%s'", machinePoolId, clusterKey)
 	}
 
 	autoscaling, replicas, minReplicas, maxReplicas, err :=
@@ -1605,13 +1625,13 @@ func editMachinePool(cmd *cobra.Command, machinePoolId string,
 			!isLabelsSet && !isTaintsSet, isMultiAZMachinePool(machinePool), cluster.OpenshiftVersion())
 
 	if err != nil {
-		return fmt.Errorf("Failed to get autoscaling or replicas: '%s'", err)
+		return fmt.Errorf("failed to get autoscaling or replicas: '%s'", err)
 	}
 
 	if cluster.MultiAZ() && isMultiAZMachinePool(machinePool) &&
 		(!autoscaling && replicas%3 != 0 ||
 			(autoscaling && (minReplicas%3 != 0 || maxReplicas%3 != 0))) {
-		return fmt.Errorf("Multi AZ clusters require that the number of MachinePool replicas be a multiple of 3")
+		return fmt.Errorf("multi AZ clusters require that the number of MachinePool replicas be a multiple of 3")
 	}
 
 	labels := cmd.Flags().Lookup("labels").Value.String()
@@ -1643,13 +1663,13 @@ func editMachinePool(cmd *cobra.Command, machinePoolId string,
 
 	machinePool, err = mpBuilder.Build()
 	if err != nil {
-		return fmt.Errorf("Failed to create machine pool for cluster '%s': %v", clusterKey, err)
+		return fmt.Errorf("failed to create machine pool for cluster '%s': %v", clusterKey, err)
 	}
 
 	r.Reporter.Debugf("Updating machine pool '%s' on cluster '%s'", machinePool.ID(), clusterKey)
 	_, err = r.OCMClient.UpdateMachinePool(cluster.ID(), machinePool)
 	if err != nil {
-		return fmt.Errorf("Failed to update machine pool '%s' on cluster '%s': %s",
+		return fmt.Errorf("failed to update machine pool '%s' on cluster '%s': %s",
 			machinePool.ID(), clusterKey, err)
 	}
 	r.Reporter.Infof("Updated machine pool '%s' on cluster '%s'", machinePool.ID(), clusterKey)
@@ -1688,16 +1708,16 @@ func editNodePool(cmd *cobra.Command, nodePoolID string,
 	r.Reporter.Debugf("Loading machine pool for hosted cluster '%s'", clusterKey)
 	nodePool, exists, err := r.OCMClient.GetNodePool(cluster.ID(), nodePoolID)
 	if err != nil {
-		return fmt.Errorf("Failed to get machine pools for hosted cluster '%s': %v", clusterKey, err)
+		return fmt.Errorf("failed to get machine pools for hosted cluster '%s': %v", clusterKey, err)
 	}
 	if !exists {
-		return fmt.Errorf("Machine pool '%s' does not exist for hosted cluster '%s'", nodePoolID, clusterKey)
+		return fmt.Errorf("machine pool '%s' does not exist for hosted cluster '%s'", nodePoolID, clusterKey)
 	}
 
 	autoscaling, replicas, minReplicas, maxReplicas, err := getNodePoolReplicas(cmd, nodePoolID,
 		nodePool.Replicas(), nodePool.Autoscaling(), isAnyAdditionalParameterSet, cluster.OpenshiftVersion())
 	if err != nil {
-		return fmt.Errorf("Failed to get autoscaling or replicas: '%s'", err)
+		return fmt.Errorf("failed to get autoscaling or replicas: '%s'", err)
 	}
 
 	err = validateNodePoolEdit(cmd, autoscaling, replicas, minReplicas, maxReplicas)
@@ -1729,7 +1749,7 @@ func editNodePool(cmd *cobra.Command, nodePoolID string,
 	if isAutorepairSet || interactive.Enabled() {
 		autorepair, err := strconv.ParseBool(cmd.Flags().Lookup("autorepair").Value.String())
 		if err != nil {
-			return fmt.Errorf("Failed to parse autorepair flag: %s", err)
+			return fmt.Errorf("failed to parse autorepair flag: %s", err)
 		}
 		if interactive.Enabled() {
 			autorepair, err = interactive.GetBool(interactive.Input{
@@ -1739,7 +1759,7 @@ func editNodePool(cmd *cobra.Command, nodePoolID string,
 				Required: false,
 			})
 			if err != nil {
-				return fmt.Errorf("Expected a valid value for autorepair: %s", err)
+				return fmt.Errorf("expected a valid value for autorepair: %s", err)
 			}
 		}
 
@@ -1780,7 +1800,7 @@ func editNodePool(cmd *cobra.Command, nodePoolID string,
 					Required: false,
 				})
 				if err != nil {
-					return fmt.Errorf("Expected a valid value for tuning configs: %s", err)
+					return fmt.Errorf("expected a valid value for tuning configs: %s", err)
 				}
 			}
 		}
@@ -1825,13 +1845,13 @@ func editNodePool(cmd *cobra.Command, nodePoolID string,
 					},
 				})
 				if err != nil {
-					return fmt.Errorf("Expected a valid value for kubelet config: %s", err)
+					return fmt.Errorf("expected a valid value for kubelet config: %s", err)
 				}
 			}
 		}
 		err = ValidateKubeletConfig(inputKubeletConfig)
 		if err != nil {
-			r.Reporter.Errorf(err.Error())
+			r.Reporter.Errorf("%s", err.Error())
 			os.Exit(1)
 		}
 		npBuilder.KubeletConfigs(inputKubeletConfig...)
@@ -1856,14 +1876,14 @@ func editNodePool(cmd *cobra.Command, nodePoolID string,
 				},
 			})
 			if err != nil {
-				return fmt.Errorf("Expected a valid value for Node drain grace period: %s", err)
+				return fmt.Errorf("expected a valid value for Node drain grace period: %s", err)
 			}
 		}
 
 		if nodeDrainGracePeriod != "" {
 			nodeDrainBuilder, err := mpHelpers.CreateNodeDrainGracePeriodBuilder(nodeDrainGracePeriod)
 			if err != nil {
-				return fmt.Errorf(err.Error())
+				return fmt.Errorf("%s", err.Error())
 			}
 			npBuilder.NodeDrainGracePeriod(nodeDrainBuilder)
 		}
@@ -1969,7 +1989,7 @@ func editNodePool(cmd *cobra.Command, nodePoolID string,
 
 	update, err := npBuilder.Build()
 	if err != nil {
-		return fmt.Errorf("Failed to create machine pool for hosted cluster '%s': %v", clusterKey, err)
+		return fmt.Errorf("failed to create machine pool for hosted cluster '%s': %v", clusterKey, err)
 	}
 
 	if isKubeletConfigSet && !promptForNodePoolNodeRecreate(
@@ -1980,7 +2000,7 @@ func editNodePool(cmd *cobra.Command, nodePoolID string,
 	r.Reporter.Debugf("Updating machine pool '%s' on hosted cluster '%s'", nodePool.ID(), clusterKey)
 	_, err = r.OCMClient.UpdateNodePool(cluster.ID(), update)
 	if err != nil {
-		return fmt.Errorf("Failed to update machine pool '%s' on hosted cluster '%s': %s",
+		return fmt.Errorf("failed to update machine pool '%s' on hosted cluster '%s': %s",
 			nodePool.ID(), clusterKey, err)
 	}
 	r.Reporter.Infof("Updated machine pool '%s' on hosted cluster '%s'", nodePool.ID(), clusterKey)
@@ -1989,20 +2009,20 @@ func editNodePool(cmd *cobra.Command, nodePoolID string,
 
 func validateNodePoolEdit(cmd *cobra.Command, autoscaling bool, replicas int, minReplicas int, maxReplicas int) error {
 	if !autoscaling && replicas < 0 {
-		return fmt.Errorf("The number of machine pool replicas needs to be a non-negative integer")
+		return fmt.Errorf("the number of machine pool replicas needs to be a non-negative integer")
 	}
 
 	if autoscaling && cmd.Flags().Changed("min-replicas") && minReplicas < 1 {
-		return fmt.Errorf("min-replicas must be greater than zero.")
+		return fmt.Errorf("min-replicas must be greater than zero")
 	}
 
 	if autoscaling && cmd.Flags().Changed("max-replicas") && maxReplicas < 1 {
-		return fmt.Errorf("max-replicas must be greater than zero.")
+		return fmt.Errorf("max-replicas must be greater than zero")
 	}
 
 	if autoscaling && cmd.Flags().Changed("max-replicas") && cmd.Flags().Changed(
 		"min-replicas") && minReplicas > maxReplicas {
-		return fmt.Errorf("The number of machine pool min-replicas needs to be less than the number of " +
+		return fmt.Errorf("the number of machine pool min-replicas needs to be less than the number of " +
 			"machine pool max-replicas")
 	}
 	return nil
@@ -2042,36 +2062,36 @@ func getNodePoolReplicas(cmd *cobra.Command,
 
 	replicas, err = cmd.Flags().GetInt("replicas")
 	if err != nil {
-		err = fmt.Errorf("Failed to get inputted replicas: %s", err)
+		err = fmt.Errorf("failed to get inputted replicas: %s", err)
 		return
 	}
 	minReplicas, err = cmd.Flags().GetInt("min-replicas")
 	if err != nil {
-		err = fmt.Errorf("Failed to get inputted min replicas: %s", err)
+		err = fmt.Errorf("failed to get inputted min replicas: %s", err)
 		return
 	}
 	maxReplicas, err = cmd.Flags().GetInt("max-replicas")
 	if err != nil {
-		err = fmt.Errorf("Failed to get inputted max replicas: %s", err)
+		err = fmt.Errorf("failed to get inputted max replicas: %s", err)
 		return
 	}
 	autoscaling, err = cmd.Flags().GetBool("enable-autoscaling")
 	if err != nil {
-		err = fmt.Errorf("Failed to get inputted autoscaling: %s", err)
+		err = fmt.Errorf("failed to get inputted autoscaling: %s", err)
 		return
 	}
 	replicasRequired := existingAutoscaling == nil
 
 	// if the user set min/max replicas and hasn't enabled autoscaling, or existing is disabled
 	if (isMinReplicasSet || isMaxReplicasSet) && !autoscaling && existingAutoscaling == nil {
-		err = fmt.Errorf("Autoscaling is not enabled on machine pool '%s'. can't set min or max replicas",
+		err = fmt.Errorf("autoscaling is not enabled on machine pool '%s'. can't set min or max replicas",
 			nodePoolID)
 		return
 	}
 
 	// if the user set replicas but enabled autoscaling or hasn't disabled existing autoscaling
 	if isReplicasSet && existingAutoscaling != nil && (!isAutoscalingSet || autoscaling) {
-		err = fmt.Errorf("Autoscaling enabled on machine pool '%s'. can't set replicas",
+		err = fmt.Errorf("autoscaling enabled on machine pool '%s'. can't set replicas",
 			nodePoolID)
 		return
 	}
@@ -2086,7 +2106,7 @@ func getNodePoolReplicas(cmd *cobra.Command,
 				Required: false,
 			})
 			if err != nil {
-				err = fmt.Errorf("Expected a valid value for enable-autoscaling: %s", err)
+				err = fmt.Errorf("expected a valid value for enable-autoscaling: %s", err)
 				return
 			}
 		}
@@ -2113,7 +2133,7 @@ func getNodePoolReplicas(cmd *cobra.Command,
 				},
 			})
 			if err != nil {
-				err = fmt.Errorf("Expected a valid number of min replicas: %s", err)
+				err = fmt.Errorf("expected a valid number of min replicas: %s", err)
 				return
 			}
 			replicaSizeValidation.MinReplicas = minReplicas
@@ -2131,7 +2151,7 @@ func getNodePoolReplicas(cmd *cobra.Command,
 				},
 			})
 			if err != nil {
-				err = fmt.Errorf("Expected a valid number of max replicas: %s", err)
+				err = fmt.Errorf("expected a valid number of max replicas: %s", err)
 				return
 			}
 		}
@@ -2153,7 +2173,7 @@ func getNodePoolReplicas(cmd *cobra.Command,
 			},
 		})
 		if err != nil {
-			err = fmt.Errorf("Expected a valid number of replicas: %s", err)
+			err = fmt.Errorf("expected a valid number of replicas: %s", err)
 			return
 		}
 	}
@@ -2207,7 +2227,7 @@ func manageReplicas(cmd *cobra.Command, args *mpOpts.CreateMachinepoolUserOption
 		})
 		if err != nil {
 			return minReplicas, maxReplicas, replicas, autoscaling,
-				fmt.Errorf("Expected a valid value for enable-autoscaling: %s", err)
+				fmt.Errorf("expected a valid value for enable-autoscaling: %s", err)
 		}
 	}
 
@@ -2215,7 +2235,7 @@ func manageReplicas(cmd *cobra.Command, args *mpOpts.CreateMachinepoolUserOption
 		// if the user set replicas and enabled autoscaling
 		if isReplicasSet {
 			return minReplicas, maxReplicas, replicas, autoscaling,
-				fmt.Errorf("Replicas can't be set when autoscaling is enabled")
+				fmt.Errorf("replicas can't be set when autoscaling is enabled")
 		}
 
 		// Min replicas
@@ -2231,7 +2251,7 @@ func manageReplicas(cmd *cobra.Command, args *mpOpts.CreateMachinepoolUserOption
 			})
 			if err != nil {
 				return minReplicas, maxReplicas, replicas, autoscaling,
-					fmt.Errorf("Expected a valid number of min replicas: %s", err)
+					fmt.Errorf("expected a valid number of min replicas: %s", err)
 			}
 		}
 		err = replicaSizeValidation.MinReplicaValidator()(minReplicas)
@@ -2253,7 +2273,7 @@ func manageReplicas(cmd *cobra.Command, args *mpOpts.CreateMachinepoolUserOption
 			})
 			if err != nil {
 				return minReplicas, maxReplicas, replicas, autoscaling,
-					fmt.Errorf("Expected a valid number of max replicas: %s", err)
+					fmt.Errorf("expected a valid number of max replicas: %s", err)
 			}
 		}
 		err = replicaSizeValidation.MaxReplicaValidator()(maxReplicas)
@@ -2264,7 +2284,7 @@ func manageReplicas(cmd *cobra.Command, args *mpOpts.CreateMachinepoolUserOption
 		// if the user set min/max replicas and hasn't enabled autoscaling
 		if isMinReplicasSet || isMaxReplicasSet {
 			return minReplicas, maxReplicas, replicas, autoscaling,
-				fmt.Errorf("Autoscaling must be enabled in order to set min and max replicas")
+				fmt.Errorf("autoscaling must be enabled in order to set min and max replicas")
 		}
 
 		// Replicas
@@ -2279,7 +2299,7 @@ func manageReplicas(cmd *cobra.Command, args *mpOpts.CreateMachinepoolUserOption
 				},
 			})
 			if err != nil {
-				return minReplicas, maxReplicas, replicas, autoscaling, fmt.Errorf("Expected a valid number of replicas: %s", err)
+				return minReplicas, maxReplicas, replicas, autoscaling, fmt.Errorf("expected a valid number of replicas: %s", err)
 			}
 		}
 		err = replicaSizeValidation.MinReplicaValidator()(replicas)

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -102,7 +102,7 @@ func (s *network) CreateStack(templateFile *string, templateBody *[]byte,
 	if err != nil {
 		deleteHelperMessage(logger, params, err)
 		helperMsg := ManualModeHelperMessage(params, tags)
-		logger.Infof(helperMsg)
+		logger.Infof("%s", helperMsg)
 		return fmt.Errorf("failed to wait for stack creation, %v", err)
 	}
 

--- a/pkg/ocm/upgrades.go
+++ b/pkg/ocm/upgrades.go
@@ -123,7 +123,7 @@ func (c *Client) GetMissingGateAgreementsHypershift(
 			// return original error if invaild version gate detected
 			if len(gates) > 0 && gates[0].ID() == "" {
 				errType := errors.ErrorType(response.Error().Status())
-				return []*cmv1.VersionGate{}, errType.Set(errors.Errorf(response.Error().Reason()))
+				return []*cmv1.VersionGate{}, errType.Set(errors.Errorf("%s", response.Error().Reason()))
 			}
 			return gates, nil
 		}
@@ -155,7 +155,7 @@ func (c *Client) GetMissingGateAgreementsClassic(
 			// return original error if invaild version gate detected
 			if len(gates) > 0 && gates[0].ID() == "" {
 				errType := errors.ErrorType(response.Error().Status())
-				return []*cmv1.VersionGate{}, errType.Set(errors.Errorf(response.Error().Reason()))
+				return []*cmv1.VersionGate{}, errType.Set(errors.Errorf("%s", response.Error().Reason()))
 			}
 			return gates, nil
 		}


### PR DESCRIPTION
1. Bumps go version
2. `go mod tidy` + `go mod vendor`
3. Bumps CI files
4. Bumps Claude.md
5. Fixes all errors caused by bumping to 1.24 (`non-constant format string in call to ...` errors)