### PR TITLE
OCM-21010 | chore: Prepare CLI 1.2.58 for release

### DIFF
--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,7 +18,7 @@ limitations under the License.
 
 package info
 
-const DefaultVersion = "1.2.57"
+const DefaultVersion = "1.2.58"
 
 // Build contains the short Git SHA of the CLI at the point it was build. Set via `-ldflags` at build time
 var Build = "local"


### PR DESCRIPTION
Update info.go to prepare for 1.2.58 release