### PR TITLE
OCM-21373 | fix: Change help msgs for create/cluster logforwarder

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -961,12 +961,12 @@ func initFlags(cmd *cobra.Command) {
 			"  cloudwatch_log_role_arn: \"role_arn_here\"\n"+
 			"  cloudwatch_log_group_name: \"group_name_here\"\n"+
 			"  applications: [\"example_app_1\", \"example_app_2\"]\n"+
-			"  groups: \"group-name\"\n"+
+			"  groups: [\"group-name\", \"group-name-2\"]\n"+
 			"s3:\n"+
 			"  s3_config_bucket_name: \"bucket_name_here\"\n"+
 			"  s3_config_bucket_prefix: \"bucket_prefix_here\"\n"+
 			"  applications: [\"example_app_1\", \"example_app_2\"]\n"+
-			"  groups: \"group-name\"\n"+
+			"  groups: [\"group-name\", \"group-name-2\"]\n"+
 			"\n"+
 			"\nPlease use interactive mode and enter '?' on the associated prompts to get the up to date lists "+
 			"for allowed Applications and allowed Groups\n",
@@ -2217,8 +2217,7 @@ func run(cmd *cobra.Command, _ []string) {
 			logFwdS3ConfigObject = yamlObject.S3
 			logFwdCloudWatchConfigObject = yamlObject.CloudWatch
 		} else if args.logFwdConfig == "" && interactive.Enabled() {
-			interactiveObject, err := interactiveLogForwarding.InteractiveLogForwardingConfig(
-				r.OCMClient, cmd.Flags().Lookup(logforwarding.FlagName).Usage)
+			interactiveObject, err := interactiveLogForwarding.InteractiveLogForwardingConfig(r.OCMClient)
 			if err != nil {
 				r.Reporter.Errorf("failed to create log fowarder config: %s", err)
 				os.Exit(1)

--- a/pkg/interactive/logforwarding/logforwarding.go
+++ b/pkg/interactive/logforwarding/logforwarding.go
@@ -15,11 +15,11 @@ const cloudWatch = "CloudWatch"
 const s3 = "S3"
 const both = "Both"
 
-func InteractiveLogForwardingConfig(ocmClient *ocm.Client, mainHelpMsg string) (
+func InteractiveLogForwardingConfig(ocmClient *ocm.Client) (
 	*logforwarding.LogForwarderYaml, error) {
 	con, err := interactive.GetOption(interactive.Input{
 		Question: "Enabled log forwarding",
-		Help:     mainHelpMsg,
+		Help:     "Whether log forwarding is enabled, and if so, which types of log forwarder(s) to create",
 		Required: false,
 		Default:  false,
 		Options:  []string{cloudWatch, s3, both},

--- a/pkg/logforwarding/helpers_test.go
+++ b/pkg/logforwarding/helpers_test.go
@@ -14,12 +14,12 @@ cloudwatch:
   cloudwatch_log_role_arn: "arn"
   cloudwatch_log_group_name: "abcd"
   applications: ["test3", "test4"]
-  groups: "group-name"
+  groups: ["group-name"]
 s3:
   s3_config_bucket_name: "foo"
   s3_config_bucket_prefix: "bar"
   applications: ["test3", "test4"]
-  groups: "group-name2"
+  groups: ["group-name2"]
 `
 
 func generateLogForwarderGroupVersions() []*cmv1.LogForwarderGroupVersions {


### PR DESCRIPTION
Better YAML example for log forwarders; better help msg for the initial interactive prompt