### PR TITLE
OCM-680 | fix: CIDR range hardcoded value

### DIFF
--- a/cmd/create/network/cloudformation.go
+++ b/cmd/create/network/cloudformation.go
@@ -512,7 +512,7 @@ Resources:
         - IpProtocol: -1
           FromPort: 0
           ToPort: 0
-          CidrIp: "10.0.0.0/16"
+          CidrIp: !Ref VpcCidr
       SecurityGroupEgress:
         - IpProtocol: -1
           FromPort: 0


### PR DESCRIPTION
Due to customization, the customer could change the CIDR. If the CIDR remains as the default 10.0.0.0, this prevents the worker nodes to access the vpce, raising an error. 
Documented in JIRA ROSA-680.