### PR TITLE
OCM-21381 | fix: Change regex to support new ID convention

### DIFF
--- a/cmd/describe/logforwarders/cmd.go
+++ b/cmd/describe/logforwarders/cmd.go
@@ -20,7 +20,7 @@ const (
 	example = `rosa describe log-forwarder <log_fwd_id> -c mycluster-hcp`
 )
 
-var logForwarderKeyRE = regexp.MustCompile(`^[a-z0-9]+$`)
+var logForwarderKeyRE = regexp.MustCompile(`^[a-z-0-9]+$`)
 
 func NewDescribeLogForwarderCommand() *cobra.Command {
 	options := NewDescribeLogForwarderUserOptions()

--- a/cmd/dlt/logforwarder/cmd.go
+++ b/cmd/dlt/logforwarder/cmd.go
@@ -41,7 +41,7 @@ var (
 	aliases = []string{"log_forwarder", "log-forwarder", "logforwarder"}
 )
 
-var logForwarderKeyRE = regexp.MustCompile(`^[a-z0-9]+$`)
+var logForwarderKeyRE = regexp.MustCompile(`^[a-z-0-9]+$`)
 
 func NewDeleteLogForwarderCommand() *cobra.Command {
 	options := NewDeleteLogForwarderUserOptions()


### PR DESCRIPTION
Some reason the IDs were changed in the API today from `normal cluster-style` IDs to `External ID` style IDs

IE it went from `2n4b8f8ai80cs6kmjmdgqlqplh73r411` to `8ea363cb-85b7-44ee-a834-ade89d9adbd2`

This MR adds new regex to satisfy this unexpected change

the new regex is backwards compatible with the old ID convention, so there's no risk with this change if it is deemed a bug in the API and changed back