### PR TITLE
OCM-20958 | feat: Introduce `--win-li` to `list/instancetypes`

### DIFF
--- a/cmd/list/instancetypes/cmd_test.go
+++ b/cmd/list/instancetypes/cmd_test.go
@@ -246,6 +246,7 @@ g4dn.12xlarge  accelerated_computing  48         192.0 GiB
 	It("Succeeds with --region", func() {
 
 		cmd.Flags().Set("region", "us-east-1")
+		cmd.Flags().Set("win-li", "false")
 
 		mockAwsClient.EXPECT().FindRoleARNs(aws.InstallerAccountRole, "").Return([]string{"fake_installer_arn"}, nil)
 
@@ -290,6 +291,7 @@ g4dn.12xlarge  accelerated_computing  48         192.0 GiB
 	It("Handles unknown --region", func() {
 
 		cmd.Flags().Set("region", "us-east-xyz")
+		cmd.Flags().Set("win-li", "false")
 
 		mockAwsClient.EXPECT().FindRoleARNs(aws.InstallerAccountRole, "").Return([]string{"fake_installer_arn"}, nil)
 
@@ -304,7 +306,7 @@ g4dn.12xlarge  accelerated_computing  48         192.0 GiB
 		stdout, stderr, err := test.RunWithOutputCapture(runWithRuntime, r, cmd)
 		Expect(err).ToNot(BeNil())
 		Expect(err.Error()).To(
-			ContainSubstring("Region 'us-east-xyz' not found."))
+			ContainSubstring("region 'us-east-xyz' not found"))
 		Expect(stderr).To(Equal(""))
 		Expect(stdout).To(Equal("INFO: Using fake_installer_arn for the Installer role\n"))
 	})
@@ -373,7 +375,7 @@ g4dn.12xlarge  accelerated_computing  48         192.0 GiB
 		stdout, stderr, err := test.RunWithOutputCapture(runWithRuntime, r, cmd)
 		Expect(err).ToNot(BeNil())
 		Expect(err.Error()).To(
-			ContainSubstring("There are no machine types supported for your account. Contact Red Hat support."))
+			ContainSubstring("there are no machine types supported for your account. Contact Red Hat support"))
 		Expect(stderr).To(Equal(""))
 		Expect(stdout).To(Equal(""))
 	})

--- a/cmd/rosa/structure_test/command_args/rosa/list/instance-types/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/list/instance-types/command_args.yml
@@ -4,3 +4,4 @@
 - name: region
 - name: role-arn
 - name: "yes"
+- name: win-li

--- a/tests/e2e/test_rosacli_machine_pool.go
+++ b/tests/e2e/test_rosacli_machine_pool.go
@@ -264,7 +264,7 @@ var _ = Describe("Create machinepool",
 				availableMachineTypes, _, err := ocmResourceService.ListInstanceTypes()
 
 				if err != nil {
-					log.Logger.Errorf("Failed to fetch instance types: %v", err)
+					log.Logger.Errorf("failed to fetch instance types: %v", err)
 				} else {
 					var availableMachineTypesIDs []string
 					for _, it := range availableMachineTypes.InstanceTypesList {


### PR DESCRIPTION
```swift
❯ ./rosa list instance-types --win-li
ID             CATEGORY               CPU_CORES  MEMORY
g4dn.metal     accelerated_computing  96         384.0 GiB
c5d.metal      compute_optimized      96         192.0 GiB
c5.metal       compute_optimized      96         192.0 GiB
c5n.metal      compute_optimized      72         192.0 GiB
c6a.metal      compute_optimized      192        384.0 GiB
c6id.metal     compute_optimized      128        256.0 GiB
c6i.metal      compute_optimized      128        256.0 GiB
m5d.metal      general_purpose        96         384.0 GiB
m5dn.metal     general_purpose        96         384.0 GiB
m5.metal       general_purpose        96         384.0 GiB
m5n.metal      general_purpose        96         384.0 GiB
m5zn.metal     general_purpose        48         192.0 GiB
m6a.metal      general_purpose        192        768.0 GiB
m6id.metal     general_purpose        128        512.0 GiB
m6i.metal      general_purpose        128        512.0 GiB
r5b.metal      memory_optimized       96         768.0 GiB
r5d.metal      memory_optimized       96         768.0 GiB
r5dn.metal     memory_optimized       96         768.0 GiB
r5.metal       memory_optimized       96         768.0 GiB
r5n.metal      memory_optimized       96         768.0 GiB
r6a.metal      memory_optimized       192        1.5 TiB
r6id.metal     memory_optimized       128        1.0 TiB
r6i.metal      memory_optimized       128        1.0 TiB
u-12tb1.metal  memory_optimized       448        12.0 TiB
u-18tb1.metal  memory_optimized       448        18.0 TiB
u-24tb1.metal  memory_optimized       448        24.0 TiB
u-6tb1.metal   memory_optimized       448        6.0 TiB
u-9tb1.metal   memory_optimized       448        9.0 TiB
x2idn.metal    memory_optimized       128        2.0 TiB
x2iedn.metal   memory_optimized       128        4.0 TiB
x2iezn.metal   memory_optimized       48         1.5 TiB
z1d.metal      memory_optimized       48         384.0 GiB
i3en.metal     storage_optimized      96         768.0 GiB
i3.metal       storage_optimized      72         512.0 GiB
i4i.metal      storage_optimized      128        1.0 TiB
```

^ With `--win-li`

```swift
❯ ./rosa list instance-types --win-li=false
ID                    CATEGORY               CPU_CORES  MEMORY
dl1.24xlarge          accelerated_computing  96         768.0 GiB
g4ad.16xlarge         accelerated_computing  64         256.0 GiB
g4ad.2xlarge          accelerated_computing  8          32.0 GiB
g4ad.4xlarge          accelerated_computing  16         64.0 GiB
g4ad.8xlarge          accelerated_computing  32         128.0 GiB
g4ad.xlarge           accelerated_computing  4          16.0 GiB
g4dn.12xlarge         accelerated_computing  48         192.0 GiB
g4dn.16xlarge         accelerated_computing  64         256.0 GiB
g4dn.2xlarge          accelerated_computing  8          32.0 GiB
g4dn.4xlarge          accelerated_computing  16         64.0 GiB
g4dn.8xlarge          accelerated_computing  32         128.0 GiB
g4dn.metal            accelerated_computing  96         384.0 GiB
g4dn.xlarge           accelerated_computing  4          16.0 GiB
...
...
...
```

^ With `--win-li=false`

```swift
❯ ./rosa list instance-types
ID                    CATEGORY               CPU_CORES  MEMORY
dl1.24xlarge          accelerated_computing  96         768.0 GiB
g4ad.16xlarge         accelerated_computing  64         256.0 GiB
g4ad.2xlarge          accelerated_computing  8          32.0 GiB
g4ad.4xlarge          accelerated_computing  16         64.0 GiB
g4ad.8xlarge          accelerated_computing  32         128.0 GiB
g4ad.xlarge           accelerated_computing  4          16.0 GiB
g4dn.12xlarge         accelerated_computing  48         192.0 GiB
g4dn.16xlarge         accelerated_computing  64         256.0 GiB
g4dn.2xlarge          accelerated_computing  8          32.0 GiB
g4dn.4xlarge          accelerated_computing  16         64.0 GiB
g4dn.8xlarge          accelerated_computing  32         128.0 GiB
g4dn.metal            accelerated_computing  96         384.0 GiB
g4dn.xlarge           accelerated_computing  4          16.0 GiB
g5.12xlarge           accelerated_computing  48         192.0 GiB
...
...
...
```

Not part of the original scope of the feature, but it is almost certainly a must-have for customers
