### PR TITLE
OCM-21402 | fix: Edit/logforwarder always use CW/S3 yaml fields

### DIFF
--- a/pkg/ocm/log_forwards_test.go
+++ b/pkg/ocm/log_forwards_test.go
@@ -199,7 +199,7 @@ var _ = Describe("EditLogForwarder", func() {
 		It("Should handle empty config", func() {
 			client := Client{}
 			emptyConfig := logforwarding.LogForwarderYaml{}
-			err := client.EditLogForwarder("cluster-123", "log-fwd-123", emptyConfig)
+			err := client.EditLogForwarder("cluster-123", "log-fwd-123", emptyConfig, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring(
 				"log forwarding config provided contained no valid log forwarders"))


### PR DESCRIPTION
Before this change, when editing a log forwarder via a YAML config file, here is the results:

```bash
time=2025-12-15T06:06:14-05:00 level=debug msg={
  "kind": "LogForwarder",
  "s3": {

  },
  "applications": [

  ],
  "groups": [
    {
      "id": "api"
    }
  ]
}
...
E: failed to edit log forwarder '2n6pdquktalfq5efvdpvaeo0ojm41bct' for cluster '2n6pdpibh23esr1bruk2mvrco71jb4dp': status is 400, identifier is '400', code is 'CLUSTERS-MGMT-400', at '2025-12-15T11:06:14Z' and operation identifier is 'f0df525b-f0eb-4af0-af1f-34d89c2055fc': S3 bucket name is required
```

^ The S3 bucket name did not change in my yaml file, because of this, it was ignored

The equality check has been removed, in favor of always passing the S3/CW specific fields (this is not the case for applications + groups). In place of this equality check, the interactive mode now has defaults for the S3/CW specific fields based on your _**current log forwarder's S3/CW specific fields which you are editing**_. This way, you should always be sending the correct data to the edit endpoint

```bash
time=2025-12-15T06:08:45-05:00 level=debug msg={
  "kind": "LogForwarder",
  "id": "2n6pdquktalfq5efvdpvaeo0ojm41bct",
  "href": "/api/clusters_mgmt/v1/clusters/2n6pdpibh23esr1bruk2mvrco71jb4dp/control_plane/log_forwarders/2n6pdquktalfq5efvdpvaeo0ojm41bct",
  "s3": {
    "bucket_name": "log-fwd-test"
  },
  "groups": [
    {
      "id": "api",
      "version": "1.0"
    }
  ],
  "status": {
    "state": "ready",
    "message": "Log forwarding configuration has been applied successfully",
    "resolved_applications": [
      "audit-webhook",
      "kube-apiserver",
      "oauth-openshift",
      "openshift-apiserver",
      "openshift-oauth-apiserver",
      "packageserver",
      "validation-webhook"
    ]
  },
  "cluster_id": "2n6pdpibh23esr1bruk2mvrco71jb4dp"
}
I: Successfully edited log forwarder '2n6pdquktalfq5efvdpvaeo0ojm41bct' for cluster '2n6pdpibh23esr1bruk2mvrco71jb4dp'
```

**INTERACTIVE MODE EXAMPLE:**

The `S3 Bucket name` prompt had `log-fwd-test` as a default value, which is correct

```bash
❯ ./rosa edit log-forwarder 2n6pdquktalfq5efvdpvaeo0ojm41bct -c hk
? S3 Bucket prefix (optional):
? S3 Bucket name: log-fwd-test
? S3 Log forwarding pod groups (optional):
? S3 Log forwarding applications: audit-webhook
I: Successfully edited log forwarder '2n6pdquktalfq5efvdpvaeo0ojm41bct' for cluster '2n6pdpibh23esr1bruk2mvrco71jb4dp'
```

* Another bug this fixes, was the fact that I never included the S3 and CW builders in the logforwarderBuilder within the edit command; which would have also caused issues even with the other fix
