### PR TITLE
OCM-21361 | fix: Allow empty list of apps for cloudwatch

### DIFF
--- a/pkg/interactive/logforwarding/logforwarding.go
+++ b/pkg/interactive/logforwarding/logforwarding.go
@@ -88,8 +88,11 @@ func interactiveCloudWatch(ocmClient *ocm.Client) (
 	if err != nil {
 		return nil, err
 	}
-	cloudWatchConfig.Applications = strings.Split(applications, ",")
-
+	if applications == "" {
+		cloudWatchConfig.Applications = []string{}
+	} else {
+		cloudWatchConfig.Applications = strings.Split(applications, ",")
+	}
 	return &cloudWatchConfig, nil
 }
 


### PR DESCRIPTION
If the apps are empty, set the apps in the logfwdconfig struct to an empty list. `strings.Split()` returns the original content (`[]string{""}` in this case, since the original content was `""`) so we must explicitly use it when the apps string is not empty 