### PR TITLE
OCM-21994 | feat: script to improve release toil

### DIFF
--- a/hack/format-jira-versions-for-errata.py
+++ b/hack/format-jira-versions-for-errata.py
@@ -1,0 +1,27 @@
+# Author: Hunter Kepley
+# 2026 
+# Red Hat
+#
+## This is meant to take in the output of ./hack/release-list-jiras.sh
+## and turn it into a usable output for Errata. This script saves quite a 
+## bit of time every single release manually fixing them
+
+a = input("Paste JIRAs received from './hack/release-list-jiras.sh' directly here: ")
+
+print("Removing extra whitespace")
+
+b = a.strip().split()
+
+print("Removing duplicates")
+
+c = list(set([x.lower() for x in b]))
+
+print("Capitalizing")
+
+final = ""
+
+for k in c:
+    final += k + " "
+
+print("\n\n--------------------\n\n" + final.strip().upper())
+


### PR DESCRIPTION
When releasing CLI on Errata, you must supply a list of Jira tickets which were included in the release
 
This is an annoying manual process that can take quite a bit of time, even when leveraging the existing tool `./hack/release-list-jiras.sh` in the ROSA CLI repo
 
I have made a personal script about 1 year ago which does this for me, saving me at the lowest 30 minutes, at the highest 2 hours, every single release


This script takes in the output of the `release-list-jiras.sh` as well as any other tickets not captured by that script **(which happens often enough!)** and turns it into a usable format for Errata

---------

Example output:


```swift
Paste JIRAs received from './hack/release-list-jiras.sh' directly here: ocm-123 OCM-123 ocm-1234 ams-222 AmS-222
Removing extra whitespace
Removing duplicates
Capitalizing


--------------------

OCM-1234 AMS-222 OCM-123
```