### PR TITLE
OCM-20977 | fix: add missing capacity-reservation-preference field in 'rosa describe machibepool'

### DIFF
--- a/pkg/ocm/output/nodepools.go
+++ b/pkg/ocm/output/nodepools.go
@@ -153,29 +153,24 @@ func PrintNodePoolDiskSize(aws *cmv1.AWSNodePool) string {
 }
 
 func PrintCapacityReservationDetails(capacityReservation *cmv1.AWSCapacityReservation) string {
-	if capacityReservation != nil {
-		id, ok := capacityReservation.GetId()
-		if !ok {
-			return ""
-		}
-		marketType, ok := capacityReservation.GetMarketType()
-		if !ok {
-			return fmt.Sprintf("\n"+
-				" - ID:                                 %s\n",
-				id)
-		}
-		preference, ok := capacityReservation.GetPreference()
-		if !ok {
-			return fmt.Sprintf("\n"+
-				" - ID:                                 %s\n"+
-				" - Type:                               %s",
-				id, marketType)
-		}
-		return fmt.Sprintf("\n"+
-			" - ID:                                 %s\n"+
-			" - Type:                               %s\n"+
-			" - Preference:                         %s",
-			id, marketType, preference)
+	if capacityReservation == nil {
+		return ""
 	}
-	return ""
+
+	var details []string
+
+	if id, ok := capacityReservation.GetId(); ok {
+		details = append(details, fmt.Sprintf(" - ID:                                 %s", id))
+	}
+	if marketType, ok := capacityReservation.GetMarketType(); ok {
+		details = append(details, fmt.Sprintf(" - Type:                               %s", marketType))
+	}
+	if preference, ok := capacityReservation.GetPreference(); ok {
+		details = append(details, fmt.Sprintf(" - Preference:                         %s", preference))
+	}
+
+	if len(details) == 0 {
+		return ""
+	}
+	return "\n" + strings.Join(details, "\n")
 }


### PR DESCRIPTION
# Details

This PR adds the `capacity-reservation-preference` field to the output of `rosa describe machinepool`, so users can see what preference was set on their node pool.

---

## Fixed Behavior

```bash
./rosa describe machinepool --cluster=mycluster test-np
```

Output:
```
...
Capacity Reservation:                  
 - Preference:                         open
Management upgrade:                    
...
```

Now the user can see the preference they configured.

---

## Additional Cases

The existing output for capacity reservations with an ID continues to work as before:

1. **ID + Type (no preference)**:
    ```
    Capacity Reservation:                  
     - ID:                                 cr-abc123
     - Type:                               OnDemand
    ```

2. **ID + Type + Preference**:
    ```
    Capacity Reservation:                  
     - ID:                                 cr-abc123
     - Type:                               OnDemand
     - Preference:                         capacity-reservations-only
    ```

3. **Preference only (new)**:
    ```
    Capacity Reservation:                  
     - Preference:                         open
    ```

---

# Ticket

Closes [OCM-20977](https://issues.redhat.com/browse/OCM-20977)