### PR TITLE
OCM-21584 | test: Improve id:72899 expiration date check

### DIFF
--- a/tests/e2e/hcp_external_auth_test.go
+++ b/tests/e2e/hcp_external_auth_test.go
@@ -82,9 +82,9 @@ var _ = Describe("External auth provider", labels.Feature.ExternalAuthProvider, 
 					By("Create a break-glass-credential to the cluster")
 					resp, err = rosaClient.BreakGlassCredential.CreateBreakGlassCredential(clusterID, value...)
 					createTime := time.Now().UTC()
-					expiredTime := createTime.Add(15 * time.Minute).Format("Jan _2 2006 15:04 MST")
+					expiredTime := createTime.Add(15 * time.Minute)
 					if key == "emptyExpiration" || key == "empty" {
-						expiredTime = createTime.Add(24 * time.Hour).Format("Jan _2 2006 15:04 MST")
+						expiredTime = createTime.Add(24 * time.Hour)
 					}
 					Expect(err).ToNot(HaveOccurred())
 					textData := rosaClient.Parser.TextData.Input(resp).Parse().Tip()
@@ -118,11 +118,10 @@ var _ = Describe("External auth provider", labels.Feature.ExternalAuthProvider, 
 					By("Describe the break-glass-credential")
 					output, err := rosaClient.BreakGlassCredential.DescribeBreakGlassCredentialsAndReflect(clusterID, breakGlassCredID)
 					Expect(err).ToNot(HaveOccurred())
-					// expiration timestamp changes from 4 to 5 seconds ahead, so have to remove second from time stamp
 					expirationTime, err := time.Parse("Jan _2 2006 15:04:05 MST", output.ExpireAt)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(output.ID).To(Equal(breakGlassCredID))
-					Expect(expirationTime.Format("Jan _2 2006 15:04 MST")).To(Equal(expiredTime))
+					Expect(expirationTime).To(BeTemporally("~", expiredTime, time.Minute))
 					Expect(output.Username).To(Equal(userName))
 					Expect(output.Status).To(Equal("issued"))
 


### PR DESCRIPTION
We were doing the check based on parsing the dates and then comparing the dates as formatted strings, but there's been a couple times where the actual date is off by enough that the minute changes in the formatted string. So, this PR changes it to just compare the delta between the 2 dates and make sure it's within a margin (1 minute for now)

Local logs:
```
TEST_PROFILE="rosa-hcp-external-auth" ginkgo run --timeout 2h --focus "id:72899" tests/e2e
Running Suite: ROSA CLI e2e tests suite - /home/jkeyne/work/repos/rosa/tests/e2e
================================================================================
Random Seed: 1767806788

Will run 1 of 280 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 280 Specs in 219.202 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 279 Skipped
PASS

Ginkgo ran 1 suite in 3m41.135577507s
Test Suite Passed
```