### PR TITLE
OCM-21151 | feat: Describe log forwarder command

### DIFF
--- a/cmd/describe/cmd.go
+++ b/cmd/describe/cmd.go
@@ -30,6 +30,7 @@ import (
 	"github.com/openshift/rosa/cmd/describe/ingress"
 	"github.com/openshift/rosa/cmd/describe/installation"
 	"github.com/openshift/rosa/cmd/describe/kubeletconfig"
+	"github.com/openshift/rosa/cmd/describe/logforwarders"
 	"github.com/openshift/rosa/cmd/describe/machinepool"
 	"github.com/openshift/rosa/cmd/describe/service"
 	"github.com/openshift/rosa/cmd/describe/tuningconfigs"
@@ -55,7 +56,7 @@ func init() {
 		machinePoolCommand, kubeletconfig,
 		autoscaler.NewDescribeAutoscalerCommand(), ingressCommand,
 		externalauthprovider.Cmd, breakglasscredential.Cmd,
-		accessrequestCommand,
+		accessrequestCommand, logforwarders.NewDescribeLogForwarderCommand(),
 	}
 	for _, cmd := range cmds {
 		Cmd.AddCommand(cmd)

--- a/cmd/describe/logforwarders/cmd.go
+++ b/cmd/describe/logforwarders/cmd.go
@@ -1,0 +1,88 @@
+package logforwarders
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/logforwarding"
+	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/output"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+const (
+	use     = "log-forwarder"
+	short   = "Show details of a specific log forwarder used by a cluster"
+	example = `rosa describe log-forwarder <log_fwd_id> -c mycluster-hcp`
+)
+
+var logForwarderKeyRE = regexp.MustCompile(`^[a-z0-9]+$`)
+
+func NewDescribeLogForwarderCommand() *cobra.Command {
+	options := NewDescribeLogForwarderUserOptions()
+	cmd := &cobra.Command{
+		Use:     use,
+		Short:   short,
+		Example: example,
+		Run:     rosa.DefaultRunner(rosa.RuntimeWithOCM(), DescribeLogForwarderRunner(options)),
+		Args:    cobra.MaximumNArgs(1),
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(
+		&options.logForwarder,
+		"log-forwarder",
+		"",
+		"Log forwarder ID of the cluster to target",
+	)
+
+	ocm.AddClusterFlag(cmd)
+	output.AddFlag(cmd)
+	return cmd
+}
+
+func DescribeLogForwarderRunner(userOptions DescribeLogForwarderUserOptions) rosa.CommandRunner {
+	return func(_ context.Context, runtime *rosa.Runtime, cmd *cobra.Command, argv []string) error {
+		options := NewDescribeLogForwarderOptions()
+		if len(argv) == 1 && !cmd.Flag("log-forwarder").Changed {
+			userOptions.logForwarder = argv[0]
+		} else {
+			err := cmd.ParseFlags(argv)
+			if err != nil {
+				return fmt.Errorf("unable to parse flags: %v", err)
+			}
+			userOptions.logForwarder = cmd.Flag("log-forwarder").Value.String()
+		}
+		err := options.Bind(userOptions)
+		if err != nil {
+			return err
+		}
+		clusterKey := runtime.GetClusterKey()
+		cluster := runtime.FetchCluster()
+		if cluster.State() != cmv1.ClusterStateReady {
+			return fmt.Errorf("cluster '%s' is not yet ready", clusterKey)
+		}
+		logForwarder, err := runtime.OCMClient.GetLogForwarderByID(cluster.ID(), options.args.logForwarder)
+		if err != nil {
+			return fmt.Errorf("failed to get log forwarder '%s': %v", options.args.logForwarder, err)
+		}
+		if logForwarder == nil {
+			return fmt.Errorf("failed to get log forwarder '%s'", options.args.logForwarder)
+		}
+
+		if output.HasFlag() {
+			err = output.Print(logForwarder)
+			if err != nil {
+				return fmt.Errorf("failed to output log forwarder '%s': %v", options.args.logForwarder, err)
+			}
+			return nil
+		}
+
+		fmt.Print(logforwarding.LogForwarderObjectAsString(logForwarder))
+		return nil
+	}
+}

--- a/cmd/describe/logforwarders/cmd_test.go
+++ b/cmd/describe/logforwarders/cmd_test.go
@@ -1,0 +1,199 @@
+package logforwarders
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+
+	"github.com/openshift/rosa/pkg/aws"
+	. "github.com/openshift/rosa/pkg/output"
+	"github.com/openshift/rosa/pkg/test"
+)
+
+var _ = Describe("Describe log forwarding", func() {
+	const (
+		s3LogForwarderOutput = `
+S3 Bucket Prefix:                     /rosa/log-forwarding
+S3 Bucket Name:                      my-log-bucket
+Applications:                        audit infrastructure
+Groups:                              (applications,v0)
+`
+		cloudwatchLogForwarderOutput = `
+Cloudwatch Log Group Name:           my-cloudwatch-log-group
+Cloudwatch Log Distribution Role Arn: arn:aws:iam::123456789012:role/cloudwatch-log-role
+Applications:                        audit infrastructure
+Groups:                              (applications,v0)
+`
+	)
+	Context("describe", func() {
+		format.TruncatedDiff = false
+
+		mockReadyCluster := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+			c.ID("123")
+			c.Region(cmv1.NewCloudRegion().ID(aws.DefaultRegion))
+			c.State(cmv1.ClusterStateReady)
+		})
+		classicClusterReady := test.FormatClusterList([]*cmv1.Cluster{mockReadyCluster})
+		mockNotReadyCluster := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+			c.ID("123")
+			c.Region(cmv1.NewCloudRegion().ID(aws.DefaultRegion))
+			c.State(cmv1.ClusterStateInstalling)
+		})
+		classicClusterNotReady := test.FormatClusterList([]*cmv1.Cluster{mockNotReadyCluster})
+
+		s3LogForwarder, err := cmv1.NewLogForwarder().
+			S3(cmv1.NewLogForwarderS3Config().
+				BucketName("my-log-bucket").
+				BucketPrefix("/rosa/log-forwarding")).
+			Applications("audit", "infrastructure").
+			Groups(cmv1.NewLogForwarderGroup().
+				ID("applications").
+				Version("0")).Build()
+		Expect(err).To(BeNil())
+		s3LogForwarderResponse := test.FormatLogForwarder(s3LogForwarder)
+
+		cloudwatchLogForwarder, err := cmv1.NewLogForwarder().
+			Cloudwatch(cmv1.NewLogForwarderCloudWatchConfig().
+				LogGroupName("my-cloudwatch-log-group").
+				LogDistributionRoleArn("arn:aws:iam::123456789012:role/cloudwatch-log-role")).
+			Applications("audit", "infrastructure").
+			Groups(cmv1.NewLogForwarderGroup().
+				ID("applications").
+				Version("0")).Build()
+		Expect(err).To(BeNil())
+		cloudwatchLogForwarderResponse := test.FormatLogForwarder(cloudwatchLogForwarder)
+
+		var t *test.TestingRuntime
+		BeforeEach(func() {
+			t = test.NewTestRuntime()
+			SetOutput("")
+		})
+
+		It("Fails if log forwarder ID has not been specified", func() {
+			runner := DescribeLogForwarderRunner(NewDescribeLogForwarderUserOptions())
+			err := t.StdOutReader.Record()
+			Expect(err).ToNot(HaveOccurred())
+			err = runner(context.Background(), t.RosaRuntime, NewDescribeLogForwarderCommand(), []string{})
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring("you need to specify a log forwarder ID"))
+		})
+
+		It("Fails if log forwarder ID is invalid", func() {
+			runner := DescribeLogForwarderRunner(NewDescribeLogForwarderUserOptions())
+			err := t.StdOutReader.Record()
+			Expect(err).ToNot(HaveOccurred())
+			cmd := NewDescribeLogForwarderCommand()
+			cmd.Flag("log-forwarder").Value.Set("INVALID_ID123")
+			cmd.Flag("cluster").Value.Set(mockReadyCluster.ID())
+			err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+			Expect(err).ToNot(BeNil())
+			Expect(
+				err.Error(),
+			).To(Equal(
+				"log forwarder identifier 'INVALID_ID123' isn't valid: it must contain only lowercase letters and digits",
+			))
+		})
+
+		It("Cluster not ready", func() {
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, classicClusterNotReady))
+			runner := DescribeLogForwarderRunner(NewDescribeLogForwarderUserOptions())
+			err := t.StdOutReader.Record()
+			Expect(err).ToNot(HaveOccurred())
+			cmd := NewDescribeLogForwarderCommand()
+			cmd.Flag("log-forwarder").Value.Set("2n4b8f8ai80cs6kmjmdgqlqplh73r411")
+			cmd.Flag("cluster").Value.Set(mockReadyCluster.ID())
+			err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(Equal("cluster '123' is not yet ready"))
+		})
+
+		It("Log forwarder not found", func() {
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, classicClusterReady))
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusNotFound, ""))
+			runner := DescribeLogForwarderRunner(NewDescribeLogForwarderUserOptions())
+			err := t.StdOutReader.Record()
+			Expect(err).ToNot(HaveOccurred())
+			cmd := NewDescribeLogForwarderCommand()
+			cmd.Flag("log-forwarder").Value.Set("2n4b8f8ai80cs6kmjmdgqlqplh73r411")
+			cmd.Flag("cluster").Value.Set(mockReadyCluster.ID())
+			err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring("failed to get log forwarder"))
+		})
+
+		It("S3 Log forwarder found", func() {
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, classicClusterReady))
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, s3LogForwarderResponse))
+			runner := DescribeLogForwarderRunner(NewDescribeLogForwarderUserOptions())
+			err := t.StdOutReader.Record()
+			Expect(err).ToNot(HaveOccurred())
+			cmd := NewDescribeLogForwarderCommand()
+			cmd.Flag("log-forwarder").Value.Set("2n4b8f8ai80cs6kmjmdgqlqplh73r411")
+			cmd.Flag("cluster").Value.Set(mockReadyCluster.ID())
+			err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+			Expect(err).ToNot(HaveOccurred())
+			stdout, err := t.StdOutReader.Read()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stdout).To(Equal(s3LogForwarderOutput))
+		})
+
+		It("CloudWatch Log forwarder found", func() {
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, classicClusterReady))
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, cloudwatchLogForwarderResponse))
+			runner := DescribeLogForwarderRunner(NewDescribeLogForwarderUserOptions())
+			err := t.StdOutReader.Record()
+			Expect(err).ToNot(HaveOccurred())
+			cmd := NewDescribeLogForwarderCommand()
+			cmd.Flag("log-forwarder").Value.Set("2n4b8f8ai80cs6kmjmdgqlqplh73r411")
+			cmd.Flag("cluster").Value.Set(mockReadyCluster.ID())
+			err = runner(context.Background(), t.RosaRuntime, cmd, []string{})
+			Expect(err).ToNot(HaveOccurred())
+			stdout, err := t.StdOutReader.Read()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stdout).To(Equal(cloudwatchLogForwarderOutput))
+		})
+
+		It("Log forwarder found through argv", func() {
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, classicClusterReady))
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, s3LogForwarderResponse))
+			args := NewDescribeLogForwarderUserOptions()
+			runner := DescribeLogForwarderRunner(args)
+			cmd := NewDescribeLogForwarderCommand()
+			cmd.Flag("cluster").Value.Set("123")
+			err := t.StdOutReader.Record()
+			Expect(err).ToNot(HaveOccurred())
+			err = runner(context.Background(), t.RosaRuntime, cmd,
+				[]string{
+					"2n4b8f8ai80cs6kmjmdgqlqplh73r411",
+				})
+			Expect(err).ToNot(HaveOccurred())
+			stdout, err := t.StdOutReader.Read()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stdout).To(Equal(s3LogForwarderOutput))
+		})
+
+		It("Log forwarder found json output", func() {
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, classicClusterReady))
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, s3LogForwarderResponse))
+			runner := DescribeLogForwarderRunner(NewDescribeLogForwarderUserOptions())
+			err := t.StdOutReader.Record()
+			Expect(err).ToNot(HaveOccurred())
+			cmd := NewDescribeLogForwarderCommand()
+			cmd.Flag("cluster").Value.Set(mockReadyCluster.ID())
+			cmd.Flag("output").Value.Set("json")
+			err = runner(context.Background(), t.RosaRuntime, cmd, []string{"2n4b8f8ai80cs6kmjmdgqlqplh73r411"})
+			Expect(err).ToNot(HaveOccurred())
+			stdout, err := t.StdOutReader.Read()
+			Expect(err).ToNot(HaveOccurred())
+			var logForwarderJson bytes.Buffer
+			cmv1.MarshalLogForwarder(s3LogForwarder, &logForwarderJson)
+			Expect(stdout).To(Equal(logForwarderJson.String() + "\n"))
+		})
+	})
+})

--- a/cmd/describe/logforwarders/main_test.go
+++ b/cmd/describe/logforwarders/main_test.go
@@ -1,0 +1,13 @@
+package logforwarders
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDescribeLogForwarders(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Describe log forwarders suite")
+}

--- a/cmd/describe/logforwarders/options.go
+++ b/cmd/describe/logforwarders/options.go
@@ -1,0 +1,42 @@
+package logforwarders
+
+import (
+	"fmt"
+
+	"github.com/openshift/rosa/pkg/reporter"
+)
+
+type DescribeLogForwarderUserOptions struct {
+	logForwarder string
+}
+
+type DescribeLogForwarderOptions struct {
+	reporter reporter.Logger
+	args     DescribeLogForwarderUserOptions
+}
+
+func NewDescribeLogForwarderUserOptions() DescribeLogForwarderUserOptions {
+	return DescribeLogForwarderUserOptions{logForwarder: ""}
+}
+
+func NewDescribeLogForwarderOptions() *DescribeLogForwarderOptions {
+	return &DescribeLogForwarderOptions{
+		reporter: reporter.CreateReporter(),
+		args:     NewDescribeLogForwarderUserOptions(),
+	}
+}
+
+func (i *DescribeLogForwarderOptions) Bind(args DescribeLogForwarderUserOptions) error {
+	if args.logForwarder == "" {
+		return fmt.Errorf("you need to specify a log forwarder ID")
+	}
+	logForwarderKey := args.logForwarder
+	if !logForwarderKeyRE.MatchString(logForwarderKey) {
+		return fmt.Errorf(
+			"log forwarder identifier '%s' isn't valid: it must contain only lowercase letters and digits",
+			logForwarderKey,
+		)
+	}
+	i.args.logForwarder = args.logForwarder
+	return nil
+}

--- a/cmd/rosa/structure_test/command_args/rosa/describe/log-forwarder/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/describe/log-forwarder/command_args.yml
@@ -1,0 +1,3 @@
+- name: cluster
+- name: output
+- name: log-forwarder

--- a/cmd/rosa/structure_test/command_structure.yml
+++ b/cmd/rosa/structure_test/command_structure.yml
@@ -69,6 +69,7 @@ children:
     - name: ingress
     - name: addon-installation
     - name: kubeletconfig
+    - name: log-forwarder
     - name: machinepool
     - name: managed-service
     - name: tuning-configs

--- a/pkg/logforwarding/logforwarding_test_suite.go
+++ b/pkg/logforwarding/logforwarding_test_suite.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestHelper(t *testing.T) {
+func TestLogforwarding(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Helper Suite")
+	RunSpecs(t, "Logforwarding Suite")
 }

--- a/pkg/logforwarding/output.go
+++ b/pkg/logforwarding/output.go
@@ -1,0 +1,62 @@
+package logforwarding
+
+import (
+	"fmt"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+)
+
+func LogForwarderObjectAsString(logForwarder *cmv1.LogForwarder) string {
+	out := "\n"
+
+	if logForwarder.S3() != nil { // S3 Log Forwarder
+		out += fmt.Sprintf("S3 Bucket Prefix:                     %s\n", logForwarder.S3().BucketPrefix())
+		out += fmt.Sprintf("S3 Bucket Name:                      %s\n", logForwarder.S3().BucketName())
+	} else if logForwarder.Cloudwatch() != nil { // Cloudwatch Log Forwarder
+		out += fmt.Sprintf("Cloudwatch Log Group Name:           %s\n",
+			logForwarder.Cloudwatch().LogGroupName())
+		out += fmt.Sprintf("Cloudwatch Log Distribution Role Arn: %s\n",
+			logForwarder.Cloudwatch().LogDistributionRoleArn())
+	}
+
+	if logForwarder.Applications() != nil && len(logForwarder.Applications()) > 0 {
+		applicationsStr := ""
+		for i, app := range logForwarder.Applications() {
+			if i > 0 {
+				applicationsStr += " "
+			}
+			applicationsStr += app
+		}
+		out += fmt.Sprintf("Applications:                        %s\n", applicationsStr)
+	}
+
+	if logForwarder.Groups() != nil && len(logForwarder.Groups()) > 0 {
+		groupsStr := ""
+		for i, group := range logForwarder.Groups() {
+			if i > 0 {
+				groupsStr += " "
+			}
+			groupsStr += fmt.Sprintf("(%s,v%s)", group.ID(), group.Version())
+		}
+		out += fmt.Sprintf("Groups:                              %s\n", groupsStr)
+	}
+
+	if logForwarder.Status() != nil {
+		if logForwarder.Status().Message() != "" {
+			out += fmt.Sprintf("Status Message:                      %s\n", logForwarder.Status().Message())
+		}
+
+		if logForwarder.Status().ResolvedApplications() != nil && len(logForwarder.Status().ResolvedApplications()) > 0 {
+			resolvedAppsStr := ""
+			for i, app := range logForwarder.Status().ResolvedApplications() {
+				if i > 0 {
+					resolvedAppsStr += " "
+				}
+				resolvedAppsStr += app
+			}
+			out += fmt.Sprintf("Resolved Applications:               %s\n", resolvedAppsStr)
+		}
+	}
+
+	return out
+}

--- a/pkg/logforwarding/output_test.go
+++ b/pkg/logforwarding/output_test.go
@@ -1,0 +1,139 @@
+package logforwarding
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+)
+
+var _ = Describe("LogForwarder Output", func() {
+	Context("LogForwarderObjectAsString", func() {
+		It("Returns formatted S3 log forwarder output", func() {
+			s3LogForwarder, err := cmv1.NewLogForwarder().
+				S3(cmv1.NewLogForwarderS3Config().
+					BucketName("my-log-bucket").
+					BucketPrefix("/rosa/log-forwarding")).
+				Applications("audit", "infrastructure").
+				Groups(cmv1.NewLogForwarderGroup().ID("applications").Version("0"),
+					cmv1.NewLogForwarderGroup().ID("api").Version("1"),
+				).Build()
+			Expect(err).To(BeNil())
+
+			result := LogForwarderObjectAsString(s3LogForwarder)
+
+			expected := "\n" +
+				"S3 Bucket Prefix:                     /rosa/log-forwarding\n" +
+				"S3 Bucket Name:                      my-log-bucket\n" +
+				"Applications:                        audit infrastructure\n" +
+				"Groups:                              (applications,v0) (api,v1)\n"
+
+			Expect(result).To(Equal(expected))
+		})
+
+		It("Returns formatted CloudWatch log forwarder output", func() {
+			cloudwatchLogForwarder, err := cmv1.NewLogForwarder().
+				Cloudwatch(cmv1.NewLogForwarderCloudWatchConfig().
+					LogGroupName("my-cloudwatch-log-group").
+					LogDistributionRoleArn("arn:aws:iam::123456789012:role/cloudwatch-log-role")).
+				Applications("audit", "infrastructure").
+				Groups(cmv1.NewLogForwarderGroup().
+					ID("applications").
+					Version("0")).Build()
+			Expect(err).To(BeNil())
+
+			result := LogForwarderObjectAsString(cloudwatchLogForwarder)
+
+			expected := "\n" +
+				"Cloudwatch Log Group Name:           my-cloudwatch-log-group\n" +
+				"Cloudwatch Log Distribution Role Arn: arn:aws:iam::123456789012:role/cloudwatch-log-role\n" +
+				"Applications:                        audit infrastructure\n" +
+				"Groups:                              (applications,v0)\n"
+
+			Expect(result).To(Equal(expected))
+		})
+
+		It("Returns S3 output with empty bucket prefix", func() {
+			s3LogForwarderNoPrefix, err := cmv1.NewLogForwarder().
+				S3(cmv1.NewLogForwarderS3Config().
+					BucketName("my-log-bucket")).
+				Applications("audit").Build()
+			Expect(err).To(BeNil())
+
+			result := LogForwarderObjectAsString(s3LogForwarderNoPrefix)
+
+			expected := "\n" +
+				"S3 Bucket Prefix:                     \n" +
+				"S3 Bucket Name:                      my-log-bucket\n" +
+				"Applications:                        audit\n"
+
+			Expect(result).To(Equal(expected))
+		})
+
+		It("Returns formatted S3 log forwarder output with status", func() {
+			s3LogForwarder, err := cmv1.NewLogForwarder().
+				S3(cmv1.NewLogForwarderS3Config().
+					BucketName("my-log-bucket").
+					BucketPrefix("/rosa/log-forwarding")).
+				Applications("audit", "infrastructure").
+				Status(cmv1.NewLogForwarderStatus().
+					Message("Log forwarder is active").
+					ResolvedApplications("audit", "infrastructure", "application")).
+				Build()
+			Expect(err).To(BeNil())
+
+			result := LogForwarderObjectAsString(s3LogForwarder)
+
+			expected := "\n" +
+				"S3 Bucket Prefix:                     /rosa/log-forwarding\n" +
+				"S3 Bucket Name:                      my-log-bucket\n" +
+				"Applications:                        audit infrastructure\n" +
+				"Status Message:                      Log forwarder is active\n" +
+				"Resolved Applications:               audit infrastructure application\n"
+
+			Expect(result).To(Equal(expected))
+		})
+
+		It("Returns formatted CloudWatch log forwarder output with status", func() {
+			cloudwatchLogForwarder, err := cmv1.NewLogForwarder().
+				Cloudwatch(cmv1.NewLogForwarderCloudWatchConfig().
+					LogGroupName("my-cloudwatch-log-group").
+					LogDistributionRoleArn("arn:aws:iam::123456789012:role/cloudwatch-log-role")).
+				Applications("audit").
+				Status(cmv1.NewLogForwarderStatus().
+					Message("CloudWatch forwarding enabled").
+					ResolvedApplications("audit", "application")).
+				Build()
+			Expect(err).To(BeNil())
+
+			result := LogForwarderObjectAsString(cloudwatchLogForwarder)
+
+			expected := "\n" +
+				"Cloudwatch Log Group Name:           my-cloudwatch-log-group\n" +
+				"Cloudwatch Log Distribution Role Arn: arn:aws:iam::123456789012:role/cloudwatch-log-role\n" +
+				"Applications:                        audit\n" +
+				"Status Message:                      CloudWatch forwarding enabled\n" +
+				"Resolved Applications:               audit application\n"
+
+			Expect(result).To(Equal(expected))
+		})
+
+		It("Returns output with only status message when resolved applications is empty", func() {
+			logForwarder, err := cmv1.NewLogForwarder().
+				S3(cmv1.NewLogForwarderS3Config().
+					BucketName("test-bucket")).
+				Status(cmv1.NewLogForwarderStatus().
+					Message("Partially configured")).
+				Build()
+			Expect(err).To(BeNil())
+
+			result := LogForwarderObjectAsString(logForwarder)
+
+			expected := "\n" +
+				"S3 Bucket Prefix:                     \n" +
+				"S3 Bucket Name:                      test-bucket\n" +
+				"Status Message:                      Partially configured\n"
+
+			Expect(result).To(Equal(expected))
+		})
+	})
+})

--- a/pkg/ocm/log_forwards.go
+++ b/pkg/ocm/log_forwards.go
@@ -81,6 +81,25 @@ func (c *Client) GetLogForwarder(clusterID string) (*cmv1.LogForwarder, error) {
 	return nil, nil
 }
 
+func (c *Client) GetLogForwarderByID(clusterID string, logForwarderID string) (*cmv1.LogForwarder, error) {
+	response, err := c.ocm.ClustersMgmt().V1().
+		Clusters().
+		Cluster(clusterID).
+		ControlPlane().
+		LogForwarders().
+		LogForwarder(logForwarderID).
+		Get().
+		Send()
+
+	if err != nil {
+		if response != nil && response.Status() == 404 {
+			return nil, nil
+		}
+		return nil, handleErr(response.Error(), err)
+	}
+	return response.Body(), nil
+}
+
 func (c *Client) SetLogForwarder(clusterID string,
 	logForwarder *cmv1.LogForwarder) (*cmv1.LogForwarder, error) {
 	response, err := c.ocm.ClustersMgmt().V1().

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -146,6 +146,14 @@ func Print(resource interface{}) error {
 		if kubeletConfigs, ok := resource.([]*cmv1.KubeletConfig); ok {
 			cmv1.MarshalKubeletConfigList(kubeletConfigs, &b)
 		}
+	case "*v1.LogForwarder":
+		if logForwarder, ok := resource.(*cmv1.LogForwarder); ok {
+			cmv1.MarshalLogForwarder(logForwarder, &b)
+		}
+	case "[]*v1.LogForwarder":
+		if logForwarders, ok := resource.([]*cmv1.LogForwarder); ok {
+			cmv1.MarshalLogForwarderList(logForwarders, &b)
+		}
 	case "*v1.ClusterAutoscaler":
 		if autoscaler, ok := resource.(*cmv1.ClusterAutoscaler); ok {
 			cmv1.MarshalClusterAutoscaler(autoscaler, &b)
@@ -247,7 +255,7 @@ func parseResource(body bytes.Buffer) (string, error) {
 		}
 		return string(out), nil
 	default:
-		return "", fmt.Errorf("Unknown format '%s'. Valid formats are %s", o, formats)
+		return "", fmt.Errorf("unknown format '%s'. Valid formats are %s", o, formats)
 	}
 }
 

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -10,7 +10,9 @@ import (
 
 	"go.uber.org/mock/gomock"
 
+	//nolint:staticcheck
 	. "github.com/onsi/ginkgo/v2"
+	//nolint:staticcheck
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
 	sdk "github.com/openshift-online/ocm-sdk-go"
@@ -18,6 +20,7 @@ import (
 	amsv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift-online/ocm-sdk-go/logging"
+	//nolint:staticcheck
 	. "github.com/openshift-online/ocm-sdk-go/testing"
 	"github.com/spf13/cobra"
 
@@ -206,6 +209,19 @@ func FormatClusterList(clusters []*v1.Cluster) string {
 
 func FormatIngressList(ingresses []*v1.Ingress) string {
 	return FormatList(ingresses, v1.MarshalIngressList, "IngressList")
+}
+
+func FormatLogForwarderList(logForwarders []*v1.LogForwarder) string {
+	return FormatList(logForwarders, v1.MarshalLogForwarderList, "LogForwarderList")
+}
+
+func FormatLogForwarder(logForwarder *v1.LogForwarder) string {
+	var json bytes.Buffer
+	err := v1.MarshalLogForwarder(logForwarder, &json)
+	if err != nil {
+		return err.Error()
+	}
+	return json.String()
 }
 
 func FormatVersionList(versions []*v1.Version) string {


### PR DESCRIPTION
Adds support for describing log forwarders from a cluster using the ID of the log forwarder within the cluster

Example of an S3 log forwarder with only Groups and BucketName as populated values:

```bash
❯ ./rosa describe log-forwarding -c hk5 2n4b8f8ai80cs6kmjmdgqlqplh73r411

S3 Bucket Prefix:
S3 Bucket Name:                      log-fwd-test
Groups:                              api
Status Message:                      Log forwarding configuration has been applied successfully
Resolved Applications:               audit-webhook kube-apiserver oauth-openshift openshift-apiserver openshift-oauth-apiserver packageserver validation-webhook
```

JSON output for the same resource
```json
./rosa describe log-forwarding -c hk5 2n4b8f8ai80cs6kmjmdgqlqplh73r411 -o json
{
  "kind": "LogForwarder",
  "id": "2n4b8f8ai80cs6kmjmdgqlqplh73r411",
  "href": "/api/clusters_mgmt/v1/clusters/2n4b8dhctbk1bs442ffkj6b9m6d3m8h9/control_plane/log_forwarders/2n4b8f8ai80cs6kmjmdgqlqplh73r411",
  "s3": {
    "bucket_name": "log-fwd-test"
  },
  "cluster_id": "2n4b8dhctbk1bs442ffkj6b9m6d3m8h9",
  "groups": [
    {
      "id": "api",
      "version": "1.0"
    },
    {
      "id": "authentication",
      "version": "1.0"
    },
    {
      "id": "controller manager",
      "version": "1.0"
    },
    {
      "id": "scheduler",
      "version": "1.0"
    }
  ],
  "status": {
    "message": "Log forwarding configuration has been applied successfully",
    "resolved_applications": [
      "audit-webhook",
      "aws-ebs-csi-driver-controller",
      "capi-provider-controller-manager",
      "catalog-operator",
      "cloud-controller-manager",
      "cloud-credential-operator",
      "cloud-network-config-controller",
      "cluster-network-operator",
      "cluster-node-tuning-operator",
      "cluster-policy-controller",
      "cluster-version-operator",
      "control-plane-operator",
      "control-plane-pki-operator",
      "csi-snapshot-controller",
      "csi-snapshot-controller-operator",
      "dns-operator",
      "hosted-cluster-config-operator",
      "ignition-server",
      "ingress-operator",
      "konnectivity-agent",
      "kube-apiserver",
      "kube-controller-manager",
      "kube-scheduler",
      "machine-approver",
      "multus-admission-controller",
      "network-node-identity",
      "oauth-openshift",
      "olm-operator",
      "openshift-apiserver",
      "openshift-controller-manager",
      "openshift-oauth-apiserver",
      "openshift-route-controller-manager",
      "ovnkube-control-plane",
      "packageserver",
      "validation-webhook"
    ],
    "state": "ready"
  }
}
```