### PR TITLE
OCM-21873 | ci: To create ocm/user role before cluster in the setup step

### DIFF
--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/rosa/tests/ci/config"
 	"github.com/openshift/rosa/tests/ci/labels"
 	utilConfig "github.com/openshift/rosa/tests/utils/config"
+	"github.com/openshift/rosa/tests/utils/constants"
 	"github.com/openshift/rosa/tests/utils/exec/occli"
 	"github.com/openshift/rosa/tests/utils/exec/rosacli"
 	"github.com/openshift/rosa/tests/utils/handler"
@@ -27,6 +28,12 @@ var _ = Describe("Cluster preparation", labels.Feature.Cluster, func() {
 			profile := handler.LoadProfileYamlFileByENV()
 			clusterHandler, err := handler.NewClusterHandler(client, profile)
 			Expect(err).ToNot(HaveOccurred())
+			//Prepare ocm role and user role before cluster creation
+			_, err = clusterHandler.GetResourcesHandler().PrepareOCMRole(constants.OCMRolePreifx, true, "/test/")
+			Expect(err).ToNot(HaveOccurred())
+			_, err = clusterHandler.GetResourcesHandler().PrepareUserRole(constants.UserRolePreifx, "/test/")
+			Expect(err).ToNot(HaveOccurred())
+
 			err = clusterHandler.CreateCluster(config.Test.GlobalENV.WaitSetupClusterReady)
 			Expect(err).ToNot(HaveOccurred())
 			clusterID := clusterHandler.GetClusterDetail().ClusterID

--- a/tests/utils/constants/general.go
+++ b/tests/utils/constants/general.go
@@ -30,3 +30,8 @@ const (
 	BillingAccount        = "090777400063"
 	ChangedBillingAccount = "487962084830"
 )
+
+const (
+	OCMRolePreifx  = "rosacli-ocm-role"
+	UserRolePreifx = "rosacli-user-role"
+)

--- a/tests/utils/handler/interface.go
+++ b/tests/utils/handler/interface.go
@@ -102,6 +102,8 @@ type Resources struct {
 	HCPVPCEndpointShareRole      string                `json:"hcp_vpc_endpoint_share_role,omitempty"`
 	ProxyInstanceID              string                `json:"proxy_instance_id,omitempty"`
 	LogForwardConigs             *LogForwardConigs     `json:"lfw_configs,omitempty" yaml:"lfw_configs,omitempty"`
+	OCMRoleArn                   string                `json:"ocm_role_arn,omitempty"`
+	UserRoleArn                  string                `json:"user_role_arn,omitempty"`
 }
 
 type FromSharedAWSAccount struct {

--- a/tests/utils/handler/resources_handler.go
+++ b/tests/utils/handler/resources_handler.go
@@ -49,6 +49,13 @@ type ResourcesHandler interface {
 	PrepareAccountRoles(namePrefix string, hcp bool, openshiftVersion string,
 		channelGroup string, path string, permissionsBoundary string, route53RoleARN string,
 		vpcEndpointRoleArn string) (accRoles *rosacli.AccountRolesUnit, err error)
+	PrepareUserRole(
+		userRolePrefix string,
+		path string) (userole *rosacli.UserRole, err error)
+	PrepareOCMRole(
+		ocmRolePrefix string,
+		admin bool,
+		path string) (ocmRole *rosacli.OCMRole, err error)
 	PrepareOperatorRolesByOIDCConfig(
 		namePrefix string,
 		oidcConfigID string,
@@ -323,6 +330,16 @@ func (rh *resourcesHandler) DestroyResources() (errors []error) {
 		}
 	}
 
+	if resources.OCMRoleArn != "" {
+		log.Logger.Infof("Find prepared ocm role with arn: %s", resources.OCMRoleArn)
+		rh.DeleteOCMRole()
+	}
+
+	if resources.UserRoleArn != "" {
+		log.Logger.Infof("Find prepared user role with prefix: %s", resources.UserRoleArn)
+		rh.DeleteUserRole()
+	}
+
 	if resources.LogForwardConigs != nil &&
 		resources.LogForwardConigs.Cloudwatch != nil &&
 		resources.LogForwardConigs.Cloudwatch.CloudwatchLogRoleArn != "" {
@@ -472,6 +489,16 @@ func (rh *resourcesHandler) registerClusterID(clusterID string) error {
 }
 func (rh *resourcesHandler) registerAccountRolesPrefix(accountRolesPrefix string) error {
 	rh.resources.AccountRolesPrefix = accountRolesPrefix
+	return rh.saveToFile()
+}
+
+func (rh *resourcesHandler) registerOCMRoleArn(ocmRoleArn string) error {
+	rh.resources.OCMRoleArn = ocmRoleArn
+	return rh.saveToFile()
+}
+
+func (rh *resourcesHandler) registerUserRoleArn(userRoleArn string) error {
+	rh.resources.UserRoleArn = userRoleArn
 	return rh.saveToFile()
 }
 

--- a/tests/utils/handler/resources_handler_clean.go
+++ b/tests/utils/handler/resources_handler_clean.go
@@ -168,6 +168,28 @@ func (rh *resourcesHandler) DeleteAccountRoles() error {
 	return nil
 }
 
+func (rh *resourcesHandler) DeleteOCMRole() error {
+	_, err := rh.rosaClient.OCMResource.DeleteOCMRole(
+		"--mode", "auto",
+		"--role-arn", rh.resources.OCMRoleArn,
+		"-y")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (rh *resourcesHandler) DeleteUserRole() error {
+	_, err := rh.rosaClient.OCMResource.DeleteUserRole(
+		"--mode", "auto",
+		"--role-arn", rh.resources.UserRoleArn,
+		"-y")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (rh *resourcesHandler) GetEIPAssociationAndAllocationIDsByInstanceID(
 	publicIP string, sharedVPC bool,
 ) (string, string, error) {


### PR DESCRIPTION
Since https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/10957  if 'aws-account-access-verification-enabled' is enabled, the ocm-role is required for access check. After confirm with backend side, https://redhat-internal.slack.com/archives/CHWDU0CP9/p1769157260572779 The flag will be enabled on int and stage env in future,we need to add step to create ocm–role in rosacli setup step. 

- Create ocm and user role before cluster creation
- Delete ocm/user role in the tear-down step
- remove 52106 as it should be deprecated after above change.

log: https://privatebin.corp.redhat.com/?4d6b5025eb07f5b7#2hd9iYbeGiokw7NMQNWhS7V22N56m19gmKWw8Sx7tFaP
