### PR TITLE
OCM-21435 | feat: Block CapRez in govcloud on a flag level

### DIFF
--- a/pkg/machinepool/machinepool.go
+++ b/pkg/machinepool/machinepool.go
@@ -814,6 +814,11 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 	// Capacity reservation ID
 	capacityReservationId := args.CapacityReservationId
 
+	if capacityReservationId != "" && fedramp.Enabled() {
+		return fmt.Errorf("capacity reservation is not supported in govcloud, please remove " +
+			"'--capacity-reservation-id' and associated flags")
+	}
+
 	if interactive.Enabled() && !autoscaling && !fedramp.Enabled() {
 		capacityReservationId, err = interactive.GetString(interactive.Input{
 			Question: "Capacity Reservation ID",


### PR DESCRIPTION
Validates that the user is not using govcloud when trying to provide a capacity reservation on a new nodepool

it was never allowed, and wouldn't send to the API if supplied, but the user would have no way of knowing