### PR TITLE
Revert "OCM-21010 | chore: Bump version on master (release process)"

### DIFF
--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,7 +18,7 @@ limitations under the License.
 
 package info
 
-const DefaultVersion = "1.2.58"
+const DefaultVersion = "1.2.57"
 
 // Build contains the short Git SHA of the CLI at the point it was build. Set via `-ldflags` at build time
 var Build = "local"


### PR DESCRIPTION
Reverts openshift/rosa#3113

Must revert due to cherry-picking #3113 into the release branch. It was created _**BEFORE**_ the `1.2.58-RC1` version change, so in CPAAS's eyes it's still `1.2.58-RC1`

To fix this, we must revert this MR, then recreate a bump to `v1.2.58` to unblock release