### PR TITLE
OCM-20730 | feat: Capacity reservation preference for create/nodepool

### DIFF
--- a/cmd/rosa/structure_test/command_args/rosa/create/machinepool/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/create/machinepool/command_args.yml
@@ -27,3 +27,4 @@
 - name: version
 - name: capacity-reservation-id
 - name: type
+- name: capacity-reservation-preference

--- a/pkg/helper/machinepools/helpers.go
+++ b/pkg/helper/machinepools/helpers.go
@@ -31,6 +31,10 @@ const (
 		nodeDrainUnitHour + "|" + nodeDrainUnitHours
 	MaxNodeDrainTimeInMinutes = 10080
 	MaxNodeDrainTimeInHours   = 168
+
+	CapacityReservationPreferenceNone = string(cmv1.CapacityReservationPreferenceNone)
+	CapacityReservationPreferenceOnly = string(cmv1.CapacityReservationPreferenceCapacityReservationsOnly)
+	CapacityReservationPreferenceOpen = string(cmv1.CapacityReservationPreferenceOpen)
 )
 
 var (
@@ -376,4 +380,28 @@ func IsValidImageType(imageType string) bool {
 		}
 	}
 	return false
+}
+
+func ValidateCapacityReservationPreference(preference, capResId string) error {
+	var preferenceValid = false
+	for _, validOption := range []string{
+		CapacityReservationPreferenceNone, CapacityReservationPreferenceOnly, CapacityReservationPreferenceOpen} {
+		if preference == validOption {
+			preferenceValid = true
+		}
+	}
+
+	if capResId != "" && preference != "" && preference != CapacityReservationPreferenceOnly {
+		return fmt.Errorf("invalid Capacity Reservation Preference: '%s'. "+
+			"When specifying a capacity reservation id ('%s'), you may only provide the "+
+			"'%s' preference", preference, capResId, CapacityReservationPreferenceOnly)
+	}
+
+	if !preferenceValid && preference != "" {
+		return fmt.Errorf("invalid Capacity Reservation Preference: '%s'. Valid options are: '%s', '%s', '%s'",
+			preference, CapacityReservationPreferenceNone, CapacityReservationPreferenceOpen,
+			CapacityReservationPreferenceOnly)
+	}
+
+	return nil
 }

--- a/pkg/options/machinepool/create.go
+++ b/pkg/options/machinepool/create.go
@@ -10,32 +10,33 @@ import (
 )
 
 type CreateMachinepoolUserOptions struct {
-	Name                  string
-	InstanceType          string
-	Replicas              int
-	AutoscalingEnabled    bool
-	MinReplicas           int
-	MaxReplicas           int
-	Labels                string
-	Taints                string
-	UseSpotInstances      bool
-	SpotMaxPrice          string
-	MultiAvailabilityZone bool
-	AvailabilityZone      string
-	Subnet                string
-	Version               string
-	Autorepair            bool
-	TuningConfigs         string
-	KubeletConfigs        string
-	RootDiskSize          string
-	SecurityGroupIds      []string
-	NodeDrainGracePeriod  string
-	Tags                  []string
-	MaxSurge              string
-	MaxUnavailable        string
-	EC2MetadataHttpTokens string
-	CapacityReservationId string
-	Type                  string
+	Name                          string
+	InstanceType                  string
+	Replicas                      int
+	AutoscalingEnabled            bool
+	MinReplicas                   int
+	MaxReplicas                   int
+	Labels                        string
+	Taints                        string
+	UseSpotInstances              bool
+	SpotMaxPrice                  string
+	MultiAvailabilityZone         bool
+	AvailabilityZone              string
+	Subnet                        string
+	Version                       string
+	Autorepair                    bool
+	TuningConfigs                 string
+	KubeletConfigs                string
+	RootDiskSize                  string
+	SecurityGroupIds              []string
+	NodeDrainGracePeriod          string
+	Tags                          []string
+	MaxSurge                      string
+	MaxUnavailable                string
+	EC2MetadataHttpTokens         string
+	CapacityReservationId         string
+	Type                          string
+	CapacityReservationPreference string
 }
 
 const (
@@ -281,6 +282,11 @@ func BuildMachinePoolCreateCommandWithOptions() (*cobra.Command, *CreateMachinep
 		"Specifies the type of AMI this machinepool uses. You may supply '--type Windows' for example if you want "+
 			"support for Windows VMs.")
 
+	flags.StringVar(&options.CapacityReservationPreference,
+		"capacity-reservation-preference",
+		"",
+		"A configurable preference for a capacity-reservation. Options are: 'none' | "+
+			"'capacity-reservsations-only' | 'open'")
 	output.AddFlag(cmd)
 	interactive.AddFlag(flags)
 	return cmd, options


### PR DESCRIPTION
Adds a new flag that is an option set of 3 options; None, Open, and Only. The inputs from the user are validated, and the information is passed into the capacity reservation builder, which only is used when the user meets the criteria for using cap-res + values are all provided.

The prompt does not call if capacit-reservation-id is not filled, and also only if there is no autoscaling enabled

In the end, this allows the following flow:

```bash
rosa create machinepool -c <hcp_cluster_id> --capacity-reservation-id <id> --capacity-reservation-preference <preference_choice>
```

And when using interactive mode, the user is prompted with a failsafe `GetOption` prompt. This only allows the user to select one of 3 options (`none` being the default since the user may not want to specify a preference)