### PR TITLE
OCM-20978 | feat: Validation error for caprez on classic

### DIFF
--- a/pkg/machinepool/machinepool.go
+++ b/pkg/machinepool/machinepool.go
@@ -86,6 +86,11 @@ func (m machinePool) CreateMachinePoolBasedOnClusterType(r *rosa.Runtime,
 func (m *machinePool) CreateMachinePool(r *rosa.Runtime, cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster,
 	args *mpOpts.CreateMachinepoolUserOptions) error {
 
+	if cmd.Flags().Changed("capacity-reservation-id") || cmd.Flags().Changed("capacity-reservation-preference") {
+		return fmt.Errorf("setting the 'capacity-reservation-id' or 'capacity-reservation-preference' flags " +
+			"is only allowed for Hosted Control Plane clusters")
+	}
+
 	// Validate flags that are only allowed for multi-AZ clusters
 	isMultiAvailabilityZoneSet := cmd.Flags().Changed("multi-availability-zone")
 	if isMultiAvailabilityZoneSet && !cluster.MultiAZ() {


### PR DESCRIPTION
Return an error if a user tries to use caprez flags for a `machinepool` rather than a `nodepool`