### PR TITLE
OCM-20194 | feat: Win-Li support (machinepool type flag)

### DIFF
--- a/cmd/create/machinepool/cmd.go
+++ b/cmd/create/machinepool/cmd.go
@@ -77,6 +77,10 @@ func CreateMachinepoolRunner(userOptions *mpOpts.CreateMachinepoolUserOptions) r
 			return err
 		}
 
+		if err := machinepool.ValidateImageType(cmd, options.args, cluster); err != nil {
+			return err
+		}
+
 		r.AWSClient, err = aws.NewClient().
 			Region(cluster.Region().ID()).
 			Logger(r.Logger).

--- a/cmd/rosa/structure_test/command_args/rosa/create/machinepool/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/create/machinepool/command_args.yml
@@ -26,3 +26,4 @@
 - name: use-spot-instances
 - name: version
 - name: capacity-reservation-id
+- name: type

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/nathan-fiscaletti/consolesize-go v0.0.0-20210105204122-a87d9f614b9d
 	github.com/onsi/ginkgo/v2 v2.17.1
 	github.com/onsi/gomega v1.30.0
+	github.com/openshift-online/ocm-api-model/clientapi v0.0.437
 	github.com/openshift-online/ocm-common v0.0.31
 	github.com/openshift-online/ocm-sdk-go v0.1.482
 	github.com/pkg/errors v0.9.1
@@ -50,7 +51,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ram v1.26.1 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/openshift-online/ocm-api-model/clientapi v0.0.437 // indirect
 	github.com/openshift-online/ocm-api-model/model v0.0.437 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 )

--- a/pkg/helper/machinepools/helpers.go
+++ b/pkg/helper/machinepools/helpers.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/validation"
 
+	v1 "github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1"
 	commonUtils "github.com/openshift-online/ocm-common/pkg/utils"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
@@ -30,6 +31,10 @@ const (
 		nodeDrainUnitHour + "|" + nodeDrainUnitHours
 	MaxNodeDrainTimeInMinutes = 10080
 	MaxNodeDrainTimeInHours   = 168
+)
+
+var (
+	ImageTypes = []string{string(v1.ImageTypeDefault), string(v1.ImageTypeWindows)}
 )
 
 var allowedTaintEffects = []string{
@@ -362,4 +367,13 @@ func ValidateUpgradeMaxSurgeUnavailable(val interface{}) error {
 	}
 
 	return nil
+}
+
+func IsValidImageType(imageType string) bool {
+	for t := range ImageTypes {
+		if ImageTypes[t] == imageType {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/options/machinepool/create.go
+++ b/pkg/options/machinepool/create.go
@@ -35,6 +35,7 @@ type CreateMachinepoolUserOptions struct {
 	MaxUnavailable        string
 	EC2MetadataHttpTokens string
 	CapacityReservationId string
+	Type                  string
 }
 
 const (
@@ -63,12 +64,6 @@ type CreateMachinepoolOptions struct {
 
 func NewCreateMachinepoolUserOptions() *CreateMachinepoolUserOptions {
 	return &CreateMachinepoolUserOptions{}
-}
-
-func NewCreateMachinepoolOptions() *CreateMachinepoolOptions {
-	return &CreateMachinepoolOptions{
-		args: &CreateMachinepoolUserOptions{},
-	}
 }
 
 func (m *CreateMachinepoolOptions) Machinepool() *CreateMachinepoolUserOptions {
@@ -279,6 +274,13 @@ func BuildMachinePoolCreateCommandWithOptions() (*cobra.Command, *CreateMachinep
 		"",
 		"The ID of an AWS On-Demand Capacity Reservation. The 'capacity-reservation-id' must be pre-created "+
 			"in advance, before creating a NodePool.")
+
+	flags.StringVar(&options.Type,
+		"type",
+		"",
+		"Specifies the type of AMI this machinepool uses. You may supply '--type Windows' for example if you want "+
+			"support for Windows VMs.")
+
 	output.AddFlag(cmd)
 	interactive.AddFlag(flags)
 	return cmd, options


### PR DESCRIPTION
Adds the `type` flag to the `create/machinepool` command for HCP (so, only nodepools)

This allows the user to make a selection of which AMI they want to use (`Default` or `Windows` for now), enabling Win-LI (Windows VM support)

```bash
❯ ./rosa create machinepool -c <cluster-name>
I: Enabling interactive mode
? Machine pool name: hk
? Image Type (optional, choose 'Skip' to skip selection; ):  [Use arrows to move, type to filter]
> Skip
  Default
  Windows
```

Simplest usage is above ^

```bash
❯ ./rosa create machinepool -c <cluster-name> --type Windows --name <machinepool-name>
? Replicas: 2
I: Checking available instance types for machine pool '<machinepool-name>'
```

Usage with flag provided ^

```bash
❯ ./rosa create machinepool -c <cluster-name> --type 123123
E: invalid image type: '123123' - please use one of: 'Default', 'Windows'
```

Failure cause 1 ^

```bash
./rosa create machinepool -c <classic-cluster-name> --type Windows
E: the '--type' flag can only be used with Hosted Control Plane clusters
```

Failure case 2 ^


This MR also contains a few small other changes:
* Unit tests
* Validation on CLI-side
* Removal of unused function in the create/machinepool options file