### PR TITLE
OCM-20714 | test: fix ids: 67412 and 75921

### DIFF
--- a/tests/e2e/test_rosacli_node_pool.go
+++ b/tests/e2e/test_rosacli_node_pool.go
@@ -813,15 +813,9 @@ var _ = Describe("Edit nodepool",
 					"")
 				Expect(err).ToNot(HaveOccurred())
 
-				By("Wait for the upgrade finished ")
-				err = machinePoolUpgradeService.WaitForUpgradeFinished(clusterID, nodePoolAutoName, 30)
+				By("Wait for the upgrade to scheduled status")
+				err = machinePoolUpgradeService.WaitForMachinepoolStatus(clusterID, nodePoolAutoName, "scheduled", 10)
 				Expect(err).ToNot(HaveOccurred())
-
-				By("Verify the upgrade result")
-				npDescription, err := machinePoolService.DescribeAndReflectNodePool(clusterID, nodePoolAutoName)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(npDescription.Version).To(Equal(availableUpgradeVersions[0]))
-				Expect(npDescription.ScheduledUpgrade).To(BeEmpty())
 			})
 
 		It("create/edit nodepool with node_drain_grace_period to HCP cluster via ROSA cli can work well - [id:72715]",


### PR DESCRIPTION
- 67412: periodical jobs often met error as the machinepool upgrade is not finished without timeout. Update to use `rosa describe upgrade` to verify the upgrade is scheduled

- 75921: the testing billing account was hardcode value, that will make 75922 failure. Fix it to choose the test billing account and recovery it with the original value.

test log: https://privatebin.corp.redhat.com/?c04ae40039e9e84e#CaDyLmZovkZqKaQkeeYNzrHdemC1j6YZgeFeM9C6KAjm