### PR TITLE
OCM-21403 | fix: edit logforwarder from yaml only if same type

### DIFF
--- a/pkg/ocm/log_forwards.go
+++ b/pkg/ocm/log_forwards.go
@@ -191,7 +191,7 @@ func (c *Client) EditLogForwarder(clusterId string, logForwarderId string,
 
 	var logForwarderConfig *cmv1.LogForwarderBuilder
 
-	if logForwarderYaml.S3 != nil {
+	if currentLogForwarder.S3() != nil && currentLogForwarder.S3().BucketName() != "" {
 		logForwarderConfigBuilder := cmv1.NewLogForwarder()
 		logForwarderS3ConfigBuilder := cmv1.NewLogForwarderS3Config()
 
@@ -213,7 +213,9 @@ func (c *Client) EditLogForwarder(clusterId string, logForwarderId string,
 
 		logForwarderConfigBuilder.S3(logForwarderS3ConfigBuilder)
 		logForwarderConfig = logForwarderConfigBuilder
-	} else if logForwarderYaml.CloudWatch != nil {
+	} else if currentLogForwarder.Cloudwatch() != nil && currentLogForwarder.Cloudwatch().
+		LogDistributionRoleArn() != "" {
+
 		logForwarderConfigBuilder := cmv1.NewLogForwarder()
 		logForwarderCWConfigBuilder := cmv1.NewLogForwarderCloudWatchConfig()
 


### PR DESCRIPTION
Uses the current log forwarder to determine which one to edit, rather than using the yaml file or user inputs themselves. This makes it so you can use the same yaml config you used when making 2 log forwarders that were S3 and CW when editing with no issues.