### PR TITLE
OCM-23781 | fix: Adding better logic for setting rosa_region tag

### DIFF
--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -80,9 +80,10 @@ const (
 
 	// Since CloudFormation stacks are region-dependent, we hard-code OCM's default region and
 	// then use it to ensure that the user always gets the stack from the same region.
-	DefaultRegion = "us-east-1"
-	Inline        = "inline"
-	Attached      = "attached"
+	DefaultRegion         = "us-east-1"
+	DefaultGovcloudRegion = "us-gov-east-1"
+	Inline                = "inline"
+	Attached              = "attached"
 
 	LocalZone      = "local-zone"
 	WavelengthZone = "wavelength-zone"

--- a/pkg/aws/cloudformation.go
+++ b/pkg/aws/cloudformation.go
@@ -29,12 +29,13 @@ import (
 	"github.com/aws/smithy-go"
 
 	"github.com/openshift/rosa/assets"
+	"github.com/openshift/rosa/pkg/fedramp"
 )
 
 func readCloudFormationTemplate(path string) (string, error) {
 	cfTemplate, err := assets.Asset(path)
 	if err != nil {
-		return "", fmt.Errorf("Unable to read cloudformation template: %s", err)
+		return "", fmt.Errorf("unable to read cloudformation template: %s", err)
 	}
 
 	return string(cfTemplate), nil
@@ -43,7 +44,17 @@ func readCloudFormationTemplate(path string) (string, error) {
 // Ensure osdCcsAdmin IAM user is created
 func (c *awsClient) EnsureOsdCcsAdminUser(stackName string, adminUserName string, awsRegion string) (bool, error) {
 	userExists := true
-	regionForInit, err := c.GetClusterRegionTagForUser(adminUserName)
+	var region string
+	if awsRegion != "" {
+		region = awsRegion
+	} else {
+		if fedramp.Enabled() {
+			region = DefaultGovcloudRegion
+		} else {
+			region = DefaultRegion
+		}
+	}
+	adminRegionTag, err := c.GetClusterRegionTagForUser(adminUserName)
 	if err != nil {
 		//If user doesn't exists proceed normally
 		//If users exists and tag is not present then add the tag
@@ -56,8 +67,13 @@ func (c *awsClient) EnsureOsdCcsAdminUser(stackName string, adminUserName string
 		}
 	}
 	if userExists {
-		if regionForInit == "" {
-			err = c.TagUserRegion(adminUserName, DefaultRegion)
+		if adminRegionTag == "" {
+			err = c.TagUserRegion(adminUserName, region)
+			if err != nil {
+				return false, err
+			}
+		} else if fedramp.Enabled() && adminRegionTag == DefaultRegion {
+			err = c.TagUserRegion(adminUserName, region)
 			if err != nil {
 				return false, err
 			}
@@ -106,7 +122,7 @@ func (c *awsClient) EnsureOsdCcsAdminUser(stackName string, adminUserName string
 		return false, err
 	}
 
-	err = c.TagUserRegion(adminUserName, awsRegion)
+	err = c.TagUserRegion(adminUserName, region)
 	if err != nil {
 		return false, err
 	}
@@ -115,7 +131,15 @@ func (c *awsClient) EnsureOsdCcsAdminUser(stackName string, adminUserName string
 
 func (c *awsClient) CreateStack(cfTemplateBody, stackName string) (bool, error) {
 	// Create cloudformation stack
-	_, err := c.cfClient.CreateStack(context.Background(), buildCreateStackInput(cfTemplateBody, stackName, []cloudformationtypes.Parameter{}, []cloudformationtypes.Tag{}))
+	_, err := c.cfClient.CreateStack(
+		context.Background(),
+		buildCreateStackInput(
+			cfTemplateBody,
+			stackName,
+			[]cloudformationtypes.Parameter{},
+			[]cloudformationtypes.Tag{},
+		),
+	)
 	if err != nil {
 		return false, err
 	}
@@ -128,7 +152,13 @@ func (c *awsClient) CreateStack(cfTemplateBody, stackName string) (bool, error) 
 	return true, nil
 }
 
-func (c *awsClient) CreateStackWithParamsTags(ctx context.Context, cfTemplateBody, stackName string, stackParams, stackTags map[string]string) (*string, error) {
+func (c *awsClient) CreateStackWithParamsTags(
+	ctx context.Context,
+	cfTemplateBody,
+	stackName string,
+	stackParams,
+	stackTags map[string]string,
+) (*string, error) {
 	// stack tags
 	var cfTags []cloudformationtypes.Tag
 	for k, v := range stackTags {
@@ -165,13 +195,16 @@ func (c *awsClient) GetCFStack(ctx context.Context, stackName string) (*cloudfor
 	}
 
 	if len(output.Stacks) == 0 {
-		return nil, fmt.Errorf("No CF stacks with name %s found", stackName)
+		return nil, fmt.Errorf("no CF stacks with name %s found", stackName)
 	}
 
 	return &output.Stacks[0], nil
 }
 
-func (c *awsClient) DescribeCFStackResources(ctx context.Context, stackName string) (*[]cloudformationtypes.StackResource, error) {
+func (c *awsClient) DescribeCFStackResources(
+	ctx context.Context,
+	stackName string,
+) (*[]cloudformationtypes.StackResource, error) {
 	output, err := c.cfClient.DescribeStackResources(ctx, &cloudformation.DescribeStackResourcesInput{
 		StackName: aws.String(stackName),
 	})
@@ -265,7 +298,12 @@ func (c *awsClient) DeleteOsdCcsAdminUser(stackName string) error {
 }
 
 // Build cloudformation create stack input
-func buildCreateStackInput(cfTemplateBody, stackName string, cfParams []cloudformationtypes.Parameter, cfTags []cloudformationtypes.Tag) *cloudformation.CreateStackInput {
+func buildCreateStackInput(
+	cfTemplateBody,
+	stackName string,
+	cfParams []cloudformationtypes.Parameter,
+	cfTags []cloudformationtypes.Tag,
+) *cloudformation.CreateStackInput {
 	// Special cloudformation capabilities are required to create IAM resources in AWS
 	cfCapabilityIAM := cloudformationtypes.CapabilityCapabilityIam
 	cfCapabilityNamedIAM := cloudformationtypes.CapabilityCapabilityNamedIam

--- a/pkg/ocm/regions.go
+++ b/pkg/ocm/regions.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/openshift/rosa/pkg/arguments"
 	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/fedramp"
 	"github.com/openshift/rosa/pkg/helper"
 	"github.com/openshift/rosa/pkg/logging"
 )
@@ -96,14 +97,14 @@ func (c *Client) GetRegions(roleARN string, externalID string) (regions []*cmv1.
 			Logger(logger).
 			Build()
 		if err != nil {
-			return nil, fmt.Errorf("Error creating AWS client: %v", err)
+			return nil, fmt.Errorf("error creating AWS client: %v", err)
 		}
 
 		// Get AWS region
 		currentAWSCreds, err := awsClient.GetIAMCredentials()
 
 		if err != nil {
-			return nil, fmt.Errorf("Failed to get local AWS credentials: %v", err)
+			return nil, fmt.Errorf("failed to get local AWS credentials: %v", err)
 		}
 
 		awsBuilder = awsBuilder.
@@ -113,7 +114,7 @@ func (c *Client) GetRegions(roleARN string, externalID string) (regions []*cmv1.
 
 	awsCredentials, err := awsBuilder.Build()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to build AWS credentials for user '%s': %v", aws.AdminUserName, err)
+		return nil, fmt.Errorf("failed to build AWS credentials for user '%s': %v", aws.AdminUserName, err)
 	}
 
 	collection := c.ocm.ClustersMgmt().V1().
@@ -151,7 +152,7 @@ func (c *Client) GetRegionList(multiAZ bool, roleARN string,
 	regionAZ map[string]bool, err error) {
 	regions, err := c.GetFilteredRegionsByVersion(roleARN, version, awsClient, externalID)
 	if err != nil {
-		err = fmt.Errorf("Failed to retrieve AWS regions: %s", err)
+		err = fmt.Errorf("failed to retrieve AWS regions: %s", err)
 		return
 	}
 
@@ -176,7 +177,9 @@ func (c *Client) GetRegionList(multiAZ bool, roleARN string,
 }
 
 func (c *Client) GetDatabaseRegionList() ([]string, error) {
-	response, err := c.ocm.ClustersMgmt().V1().CloudProviders().CloudProvider("aws").Regions().List().Send()
+	filter := fmt.Sprintf("govcloud is %t", fedramp.Enabled())
+	response, err :=
+		c.ocm.ClustersMgmt().V1().CloudProviders().CloudProvider("aws").Regions().List().Parameter("search", filter).Send()
 	if err != nil {
 		return []string{}, weberr.Errorf("Failed to get regions listing: %v", err)
 	}
@@ -202,7 +205,7 @@ func (c *Client) ValidateAwsClientRegion() error {
 		return err
 	}
 	if !helper.Contains(supportedRegions, awsRegionInUserConfig) {
-		return fmt.Errorf("Unsupported region '%s', available regions: %s",
+		return fmt.Errorf("unsupported region '%s', available regions: %s",
 			awsRegionInUserConfig, helper.SliceToSortedString(supportedRegions))
 	}
 	return nil

--- a/tests/e2e/test_rosacli_cluster.go
+++ b/tests/e2e/test_rosacli_cluster.go
@@ -1366,7 +1366,7 @@ var _ = Describe("Classic cluster creation validation",
 							"2":  "Multi AZ cluster requires at least 3 compute nodes",
 							"0":  "Multi AZ cluster requires at least 3 compute nodes",
 							"-3": "must be non-negative",
-							"5":  "multi AZ clusters require that the replicas be a multiple of 3",
+							"5":  "Multi AZ clusters require that the replicas be a multiple of 3",
 						}
 						for k, v := range invalidReplicasErrorMapMultiAZ {
 							rosalCommand.ReplaceFlagValue(map[string]string{
@@ -1402,7 +1402,7 @@ var _ = Describe("Classic cluster creation validation",
 				})
 				stdout, err = rosaClient.Runner.RunCMD(strings.Split(rosalCommand.GetFullCommand(), " "))
 				Expect(err).NotTo(BeNil())
-				Expect(stdout.String()).To(ContainSubstring("Unsupported region"))
+				Expect(stdout.String()).To(ContainSubstring("unsupported region"))
 
 				By("Check the validation for invalid billing-account for classic sts cluster")
 				rosalCommand.ReplaceFlagValue(map[string]string{

--- a/tests/e2e/test_rosacli_region.go
+++ b/tests/e2e/test_rosacli_region.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //nolint:staticcheck
+	. "github.com/onsi/gomega"    //nolint:staticcheck
 
 	"github.com/openshift/rosa/tests/ci/labels"
 	"github.com/openshift/rosa/tests/utils/exec/rosacli"
@@ -19,7 +19,7 @@ var _ = Describe("Region",
 		var (
 			rosaClient             *rosacli.Client
 			ocmResourceService     rosacli.OCMResourceService
-			permissionsBoundaryArn string = "arn:aws:iam::aws:policy/AdministratorAccess"
+			permissionsBoundaryArn = "arn:aws:iam::aws:policy/AdministratorAccess"
 		)
 
 		BeforeEach(func() {
@@ -132,6 +132,6 @@ var _ = Describe("Region",
 				availableMachineTypes, output, err := ocmResourceService.ListInstanceTypes(
 					"--region", "xxx", "--role-arn", classicInstallerRoleArn)
 				Expect(err).To(HaveOccurred())
-				Expect(output.String()).Should(ContainSubstring("ERR: Unsupported region 'xxx', available regions"))
+				Expect(output.String()).Should(ContainSubstring("ERR: unsupported region 'xxx', available regions"))
 			})
 	})


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For contributor workflow, see: ./CONTRIBUTING.md
For repo-local agent guidance, see: ./AGENTS.md
-->

## PR Summary
Updating the logic when creating the osdCcsAdmin user to always set the same value for the `rosa_region` tag regardless of whether or not the user already exists. Also, adding a bit of logic to change the value if running in FedRAMP and the value is set to a non-Govcloud region

There's also some included changes that were necessary to fix linting issues since I'm updating files that haven't been touched in a while

## Detailed Description of the Issue
There's an issue where if the user was running in FedRAMP, and already had a `osdCcsAdmin` user created, but that user was missing the `rosa_region` tag, then when they ran `rosa init` it would set the `rosa_region` tag to `us-east-1`. That would then prevent the user from creating clusters as we default to running in that region if that user and tag exist.

Slack threads:
- https://redhat-internal.slack.com/archives/C096LQMAXA7/p1776116505044729?thread_ts=1775841383.565369&cid=C096LQMAXA7
- https://redhat-internal.slack.com/archives/C0A8S4L99C2/p1776192008488119

## Related Issues and PRs
<!-- Link all tracking items and related code changes -->
- Jira: [OCM-23781](https://redhat.atlassian.net/browse/OCM-23781)

## Type of Change
<!-- Check the primary type this PR represents -->
- [ ] feat - adds a new user-facing capability.
- [x] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
When the user ran `rosa init` and created the `osdCcsAdmin` user it was a bit of a toss up as to what the `rosa_region` value would be set to. If the user already existed, but did not have that tag set, then it would always be set to `us-east-1`. If the user already existed, and the tag was set, then it doesn't update the tag. If the user did not already exist, then it would be set to whatever value the user passed as `--region`

## Behavior After This Change
Now things have been more unified. In either case of when the `rosa_region` tag needs to be updated, it will be set to the same value. The new way to determine the value is:
- If the user provides a region with `--region`, then use that value
- If the user doesn't provide a region, then check if they're in FedRAMP:
    - If they are, then set it to a default value of `us-gov-east-1`
    - Otherwise set it to the default value of `us-east-1`

I also added a check for if the user is in FedRAMP, and for some reason the tag is set to the old default of `us-east-1`, then it will update the tag to the new value as specified above

If the user and tag already exist, then there is still no change (except for the previous exception)

## How to Test (Step-by-Step)
<!-- Provide reproducible validation instructions -->
### Preconditions
<!-- Required setup, environment, credentials, flags, cluster state, etc. -->

### Test Steps
1. Make sure there's no `osdCcsAdmin` user in the AWS account
2. Run `rosa init`, and check the created `osdCcsAdmin` and the `rosa_region` tag on the user. It should be set to `us-east-1`
3. Run `rosa init --region us-west-2`, and check that the `rosa_region` tag hasn't been updated
4. Delete the `rosa_region` tag
5. Run `rosa init --region us-west-2`, and check that the `rosa_region` tag has been set to `us-west-2`
6. In FedRAMP:
    1. Repeat the previous steps, but with `us-gov-east-1` and `us-gov-west-1`
    2. Modify the `rosa_region` tag to be set to `us-east-1`
    3. Run `rosa init --region us-gov-west-1`, and check that the `rosa_region` tag has been set to `us-gov-west-1`

## Proof of the Fix
<!-- Attach evidence that demonstrates the changed behavior -->
- Screenshots:
- Videos:
- Logs/CLI output:
- Other artifacts:

### Running the modified test cases locally
```
TEST_PROFILE="rosa-advanced" ginkgo run --timeout 2h --focus "id:38770" tests/e2e
Running Suite: ROSA CLI e2e tests suite - /home/jericho/work/repos/rosa/tests/e2e
=================================================================================
Random Seed: 1776286919

Will run 1 of 282 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 282 Specs in 226.049 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 281 Skipped
PASS

Ginkgo ran 1 suite in 3m48.939664017s
Test Suite Passed

TEST_PROFILE="rosa-advanced" ginkgo run --timeout 2h --focus "id:72174" tests/e2e
Running Suite: ROSA CLI e2e tests suite - /home/jericho/work/repos/rosa/tests/e2e
=================================================================================
Random Seed: 1776287533

Will run 1 of 282 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 282 Specs in 141.790 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 281 Skipped
PASS

Ginkgo ran 1 suite in 2m24.898423605s
Test Suite Passed
```
## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
<!-- Required only when breaking changes are introduced -->

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [x] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.


[OCM-23781]: https://redhat.atlassian.net/browse/OCM-23781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FedRAMP-aware region selection that automatically chooses between govcloud and standard AWS regions based on compliance configuration.

* **Improvements**
  * Updated region validation and error messaging for consistency across the CLI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->