### PR TITLE
OCM-21150 | feat: List command for logforwarders

### DIFF
--- a/cmd/list/cmd.go
+++ b/cmd/list/cmd.go
@@ -33,6 +33,7 @@ import (
 	"github.com/openshift/rosa/cmd/list/ingress"
 	"github.com/openshift/rosa/cmd/list/instancetypes"
 	"github.com/openshift/rosa/cmd/list/kubeletconfig"
+	"github.com/openshift/rosa/cmd/list/logforwarders"
 	"github.com/openshift/rosa/cmd/list/machinepool"
 	"github.com/openshift/rosa/cmd/list/ocmroles"
 	"github.com/openshift/rosa/cmd/list/oidcconfig"
@@ -86,6 +87,8 @@ func init() {
 	Cmd.AddCommand(breakglasscredential.Cmd)
 	kubeletconfig := kubeletconfig.NewListKubeletConfigsCommand()
 	Cmd.AddCommand(kubeletconfig)
+	logforwardersCommand := logforwarders.NewListLogForwardersCommand()
+	Cmd.AddCommand(logforwardersCommand)
 	accessrequest := accessrequests.NewListAccessRequestsCommand()
 	Cmd.AddCommand(accessrequest)
 	flags := Cmd.PersistentFlags()
@@ -101,7 +104,7 @@ func init() {
 		gates.Cmd, iamserviceaccounts.Cmd, idp.Cmd, ingress.Cmd, machinePoolCommand,
 		operatorroles.Cmd, region.Cmd, rhRegion.Cmd,
 		service.Cmd, tuningconfigs.Cmd, upgrade.Cmd,
-		user.Cmd, version.Cmd, kubeletconfig, accessrequest,
+		user.Cmd, version.Cmd, kubeletconfig, logforwardersCommand, accessrequest,
 	}
 	arguments.MarkRegionDeprecated(Cmd, globallyAvailableCommands)
 }

--- a/cmd/list/logforwarders/cmd.go
+++ b/cmd/list/logforwarders/cmd.go
@@ -1,0 +1,116 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logforwarders
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/output"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+const (
+	use     = "log-forwarders -c <cluster-id>"
+	short   = "List cluster log forwarders"
+	long    = "List log forwarders configured on a cluster, given a cluster ID"
+	example = "  # List all log forwarders on a cluster named \"mycluster\": " +
+		"rosa list log-forwarders --cluster=mycluster"
+)
+
+var aliases = []string{"logforwarders", "log-forwarder", "logforwarder"}
+
+func NewListLogForwardersCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     use,
+		Short:   short,
+		Long:    long,
+		Aliases: aliases,
+		Example: example,
+		Args:    cobra.NoArgs,
+		Run:     rosa.DefaultRunner(rosa.RuntimeWithOCM(), ListLogForwardersRunner()),
+	}
+
+	ocm.AddClusterFlag(cmd)
+	output.AddFlag(cmd)
+	return cmd
+}
+
+func ListLogForwardersRunner() rosa.CommandRunner {
+	return func(_ context.Context, runtime *rosa.Runtime, cmd *cobra.Command, _ []string) error {
+		clusterKey := runtime.GetClusterKey()
+
+		cluster, err := runtime.OCMClient.GetCluster(clusterKey, runtime.Creator)
+		if err != nil {
+			return err
+		}
+		if cluster.State() != cmv1.ClusterStateReady &&
+			cluster.State() != cmv1.ClusterStateHibernating {
+			return fmt.Errorf("cluster '%s' is not yet ready", clusterKey)
+		}
+
+		runtime.Reporter.Debugf("Loading log forwarders for cluster '%s'", clusterKey)
+		logForwarders, err := runtime.OCMClient.GetLogForwarders(cluster.ID())
+		if err != nil {
+			return fmt.Errorf("failed to get log forwarders for cluster '%s': %v", clusterKey, err)
+		}
+
+		if output.HasFlag() {
+			err = output.Print(logForwarders)
+			if err != nil {
+				return fmt.Errorf("failed to output log forwarders: %v", err)
+			}
+			return nil
+		}
+
+		if len(logForwarders) == 0 {
+			runtime.Reporter.Infof("There are no log forwarders configured for cluster '%s'", clusterKey)
+			return nil
+		}
+
+		writer := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
+
+		fmt.Fprintf(writer, "ID\tTYPE\tSTATUS\n")
+		for _, logForwarder := range logForwarders {
+			logType := "Unknown"
+			if logForwarder.S3() != nil {
+				logType = "S3"
+			} else if logForwarder.Cloudwatch() != nil {
+				logType = "CloudWatch"
+			}
+
+			status := "N/A"
+			if logForwarder.Status() != nil && logForwarder.Status().State() != "" {
+				status = logForwarder.Status().State()
+			}
+
+			fmt.Fprintf(writer, "%s\t%s\t%s\n",
+				logForwarder.ID(),
+				logType,
+				status,
+			)
+		}
+		writer.Flush()
+		return nil
+	}
+}

--- a/cmd/list/logforwarders/cmd_test.go
+++ b/cmd/list/logforwarders/cmd_test.go
@@ -1,0 +1,87 @@
+package logforwarders
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+
+	"github.com/openshift/rosa/pkg/output"
+	. "github.com/openshift/rosa/pkg/test"
+)
+
+var _ = Describe("list logforwarders", func() {
+
+	It("Correctly builds the command", func() {
+		cmd := NewListLogForwardersCommand()
+		Expect(cmd).NotTo(BeNil())
+
+		Expect(cmd.Use).To(Equal(use))
+		Expect(cmd.Short).To(Equal(short))
+		Expect(cmd.Long).To(Equal(long))
+		Expect(cmd.Aliases).To(ContainElements(aliases))
+		Expect(cmd.Run).NotTo(BeNil())
+
+		Expect(cmd.Flags().Lookup("cluster")).NotTo(BeNil())
+	})
+
+	Context("List LogForwarders Runner", func() {
+
+		var t *TestingRuntime
+
+		BeforeEach(func() {
+			t = NewTestRuntime()
+			output.SetOutput("")
+		})
+
+		AfterEach(func() {
+			output.SetOutput("")
+		})
+
+		It("Returns an error if the cluster does not exist", func() {
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, FormatClusterList(make([]*cmv1.Cluster, 0))))
+			t.SetCluster("cluster", nil)
+
+			runner := ListLogForwardersRunner()
+			err := runner(context.Background(), t.RosaRuntime, nil, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("There is no cluster with identifier or name 'cluster'"))
+		})
+
+		It("Returns an error if the cluster is not ready", func() {
+			cluster := MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateInstalling)
+			})
+
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, FormatClusterList([]*cmv1.Cluster{cluster})))
+			t.SetCluster("cluster", cluster)
+
+			runner := ListLogForwardersRunner()
+			err := runner(context.Background(), t.RosaRuntime, nil, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cluster 'cluster' is not yet ready"))
+		})
+
+		It("Returns an error if OCM API fails to list log forwarders", func() {
+			cluster := MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateReady)
+			})
+
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, FormatClusterList([]*cmv1.Cluster{cluster})))
+			t.SetCluster("cluster", cluster)
+			t.ApiServer.RouteToHandler(
+				"GET",
+				fmt.Sprintf("/api/clusters_mgmt/v1/clusters/%s/control_plane/log_forwarders", cluster.ID()),
+				RespondWithJSON(http.StatusInternalServerError, "{}"))
+
+			runner := ListLogForwardersRunner()
+			err := runner(context.Background(), t.RosaRuntime, nil, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to get log forwarders for cluster 'cluster'"))
+		})
+	})
+})

--- a/cmd/list/logforwarders/logforwarders_suite_test.go
+++ b/cmd/list/logforwarders/logforwarders_suite_test.go
@@ -1,0 +1,13 @@
+package logforwarders
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestLogForwarders(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "List LogForwarders Suite")
+}

--- a/cmd/rosa/structure_test/command_args/rosa/list/log-forwarders/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/list/log-forwarders/command_args.yml
@@ -1,0 +1,4 @@
+- name: cluster
+- name: output
+- name: profile
+- name: region

--- a/cmd/rosa/structure_test/command_structure.yml
+++ b/cmd/rosa/structure_test/command_structure.yml
@@ -125,6 +125,7 @@ children:
     - name: ingresses
     - name: instance-types
     - name: kubeletconfigs
+    - name: log-forwarders
     - name: machinepools
     - name: ocm-roles
     - name: oidc-config

--- a/pkg/ocm/log_forwards.go
+++ b/pkg/ocm/log_forwards.go
@@ -81,6 +81,33 @@ func (c *Client) GetLogForwarder(clusterID string) (*cmv1.LogForwarder, error) {
 	return nil, nil
 }
 
+func (c *Client) GetLogForwarders(clusterId string) ([]*cmv1.LogForwarder, error) {
+	var LogForwarderList []*cmv1.LogForwarder
+	collection := c.ocm.ClustersMgmt().V1().
+		Clusters().
+		Cluster(clusterId).
+		ControlPlane().LogForwarders().List()
+
+	page := 1
+	size := 100
+	for {
+		response, err := collection.
+			Page(page).
+			Size(size).
+			Send()
+		if err != nil {
+			return nil, handleErr(response.Error(), err)
+		}
+		LogForwarderList = append(LogForwarderList, response.Items().Slice()...)
+		if response.Size() < size {
+			break
+		}
+		page++
+	}
+
+	return LogForwarderList, nil
+}
+
 func (c *Client) GetLogForwarderByID(clusterID string, logForwarderID string) (*cmv1.LogForwarder, error) {
 	response, err := c.ocm.ClustersMgmt().V1().
 		Clusters().


### PR DESCRIPTION
List support for log forwarders

```bash
❯ ./rosa list log-forwarders -c hk5
ID                                TYPE  STATUS
2n4b8f8ai80cs6kmjmdgqlqplh73r411  S3    Log forwarding configuration has been applied successfully
```