### PR TITLE
OCM-21426 | fix: Allow both S3 and CW day2 create

### DIFF
--- a/cmd/create/logforwarder/cmd.go
+++ b/cmd/create/logforwarder/cmd.go
@@ -127,9 +127,11 @@ func CreateLogForwarderRunner(userOptions *CreateLogForwarderUserOptions) rosa.C
 		var logForwarderBuilder *cmv1.LogForwarderBuilder
 		if logFwdS3ConfigObject != nil {
 			logForwarderBuilder = logforwarding.BindS3LogForwarder(logFwdS3ConfigObject)
-		} else if logFwdCloudWatchConfigObject != nil {
+		}
+		if logFwdCloudWatchConfigObject != nil {
 			logForwarderBuilder = logforwarding.BindCloudWatchLogForwarder(logFwdCloudWatchConfigObject)
-		} else {
+		}
+		if logForwarderBuilder == nil {
 			return fmt.Errorf("no proper log forwarding configuration provided")
 		}
 


### PR DESCRIPTION
Originally, the create would favor S3 over CW, only create CW if no S3 config was provided for both the YAML and interactive mode