### PR TITLE
OCM-21111 | test: fix id: 45745

### DIFF
--- a/tests/utils/helper/helper.go
+++ b/tests/utils/helper/helper.go
@@ -2,8 +2,11 @@ package helper
 
 import (
 	"crypto/rand"
+	"fmt"
 	"math/big"
 	"os"
+
+	"github.com/Masterminds/semver"
 
 	"github.com/openshift/rosa/tests/utils/constants"
 )
@@ -32,4 +35,15 @@ func GetConsoleUrlBasedOnEnv(ocmApi string) string {
 	default:
 		return ""
 	}
+}
+
+func GetMajorMinorFromVersion(version string) (major int64, minor int64, majorMinorVersion string, err error) {
+	var semverVersion *semver.Version
+	if semverVersion, err = semver.NewVersion(version); err != nil {
+		return
+	}
+	major = semverVersion.Major()
+	minor = semverVersion.Minor()
+	majorMinorVersion = fmt.Sprintf("%d.%d", major, minor)
+	return
 }


### PR DESCRIPTION
Fixed 45745.

Before this fix, 45745 uses `rosa list version` to find out the upgrading version. This would cause upgrade failure. Now the correct way to find the available upgrading version is using `rosa list upgrade -c <cluster_id>`, this PR fixes it like that.

local testing log is: https://privatebin.corp.redhat.com/?3ef6df4bd9946d82#oJYKkBTwCu7MjdMGTmpjxSG15Y7nqwGFzN7wN33RVxT