### PR TITLE
OCM-21625 | test: fix ids: 86415,60688

### DIFF
--- a/tests/e2e/hcp_cluster_test.go
+++ b/tests/e2e/hcp_cluster_test.go
@@ -72,6 +72,9 @@ var _ = Describe("HCP cluster testing",
 					originalCWARN          string
 					originCWLogGroupName   string
 				)
+				if !profile.ClusterConfig.LogForward {
+					Skip("This case is only for the cluster with log forwarder config")
+				}
 				logForwarderService := rosaClient.LogForwarderService
 				By("List log forwarders")
 

--- a/tests/e2e/test_rosacli_cluster.go
+++ b/tests/e2e/test_rosacli_cluster.go
@@ -3728,6 +3728,9 @@ var _ = Describe("Reusing opeartor prefix and oidc config to create clsuter", la
 					"--domain-prefix": "dp60688",
 				})
 			}
+			if profile.ClusterConfig.LogForward {
+				rosalCommand.DeleteFlag("--log-fwd-config", true)
+			}
 
 			By("Reuse the oidc config and operator-roles")
 			stdout, err := rosaClient.Runner.RunCMD(strings.Split(rosalCommand.GetFullCommand(), " "))


### PR DESCRIPTION
86415: Skip if the cluster profile is not enabling log-forwarders to avoid failure in some job, for example [https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-rosa-master-e2e-rosa-hcp-advanced-critical-high-f3/2010041434828181504](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-rosa-master-e2e-rosa-hcp-private-link-critical-high-f3/2009346324889079808)


60688: 60688 is a test case not for log-forwarder feature, remove '--log-fwd-config' from existing command, failure job https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-rosa-master-e2e-rosa-hcp-advanced-critical-high-f3/2010041434828181504

test log on local: https://privatebin.corp.redhat.com/?f2c4a5d875532af5#B8LLMTW8Ni78Vcr3hLqypekEyrRWffsd9VakNyJnp8pg