### PR TITLE
OCM-23979 | fix: support set min_replicas=0 when editing nodepool

### DIFF
--- a/pkg/machinepool/helper.go
+++ b/pkg/machinepool/helper.go
@@ -246,6 +246,9 @@ func (r *ReplicaSizeValidation) MaxReplicaValidator() interactive.Validator {
 		if err != nil {
 			return err
 		}
+		if maxReplicas <= 0 {
+			return fmt.Errorf("max-replicas must be greater than zero")
+		}
 		if r.MinReplicas > maxReplicas {
 			return fmt.Errorf("max-replicas must be greater or equal to min-replicas")
 		}

--- a/pkg/machinepool/helper_test.go
+++ b/pkg/machinepool/helper_test.go
@@ -515,6 +515,18 @@ var _ = Describe("Machine pool min/max replicas validation", func() {
 			true,
 			false,
 		),
+		Entry("Max = 0 -> NOT OK",
+			0,
+			0,
+			false,
+			true,
+		),
+		Entry("Max < 0 -> NOT OK",
+			1,
+			-1,
+			false,
+			true,
+		),
 	)
 
 	DescribeTable("NodePool (HCP) min replicas validation",

--- a/pkg/machinepool/machinepool.go
+++ b/pkg/machinepool/machinepool.go
@@ -1507,9 +1507,9 @@ func (m *machinePool) EditMachinePool(cmd *cobra.Command, machinePoolId string, 
 
 // fillAutoScalingAndReplicas is filling either autoscaling or replicas value in the builder
 func fillAutoScalingAndReplicas(npBuilder *cmv1.NodePoolBuilder, autoscaling bool, existingNodepool *cmv1.NodePool,
-	minReplicas int, maxReplicas int, replicas int) {
+	minReplicas int, maxReplicas int, replicas int, isMinReplicasSet bool, isMaxReplicasSet bool) {
 	if autoscaling {
-		npBuilder.Autoscaling(editAutoscaling(existingNodepool, minReplicas, maxReplicas))
+		npBuilder.Autoscaling(editAutoscaling(existingNodepool, minReplicas, maxReplicas, isMinReplicasSet, isMaxReplicasSet))
 	} else {
 		npBuilder.Replicas(replicas)
 	}
@@ -1818,7 +1818,8 @@ func editNodePool(cmd *cobra.Command, nodePoolID string,
 		return fmt.Errorf("failed to get autoscaling or replicas: '%s'", err)
 	}
 
-	err = validateNodePoolEdit(cmd, autoscaling, replicas, minReplicas, maxReplicas)
+	err = validateNodePoolEdit(cmd, autoscaling, replicas, minReplicas, maxReplicas, nodePool,
+		isMinReplicasSet, isMaxReplicasSet)
 	if err != nil {
 		return err
 	}
@@ -1842,7 +1843,8 @@ func editNodePool(cmd *cobra.Command, nodePoolID string,
 		npBuilder = npBuilder.Taints(taintBuilders...)
 	}
 
-	fillAutoScalingAndReplicas(npBuilder, autoscaling, nodePool, minReplicas, maxReplicas, replicas)
+	fillAutoScalingAndReplicas(npBuilder, autoscaling, nodePool, minReplicas, maxReplicas, replicas,
+		isMinReplicasSet, isMaxReplicasSet)
 
 	if isAutorepairSet || interactive.Enabled() {
 		autorepair, err := strconv.ParseBool(cmd.Flags().Lookup("autorepair").Value.String())
@@ -2105,7 +2107,8 @@ func editNodePool(cmd *cobra.Command, nodePoolID string,
 	return nil
 }
 
-func validateNodePoolEdit(cmd *cobra.Command, autoscaling bool, replicas int, minReplicas int, maxReplicas int) error {
+func validateNodePoolEdit(cmd *cobra.Command, autoscaling bool, replicas int, minReplicas int, maxReplicas int,
+	nodePool *cmv1.NodePool, isMinReplicasSet bool, isMaxReplicasSet bool) error {
 	if !autoscaling && replicas < 0 {
 		return fmt.Errorf("the number of machine pool replicas needs to be a non-negative integer")
 	}
@@ -2118,10 +2121,29 @@ func validateNodePoolEdit(cmd *cobra.Command, autoscaling bool, replicas int, mi
 		return fmt.Errorf("max-replicas must be greater than zero")
 	}
 
-	if autoscaling && cmd.Flags().Changed("max-replicas") && cmd.Flags().Changed(
-		"min-replicas") && minReplicas > maxReplicas {
-		return fmt.Errorf("the number of machine pool min-replicas needs to be less than the number of " +
-			"machine pool max-replicas")
+	// Validate the final computed min/max range after merging with existing values
+	// This catches cases where only one bound is changed, producing invalid range
+	if autoscaling && (isMinReplicasSet || isMaxReplicasSet || interactive.Enabled()) {
+		finalMin := minReplicas
+		finalMax := maxReplicas
+
+		// Get existing values if only one bound is being changed
+		if nodePool.Autoscaling() != nil {
+			if !isMinReplicasSet && !interactive.Enabled() {
+				finalMin = nodePool.Autoscaling().MinReplica()
+			}
+			if !isMaxReplicasSet && !interactive.Enabled() {
+				finalMax = nodePool.Autoscaling().MaxReplica()
+			}
+		}
+
+		if finalMax < 1 {
+			return fmt.Errorf("max-replicas must be greater than zero")
+		}
+
+		if finalMin > finalMax {
+			return fmt.Errorf("the number of machine pool min-replicas must not be greater than max-replicas")
+		}
 	}
 	return nil
 }
@@ -2219,12 +2241,19 @@ func getNodePoolReplicas(cmd *cobra.Command,
 	}
 
 	if autoscaling {
+		defaultMin := existingReplicas
+		defaultMax := existingReplicas
+		if existingAutoscaling != nil {
+			defaultMin = existingAutoscaling.MinReplica()
+			defaultMax = existingAutoscaling.MaxReplica()
+		}
+
 		// Prompt for min replicas if neither min or max is set or interactive mode
 		if !isMinReplicasSet && (interactive.Enabled() || !isMaxReplicasSet && !isAnyAdditionalParameterSet) {
 			minReplicas, err = interactive.GetInt(interactive.Input{
 				Question: "Min replicas",
 				Help:     cmd.Flags().Lookup("min-replicas").Usage,
-				Default:  existingAutoscaling.MinReplica(),
+				Default:  defaultMin,
 				Required: replicasRequired,
 				Validators: []interactive.Validator{
 					replicaSizeValidation.MinReplicaValidator(),
@@ -2242,7 +2271,7 @@ func getNodePoolReplicas(cmd *cobra.Command,
 			maxReplicas, err = interactive.GetInt(interactive.Input{
 				Question: "Max replicas",
 				Help:     cmd.Flags().Lookup("max-replicas").Usage,
-				Default:  existingAutoscaling.MaxReplica(),
+				Default:  defaultMax,
 				Required: replicasRequired,
 				Validators: []interactive.Validator{
 					replicaSizeValidation.MaxReplicaValidator(),
@@ -2251,6 +2280,15 @@ func getNodePoolReplicas(cmd *cobra.Command,
 			if err != nil {
 				err = fmt.Errorf("expected a valid number of max replicas: %s", err)
 				return
+			}
+		}
+
+		if existingAutoscaling == nil && !interactive.Enabled() {
+			if !isMinReplicasSet && minReplicas == 0 {
+				minReplicas = existingReplicas
+			}
+			if !isMaxReplicasSet && maxReplicas == 0 {
+				maxReplicas = existingReplicas
 			}
 		}
 	} else if interactive.Enabled() || !isReplicasSet {
@@ -2282,21 +2320,31 @@ func getNodePoolReplicas(cmd *cobra.Command,
 	return
 }
 
-func editAutoscaling(nodePool *cmv1.NodePool, minReplicas int, maxReplicas int) *cmv1.NodePoolAutoscalingBuilder {
-	existingMinReplica := nodePool.Autoscaling().MinReplica()
-	existingMaxReplica := nodePool.Autoscaling().MaxReplica()
+func editAutoscaling(nodePool *cmv1.NodePool, minReplicas int, maxReplicas int,
+	isMinReplicasSet bool, isMaxReplicasSet bool) *cmv1.NodePoolAutoscalingBuilder {
+	// Get existing values if autoscaling is already enabled
+	min := 0
+	max := 0
+	if nodePool.Autoscaling() != nil {
+		min = nodePool.Autoscaling().MinReplica()
+		max = nodePool.Autoscaling().MaxReplica()
+	} else if nodePool.Replicas() > 0 {
+		min = nodePool.Replicas()
+		max = nodePool.Replicas()
+	}
 
-	min := existingMinReplica
-	max := existingMaxReplica
-
-	if minReplicas != 0 {
+	// Update values if flag was set or in interactive mode
+	if (isMinReplicasSet || interactive.Enabled()) && minReplicas >= 0 {
 		min = minReplicas
 	}
-	if maxReplicas != 0 {
+	if (isMaxReplicasSet || interactive.Enabled()) && maxReplicas >= 1 {
 		max = maxReplicas
 	}
 
-	if min >= 1 && max >= 1 {
+	// Return builder if enabling autoscaling or changing values
+	if nodePool.Autoscaling() == nil ||
+		min != nodePool.Autoscaling().MinReplica() ||
+		max != nodePool.Autoscaling().MaxReplica() {
 		return cmv1.NewNodePoolAutoscaling().MinReplica(min).MaxReplica(max)
 	}
 

--- a/pkg/machinepool/machinepool_test.go
+++ b/pkg/machinepool/machinepool_test.go
@@ -73,60 +73,167 @@ var _ = Describe("Machinepool and nodepool", func() {
 			testCommand.Flags().Lookup("min-replicas").Changed = true
 			testCommand.Flags().Lookup("max-replicas").Changed = true
 		})
-		It("editAutoscaling should not be nil if nothing is changed", func() {
+		It("editAutoscaling should return nil if nothing is changed", func() {
 			nodepool, err := cmv1.NewNodePool().
 				Autoscaling(cmv1.NewNodePoolAutoscaling().MaxReplica(2).MinReplica(1)).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
-			builder := editAutoscaling(nodepool, 1, 2)
-			Expect(builder).To(Not(BeNil()))
+			builder := editAutoscaling(nodepool, 1, 2, true, true)
+			Expect(builder).To(BeNil())
 		})
 		It("editAutoscaling should equal the expected output", func() {
 			nodepool, err := cmv1.NewNodePool().
 				Autoscaling(cmv1.NewNodePoolAutoscaling().MaxReplica(2).MinReplica(1)).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
-			builder := editAutoscaling(nodepool, 2, 3)
+			builder := editAutoscaling(nodepool, 2, 3, true, true)
 			asBuilder := cmv1.NewNodePoolAutoscaling().MaxReplica(3).MinReplica(2)
 			Expect(builder).To(Equal(asBuilder))
 		})
-		It("editAutoscaling should equal the expected output with no min replica value", func() {
+		It("editAutoscaling should equal the expected output with no min replica flag set", func() {
 			nodepool, err := cmv1.NewNodePool().
 				Autoscaling(cmv1.NewNodePoolAutoscaling().MaxReplica(2).MinReplica(1)).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
-			builder := editAutoscaling(nodepool, 0, 3)
+			// Only max flag set, min flag not set (so min value ignored)
+			builder := editAutoscaling(nodepool, 0, 3, false, true)
 			asBuilder := cmv1.NewNodePoolAutoscaling().MaxReplica(3).MinReplica(1)
 			Expect(builder).To(Equal(asBuilder))
 		})
-		It("editAutoscaling should equal the expected output with no max replica value", func() {
+		It("editAutoscaling should equal the expected output with no max replica flag set", func() {
 			nodepool, err := cmv1.NewNodePool().
 				Autoscaling(cmv1.NewNodePoolAutoscaling().MaxReplica(4).MinReplica(1)).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
-			builder := editAutoscaling(nodepool, 2, 0)
+			// Only min flag set, max flag not set (so max value ignored)
+			builder := editAutoscaling(nodepool, 2, 0, true, false)
 			asBuilder := cmv1.NewNodePoolAutoscaling().MaxReplica(4).MinReplica(2)
 			Expect(builder).To(Equal(asBuilder))
 		})
+		It("editAutoscaling should support min=0 with autoscaling (OCM-21663)", func() {
+			nodepool, err := cmv1.NewNodePool().
+				Autoscaling(cmv1.NewNodePoolAutoscaling().MaxReplica(2).MinReplica(1)).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			// User sets min=0, max=2 (both flags set)
+			builder := editAutoscaling(nodepool, 0, 2, true, true)
+			asBuilder := cmv1.NewNodePoolAutoscaling().MaxReplica(2).MinReplica(0)
+			Expect(builder).To(Equal(asBuilder))
+		})
+		It("fillAutoScalingAndReplicas should enable autoscaling with min=0 on replicas-only nodepool", func() {
+			// Regression test: nodepool has replicas=2, no autoscaling
+			// User enables autoscaling with min=0, max=2
+			nodepool, err := cmv1.NewNodePool().
+				Replicas(2).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(nodepool.Autoscaling()).To(BeNil())
+
+			npBuilder := cmv1.NewNodePool()
+			fillAutoScalingAndReplicas(npBuilder, true, nodepool, 0, 2, 0, true, true)
+
+			patch, err := npBuilder.Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(patch.Autoscaling()).ToNot(BeNil())
+			Expect(patch.Autoscaling().MinReplica()).To(Equal(0))
+			Expect(patch.Autoscaling().MaxReplica()).To(Equal(2))
+		})
 		It("Test edit nodepool min-replicas = 0 when autoscaling is set - should succeed", func() {
-			err := validateNodePoolEdit(testCommand, true, 0, 0, 1)
+			nodepool, _ := cmv1.NewNodePool().Build()
+			err := validateNodePoolEdit(testCommand, true, 0, 0, 1, nodepool, true, true)
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("Test edit nodepool min-replicas < 0 when autoscaling is set - should fail", func() {
-			err := validateNodePoolEdit(testCommand, true, 0, -1, 1)
+			nodepool, _ := cmv1.NewNodePool().Build()
+			err := validateNodePoolEdit(testCommand, true, 0, -1, 1, nodepool, true, false)
 			Expect(err.Error()).To(Equal("min-replicas must be a non-negative number when autoscaling is set"))
 		})
 		It("Test edit nodepool !autoscaling and replicas < 0 for nodepools", func() {
-			err := validateNodePoolEdit(testCommand, false, -1, 0, 0)
+			nodepool, _ := cmv1.NewNodePool().Build()
+			err := validateNodePoolEdit(testCommand, false, -1, 0, 0, nodepool, false, false)
 			Expect(err.Error()).To(Equal("the number of machine pool replicas needs to be a non-negative integer"))
 		})
-		It("Test edit nodepool autoscaling and minReplicas > maxReplicas", func() {
-			err := validateNodePoolEdit(testCommand, true, 0, 5, 1)
-			Expect(err.Error()).To(Equal("the number of machine pool min-replicas needs to be less " +
-				"than the number of machine pool max-replicas"))
+		It("Test edit nodepool autoscaling and minReplicas > maxReplicas (both flags set)", func() {
+			nodepool, _ := cmv1.NewNodePool().Build()
+			err := validateNodePoolEdit(testCommand, true, 0, 5, 1, nodepool, true, true)
+			Expect(err.Error()).To(Equal("the number of machine pool min-replicas must not be greater than max-replicas"))
+		})
+		It("Test edit nodepool autoscaling and minReplicas > maxReplicas (only min flag set)", func() {
+			// Existing: min=1, max=3; User sets: --min-replicas=5
+			// Final: min=5, max=3 (invalid)
+			nodepool, _ := cmv1.NewNodePool().
+				Autoscaling(cmv1.NewNodePoolAutoscaling().MinReplica(1).MaxReplica(3)).
+				Build()
+			err := validateNodePoolEdit(testCommand, true, 0, 5, 3, nodepool, true, false)
+			Expect(err.Error()).To(Equal("the number of machine pool min-replicas must not be greater than max-replicas"))
 		})
 		It("Test edit nodepool autoscaling and maxReplicas < 1", func() {
-			err := validateNodePoolEdit(testCommand, true, 0, 1, 0)
+			nodepool, _ := cmv1.NewNodePool().Build()
+			err := validateNodePoolEdit(testCommand, true, 0, 1, 0, nodepool, false, true)
+			Expect(err.Error()).To(Equal("max-replicas must be greater than zero"))
+		})
+		It("editAutoscaling should handle nil autoscaling when converting from fixed replicas", func() {
+			// Nodepool has fixed replicas=2, no autoscaling
+			nodepool, err := cmv1.NewNodePool().
+				Replicas(2).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(nodepool.Autoscaling()).To(BeNil())
+
+			// User enables autoscaling with min=0, max=2
+			builder := editAutoscaling(nodepool, 0, 2, true, true)
+			Expect(builder).ToNot(BeNil())
+
+			asBuilder := cmv1.NewNodePoolAutoscaling().MinReplica(0).MaxReplica(2)
+			Expect(builder).To(Equal(asBuilder))
+		})
+
+		It("editAutoscaling should default max to replicas when only min is set", func() {
+			// Nodepool has fixed replicas=3, no autoscaling
+			nodepool, err := cmv1.NewNodePool().
+				Replicas(3).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(nodepool.Autoscaling()).To(BeNil())
+
+			// User enables autoscaling with only min=0 (max not set, so maxReplicas=0)
+			builder := editAutoscaling(nodepool, 0, 0, true, false)
+			Expect(builder).ToNot(BeNil())
+
+			// Expect min=0 (from user) and max=3 (defaulted from replicas)
+			asBuilder := cmv1.NewNodePoolAutoscaling().MinReplica(0).MaxReplica(3)
+			Expect(builder).To(Equal(asBuilder))
+		})
+
+		It("editAutoscaling should default min to replicas when only max is set", func() {
+			// Nodepool has fixed replicas=2, no autoscaling
+			nodepool, err := cmv1.NewNodePool().
+				Replicas(2).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(nodepool.Autoscaling()).To(BeNil())
+
+			// User enables autoscaling with only max=5 (min not set, so minReplicas=0)
+			builder := editAutoscaling(nodepool, 0, 5, false, true)
+			Expect(builder).ToNot(BeNil())
+
+			// Expect min=2 (defaulted from replicas) and max=5 (from user)
+			asBuilder := cmv1.NewNodePoolAutoscaling().MinReplica(2).MaxReplica(5)
+			Expect(builder).To(Equal(asBuilder))
+		})
+
+		It("validateNodePoolEdit should reject enabling autoscaling on replicas=0 nodepool with omitted max", func() {
+			// Nodepool has fixed replicas=0, no autoscaling
+			nodepool, err := cmv1.NewNodePool().
+				Replicas(0).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(nodepool.Autoscaling()).To(BeNil())
+
+			// User enables autoscaling with only min=0 (max omitted, so maxReplicas=0 defaulted)
+			// This should fail validation because finalMax=0 after defaulting from replicas
+			err = validateNodePoolEdit(testCommand, true, 0, 0, 0, nodepool, true, false)
+			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("max-replicas must be greater than zero"))
 		})
 
@@ -261,7 +368,7 @@ var _ = Describe("Machinepool and nodepool", func() {
 			Expect(err).ToNot(HaveOccurred())
 			It("Autoscaling set", func() {
 				npBuilder = cmv1.NewNodePool()
-				fillAutoScalingAndReplicas(npBuilder, true, existingNodepool, 1, 3, 2)
+				fillAutoScalingAndReplicas(npBuilder, true, existingNodepool, 1, 3, 2, true, true)
 				npPatch, err := npBuilder.Build()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(npPatch.Autoscaling()).ToNot(BeNil())
@@ -270,7 +377,7 @@ var _ = Describe("Machinepool and nodepool", func() {
 			})
 			It("Replicas set", func() {
 				npBuilder = cmv1.NewNodePool()
-				fillAutoScalingAndReplicas(npBuilder, false, existingNodepool, 0, 0, 2)
+				fillAutoScalingAndReplicas(npBuilder, false, existingNodepool, 0, 0, 2, false, false)
 				npPatch, err := npBuilder.Build()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(npPatch.Autoscaling()).To(BeNil())


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For contributor workflow, see: ./CONTRIBUTING.md
For repo-local agent guidance, see: ./AGENTS.md
-->

## PR Summary
<!-- brief text of 1 or 2 lines with the most important changes and outcomes -->
currently when edit nodepool(machinepool for hcp cluster), if set min_replicas=0, the edit command will success but in fact the update does not occur. This pr is to fix this problem. It also makes enhancement to existing validation to gurantee the min never greater than max

## Detailed Description of the Issue
<!-- Describe the root problem, scope, impact, and user/business context -->

## Related Issues and PRs
<!-- Link all tracking items and related code changes -->
- Jira: [OCM-23979](https://redhat.atlassian.net/browse/OCM-23979)
- Fixes: `#`
- Related PR(s):
- Related design/docs:

## Type of Change
<!-- Check the primary type this PR represents -->
- [ ] feat - adds a new user-facing capability.
- [x] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
<!-- What users or systems experienced before this change -->

## Behavior After This Change
<!-- What changes now, including user-visible and non-user-visible behavior -->

## How to Test (Step-by-Step)
<!-- Provide reproducible validation instructions -->
### Preconditions
<!-- Required setup, environment, credentials, flags, cluster state, etc. -->

### Test Steps
1. create a hcp cluster with nodepool replicas=2
2. edit nodepool to enable autoscaling with min_replica=0
3. 

### Expected Results
<!-- What should happen after running the steps above -->
use describe command to verify the nodepool is updated: autoscaling is enabled, and min replicas is 0

## Proof of the Fix
<!-- Attach evidence that demonstrates the changed behavior -->
- Screenshots:
- Videos:
- Logs/CLI output:
```
bash-5.2$ ./rosa list machinepool -c marco0419
ID       AUTOSCALING  REPLICAS  INSTANCE TYPE  LABELS    TAINTS    AVAILABILITY ZONE  SUBNET                    DISK SIZE  VERSION  AUTOREPAIR  
workers  No           2/2       m5.xlarge                          us-west-2a         subnet-0464543fcd59f75d6  300 GiB    4.21.7   Yes         
bash-5.2$ ./rosa edit machinepool -c marco0419 workers
? Enable autoscaling: Yes
? Min replicas: 0
? Max replicas: 2
? Labels (optional): 
? Taints (optional): 
? Autorepair: Yes
? Node drain grace period (optional): 
? Max surge: 1
? Max unavailable: 0
I: Updated machine pool 'workers' on hosted cluster 'marco0419'
bash-5.2$ ./rosa list machinepool -c marco0419
ID       AUTOSCALING  REPLICAS  INSTANCE TYPE  LABELS    TAINTS    AVAILABILITY ZONE  SUBNET                    DISK SIZE  VERSION  AUTOREPAIR  
workers  Yes          2/0-2     m5.xlarge                          us-west-2a         subnet-0464543fcd59f75d6  300 GiB    4.21.7   Yes  
```
- Other artifacts:

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
<!-- Required only when breaking changes are introduced -->

## Developer Verification Checklist
- [ ] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [ ] PR description clearly explains both **what** changed and **why**.
- [ ] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [ ] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [ ] `make test` passes.
- [ ] `make lint` passes.
- [ ] `make rosa` passes.
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [ ] Any risk, limitation, or follow-up work is documented.


[OCM-23979]: https://redhat.atlassian.net/browse/OCM-23979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved autoscaling validation and editing: correct detection of min/max changes, better handling of interactive edits, support for min replicas = 0, and more reliable prompt defaults that prefer existing autoscaling bounds.
  * Strengthened max-replicas validation to reject non‑positive values.

* **Tests**
  * Updated and expanded tests to cover explicit min/max flag behavior, min=0 cases, max<=0 cases, and related regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->