### PR TITLE
OCM-21522 | test: automate ids: 86448,86415 day1 and day2 log forwarder config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.15 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.5 // indirect
-	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.35.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.35.1
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.3.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.7 // indirect

--- a/tests/ci/data/profiles/rosa-hcp.yaml
+++ b/tests/ci/data/profiles/rosa-hcp.yaml
@@ -33,6 +33,7 @@ profiles:
     registries_config: true
     allowed_registries: true
     billing_account: "487962084830"
+    log_forward: true
   account-role:
     customized_prefix: true
     path: ""

--- a/tests/utils/exec/rosacli/cmd_client.go
+++ b/tests/utils/exec/rosacli/cmd_client.go
@@ -50,6 +50,7 @@ type Client struct {
 	Upgrade              UpgradeService
 	Verify               VerifyService
 	Version              VersionService
+	LogForwarderService  LogForwarderService
 }
 
 func NewClient() *Client {
@@ -82,6 +83,7 @@ func NewClient() *Client {
 	client.Upgrade = NewUpgradeService(client)
 	client.Verify = NewVerifyService(client)
 	client.Version = NewVersionService(client)
+	client.LogForwarderService = NewLogForwarderService(client)
 
 	return client
 }

--- a/tests/utils/exec/rosacli/log_forwarder_service.go
+++ b/tests/utils/exec/rosacli/log_forwarder_service.go
@@ -1,0 +1,99 @@
+package rosacli
+
+import (
+	"bytes"
+)
+
+type LogForwarderService interface {
+	DescribeLogForwarder(clusterID string, flags ...string) (bytes.Buffer, error)
+	ListLogForwarder(clusterID string, flags ...string) (bytes.Buffer, error)
+	CreateLogForwarder(clusterName string, flags ...string) (bytes.Buffer, error)
+	DeleteLogForwarder(clusterID string, flags ...string) (bytes.Buffer, error)
+	EditLogForwarder(clusterID string, flags ...string) (bytes.Buffer, error)
+	ReflectLogForwarderList(result bytes.Buffer) (logForwardersList *LogForwarderList, err error)
+}
+
+type logForwarderService struct {
+	ResourcesService
+}
+
+func NewLogForwarderService(client *Client) LogForwarderService {
+	return &logForwarderService{
+		ResourcesService: ResourcesService{
+			client: client,
+		},
+	}
+}
+
+// Struct for the 'rosa list log-forwarders' output
+type LogForwarderListItem struct {
+	ID     string `yaml:"ID,omitempty"`
+	Type   string `yaml:"TYPE,omitempty"`
+	Status string `yaml:"STATUS,omitempty"`
+}
+type LogForwarderList struct {
+	LogForwarders []*LogForwarderListItem `yaml:"LogForwarders,omitempty"`
+}
+
+func (l *logForwarderService) DescribeLogForwarder(clusterID string, flags ...string) (bytes.Buffer, error) {
+	combflags := append([]string{"-c", clusterID}, flags...)
+	describe := l.client.Runner.
+		Cmd("describe", "log-forwarder").
+		CmdFlags(combflags...)
+	return describe.Run()
+}
+
+func (l *logForwarderService) ListLogForwarder(clusterID string, flags ...string) (bytes.Buffer, error) {
+	combflags := append([]string{"-c", clusterID}, flags...)
+	list := l.client.Runner.Cmd("list", "log-forwarders").CmdFlags(combflags...)
+	return list.Run()
+}
+
+func (l *logForwarderService) CreateLogForwarder(clusterName string, flags ...string) (bytes.Buffer, error) {
+	combflags := append([]string{"-c", clusterName}, flags...)
+	createCommand := l.client.Runner.
+		Cmd("create", "log-forwarder").
+		CmdFlags(combflags...)
+	output, err := createCommand.Run()
+	return output, err
+}
+
+func (l *logForwarderService) DeleteLogForwarder(clusterID string, flags ...string) (bytes.Buffer, error) {
+	combflags := append([]string{"-c", clusterID}, flags...)
+	deleteCluster := l.client.Runner.
+		Cmd("delete", "log-forwarder").
+		CmdFlags(combflags...)
+	return deleteCluster.Run()
+}
+
+func (l *logForwarderService) EditLogForwarder(clusterID string, flags ...string) (bytes.Buffer, error) {
+	combflags := append([]string{"-c", clusterID}, flags...)
+	editCluster := l.client.Runner.
+		Cmd("edit", "log-forwarder").
+		CmdFlags(combflags...)
+	return editCluster.Run()
+}
+
+func (l *logForwarderService) ReflectLogForwarderList(result bytes.Buffer) (
+	logForwardersList *LogForwarderList, err error) {
+	logForwardersList = &LogForwarderList{}
+	theMap := l.client.Parser.TableData.Input(result).Parse().Output()
+	for _, item := range theMap {
+		logForwarder := &LogForwarderListItem{}
+		err = MapStructure(item, logForwarder)
+		if err != nil {
+			return logForwardersList, err
+		}
+		logForwardersList.LogForwarders = append(logForwardersList.LogForwarders, logForwarder)
+	}
+	return logForwardersList, err
+}
+
+func (logForwardsList LogForwarderList) GetLogForwarderByType(ltype string) (logForwarder *LogForwarderListItem) {
+	for _, lfwd := range logForwardsList.LogForwarders {
+		if lfwd.Type == ltype {
+			return lfwd
+		}
+	}
+	return
+}

--- a/tests/utils/handler/interface.go
+++ b/tests/utils/handler/interface.go
@@ -76,6 +76,7 @@ type ClusterConfig struct {
 	ZeroEgress                    bool   `yaml:"zero_egress" json:"zero_egress,omitempty"`
 	UseLocalCredentials           bool   `yaml:"use_local_credentials,omitempty" json:"use_local_credentials,omitempty"`
 	Add_UnManaged_Tag             bool   `yaml:"add_unmanaged_tag" json:"add_unmanaged_tag,omitempty"`
+	LogForward                    bool   `yaml:"log_forward,omitempty" json:"log_forward,omitempty"`
 }
 
 // Resources will record the resources prepared
@@ -100,11 +101,30 @@ type Resources struct {
 	HCPRoute53ShareRole          string                `json:"hcp_route53_share_role,omitempty"`
 	HCPVPCEndpointShareRole      string                `json:"hcp_vpc_endpoint_share_role,omitempty"`
 	ProxyInstanceID              string                `json:"proxy_instance_id,omitempty"`
+	LogForwardConigs             *LogForwardConigs     `json:"lfw_configs,omitempty" yaml:"lfw_configs,omitempty"`
 }
 
 type FromSharedAWSAccount struct {
 	VPC                 bool `json:"vpc,omitempty"`
 	AdditionalPrincipls bool `json:"additional_principals,omitempty"`
+}
+
+type LogForwardConigs struct {
+	Cloudwatch *CloudWatchLogForward `json:"cloudwatch,omitempty" yaml:"cloudwatch,omitempty"`
+	S3         *S3LogForward         `json:"s3,omitempty" yaml:"s3,omitempty"`
+}
+type S3LogForward struct {
+	Applications         []string `json:"applications,omitempty" yaml:"applications,omitempty"`
+	Groups               []string `json:"groups,omitempty" yaml:"groups,omitempty"`
+	S3ConfigBucketName   string   `json:"s3_config_bucket_name,omitempty" yaml:"s3_config_bucket_name,omitempty"`
+	S3ConfigBucketPrefix string   `json:"s3_config_bucket_prefix,omitempty" yaml:"s3_config_bucket_prefix,omitempty"`
+}
+
+type CloudWatchLogForward struct {
+	CloudwatchLogRoleArn   string   `json:"cloudwatch_log_role_arn,omitempty" yaml:"cloudwatch_log_role_arn,omitempty"`
+	CloudwatchLogGroupName string   `json:"cloudwatch_log_group_name,omitempty" yaml:"cloudwatch_log_group_name,omitempty"`
+	Applications           []string `json:"applications,omitempty" yaml:"applications,omitempty"`
+	Groups                 []string `json:"groups,omitempty" yaml:"groups,omitempty"`
 }
 
 // ClusterDetail will record basic cluster info to support other team's testing

--- a/tests/utils/handler/resources_handler_clean.go
+++ b/tests/utils/handler/resources_handler_clean.go
@@ -62,6 +62,15 @@ func (rh *resourcesHandler) DeleteAuditLogRoleArn() error {
 	return awsClent.DeleteRoleAndPolicy(roleName, false)
 }
 
+func (rh *resourcesHandler) DeleteCWLogForwardRoleArn() error {
+	roleName := strings.Split(rh.resources.LogForwardConigs.Cloudwatch.CloudwatchLogRoleArn, "/")[1]
+	awsClent, err := rh.GetAWSClient(false)
+	if err != nil {
+		return err
+	}
+	return awsClent.DeleteRoleAndPolicy(roleName, false)
+}
+
 func (rh *resourcesHandler) DeleteHostedZone(hostedZoneID string) error {
 	awsClient, err := rh.GetAWSClient(true)
 	if err != nil {


### PR DESCRIPTION
Add e2e automation for day1 and day2 operations of log forwarder config.

- Create cluster with log forwarding config as day1
- post check for the log forwarding config
- Create/Delete/List/Describe/Edit log forwarders
- Add resource destroy steps for log forwarders resources,used in tear_down job step
- Fix some lint error

logs: https://privatebin.corp.redhat.com/?045350fc049c546e#93We9La5FVn8X1joVUU8gpyTvDetPiV6GbE9n5wiAap2