### PR TITLE
OCM-21187 | fix: only set logForwarders on HCP clusters

### DIFF
--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -1223,11 +1223,12 @@ func (c *Client) createClusterSpec(config Spec) (*cmv1.Cluster, error) {
 		clusterBuilder.Autoscaler(BuildClusterAutoscaler(config.AutoscalerConfig))
 	}
 
-	// LogForwarder
-	logFwBuilder := BuildLogForwader(config.LogForwarder)
-	if logFwBuilder != nil {
-		clusterBuilder.ControlPlane(cmv1.NewControlPlane().
-			LogForwarders(cmv1.NewLogForwarderList().Items(logFwBuilder)))
+	if config.Hypershift.Enabled {
+		logFwBuilder := BuildLogForwader(config.LogForwarder)
+		if logFwBuilder != nil {
+			clusterBuilder.ControlPlane(cmv1.NewControlPlane().
+				LogForwarders(cmv1.NewLogForwarderList().Items(logFwBuilder)))
+		}
 	}
 
 	clusterSpec, err := clusterBuilder.Build()


### PR DESCRIPTION
the logForwarders object can only be set on HCP clusters but is being provided for all clusters by the CLI, which is breaking all classic cluster creation

https://issues.redhat.com/browse/OCM-21187