### PR TITLE
OCM-22011 | fix: Add output flag to create/logfwder

### DIFF
--- a/cmd/create/logforwarder/cmd.go
+++ b/cmd/create/logforwarder/cmd.go
@@ -68,6 +68,7 @@ func NewCreateLogForwarderCommand() *cobra.Command {
 	)
 
 	ocm.AddClusterFlag(cmd)
+	output.AddFlag(cmd)
 	interactive.AddFlag(flags)
 	return cmd
 }

--- a/cmd/rosa/structure_test/command_args/rosa/create/log-forwarder/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/create/log-forwarder/command_args.yml
@@ -1,3 +1,4 @@
 - name: cluster
 - name: interactive
 - name: log-fwd-config
+- name: output


### PR DESCRIPTION
Forgot to add the flag when I put in functionality, got approved+merged, need to add the flag in retrospect