### PR TITLE
OCM-21587 | fix: Removing fedramp checks that prevent setting HCP billing accounts

### DIFF
--- a/cmd/create/cluster/cmd_test.go
+++ b/cmd/create/cluster/cmd_test.go
@@ -481,7 +481,7 @@ var _ = Describe("validateBillingAccount()", func() {
 		wrongBillingAccount := "123"
 		err := ocm.ValidateBillingAccount(wrongBillingAccount)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal("Provided billing account number 123 is not valid. " +
+		Expect(err.Error()).To(Equal("provided billing account number 123 is not valid. " +
 			"Rerun the command with a valid billing account number"))
 	})
 
@@ -489,7 +489,7 @@ var _ = Describe("validateBillingAccount()", func() {
 		wrongBillingAccount := ""
 		err := ocm.ValidateBillingAccount(wrongBillingAccount)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal("A billing account number is required"))
+		Expect(err.Error()).To(Equal("a billing account number is required"))
 	})
 
 })

--- a/cmd/edit/cluster/cmd.go
+++ b/cmd/edit/cluster/cmd.go
@@ -887,12 +887,8 @@ func run(cmd *cobra.Command, _ []string) {
 		if cmd.Flags().Changed("billing-account") {
 			billingAccount = args.billingAccount
 
-			if billingAccount != "" && fedramp.Enabled() {
-				_ = r.Reporter.Errorf("Billing accounts are not supported for govcloud clusters")
-				os.Exit(1)
-			}
 			if billingAccount != "" && !ocm.IsValidAWSAccount(billingAccount) {
-				_ = r.Reporter.Errorf("Provided billing account number %s is not valid. "+
+				_ = r.Reporter.Errorf("provided billing account number %s is not valid. "+
 					"Rerun the command with a valid billing account number", billingAccount)
 				os.Exit(1)
 			}
@@ -900,8 +896,8 @@ func run(cmd *cobra.Command, _ []string) {
 			billingAccount = cluster.AWS().BillingAccountID()
 		}
 
-		if interactive.Enabled() && !fedramp.Enabled() &&
-			(aws.IsHostedCP(cluster) && isClassicBillingCapabilityEnabled) {
+		if interactive.Enabled() &&
+			(aws.IsHostedCP(cluster) || isClassicBillingCapabilityEnabled) {
 			cloudAccounts, err := r.OCMClient.GetBillingAccounts()
 			if err != nil {
 				_ = r.Reporter.Errorf("%s", err)

--- a/pkg/ocm/billing.go
+++ b/pkg/ocm/billing.go
@@ -43,10 +43,10 @@ func (c *Client) GetBillingAccounts() ([]*v1.CloudAccount, error) {
 	}
 
 	if len(billingAccounts) == 0 {
-		return billingAccounts, errors.New("No valid billing account associated." +
+		return billingAccounts, errors.New("no valid billing account associated." +
 			" Go to https://console.aws.amazon.com/rosa/home#/get-started" +
 			" to enable ROSA with HCP for your intended billing account." +
-			" You must have a valid billing account associated to continue.")
+			" You must have a valid billing account associated to continue")
 	}
 
 	return billingAccounts, nil
@@ -101,10 +101,10 @@ func IsValidAWSAccount(account string) bool {
 
 func ValidateBillingAccount(billingAccount string) error {
 	if billingAccount == "" {
-		return fmt.Errorf("A billing account number is required")
+		return fmt.Errorf("a billing account number is required")
 	}
 	if !IsValidAWSAccount(billingAccount) {
-		return fmt.Errorf("Provided billing account number %s is not valid. "+
+		return fmt.Errorf("provided billing account number %s is not valid. "+
 			"Rerun the command with a valid billing account number", billingAccount)
 	}
 	return nil


### PR DESCRIPTION
I tested that I can make a cluster non-interactively with the billing account set (I don't have the logs for that now though...)

I tested that `rosa create cluster -i` shows the billing account selection:
```
❯ ~/work/repos/rosa_fedramp/rosa create cluster -i
I: Interactive mode enabled.
Any optional fields can be left empty and a default will be selected.
? Cluster name: testing
? Domain prefix (optional):
? Deploy cluster with Hosted Control Plane: Yes
? Create cluster admin user: No
? Billing Account:  [Use arrows to move, type to filter, ? for more help]
> REDACTED
```

I tested that I can run `rosa edit cluster` non-interactively and change the billing account (I only have one billing account though, so I can't actually test fully changing it)
```
❯ ~/work/repos/rosa_fedramp/rosa edit cluster -c jkeyne-0107-10 --billing-account REDACTED
I: Updated cluster 'jkeyne-0107-10'

❯ ~/work/repos/rosa_fedramp/rosa edit cluster -c jkeyne-0107-10 --billing-account 123456789012
E: Failed to update cluster: status is 400, identifier is '400', code is 'CLUSTERS-MGMT-400', at '2026-01-07T22:18:45Z' and operation identifier is '8c764f54-38c0-4170-aec4-b3826f35b14b': billing account 123456789012 not linked to organization REDACTED at the aws marketplace
```

I tested that `rosa edit cluster -i` shows the billing account select (also fixed a bug that it checked if both the cluster was an HCP cluster AND that classic billing account are enabled, instead of checking if EITHER is true):
```
❯ ~/work/repos/rosa_fedramp/rosa edit cluster -i -c jkeyne-0107-10
I: Interactive mode enabled.
Any optional fields can be ignored and will not be updated.
? Private cluster, check this command's help for possible impacts: Yes
? Update cluster-wide proxy: No
? Update additional trust bundle: No
? Update additional allowed principals: No
? Enable audit log forwarding to AWS CloudWatch: No
? Update registries config: No
? Enable cluster deletion protection: No
? Update billing account (current = 'REDACTED'):  [Use arrows to move, type to filter, ? for more help]
> REDACTED
```