### PR TITLE
OCM-20737 | test: Updated id:65793 to test the --all flag as well

### DIFF
--- a/tests/e2e/test_rosacli_dns_domain.go
+++ b/tests/e2e/test_rosacli_dns_domain.go
@@ -1,7 +1,9 @@
 package e2e
 
 import (
+	// nolint:staticcheck
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:staticcheck
 	. "github.com/onsi/gomega"
 
 	"github.com/openshift/rosa/tests/ci/labels"
@@ -95,6 +97,51 @@ var _ = Describe("DNS domain tests",
 				Expect(dnsDomain.ID).To(Equal(dnsDomainH))
 				Expect(dnsDomain.UserDefined).To(Equal("Yes"))
 				Expect(dnsDomain.Architecture).To(Equal("hcp"))
+				dnsDomain = dnsDomainList.GetDNSDomain(dnsDomainC)
+				Expect(dnsDomain.ID).To(BeEmpty())
+				Expect(dnsDomain.UserDefined).To(BeEmpty())
+				Expect(dnsDomain.Architecture).To(BeEmpty())
+
+				By("List all created dns-domains for hosted-cp and classic clusters")
+				out, err = dnsDomainService.ListDNSDomain("--all")
+				Expect(err).ToNot(HaveOccurred())
+				dnsDomainList, err = dnsDomainService.ReflectDNSDomainList(out)
+				Expect(err).ToNot(HaveOccurred())
+				dnsDomain = dnsDomainList.GetDNSDomain(dnsDomainH)
+				Expect(dnsDomain.ID).To(Equal(dnsDomainH))
+				Expect(dnsDomain.UserDefined).To(Equal("Yes"))
+				Expect(dnsDomain.Architecture).To(Equal("hcp"))
+				dnsDomain = dnsDomainList.GetDNSDomain(dnsDomainC)
+				Expect(dnsDomain.ID).To(Equal(dnsDomainC))
+				Expect(dnsDomain.UserDefined).To(Equal("Yes"))
+				Expect(dnsDomain.Architecture).To(Equal("classic"))
+
+				By("List all created dns-domains with '--hosted-cp' flag")
+				out, err = dnsDomainService.ListDNSDomain("--all", "--hosted-cp")
+				Expect(err).ToNot(HaveOccurred())
+				dnsDomainList, err = dnsDomainService.ReflectDNSDomainList(out)
+				Expect(err).ToNot(HaveOccurred())
+				dnsDomain = dnsDomainList.GetDNSDomain(dnsDomainH)
+				Expect(dnsDomain.ID).To(Equal(dnsDomainH))
+				Expect(dnsDomain.UserDefined).To(Equal("Yes"))
+				Expect(dnsDomain.Architecture).To(Equal("hcp"))
+				dnsDomain = dnsDomainList.GetDNSDomain(dnsDomainC)
+				Expect(dnsDomain.ID).To(BeEmpty())
+				Expect(dnsDomain.UserDefined).To(BeEmpty())
+				Expect(dnsDomain.Architecture).To(BeEmpty())
+
+				By("Make sure that '--all' lists more domains as without it")
+				out, err = dnsDomainService.ListDNSDomain("--all")
+				Expect(err).ToNot(HaveOccurred())
+				dnsDomainList, err = dnsDomainService.ReflectDNSDomainList(out)
+				Expect(err).ToNot(HaveOccurred())
+				allDomainsLength := len(dnsDomainList.DNSDomainList)
+				out, err = dnsDomainService.ListDNSDomain()
+				Expect(err).ToNot(HaveOccurred())
+				dnsDomainList, err = dnsDomainService.ReflectDNSDomainList(out)
+				Expect(err).ToNot(HaveOccurred())
+				domainsLength := len(dnsDomainList.DNSDomainList)
+				Expect(allDomainsLength).To(BeNumerically(">", domainsLength))
 			})
 
 	})


### PR DESCRIPTION
I'm adding a quick test to make sure the "--all" flag works. I also added a quick check to make sure that the classic DNS domain doesn't show up when you add the "--hosted-cp" flag. 

Local output:
```
$ TEST_PROFILE="" ginkgo run --timeout 2h --focus "id:65793" tests/e2e
Running Suite: ROSA CLI e2e tests suite - /home/jkeyne/work/repos/rosa/tests/e2e
================================================================================
Random Seed: 1764956767

Will run 1 of 278 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 278 Specs in 15.644 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 277 Skipped
PASS

Ginkgo ran 1 suite in 18.411636438s
Test Suite Passed
```