### PR TITLE
OHSS-50386 | fix: Add check for if zero egress property does not exist

### DIFF
--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -1053,12 +1053,14 @@ func getRolePolicyBindings(roleARN string, rolePolicyDetails map[string][]aws.Po
 func getZeroEgressStatus(cluster *cmv1.Cluster) (string, error) {
 	zeroEgressOutput := DisabledOutput
 	zeroEgressPropVal, exists := cluster.Properties()["zero_egress"]
-	boolZeroEgressPropVal, err := strconv.ParseBool(zeroEgressPropVal)
-	if err != nil {
-		return "", err
-	}
-	if exists && boolZeroEgressPropVal {
-		zeroEgressOutput = EnabledOutput
+	if exists {
+		boolZeroEgressPropVal, err := strconv.ParseBool(zeroEgressPropVal)
+		if err != nil {
+			return "", err
+		}
+		if boolZeroEgressPropVal {
+			zeroEgressOutput = EnabledOutput
+		}
 	}
 	str := fmt.Sprintf("Zero Egress:                %s\n", zeroEgressOutput)
 	return str, nil


### PR DESCRIPTION
Adds a simple check to check if the `zero_egress` property is actually in the cluster properties

Old output:
```
❯ rosa describe cluster -c jkeyne-0209-10
E: Failed to get zero egress info: strconv.ParseBool: parsing "": invalid syntax
```

New output:
```
❯ ./rosa describe cluster -c jkeyne-0209-10

Name:                       jkeyne-0209-10
Domain Prefix:              jkeyne-0209-10
Display Name:               jkeyne-0209-10
ID:                         2obq5vsl3fci9g4d886q75ga02e92i4h
External ID:                816acda9-f55e-4f42-8679-a1d2f3d323ad
Control Plane:              ROSA Service Hosted
OpenShift Version:          4.20.8
Channel Group:              stable
DNS:                        Not ready
AWS Account:                090777400063
AWS Billing Account:        090777400063
API URL:
Console URL:
Region:                     us-west-2
Availability:
 - Control Plane:           MultiAZ
 - Data Plane:              SingleAZ

Nodes:
 - Compute (desired):       2
 - Compute (current):       0
Network:
 - Type:                    OVNKubernetes
 - Service CIDR:            172.30.0.0/16
 - Machine CIDR:            10.0.0.0/16
 - Pod CIDR:                10.128.0.0/14
 - Host Prefix:             /23
 - Subnets:                 subnet-00203513dc94de863
EC2 Metadata Http Tokens:   required
Role (STS) ARN:             arn:aws:iam::090777400063:role/jkeyne-HCP-ROSA-Installer-Role
Support Role ARN:           arn:aws:iam::090777400063:role/jkeyne-HCP-ROSA-Support-Role
Instance IAM Roles:
 - Worker:                  arn:aws:iam::090777400063:role/jkeyne-HCP-ROSA-Worker-Role
Operator IAM Roles:
 - arn:aws:iam::090777400063:role/jkeyne-0209-10-v2a7-kube-system-capa-controller-manager
 - arn:aws:iam::090777400063:role/jkeyne-0209-10-v2a7-kube-system-control-plane-operator
 - arn:aws:iam::090777400063:role/jkeyne-0209-10-v2a7-kube-system-kms-provider
 - arn:aws:iam::090777400063:role/jkeyne-0209-10-v2a7-openshift-image-registry-installer-cloud-cre
 - arn:aws:iam::090777400063:role/jkeyne-0209-10-v2a7-openshift-ingress-operator-cloud-credentials
 - arn:aws:iam::090777400063:role/jkeyne-0209-10-v2a7-openshift-cluster-csi-drivers-ebs-cloud-cred
 - arn:aws:iam::090777400063:role/jkeyne-0209-10-v2a7-openshift-cloud-network-config-controller-cl
 - arn:aws:iam::090777400063:role/jkeyne-0209-10-v2a7-kube-system-kube-controller-manager
Managed Policies:           Yes
State:                      waiting (Operator Role(s) not found: Role name 'jkeyne-0209-10-v2a7-kube-system-capa-controller-manager' does not exists for cluster '2obq5vsl3fci9g4d886q75ga02e92i4h')
Private:                    Yes
Delete Protection:          Disabled
Created:                    Feb  9 2026 14:36:51 UTC
OIDC Endpoint URL:          https://oidc.oi1.devshift.org/2obq5r6hqkrjsh4dh4bjrqkhufhjkocs (Managed)
Etcd Encryption:            Disabled
Audit Log Forwarding:       Disabled
AutoNode:                   Disabled
External Authentication:    Enabled
Zero Egress:                Disabled
```