### PR TITLE
OCM-21152 | feat: Create command for logforwarders

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -956,20 +956,7 @@ func initFlags(cmd *cobra.Command) {
 		&args.logFwdConfig,
 		logforwarding.FlagName,
 		"",
-		"A path to a log forwarding config file. This should be a YAML file with the following structure:\n\n"+
-			"cloudwatch:\n"+
-			"  cloudwatch_log_role_arn: \"role_arn_here\"\n"+
-			"  cloudwatch_log_group_name: \"group_name_here\"\n"+
-			"  applications: [\"example_app_1\", \"example_app_2\"]\n"+
-			"  groups: \"group-name\"\n"+
-			"s3:\n"+
-			"  s3_config_bucket_name: \"bucket_name_here\"\n"+
-			"  s3_config_bucket_prefix: \"bucket_prefix_here\"\n"+
-			"  applications: [\"example_app_1\", \"example_app_2\"]\n"+
-			"  groups: \"group-name\"\n"+
-			"\n"+
-			"\nPlease use interactive mode and enter '?' on the associated prompts to get the up to date lists "+
-			"for allowed Applications and allowed Groups\n",
+		logforwarding.LogFwdConfigHelpMessage,
 	)
 
 	interactive.AddModeFlag(cmd)

--- a/cmd/create/cmd.go
+++ b/cmd/create/cmd.go
@@ -31,6 +31,7 @@ import (
 	"github.com/openshift/rosa/cmd/create/idp"
 	"github.com/openshift/rosa/cmd/create/imagemirror"
 	"github.com/openshift/rosa/cmd/create/kubeletconfig"
+	"github.com/openshift/rosa/cmd/create/logforwarder"
 	"github.com/openshift/rosa/cmd/create/machinepool"
 	"github.com/openshift/rosa/cmd/create/network"
 	"github.com/openshift/rosa/cmd/create/ocmrole"
@@ -72,6 +73,8 @@ func init() {
 	Cmd.AddCommand(autoscalerCommand)
 	kubeletConfig := kubeletconfig.NewCreateKubeletConfigCommand()
 	Cmd.AddCommand(kubeletConfig)
+	logforwarderCommand := logforwarder.NewCreateLogForwarderCommand()
+	Cmd.AddCommand(logforwarderCommand)
 	imageMirrorCommand := imagemirror.NewCreateImageMirrorCommand()
 	Cmd.AddCommand(imageMirrorCommand)
 	Cmd.AddCommand(externalauthprovider.Cmd)

--- a/cmd/create/logforwarder/cmd.go
+++ b/cmd/create/logforwarder/cmd.go
@@ -1,0 +1,157 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logforwarder
+
+import (
+	"context"
+	"fmt"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/interactive"
+	interactiveLogForwarding "github.com/openshift/rosa/pkg/interactive/logforwarding"
+	"github.com/openshift/rosa/pkg/logforwarding"
+	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/output"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+const (
+	use   = "log-forwarder -c <cluster-id>"
+	short = "Create a log forwarder for a Hosted Control Plane cluster"
+	long  = "Create a log forwarder to forward logs from a hosted cluster to external services " +
+		"such as S3 or CloudWatch. Must create for an existing Hosted Control Plane cluster"
+	example = `  # Create a log forwarder using a config file
+  rosa create log-forwarder -c mycluster-hcp --log-fwd-config=s3.yml
+  
+  # Create a log forwarder interactively
+  rosa create log-forwarder -c mycluster-hcp --interactive`
+)
+
+var aliases = []string{"logforwarder", "log-forwarder"}
+
+func NewCreateLogForwarderCommand() *cobra.Command {
+	options := NewCreateLogForwarderUserOptions()
+	cmd := &cobra.Command{
+		Use:     use,
+		Short:   short,
+		Long:    long,
+		Aliases: aliases,
+		Example: example,
+		Args:    cobra.NoArgs,
+		Run:     rosa.DefaultRunner(rosa.RuntimeWithOCM(), CreateLogForwarderRunner(options)),
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(
+		&options.logFwdConfig,
+		logforwarding.FlagName,
+		"",
+		logforwarding.LogFwdConfigHelpMessage,
+	)
+
+	ocm.AddClusterFlag(cmd)
+	interactive.AddFlag(flags)
+	return cmd
+}
+
+func CreateLogForwarderRunner(userOptions *CreateLogForwarderUserOptions) rosa.CommandRunner {
+	return func(_ context.Context, r *rosa.Runtime, cmd *cobra.Command, _ []string) error {
+		options := NewCreateLogForwarderOptions()
+
+		err := options.Bind(userOptions)
+		if err != nil {
+			return err
+		}
+
+		clusterKey := r.GetClusterKey()
+		cluster, err := r.OCMClient.GetCluster(clusterKey, r.Creator)
+		if err != nil {
+			return err
+		}
+
+		if cluster.State() != cmv1.ClusterStateReady {
+			return fmt.Errorf("cluster '%s' is not yet ready", clusterKey)
+		}
+
+		if !cluster.Hypershift().Enabled() {
+			return fmt.Errorf("log forwarders are only supported for Hosted Control Plane clusters")
+		}
+
+		var logFwdS3ConfigObject *logforwarding.S3LogForwarderConfig
+		var logFwdCloudWatchConfigObject *logforwarding.CloudWatchLogForwarderConfig
+
+		if userOptions.logFwdConfig == "" {
+			interactive.Enable()
+		}
+
+		if userOptions.logFwdConfig != "" {
+			yamlObject, err := logforwarding.UnmarshalLogForwarderConfigYaml(userOptions.logFwdConfig)
+			if err != nil {
+				return fmt.Errorf("error parsing log forwarder config '%s': %v", userOptions.logFwdConfig, err)
+			}
+			if yamlObject.S3 != nil {
+				logFwdS3ConfigObject = yamlObject.S3
+			}
+			if yamlObject.CloudWatch != nil {
+				logFwdCloudWatchConfigObject = yamlObject.CloudWatch
+			}
+		} else if interactive.Enabled() {
+			interactiveObject, err := interactiveLogForwarding.InteractiveLogForwardingConfig(r.OCMClient)
+			if err != nil {
+				return fmt.Errorf("failed to create log forwarder config: %v", err)
+			}
+			if interactiveObject.S3 != nil && interactiveObject.S3.S3ConfigBucketName != "" {
+				logFwdS3ConfigObject = interactiveObject.S3
+			}
+			if interactiveObject.CloudWatch != nil && interactiveObject.CloudWatch.CloudWatchLogRoleArn != "" {
+				logFwdCloudWatchConfigObject = interactiveObject.CloudWatch
+			}
+		}
+
+		var logForwarderBuilder *cmv1.LogForwarderBuilder
+		if logFwdS3ConfigObject != nil {
+			logForwarderBuilder = logforwarding.BindS3LogForwarder(logFwdS3ConfigObject)
+		} else if logFwdCloudWatchConfigObject != nil {
+			logForwarderBuilder = logforwarding.BindCloudWatchLogForwarder(logFwdCloudWatchConfigObject)
+		} else {
+			return fmt.Errorf("no proper log forwarding configuration provided")
+		}
+
+		logForwarder, err := logForwarderBuilder.Build()
+		if err != nil {
+			return fmt.Errorf("failed to build log forwarder from inputs: %v", err)
+		}
+
+		createdLogForwarder, err := r.OCMClient.SetLogForwarder(cluster.ID(), logForwarder)
+		if err != nil {
+			return fmt.Errorf("failed to create log forwarder: %v", err)
+		}
+
+		if output.HasFlag() {
+			err = output.Print(createdLogForwarder)
+			if err != nil {
+				return fmt.Errorf("failed to output log forwarder: %v", err)
+			}
+			return nil
+		}
+
+		r.Reporter.Infof("Successfully created log forwarder for HCP cluster '%s'", clusterKey)
+		return nil
+	}
+}

--- a/cmd/create/logforwarder/cmd_test.go
+++ b/cmd/create/logforwarder/cmd_test.go
@@ -1,0 +1,97 @@
+package logforwarder
+
+import (
+	"context"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+
+	"github.com/openshift/rosa/pkg/logforwarding"
+	"github.com/openshift/rosa/pkg/output"
+	. "github.com/openshift/rosa/pkg/test"
+)
+
+var _ = Describe("create LogForwarder", func() {
+
+	It("Correctly builds the command", func() {
+		cmd := NewCreateLogForwarderCommand()
+		Expect(cmd).NotTo(BeNil())
+
+		Expect(cmd.Use).To(Equal(use))
+		Expect(cmd.Short).To(Equal(short))
+		Expect(cmd.Long).To(Equal(long))
+		Expect(cmd.Run).NotTo(BeNil())
+
+		Expect(cmd.Flags().Lookup("cluster")).NotTo(BeNil())
+		Expect(cmd.Flags().Lookup("interactive")).NotTo(BeNil())
+		Expect(cmd.Flags().Lookup(logforwarding.FlagName)).NotTo(BeNil())
+	})
+
+	Context("Create LogForwarder Runner", func() {
+
+		var t *TestingRuntime
+
+		BeforeEach(func() {
+			t = NewTestRuntime()
+			output.SetOutput("")
+		})
+
+		AfterEach(func() {
+			output.SetOutput("")
+		})
+
+		It("Returns an error if the cluster does not exist", func() {
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, FormatClusterList(make([]*cmv1.Cluster, 0))))
+			t.SetCluster("cluster", nil)
+
+			userOptions := NewCreateLogForwarderUserOptions()
+			userOptions.logFwdConfig = ""
+
+			runner := CreateLogForwarderRunner(userOptions)
+			err := runner(context.Background(), t.RosaRuntime, nil, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("There is no cluster with identifier or name 'cluster'"))
+		})
+
+		It("Returns an error if the cluster is not an HCP cluster", func() {
+			cluster := MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateReady)
+			})
+
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, FormatClusterList([]*cmv1.Cluster{cluster})))
+			t.SetCluster("cluster", cluster)
+
+			userOptions := NewCreateLogForwarderUserOptions()
+			userOptions.logFwdConfig = ""
+
+			runner := CreateLogForwarderRunner(userOptions)
+			err := runner(context.Background(), t.RosaRuntime, nil, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(
+				Equal("log forwarders are only supported for Hosted Control Plane clusters"))
+		})
+
+		It("Returns an error if the cluster is a not-ready HCP cluster", func() {
+			cluster := MockCluster(func(c *cmv1.ClusterBuilder) {
+				b := cmv1.HypershiftBuilder{}
+				b.Enabled(true)
+				c.Hypershift(&b)
+				c.State(cmv1.ClusterStateInstalling)
+			})
+
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, FormatClusterList([]*cmv1.Cluster{cluster})))
+			t.SetCluster("cluster", cluster)
+
+			userOptions := NewCreateLogForwarderUserOptions()
+			userOptions.logFwdConfig = ""
+
+			runner := CreateLogForwarderRunner(userOptions)
+			err := runner(context.Background(), t.RosaRuntime, nil, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cluster 'cluster' is not yet ready"))
+		})
+	})
+})

--- a/cmd/create/logforwarder/main_test.go
+++ b/cmd/create/logforwarder/main_test.go
@@ -1,0 +1,13 @@
+package logforwarder
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCreateLogForwarder(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Create Log Forwarder Suite")
+}

--- a/cmd/create/logforwarder/options.go
+++ b/cmd/create/logforwarder/options.go
@@ -1,0 +1,30 @@
+package logforwarder
+
+import (
+	"github.com/openshift/rosa/pkg/reporter"
+)
+
+type CreateLogForwarderUserOptions struct {
+	logFwdConfig string
+}
+
+type CreateLogForwarderOptions struct {
+	reporter reporter.Logger
+	args     *CreateLogForwarderUserOptions
+}
+
+func NewCreateLogForwarderUserOptions() *CreateLogForwarderUserOptions {
+	return &CreateLogForwarderUserOptions{logFwdConfig: ""}
+}
+
+func NewCreateLogForwarderOptions() *CreateLogForwarderOptions {
+	return &CreateLogForwarderOptions{
+		reporter: reporter.CreateReporter(),
+		args:     NewCreateLogForwarderUserOptions(),
+	}
+}
+
+func (i *CreateLogForwarderOptions) Bind(args *CreateLogForwarderUserOptions) error {
+	i.args.logFwdConfig = args.logFwdConfig
+	return nil
+}

--- a/cmd/create/logforwarder/options_test.go
+++ b/cmd/create/logforwarder/options_test.go
@@ -1,0 +1,38 @@
+package logforwarder
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("CreateLogForwarderOptions", func() {
+	var (
+		logForwarderOptions *CreateLogForwarderOptions
+		userOptions         *CreateLogForwarderUserOptions
+	)
+
+	BeforeEach(func() {
+		logForwarderOptions = NewCreateLogForwarderOptions()
+		userOptions = NewCreateLogForwarderUserOptions()
+	})
+
+	Context("Bind", func() {
+		It("should bind user options correctly", func() {
+			userOptions.logFwdConfig = "test-config.yml"
+
+			err := logForwarderOptions.Bind(userOptions)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(logForwarderOptions.args.logFwdConfig).To(Equal("test-config.yml"))
+		})
+
+		It("should handle empty config file path", func() {
+			userOptions.logFwdConfig = ""
+
+			err := logForwarderOptions.Bind(userOptions)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(logForwarderOptions.args.logFwdConfig).To(Equal(""))
+		})
+	})
+})

--- a/cmd/rosa/structure_test/command_args/rosa/create/log-forwarder/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/create/log-forwarder/command_args.yml
@@ -1,0 +1,3 @@
+- name: cluster
+- name: interactive
+- name: log-fwd-config

--- a/cmd/rosa/structure_test/command_structure.yml
+++ b/cmd/rosa/structure_test/command_structure.yml
@@ -24,6 +24,7 @@ children:
     - name: iamserviceaccount
     - name: image-mirror
     - name: kubeletconfig
+    - name: log-forwarder
     - name: machinepool
     - name: ocm-role
     - name: oidc-config

--- a/pkg/logforwarding/helpers.go
+++ b/pkg/logforwarding/helpers.go
@@ -11,6 +11,18 @@ import (
 
 // FlagName contains the common log forwarding config command flag name
 const FlagName = "log-fwd-config"
+const LogFwdConfigHelpMessage = "A path to a log forwarding config file. This should be a YAML file with the" +
+	" following structure:\n\n" +
+	"cloudwatch:\n" +
+	"  cloudwatch_log_role_arn: \"role_arn_here\"\n" +
+	"  cloudwatch_log_group_name: \"group_name_here\"\n" +
+	"  applications: [\"example_app_1\", \"example_app_2\"]\n" +
+	"  groups: [\"group-name\", \"group_name-2\"]\n" +
+	"s3:\n" +
+	"  s3_config_bucket_name: \"bucket_name_here\"\n" +
+	"  s3_config_bucket_prefix: \"bucket_prefix_here\"\n" +
+	"  applications: [\"example_app_1\", \"example_app_2\"]\n" +
+	"  groups: [\"group-name\"]"
 
 // S3LogForwarderConfig represents the log forward config for S3
 type S3LogForwarderConfig struct {


### PR DESCRIPTION
```bash
❯ ./rosa create log-forwarder -c hk5
? Enabled log forwarding (optional, choose 'Skip' to skip selection; ): CloudWatch
? CloudWatch Log forwarding role ARN: test
? CloudWatch log group name: t
? CloudWatch Log forwarding pod groups: api, authentication, controller manager
? CloudWatch Log forwarding applications (optional):
E: failed to create log forwarder: status is 400, identifier is '400', code is 'CLUSTERS-MGMT-400', at '2025-12-12T19:20:54Z' and operation identifier is 'ec32cbdf-9e35-4e76-8f34-10de66fc5e02': Log distribution role does not exist or is not accessible


❯ ./rosa create log-forwarder -c hk5
? Enabled log forwarding (optional, choose 'Skip' to skip selection; ): S3
? S3 Bucket prefix (optional):
? S3 Bucket name: log-fwd-test
? S3 Log forwarding pod groups: authentication, controller manager, scheduler
? S3 Log forwarding applications (optional):
E: failed to create log forwarder: status is 409, identifier is '409', code is 'CLUSTERS-MGMT-409', at '2025-12-12T19:21:07Z' and operation identifier is '46016f3d-3e96-4f74-919a-4d4fcfd90ce5': A log forwarder of type 's3' already exists for this cluster. Only one log forwarder per type is allowed.



❯ ./rosa create log-forwarder -c hk5 --log-fwd-config ../test.yaml
E: failed to create log forwarder: status is 409, identifier is '409', code is 'CLUSTERS-MGMT-409', at '2025-12-12T19:30:06Z' and operation identifier is '328916db-7629-42c3-b025-824699638295': A log forwarder of type 's3' already exists for this cluster. Only one log forwarder per type is allowed.
```

**Basic creation command which leverages previously-made interactive prompts for minimal code changes**

All of the functions used are already tested, only real thing happening otherwise is sending the payload to the API. I argue therefore that it's almost useless for me to write a E2E test here with mocking due to the _**time contraint**_ as well as the _**functionality of the test**_ which would just be making sure we sent the right API object.. And it's already _**obvious**_ that we are sending the right API object since we are using the OCM SDK