### PR TITLE
OCM-20984 | fix: Dont allow winli+fedramp

### DIFF
--- a/pkg/machinepool/helper.go
+++ b/pkg/machinepool/helper.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/fedramp"
 	mpHelpers "github.com/openshift/rosa/pkg/helper/machinepools"
 	"github.com/openshift/rosa/pkg/helper/versions"
 	"github.com/openshift/rosa/pkg/interactive"
@@ -62,6 +63,9 @@ func ValidateLabels(cmd *cobra.Command, args *mpOpts.CreateMachinepoolUserOption
 // Validate that the image type is a real one
 func ValidateImageType(cmd *cobra.Command, args *mpOpts.CreateMachinepoolUserOptions, cluster *cmv1.Cluster) error {
 	if cmd.Flags().Changed("type") {
+		if fedramp.Enabled() {
+			return fmt.Errorf("the '--type' flag cannot be used for AWS Govcloud clusters")
+		}
 		if !cluster.Hypershift().Enabled() {
 			return fmt.Errorf("the '--type' flag can only be used with Hosted Control Plane clusters")
 		}

--- a/pkg/machinepool/machinepool.go
+++ b/pkg/machinepool/machinepool.go
@@ -551,7 +551,7 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 	}
 
 	// Image type (supports things such as WinLI // Windows VMs)
-	if interactive.Enabled() && cluster.Hypershift().Enabled() {
+	if interactive.Enabled() && cluster.Hypershift().Enabled() && !fedramp.Enabled() {
 		imageType, err = interactive.GetOption(interactive.Input{
 			Question: "Image Type",
 			Default:  cmv1.ImageTypeDefault,
@@ -563,7 +563,7 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 		}
 	}
 
-	if imageType != "" && !mpHelpers.IsValidImageType(imageType) {
+	if imageType != "" && !mpHelpers.IsValidImageType(imageType) && !fedramp.Enabled() {
 		return fmt.Errorf("expected a valid image type for the machine pool: '%s'", imageType)
 	}
 


### PR DESCRIPTION
API ignores the image type when using fedramp, but we shouldn't confuse users