### PR TITLE
OCM-00000 | fix(ci): pin e2e builder to Go 1.25.8

### DIFF
--- a/images/Dockerfile.e2e
+++ b/images/Dockerfile.e2e
@@ -1,6 +1,11 @@
 # The image is for Prow CI steps to manage the ROSA cluster lifecycle and testing
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 as builder
-WORKDIR /go/src/github.com/openshift/rosa
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8 as builder
+WORKDIR /rosa
+USER root
+ENV GOBIN=/go/bin
+ENV PATH="/go/bin:${PATH}"
+ENV GOFLAGS=-buildvcs=false
+RUN mkdir -p /go/bin
 COPY . .
 RUN go install ./cmd/rosa
 RUN go test -c -o /go/bin/rosatest ./tests/e2e
@@ -13,12 +18,14 @@ RUN go install github.com/openshift-online/rosa-support@latest
 
 FROM registry.ci.openshift.org/ci/cli-ocm:latest as ocmcli
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8
+USER root
 COPY --from=builder /go/bin/rosa* /usr/bin
-COPY --from=builder /go/src/github.com/openshift/rosa/tests/ci/data /rosa/tests/ci/data
-COPY --from=builder /go/src/github.com/openshift/rosa/tests/prow_ci.sh /rosa/tests/
+COPY --from=builder /rosa/tests/ci/data /rosa/tests/ci/data
+COPY --from=builder /rosa/tests/prow_ci.sh /rosa/tests/
 COPY --from=ocmcli /usr/bin/ocm /usr/bin/ocm
 COPY --from=rosa-support /opt/app-root/src/go/bin/rosa-support /usr/bin
+RUN mkdir -p /rosa/tests /tests/output && ln -s /tests/output /rosa/tests/output
 RUN yum -y install --setopt=skip_missing_names_on_install=False \
     jq \
     unzip && yum clean all
@@ -28,4 +35,9 @@ RUN curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscl
     rm -rf awscliv2.zip aws &&\
     aws --version
 RUN rosa verify openshift-client
+RUN groupadd --system appuser && \
+    useradd --system --gid appuser --home-dir /rosa --shell /bin/bash appuser && \
+    chown -R appuser:appuser /rosa /usr/local/aws-cli && \
+    chown appuser:appuser /usr/bin/rosa /usr/bin/rosatest /usr/bin/ocm /usr/bin/rosa-support /usr/local/bin/aws
 WORKDIR /rosa
+USER appuser

--- a/images/Dockerfile.e2e
+++ b/images/Dockerfile.e2e
@@ -7,6 +7,7 @@ ENV PATH="/go/bin:${PATH}"
 ENV GOFLAGS=-buildvcs=false
 RUN mkdir -p /go/bin
 COPY . .
+RUN git config --global --add safe.directory /rosa
 RUN go install ./cmd/rosa
 RUN go test -c -o /go/bin/rosatest ./tests/e2e
 RUN rosa verify openshift-client


### PR DESCRIPTION
## PR Summary
Pin the ROSA e2e image build to the verified UBI Go 1.25.8 toolchain and keep the builder-stage binary paths aligned with that image layout.

## Detailed Description of the Issue
The Prow image jobs were failing in `images/Dockerfile.e2e` during `go install ./cmd/rosa` because the builder path was still effectively exposing Go 1.25.7 while the repo requires Go 1.25.8. This change stops relying on the floating `ocp/builder` stream for the ROSA e2e image and uses the verified `ubi9/go-toolset:1.25.8` path instead.

## Related Issues and PRs
- Jira: [OCM-22871](https://issues.redhat.com/browse/OCM-22871)
- Fixes: `N/A`
- Related PR(s):
  - openshift/release#78215
- Related design/docs:
  - N/A

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [x] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [x] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
The ROSA e2e image build could inherit a stale Go 1.25.7 toolchain from the Prow builder path, which caused `go install ./cmd/rosa` to fail once the repo moved to Go 1.25.8.

## Behavior After This Change
The e2e Dockerfile now builds on the verified UBI Go 1.25.8 image, keeps `/go/bin` on `PATH`, and copies the built artifacts from the updated workspace layout into the runtime image.

## How to Test (Step-by-Step)
### Preconditions
- `podman` installed

### Test Steps
1. Run `printf '%s\n' 'FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8' 'WORKDIR /rosa' 'USER root' 'ENV GOBIN=/go/bin' 'RUN mkdir -p /go/bin' 'COPY . .' 'RUN go version' 'RUN go install ./cmd/rosa' | podman build --platform linux/amd64 -f - .`
2. Run `podman build --platform linux/amd64 -f images/Dockerfile.e2e --target builder .`
3. Confirm both builds complete successfully.

### Expected Results
The ad-hoc builder and the real `images/Dockerfile.e2e` builder target complete without the previous `go.mod requires go >= 1.25.8 (running go 1.25.7)` failure.

## Proof of the Fix
- Screenshots: N/A
- Videos: N/A
- Logs/CLI output:
  - `go version go1.25.8 (Red Hat 1.25.8-1.el9_7) linux/amd64`
  - `podman build --platform linux/amd64 -f images/Dockerfile.e2e --target builder .` exited 0 after `go install ./cmd/rosa`
- Other artifacts: openshift/release#78215

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [ ] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [ ] `make test` passes.
- [ ] `make lint` passes.
- [ ] `make rosa` passes.
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

[OCM-22871]: https://redhat.atlassian.net/browse/OCM-22871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container build and runtime to a Red Hat UBI Go toolset for improved compatibility and consistency.
  * Adjusted build/install layout so compiled tools and test assets are available at runtime.
  * Runtime container now creates and uses a non-root application user and fixes ownership of application files and installed tools for improved security and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->