### PR TITLE
OCM-20976 | feat: Introduce filtering for winli create/nodepool

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -2634,7 +2634,7 @@ func run(cmd *cobra.Command, _ []string) {
 		computeMachineType, err = interactive.GetOption(interactive.Input{
 			Question: "Compute nodes instance type",
 			Help:     cmd.Flags().Lookup("compute-machine-type").Usage,
-			Options:  computeMachineTypeList.GetAvailableIDs(multiAZ),
+			Options:  computeMachineTypeList.GetAvailableIDs(multiAZ).IDs(),
 			Default:  computeMachineType,
 		})
 		if err != nil {

--- a/pkg/machinepool/machinepool.go
+++ b/pkg/machinepool/machinepool.go
@@ -309,7 +309,7 @@ func (m *machinePool) CreateMachinePool(r *rosa.Runtime, cmd *cobra.Command, clu
 		instanceType, err = interactive.GetOption(interactive.Input{
 			Question: "Instance type",
 			Help:     cmd.Flags().Lookup("instance-type").Usage,
-			Options:  instanceTypeList.GetAvailableIDs(cluster.MultiAZ()),
+			Options:  instanceTypeList.GetAvailableIDs(cluster.MultiAZ()).IDs(),
 			Default:  instanceType,
 			Required: true,
 		})
@@ -722,10 +722,11 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 		if instanceType == "" {
 			instanceType = instanceTypeList.Items[0].MachineType.ID()
 		}
+
 		instanceType, err = interactive.GetOption(interactive.Input{
 			Question: "Instance type",
 			Help:     cmd.Flags().Lookup("instance-type").Usage,
-			Options:  instanceTypeList.GetAvailableIDs(cluster.MultiAZ()),
+			Options:  instanceTypeList.GetAvailableIDs(cluster.MultiAZ()).GetWinLi(imageType).IDs(),
 			Default:  instanceType,
 			Required: true,
 		})

--- a/pkg/ocm/helpers_test.go
+++ b/pkg/ocm/helpers_test.go
@@ -695,3 +695,42 @@ var _ = Describe("GetAutoNodeRoleArn", func() {
 		Expect(exists).To(BeTrue())
 	})
 })
+
+var _ = Describe("GetWinLi", func() {
+	It("OK: Filters when WinLi is the image type properly", func() {
+		winLiMachineType, err := cmv1.NewMachineType().ID("test").Features(cmv1.NewMachineTypeFeatures().
+			WinLI(true)).Build()
+		nonWinLiMachineType, err := cmv1.NewMachineType().ID("test2").Features(cmv1.NewMachineTypeFeatures().
+			WinLI(false)).Build()
+		Expect(err).ToNot(HaveOccurred())
+		list := MachineTypeList{}
+		list.Items = []*MachineType{
+			{winLiMachineType, true, 1},
+			{nonWinLiMachineType, true, 1},
+		}
+
+		winLiList := list.GetWinLi("Windows")
+
+		Expect(winLiList.Items).To(HaveLen(1))
+		Expect(winLiList.Items[0].MachineType).ToNot(BeNil())
+		Expect(winLiList.Items[0].MachineType).To(Equal(winLiMachineType))
+
+		defaultList := list.GetWinLi("Default")
+
+		Expect(defaultList.Items).To(HaveLen(2))
+		Expect(defaultList.Items[0].MachineType).To(Equal(winLiMachineType))
+		Expect(defaultList.Items[1].MachineType).To(Equal(nonWinLiMachineType))
+
+		skipList := list.GetWinLi("Skip")
+
+		Expect(skipList.Items).To(HaveLen(2))
+		Expect(skipList.Items[0].MachineType).To(Equal(winLiMachineType))
+		Expect(skipList.Items[1].MachineType).To(Equal(nonWinLiMachineType))
+
+		lowercaseWinLiList := list.GetWinLi("windows")
+
+		Expect(lowercaseWinLiList.Items).To(HaveLen(1))
+		Expect(lowercaseWinLiList.Items[0].MachineType).ToNot(BeNil())
+		Expect(lowercaseWinLiList.Items[0].MachineType).To(Equal(winLiMachineType))
+	})
+})


### PR DESCRIPTION
```bash
❯ ./rosa create machinepool -c lmizell-int-02
test
I: Enabling interactive mode
? Machine pool name: test
? Image Type (optional, choose 'Skip' to skip selection; ): Default
? OpenShift version (default = '4.19.18'): 4.19.18
? Select subnet for a hosted machine pool: No
? AWS availability zone (default = 'us-west-2a'): us-west-2a
? Enable autoscaling: No
? Replicas: 2
? Labels (optional):
? Taints (optional):
? Additional 'Machine Pool' Security Group IDs (optional):
? Tags (optional):
I: Checking available instance types for machine pool 'test'
? Instance type (default = 'm5.xlarge'):  [Use arrows to move, type to filter, ? for more help]
  m5n.metal
  m5.xlarge
  m5zn.metal
> m6a.12xlarge
  m6a.16xlarge
  m6a.24xlarge
  m6a.2xlarge
```
^ `Default`

```bash
❯ ./rosa create machinepool -c lmizell-int-02
test
I: Enabling interactive mode
? Machine pool name: test
? Image Type (optional, choose 'Skip' to skip selection; ): Skip
? OpenShift version (default = '4.19.18'): 4.19.18
? Select subnet for a hosted machine pool: No
? AWS availability zone (default = 'us-west-2a'): us-west-2a
? Enable autoscaling: No
? Replicas: 2
? Labels (optional):
? Taints (optional):
? Additional 'Machine Pool' Security Group IDs (optional):
? Tags (optional):
I: Checking available instance types for machine pool 'test'
? Instance type (default = 'm5.xlarge'):  [Use arrows to move, type to filter, ? for more help]
  m5.xlarge
  m5zn.metal
  m6a.12xlarge
> m6a.16xlarge
  m6a.24xlarge
  m6a.2xlarge
  m6a.32xlarge
```
^ `Skip`

```bash
❯ ./rosa create machinepool -c lmizell-int-02
test
I: Enabling interactive mode
? Machine pool name: test
? Image Type (optional, choose 'Skip' to skip selection; ): Windows
? OpenShift version (default = '4.19.18'): 4.19.18
? Select subnet for a hosted machine pool: No
? AWS availability zone (default = 'us-west-2a'): us-west-2a
? Enable autoscaling: No
X Sorry, your reply was invalid: Value is required
? Replicas: 2
? Labels (optional):
? Taints (optional):
? Additional 'Machine Pool' Security Group IDs (optional):
? Tags (optional):
I: Checking available instance types for machine pool 'test'
? Instance type (default = 'm5.xlarge'):  [Use arrows to move, type to filter, ? for more help]
  r5b.metal
  r5d.metal
  r5dn.metal
> r5.metal
  r5n.metal
  r6a.metal
  r6id.metal
```
^ `Windows` (***FILTERS FOR WINLI INSTANCE TYPES***)