### PR TITLE
OCM-19908 | fix: added autonode status on the describe command

### DIFF
--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -566,6 +566,9 @@ func run(cmd *cobra.Command, argv []string) {
 				str = fmt.Sprintf("%s"+
 					"  IAM Role ARN:             %s\n", str, cluster.AWS().AutoNode().RoleArn())
 			}
+		} else {
+			str = fmt.Sprintf("%s"+
+				"AutoNode:                   %s\n", str, DisabledOutput)
 		}
 		str = fmt.Sprintf("%s"+
 			"External Authentication:    %s\n", str, getExternalAuthConfigStatus(cluster))


### PR DESCRIPTION
# Details

This PR fixes a usability issue where `rosa describe cluster` was not displaying AutoNode configuration when it was disabled, unlike other disabled configurations (Etcd Encryption, Audit Log Forwarding, External Authentication, Zero Egress) which always show their status.

---

## Fixed Behavior

1. Run the describe command on a cluster without AutoNode enabled:

    ```bash
    rosa describe cluster -c <cluster-id>
    ```

2. Now shows **AutoNode status** alongside other disabled configurations:

    ```
    Etcd Encryption:            Disabled
    Audit Log Forwarding:       Disabled
    AutoNode:                   Disabled
    External Authentication:    Disabled
    Zero Egress:                Disabled
    ```

---

## Previous Behavior

Before this fix, clusters without AutoNode enabled would show no AutoNode information at all:

```bash
rosa describe cluster -c 2m4m7aohb3v050dg5g2gj3t1jugblf9g
```

Output (truncated):
```
...
Etcd Encryption:            Disabled
Audit Log Forwarding:       Disabled
External Authentication:    Disabled
Zero Egress:                Disabled
```

---

# Ticket

Closes [OCM-19908](https://issues.redhat.com/browse/OCM-19908)