### PR TITLE
OCM-21436 | feat: Disable usage of logfwding on fedramp

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -980,6 +980,12 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
+	if fedramp.Enabled() && args.logFwdConfig != "" {
+		r.Reporter.Errorf("log forwarding is not supported on Govcloud, please remove the '--%s' flag",
+			logforwarding.FlagName)
+		os.Exit(1)
+	}
+
 	for _, val := range userSpecifiedAutoscalerValues {
 		if val.Changed && !args.autoscalingEnabled {
 			r.Reporter.Errorf("Using autoscaling flag '%s', requires flag '--enable-autoscaling'. "+
@@ -2193,7 +2199,7 @@ func run(cmd *cobra.Command, _ []string) {
 	// Log forwarding for HCP:
 	var logFwdS3ConfigObject *logforwarding.S3LogForwarderConfig
 	var logFwdCloudWatchConfigObject *logforwarding.CloudWatchLogForwarderConfig
-	if isHostedCP {
+	if isHostedCP && !fedramp.Enabled() {
 		if args.logFwdConfig != "" {
 			yamlObject, err := logforwarding.UnmarshalLogForwarderConfigYaml(
 				args.logFwdConfig)

--- a/cmd/create/logforwarder/cmd.go
+++ b/cmd/create/logforwarder/cmd.go
@@ -23,6 +23,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/rosa/pkg/fedramp"
 	"github.com/openshift/rosa/pkg/interactive"
 	interactiveLogForwarding "github.com/openshift/rosa/pkg/interactive/logforwarding"
 	"github.com/openshift/rosa/pkg/logforwarding"
@@ -73,6 +74,10 @@ func NewCreateLogForwarderCommand() *cobra.Command {
 func CreateLogForwarderRunner(userOptions *CreateLogForwarderUserOptions) rosa.CommandRunner {
 	return func(_ context.Context, r *rosa.Runtime, cmd *cobra.Command, _ []string) error {
 		options := NewCreateLogForwarderOptions()
+
+		if fedramp.Enabled() {
+			return fmt.Errorf("log forwarding is not supported on Govcloud")
+		}
 
 		err := options.Bind(userOptions)
 		if err != nil {

--- a/cmd/dlt/logforwarder/cmd.go
+++ b/cmd/dlt/logforwarder/cmd.go
@@ -24,6 +24,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/rosa/pkg/fedramp"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/rosa"
@@ -71,6 +72,10 @@ func NewDeleteLogForwarderCommand() *cobra.Command {
 func DeleteLogForwarderRunner(userOptions *DeleteLogForwarderUserOptions) rosa.CommandRunner {
 	return func(_ context.Context, runtime *rosa.Runtime, cmd *cobra.Command, argv []string) error {
 		options := NewDeleteLogForwarderOptions()
+
+		if fedramp.Enabled() {
+			return fmt.Errorf("log forwarding is not supported on Govcloud")
+		}
 
 		err := options.Bind(userOptions, argv)
 		if err != nil {

--- a/cmd/edit/logforwarder/cmd.go
+++ b/cmd/edit/logforwarder/cmd.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/cobra"
 	errors "github.com/zgalor/weberr"
 
+	"github.com/openshift/rosa/pkg/fedramp"
 	interactiveLogForwarding "github.com/openshift/rosa/pkg/interactive/logforwarding"
 	"github.com/openshift/rosa/pkg/logforwarding"
 	"github.com/openshift/rosa/pkg/ocm"
@@ -69,6 +70,10 @@ func NewEditLogForwarderCommand() *cobra.Command {
 func EditLogForwarderRunner(_ context.Context, r *rosa.Runtime, _ *cobra.Command, argv []string) error {
 	if len(argv) != 1 {
 		return fmt.Errorf("expected exactly one argument: log-forwarder ID")
+	}
+
+	if fedramp.Enabled() {
+		return fmt.Errorf("log forwarding is not supported on Govcloud")
 	}
 
 	logFwdID := argv[0]

--- a/cmd/list/logforwarders/cmd.go
+++ b/cmd/list/logforwarders/cmd.go
@@ -25,6 +25,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/rosa/pkg/fedramp"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/rosa"
@@ -59,6 +60,10 @@ func NewListLogForwardersCommand() *cobra.Command {
 func ListLogForwardersRunner() rosa.CommandRunner {
 	return func(_ context.Context, runtime *rosa.Runtime, cmd *cobra.Command, _ []string) error {
 		clusterKey := runtime.GetClusterKey()
+
+		if fedramp.Enabled() {
+			return fmt.Errorf("log forwarding is not supported on Govcloud")
+		}
 
 		cluster, err := runtime.OCMClient.GetCluster(clusterKey, runtime.Creator)
 		if err != nil {


### PR DESCRIPTION
Blocks usage of logfwding on fedramp with validations returned to the user