### PR TITLE
OCM-00000 | chore: update OWNERS approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,15 +1,10 @@
-reviewers:
-- olucasfreitas
-- jerichokeyne
-- yuwang-RH
 approvers:
-- gdbranco
-- robpblake
-- jerichokeyne
-- davidleerh
 - olucasfreitas
+- jerichokeyne
+- amandahla
 - BraeTroutman
 - marcolan018
-- yuwang-RH
-- amandahla
+- gdbranco
+- robpblake
+- davidleerh
 - red-hat-konflux[bot]


### PR DESCRIPTION
## Summary
- update the root OWNERS approvers to the requested set
- remove the outdated reviewers section so the file only contains the requested approver list

## Test Plan
- [x] `update-rebase-main` equivalent sync completed with build, lint, coverage, and unit/integration checks on `master`
- [x] Verified `OWNERS` content matches the requested approver list exactly
- [x] Ran `git diff --check`