### PR TITLE
OCM-20882 | fix: Accidental assignment of incorrect value

### DIFF
--- a/pkg/machinepool/machinepool.go
+++ b/pkg/machinepool/machinepool.go
@@ -803,7 +803,7 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 	capacityReservationPreference := args.CapacityReservationPreference
 
 	if interactive.Enabled() && !autoscaling && !fedramp.Enabled() {
-		capacityReservationId, err = interactive.GetOption(interactive.Input{
+		capacityReservationPreference, err = interactive.GetOption(interactive.Input{
 			Question: "Capacity Reservation Preference",
 			Help:     cmd.Flags().Lookup("capacity-reservation-preference").Usage,
 			Options: []string{mpHelpers.CapacityReservationPreferenceNone,


### PR DESCRIPTION
Originally, I had mistakenly used the `capacityReservationId` to take data back from the interactive prompt. Due to the API not being ready, I did not catch this mistake

Fixed by replacing it with the `capacityReservationPreference` var