### PR TITLE
OCM-20975 | fix: Send EITHER capres ID or preference to api

### DIFF
--- a/pkg/machinepool/machinepool.go
+++ b/pkg/machinepool/machinepool.go
@@ -822,9 +822,6 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 		}
 	}
 
-	capacityReservation := cmv1.NewAWSCapacityReservation().Id(capacityReservationId).Preference(
-		cmv1.CapacityReservationPreference(capacityReservationPreference))
-
 	kubeletConfigs := args.KubeletConfigs
 
 	if (kubeletConfigs != "" || interactive.Enabled()) && !fedramp.Enabled() {
@@ -949,8 +946,21 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 		rootDiskSize,
 	)
 
-	if capacityReservationId != "" && !fedramp.Enabled() && !autoscaling {
-		awsNodepoolBuilder = awsNodepoolBuilder.CapacityReservation(capacityReservation)
+	if !fedramp.Enabled() && !autoscaling {
+		capacityReservation := cmv1.NewAWSCapacityReservation()
+		changed := false
+		if capacityReservationId != "" {
+			capacityReservation = capacityReservation.Id(capacityReservationId)
+			changed = true
+		}
+		if capacityReservationPreference != "" {
+			capacityReservation = capacityReservation.Preference(
+				cmv1.CapacityReservationPreference(capacityReservationPreference))
+			changed = true
+		}
+		if changed {
+			awsNodepoolBuilder = awsNodepoolBuilder.CapacityReservation(capacityReservation)
+		}
 	}
 
 	npBuilder.AWSNodePool(awsNodepoolBuilder)


### PR DESCRIPTION
Preference has a bug where it won't be sent until ID is populated. This breaks the feature

Fix is to add both and send if one or both are changed

I was going to use `reflect.DeepEquals` in that final if statement.. but im afraid it may not work the way I expect with the values being builders, so I just rolled with a more idiomatic solution of a local bool that is flipped when they are changed. its also much easier to read than a deep equals IMO for this situation