### PR TITLE
OCM-21154 | feat: Delete command for logforwarders

### DIFF
--- a/cmd/dlt/cmd.go
+++ b/cmd/dlt/cmd.go
@@ -30,6 +30,7 @@ import (
 	"github.com/openshift/rosa/cmd/dlt/imagemirror"
 	"github.com/openshift/rosa/cmd/dlt/ingress"
 	"github.com/openshift/rosa/cmd/dlt/kubeletconfig"
+	"github.com/openshift/rosa/cmd/dlt/logforwarder"
 	"github.com/openshift/rosa/cmd/dlt/machinepool"
 	"github.com/openshift/rosa/cmd/dlt/ocmrole"
 	"github.com/openshift/rosa/cmd/dlt/oidcconfig"
@@ -75,6 +76,8 @@ func init() {
 	Cmd.AddCommand(kubeletconfig)
 	imageMirrorCommand := imagemirror.NewDeleteImageMirrorCommand()
 	Cmd.AddCommand(imageMirrorCommand)
+	logForwarderCommand := logforwarder.NewDeleteLogForwarderCommand()
+	Cmd.AddCommand(logForwarderCommand)
 	Cmd.AddCommand(externalauthprovider.Cmd)
 
 	flags := Cmd.PersistentFlags()
@@ -88,7 +91,7 @@ func init() {
 		oidcprovider.Cmd, upgrade.Cmd, admin.Cmd,
 		service.Cmd, autoscalerCommand, iamserviceaccount.Cmd, idp.Cmd,
 		imageMirrorCommand, cluster.Cmd, dnsdomains.Cmd, externalauthprovider.Cmd,
-		kubeletconfig, machinepoolCommand, tuningconfigs.Cmd,
+		kubeletconfig, machinepoolCommand, tuningconfigs.Cmd, logForwarderCommand,
 	}
 	arguments.MarkRegionDeprecated(Cmd, globallyAvailableCommands)
 }

--- a/cmd/dlt/logforwarder/cmd.go
+++ b/cmd/dlt/logforwarder/cmd.go
@@ -1,0 +1,113 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logforwarder
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/interactive/confirm"
+	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+const (
+	use     = "log-forwarder -c <cluster-id> <log-forwarder-id>"
+	short   = "Delete log forwarder"
+	long    = "Delete a log forwarder from a cluster."
+	example = `  # Delete log forwarder with ID 'example-id' from a cluster named 'mycluster-hcp'
+  rosa delete log-forwarder --cluster=mycluster-hcp example-id`
+)
+
+var (
+	aliases = []string{"log_forwarder", "log-forwarder", "logforwarder"}
+)
+
+var logForwarderKeyRE = regexp.MustCompile(`^[a-z0-9]+$`)
+
+func NewDeleteLogForwarderCommand() *cobra.Command {
+	options := NewDeleteLogForwarderUserOptions()
+	cmd := &cobra.Command{
+		Use:     use,
+		Aliases: aliases,
+		Short:   short,
+		Long:    long,
+		Example: example,
+		Run:     rosa.DefaultRunner(rosa.RuntimeWithOCM(), DeleteLogForwarderRunner(options)),
+		Args:    cobra.MaximumNArgs(1),
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(
+		&options.logForwarder,
+		"log-forwarder",
+		"",
+		"Log forwarder ID to delete",
+	)
+
+	ocm.AddClusterFlag(cmd)
+	confirm.AddFlag(flags)
+	return cmd
+}
+
+func DeleteLogForwarderRunner(userOptions *DeleteLogForwarderUserOptions) rosa.CommandRunner {
+	return func(_ context.Context, runtime *rosa.Runtime, cmd *cobra.Command, argv []string) error {
+		options := NewDeleteLogForwarderOptions()
+
+		err := options.Bind(userOptions, argv)
+		if err != nil {
+			return err
+		}
+
+		clusterKey := runtime.GetClusterKey()
+		cluster, err := runtime.OCMClient.GetCluster(clusterKey, runtime.Creator)
+		if err != nil {
+			return err
+		}
+		if cluster.State() != cmv1.ClusterStateReady {
+			return fmt.Errorf("cluster '%s' is not yet ready", clusterKey)
+		}
+
+		logForwarder, err := runtime.OCMClient.GetLogForwarderByID(cluster.ID(), options.LogForwarder())
+		if err != nil {
+			return fmt.Errorf("failed to get log forwarder '%s': %v", options.LogForwarder(), err)
+		}
+		if logForwarder == nil {
+			return fmt.Errorf("log forwarder '%s' not found", options.LogForwarder())
+		}
+
+		if !confirm.Confirm("delete log forwarder '%s'?", options.LogForwarder()) {
+			return nil
+		}
+
+		runtime.Reporter.Debugf("Deleting log forwarder '%s' for cluster '%s'", options.LogForwarder(),
+			clusterKey)
+
+		err = runtime.OCMClient.DeleteLogForwarder(cluster.ID(), options.LogForwarder())
+		if err != nil {
+			return fmt.Errorf("failed to delete log forwarder '%s': %v", options.LogForwarder(), err)
+		}
+
+		runtime.Reporter.Infof("Successfully deleted log forwarder '%s' from cluster '%s'",
+			options.LogForwarder(), clusterKey)
+		return nil
+	}
+}

--- a/cmd/dlt/logforwarder/cmd_test.go
+++ b/cmd/dlt/logforwarder/cmd_test.go
@@ -1,0 +1,109 @@
+package logforwarder
+
+import (
+	"context"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+
+	"github.com/openshift/rosa/pkg/output"
+	. "github.com/openshift/rosa/pkg/test"
+)
+
+var _ = Describe("delete logforwarder", func() {
+
+	It("Correctly builds the command", func() {
+		cmd := NewDeleteLogForwarderCommand()
+		Expect(cmd).NotTo(BeNil())
+
+		Expect(cmd.Use).To(Equal(use))
+		Expect(cmd.Short).To(Equal(short))
+		Expect(cmd.Long).To(Equal(long))
+		Expect(cmd.Run).NotTo(BeNil())
+
+		Expect(cmd.Flags().Lookup("cluster")).NotTo(BeNil())
+		Expect(cmd.Flags().Lookup("log-forwarder")).NotTo(BeNil())
+		Expect(cmd.Flags().Lookup("yes")).NotTo(BeNil())
+	})
+
+	Context("Delete LogForwarder Runner", func() {
+
+		var t *TestingRuntime
+
+		BeforeEach(func() {
+			t = NewTestRuntime()
+			output.SetOutput("")
+		})
+
+		AfterEach(func() {
+			output.SetOutput("")
+		})
+
+		It("Returns an error if the cluster does not exist", func() {
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, FormatClusterList(make([]*cmv1.Cluster, 0))))
+			t.SetCluster("cluster", nil)
+
+			userOptions := NewDeleteLogForwarderUserOptions()
+			userOptions.logForwarder = "testid123"
+
+			runner := DeleteLogForwarderRunner(userOptions)
+			err := runner(context.Background(), t.RosaRuntime, nil, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("There is no cluster with identifier or name 'cluster'"))
+		})
+
+		It("Returns an error if the cluster is not ready", func() {
+			cluster := MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateInstalling)
+			})
+
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, FormatClusterList([]*cmv1.Cluster{cluster})))
+			t.SetCluster("cluster", cluster)
+
+			userOptions := NewDeleteLogForwarderUserOptions()
+			userOptions.logForwarder = "testid123"
+
+			runner := DeleteLogForwarderRunner(userOptions)
+			err := runner(context.Background(), t.RosaRuntime, nil, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cluster 'cluster' is not yet ready"))
+		})
+
+		It("Returns an error if log forwarder ID is not provided", func() {
+			cluster := MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateReady)
+			})
+
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, FormatClusterList([]*cmv1.Cluster{cluster})))
+			t.SetCluster("cluster", cluster)
+
+			userOptions := NewDeleteLogForwarderUserOptions()
+
+			runner := DeleteLogForwarderRunner(userOptions)
+			err := runner(context.Background(), t.RosaRuntime, nil, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("you must specify a log forwarder ID with '--log-forwarder'"))
+		})
+
+		It("Returns an error if log forwarder ID has invalid format", func() {
+			cluster := MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateReady)
+			})
+
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, FormatClusterList([]*cmv1.Cluster{cluster})))
+			t.SetCluster("cluster", cluster)
+
+			userOptions := NewDeleteLogForwarderUserOptions()
+			userOptions.logForwarder = "Invalid-ID"
+
+			runner := DeleteLogForwarderRunner(userOptions)
+			err := runner(context.Background(), t.RosaRuntime, nil, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("log forwarder ID 'Invalid-ID' is not valid: it must " +
+				"contain only lowercase letters and digits"))
+		})
+	})
+})

--- a/cmd/dlt/logforwarder/logforwarder_suite_test.go
+++ b/cmd/dlt/logforwarder/logforwarder_suite_test.go
@@ -1,0 +1,13 @@
+package logforwarder
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestLogForwarder(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Delete LogForwarder Suite")
+}

--- a/cmd/dlt/logforwarder/options.go
+++ b/cmd/dlt/logforwarder/options.go
@@ -1,0 +1,52 @@
+package logforwarder
+
+import (
+	"fmt"
+
+	"github.com/openshift/rosa/pkg/reporter"
+)
+
+type DeleteLogForwarderUserOptions struct {
+	logForwarder string
+}
+
+type DeleteLogForwarderOptions struct {
+	reporter reporter.Logger
+
+	args *DeleteLogForwarderUserOptions
+}
+
+func NewDeleteLogForwarderUserOptions() *DeleteLogForwarderUserOptions {
+	return &DeleteLogForwarderUserOptions{logForwarder: ""}
+}
+
+func NewDeleteLogForwarderOptions() *DeleteLogForwarderOptions {
+	return &DeleteLogForwarderOptions{
+		reporter: reporter.CreateReporter(),
+		args:     &DeleteLogForwarderUserOptions{},
+	}
+}
+
+func (l *DeleteLogForwarderOptions) LogForwarder() string {
+	return l.args.logForwarder
+}
+
+func (l *DeleteLogForwarderOptions) Bind(args *DeleteLogForwarderUserOptions, argv []string) error {
+	l.args = args
+	if l.LogForwarder() == "" {
+		if len(argv) > 0 {
+			l.args.logForwarder = argv[0]
+		}
+	}
+	if args.logForwarder == "" {
+		return fmt.Errorf("you must specify a log forwarder ID with '--log-forwarder'")
+	}
+	if !logForwarderKeyRE.MatchString(args.logForwarder) {
+		return fmt.Errorf(
+			"log forwarder ID '%s' is not valid: it must contain only lowercase letters and digits",
+			args.logForwarder,
+		)
+	}
+	l.args.logForwarder = args.logForwarder
+	return nil
+}

--- a/cmd/rosa/structure_test/command_args/rosa/delete/log-forwarder/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/delete/log-forwarder/command_args.yml
@@ -1,0 +1,5 @@
+- name: cluster
+- name: profile
+- name: region
+- name: log-forwarder
+- name: "yes"

--- a/cmd/rosa/structure_test/command_structure.yml
+++ b/cmd/rosa/structure_test/command_structure.yml
@@ -47,6 +47,7 @@ children:
     - name: image-mirror
     - name: ingress
     - name: kubeletconfig
+    - name: log-forwarder
     - name: machinepool
     - name: ocm-role
     - name: oidc-config

--- a/pkg/ocm/log_forwards.go
+++ b/pkg/ocm/log_forwards.go
@@ -112,6 +112,20 @@ func (c *Client) SetLogForwarder(clusterID string,
 	return response.Body(), nil
 }
 
+func (c *Client) DeleteLogForwarder(clusterID string, logForwarderID string) error {
+	response, err := c.ocm.ClustersMgmt().V1().
+		Clusters().Cluster(clusterID).
+		ControlPlane().
+		LogForwarders().
+		LogForwarder(logForwarderID).
+		Delete().
+		Send()
+	if err != nil {
+		return handleErr(response.Error(), err)
+	}
+	return nil
+}
+
 func (c *Client) GetLogForwarderGroupVersions() ([]*cmv1.LogForwarderGroupVersions, error) {
 	response, err := c.ocm.ClustersMgmt().V1().LogForwarding().Groups().List().Send()
 	if err != nil {


### PR DESCRIPTION
```bash
❯ ./rosa delete log-forwarder -c hk5 2n4b8f8ai80cs6kmjmdgqlqplh73r411
? Are you sure you want to delete log forwarder '2n4b8f8ai80cs6kmjmdgqlqplh73r411'?? No
❯ ./rosa delete log-forwarder -c hk5 2n4b8f8ai80cs6kmjmdgqlqplh73r411
? Are you sure you want to delete log forwarder '2n4b8f8ai80cs6kmjmdgqlqplh73r411'?? Yes
I: Successfully deleted log forwarder '2n4b8f8ai80cs6kmjmdgqlqplh73r411' from cluster 'hk5'
❯ ./rosa delete log-forwarder -c hk5 2n4b8f8ai80cs6kmjmdgqlqplh73r411 -y
E: log forwarder '2n4b8f8ai80cs6kmjmdgqlqplh73r411' not found
```

Then, negative cases for not supplying flags needed:
```bash
❯ ./rosa delete log-forwarder -c hk5
E: you must specify a log forwarder ID with '--log-forwarder'
❯ ./rosa delete log-forwarder 2n4b8f8ai80cs6kmjmdgqlqplh73r411
Error: required flag(s) "cluster" not set
Usage:
  rosa delete log-forwarder -c <cluster-id> <log-forwarder-id> [flags]

Aliases:
  log-forwarder, log_forwarder, logforwarder

Examples:
  # Delete log forwarder with ID 'example-id' from a cluster named 'mycluster-hcp'
  rosa delete log-forwarder --cluster=mycluster-hcp example-id

Flags:
  -c, --cluster string         Name or ID of the cluster.
  -h, --help                   help for log-forwarder
      --log-forwarder string   Log forwarder ID to delete
  -y, --yes                    Automatically answer yes to confirm operation.

Global Flags:
      --color string     Surround certain characters with escape sequences to display them in color on the terminal. Allowed options are [auto never always] (default "auto")
      --debug            Enable debug mode.
      --profile string   Use a specific AWS profile from your credential file.
      --region string    Use a specific AWS region, overriding the AWS_REGION environment variable.

Failed to execute root command: required flag(s) "cluster" not set
```

