### PR TITLE
OCM-20883 | fix: Fix typo in caprez help msg

### DIFF
--- a/pkg/options/machinepool/create.go
+++ b/pkg/options/machinepool/create.go
@@ -286,7 +286,7 @@ func BuildMachinePoolCreateCommandWithOptions() (*cobra.Command, *CreateMachinep
 		"capacity-reservation-preference",
 		"",
 		"A configurable preference for a capacity-reservation. Options are: 'none' | "+
-			"'capacity-reservsations-only' | 'open'")
+			"'capacity-reservations-only' | 'open'")
 	output.AddFlag(cmd)
 	interactive.AddFlag(flags)
 	return cmd, options


### PR DESCRIPTION
Typo in help message which would lead to an incorrect value + validation error if the user tried to pass it in