### PR TITLE
OSDOCS-17762 | docs: Add intro text to clibyexample template

### DIFF
--- a/templates/clibyexample/template
+++ b/templates/clibyexample/template
@@ -3,6 +3,11 @@
 [id="rosa-cli-commands_{context}"]
 = ROSA CLI commands
 
+[role="_abstract"]
+This reference provides descriptions and example commands for ROSA CLI (`rosa`) commands.
+
+Run `rosa -h` to list all commands or run `rosa <command> --help` to get additional details for a specific command.
+
 {{range .Items}}
 
 == {{.FullName}}


### PR DESCRIPTION
This adds intro text for the template that's used to generate the ROSA CLI command ref documentation.