### PR TITLE
OCM-20775 | feat: Describe/nodepool support for image type

### DIFF
--- a/cmd/describe/machinepool/cmd_test.go
+++ b/cmd/describe/machinepool/cmd_test.go
@@ -27,6 +27,7 @@ Autoscaling:                           No
 Desired replicas:                      0
 Current replicas:                      
 Instance type:                         m5.xlarge
+Image type:                            
 Labels:                                
 Tags:                                  
 Taints:                                
@@ -54,6 +55,7 @@ Autoscaling:                           No
 Desired replicas:                      0
 Current replicas:                      
 Instance type:                         m5.xlarge
+Image type:                            
 Labels:                                
 Tags:                                  
 Taints:                                
@@ -83,6 +85,7 @@ Autoscaling:                           No
 Desired replicas:                      0
 Current replicas:                      
 Instance type:                         m5.xlarge
+Image type:                            
 Labels:                                
 Tags:                                  
 Taints:                                
@@ -111,6 +114,7 @@ Autoscaling:                           No
 Desired replicas:                      0
 Current replicas:                      
 Instance type:                         m5.xlarge
+Image type:                            
 Labels:                                
 Tags:                                  foo=bar
 Taints:                                

--- a/pkg/machinepool/output.go
+++ b/pkg/machinepool/output.go
@@ -16,6 +16,7 @@ var nodePoolOutputString string = "\n" +
 	"Desired replicas:                      %s\n" +
 	"Current replicas:                      %s\n" +
 	"Instance type:                         %s\n" +
+	"Image type:                            %s\n" +
 	"Labels:                                %s\n" +
 	"Tags:                                  %s\n" +
 	"Taints:                                %s\n" +
@@ -74,6 +75,7 @@ func nodePoolOutput(clusterId string, nodePool *cmv1.NodePool) string {
 		ocmOutput.PrintNodePoolReplicas(nodePool.Autoscaling(), nodePool.Replicas()),
 		ocmOutput.PrintNodePoolCurrentReplicas(nodePool.Status()),
 		ocmOutput.PrintNodePoolInstanceType(nodePool.AWSNodePool()),
+		ocmOutput.PrintNodePoolImageType(nodePool.ImageType()),
 		ocmOutput.PrintLabels(nodePool.Labels()),
 		ocmOutput.PrintUserAwsTags(nodePool.AWSNodePool().Tags()),
 		ocmOutput.PrintTaints(nodePool.Taints()),

--- a/pkg/machinepool/output_test.go
+++ b/pkg/machinepool/output_test.go
@@ -120,8 +120,8 @@ var _ = Describe("Output", Ordered, func() {
 			managementUpgradeOutput := ocmOutput.PrintNodePoolManagementUpgrade(mgmtUpgrade)
 
 			out := fmt.Sprintf(nodePoolOutputString,
-				"test-mp", "test-cluster", "Yes", replicasOutput, "", "", labelsOutput, "", taintsOutput, "test-az",
-				"test-subnets", "300 GiB", "1", "optional", "No", "test-tc", "test-kc", "", "", "",
+				"test-mp", "test-cluster", "Yes", replicasOutput, "", "", "", labelsOutput, "", taintsOutput,
+				"test-az", "test-subnets", "300 GiB", "1", "optional", "No", "test-tc", "test-kc", "", "", "",
 				managementUpgradeOutput, "")
 
 			result := nodePoolOutput("test-cluster", nodePool)
@@ -140,7 +140,7 @@ var _ = Describe("Output", Ordered, func() {
 			taintsOutput := ocmOutput.PrintTaints([]*cmv1.Taint{taint})
 
 			out := fmt.Sprintf(nodePoolOutputString,
-				"test-mp", "test-cluster", "No", "4", "", "", labelsOutput, "", taintsOutput, "test-az",
+				"test-mp", "test-cluster", "No", "4", "", "", "", labelsOutput, "", taintsOutput, "test-az",
 				"test-subnets", "300 GiB", "1", "optional", "No", "test-tc", "test-kc", "", "", "", "", "")
 
 			result := nodePoolOutput("test-cluster", nodePool)
@@ -158,7 +158,7 @@ var _ = Describe("Output", Ordered, func() {
 			taintsOutput := ocmOutput.PrintTaints([]*cmv1.Taint{taint})
 
 			out := fmt.Sprintf(nodePoolOutputString,
-				"test-mp", "test-cluster", "No", "4", "", "", labelsOutput, "", taintsOutput, "test-az",
+				"test-mp", "test-cluster", "No", "4", "", "", "", labelsOutput, "", taintsOutput, "test-az",
 				"test-subnets", "256 GiB", "1", "optional", "No", "test-tc", "test-kc", "", "", "", "", "")
 
 			result := nodePoolOutput("test-cluster", nodePool)
@@ -179,7 +179,7 @@ var _ = Describe("Output", Ordered, func() {
 			taintsOutput := ocmOutput.PrintTaints([]*cmv1.Taint{taint})
 
 			out := fmt.Sprintf(nodePoolOutputString,
-				"test-mp", "test-cluster", "No", "4", "", "", labelsOutput, "", taintsOutput, "test-az",
+				"test-mp", "test-cluster", "No", "4", "", "", "", labelsOutput, "", taintsOutput, "test-az",
 				"test-subnets", "256 GiB", "1", "optional", "No", "test-tc", "test-kc", "", "",
 				"\n - ID:                                 test-id\n - Type:                               OnDemand",
 				"", "")

--- a/pkg/ocm/output/nodepools.go
+++ b/pkg/ocm/output/nodepools.go
@@ -61,6 +61,10 @@ func PrintNodePoolInstanceType(aws *cmv1.AWSNodePool) string {
 	return aws.InstanceType()
 }
 
+func PrintNodePoolImageType(imgType cmv1.ImageType) string {
+	return string(imgType)
+}
+
 func PrintNodePoolAdditionalSecurityGroups(aws *cmv1.AWSNodePool) string {
 	if aws == nil {
 		return ""


### PR DESCRIPTION
Adds `Image type:` output for `describe/nodepool` (including the JSON, at least assumably based on how it's set up)

Also fixes tests surrounding this change