### PR TITLE
OCM-24123: Refactor proxy URL validation logic

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -497,7 +497,7 @@ func initFlags(cmd *cobra.Command) {
 		&args.httpsProxy,
 		"https-proxy",
 		"",
-		"A proxy URL to use for creating HTTPS connections outside the cluster.",
+		"A proxy URL to use for creating HTTPS connections outside the cluster. The URL scheme must be http or https.",
 	)
 
 	flags.StringSliceVar(

--- a/cmd/edit/cluster/cmd.go
+++ b/cmd/edit/cluster/cmd.go
@@ -161,7 +161,7 @@ func initFlags(cmd *cobra.Command) {
 		&args.httpsProxy,
 		"https-proxy",
 		"",
-		"A proxy URL to use for creating HTTPS connections outside the cluster.",
+		"A proxy URL to use for creating HTTPS connections outside the cluster. The URL scheme must be http or https.",
 	)
 
 	flags.StringSliceVar(

--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -134,8 +134,28 @@ func ClusterDomainPrefixValidator(domainPrefix interface{}) error {
 	return fmt.Errorf("can only validate strings, got '%v'", domainPrefix)
 }
 
-// validateProxyURL validates common proxy URL requirements
-func validateProxyURL(proxyURL string, proxyType string, expectedScheme string) error {
+// proxyAllowedURLSchemeErrorFragment lists allowed schemes for error messages, for example
+// 'http://' or 'https://' for two schemes.
+func proxyAllowedURLSchemeErrorFragment(allowedSchemes []string) string {
+	quoted := make([]string, len(allowedSchemes))
+	for i, s := range allowedSchemes {
+		quoted[i] = fmt.Sprintf("'%s://'", s)
+	}
+	switch len(quoted) {
+	case 0:
+		return ""
+	case 1:
+		return quoted[0]
+	case 2:
+		return quoted[0] + " or " + quoted[1]
+	default:
+		return strings.Join(quoted[:len(quoted)-1], ", ") + ", or " + quoted[len(quoted)-1]
+	}
+}
+
+// validateProxyURL validates common proxy URL requirements. allowedSchemes lists
+// acceptable URL schemes without the "://" suffix (for example "http", "https").
+func validateProxyURL(proxyURL string, proxyType string, allowedSchemes []string) error {
 	if strings.Contains(proxyURL, " ") {
 		return fmt.Errorf("invalid %s value: URL cannot contain spaces", proxyType)
 	}
@@ -153,8 +173,20 @@ func validateProxyURL(proxyURL string, proxyType string, expectedScheme string) 
 		return fmt.Errorf("invalid %s value: %v", proxyType, err)
 	}
 
-	if parsedURL.Scheme != expectedScheme {
-		return fmt.Errorf("expected '%s' to have an '%s://' scheme", proxyType, expectedScheme)
+	scheme := strings.ToLower(parsedURL.Scheme)
+	okScheme := false
+	for _, allowed := range allowedSchemes {
+		if scheme == strings.ToLower(allowed) {
+			okScheme = true
+			break
+		}
+	}
+	if !okScheme {
+		if len(allowedSchemes) == 0 {
+			return fmt.Errorf("invalid %s value: URL scheme is not allowed", proxyType)
+		}
+		schemeList := proxyAllowedURLSchemeErrorFragment(allowedSchemes)
+		return fmt.Errorf("invalid %s value: URL scheme must be %s", proxyType, schemeList)
 	}
 
 	if parsedURL.Host == "" {
@@ -174,7 +206,7 @@ func ValidateHTTPProxy(val interface{}) error {
 		if httpProxy == "" {
 			return nil
 		}
-		return validateProxyURL(httpProxy, "http-proxy", "http")
+		return validateProxyURL(httpProxy, "http-proxy", []string{"http"})
 	}
 	return fmt.Errorf("can only validate strings, got '%v'", val)
 }
@@ -184,7 +216,7 @@ func ValidateHTTPSProxy(val interface{}) error {
 		if httpsProxy == "" {
 			return nil
 		}
-		return validateProxyURL(httpsProxy, "https-proxy", "https")
+		return validateProxyURL(httpsProxy, "https-proxy", []string{"http", "https"})
 	}
 	return fmt.Errorf("can only validate strings, got '%v'", val)
 }

--- a/pkg/ocm/helpers_test.go
+++ b/pkg/ocm/helpers_test.go
@@ -787,7 +787,13 @@ var _ = Describe("ValidateHTTPProxy", func() {
 	It("rejects proxy with https scheme", func() {
 		err := ValidateHTTPProxy("https://proxy.example.com:8080")
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal("expected 'http-proxy' to have an 'http://' scheme"))
+		Expect(err.Error()).To(Equal("invalid http-proxy value: URL scheme must be 'http://'"))
+	})
+
+	It("rejects proxy with non-http scheme", func() {
+		err := ValidateHTTPProxy("ftp://proxy.example.com:1080")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("invalid http-proxy value: URL scheme must be 'http://'"))
 	})
 
 	It("rejects proxy without scheme", func() {
@@ -876,10 +882,15 @@ var _ = Describe("ValidateHTTPSProxy", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("rejects proxy with http scheme", func() {
+	It("accepts proxy with http scheme", func() {
 		err := ValidateHTTPSProxy("http://proxy.example.com:8080")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("rejects proxy with disallowed scheme", func() {
+		err := ValidateHTTPSProxy("ftp://proxy.example.com:1080")
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal("expected 'https-proxy' to have an 'https://' scheme"))
+		Expect(err.Error()).To(Equal("invalid https-proxy value: URL scheme must be 'http://' or 'https://'"))
 	})
 
 	It("rejects proxy without scheme", func() {
@@ -916,5 +927,40 @@ var _ = Describe("ValidateHTTPSProxy", func() {
 		err := ValidateHTTPSProxy("https://proxy.example.com:8080/path")
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal("invalid https-proxy value: proxy URL should not contain a path '/path'"))
+	})
+})
+
+var _ = Describe("validateProxyURL", func() {
+	It("rejects URL when allowed scheme list is empty", func() {
+		err := validateProxyURL("http://host.example", "test-proxy", []string{})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("invalid test-proxy value: URL scheme is not allowed"))
+	})
+
+	It("lists three allowed schemes in scheme mismatch errors", func() {
+		err := validateProxyURL("ftp://host.example", "test-proxy", []string{"http", "https", "socks5"})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal(
+			"invalid test-proxy value: URL scheme must be 'http://', 'https://', or 'socks5://'",
+		))
+	})
+})
+
+var _ = Describe("proxyAllowedURLSchemeErrorFragment", func() {
+	It("returns empty string for no schemes", func() {
+		Expect(proxyAllowedURLSchemeErrorFragment(nil)).To(Equal(""))
+		Expect(proxyAllowedURLSchemeErrorFragment([]string{})).To(Equal(""))
+	})
+
+	It("quotes a single scheme", func() {
+		Expect(proxyAllowedURLSchemeErrorFragment([]string{"http"})).To(Equal("'http://'"))
+	})
+
+	It("joins two schemes with or", func() {
+		Expect(proxyAllowedURLSchemeErrorFragment([]string{"http", "https"})).To(Equal("'http://' or 'https://'"))
+	})
+
+	It("joins three or more schemes with commas and or", func() {
+		Expect(proxyAllowedURLSchemeErrorFragment([]string{"a", "b", "c"})).To(Equal("'a://', 'b://', or 'c://'"))
 	})
 })

--- a/tests/e2e/test_rosacli_cluster.go
+++ b/tests/e2e/test_rosacli_cluster.go
@@ -885,10 +885,11 @@ var _ = Describe("Edit cluster validation should", labels.Feature.Cluster, func(
 			}
 			fmt.Println(originalHttpProxy, originalHTTPSProxy, originalNoProxy, originalCAFile)
 
-			By("Edit cluster with invalid http_proxy not started with http")
+			By("Edit cluster with invalid http_proxy values")
 			invalidHTTPProxy := map[string]string{
-				"invalidvalue":           "ERR: invalid http-proxy value: URL is missing scheme",
-				"https://test-proxy.com": "ERR: expected 'http-proxy' to have an 'http://' scheme",
+				"invalidvalue":                "ERR: invalid http-proxy value: URL is missing scheme",
+				"https://test-proxy.com":      "ERR: invalid http-proxy value: URL scheme must be 'http://'",
+				"http://test-proxy.com/extra": "ERR: invalid http-proxy value: proxy URL should not contain a path '/extra'",
 			}
 			for illegalHttpProxy, errMessage := range invalidHTTPProxy {
 				output, err := clusterService.EditCluster(clusterID,
@@ -899,14 +900,21 @@ var _ = Describe("Edit cluster validation should", labels.Feature.Cluster, func(
 			}
 
 			By("Edit cluster with invalid https_proxy set")
-			output, err := clusterService.EditCluster(clusterID,
-				"--https-proxy", "invalid",
-			)
-			Expect(err).To(HaveOccurred())
-			Expect(output.String()).Should(ContainSubstring("ERR: invalid https-proxy value: URL is missing scheme"))
+			invalidHTTPSProxy := map[string]string{
+				"invalidvalue":                 "ERR: invalid https-proxy value: URL is missing scheme",
+				"ftp://test-proxy.com":         "ERR: invalid https-proxy value: URL scheme must be 'http://' or 'https://'",
+				"https://test-proxy.com/extra": "ERR: invalid https-proxy value: proxy URL should not contain a path '/extra'",
+			}
+			for illegalHTTPSProxy, errMessage := range invalidHTTPSProxy {
+				output, err := clusterService.EditCluster(clusterID,
+					"--https-proxy", illegalHTTPSProxy,
+				)
+				Expect(err).To(HaveOccurred())
+				Expect(output.String()).Should(ContainSubstring(errMessage))
+			}
 
 			By("Edit cluster with invalid no_proxy ")
-			output, err = clusterService.EditCluster(clusterID,
+			output, err := clusterService.EditCluster(clusterID,
 				"--no-proxy", "*",
 			)
 			Expect(err).To(HaveOccurred())


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For contributor workflow, see: ./CONTRIBUTING.md
For repo-local agent guidance, see: ./AGENTS.md
-->

## PR Summary
<!-- brief text of 1 or 2 lines with the most important changes and outcomes -->
Refactor proxy URL validation logic to accept any non-empty scheme. Update tests to reflect changes in acceptance criteria for HTTP and HTTPS proxies.

## Detailed Description of the Issue
<!-- Describe the root problem, scope, impact, and user/business context -->
Proxies may use HTTP or HTTPS schemes, but the ROSA CLI mandates `http-proxy` uses `http` scheme and `https-proxy` uses `https` scheme. This is not correct.

## Related Issues and PRs
<!-- Link all tracking items and related code changes -->
- Jira: [OCM-24123](https://redhat.atlassian.net/browse/OCM-24123)

## Type of Change
<!-- Check the primary type this PR represents -->
- [ ] feat - adds a new user-facing capability.
- [x] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
<!-- What users or systems experienced before this change -->
```
--http-proxy http://ip-172-17-1-167.ap-southeast-1.compute.internal:3128/ \
--https-proxy http://ip-172-17-1-167.ap-southeast-1.compute.internal:3128/ \
```
Fails with
```
E: expected 'https-proxy' to have an 'https://' scheme
```

## Behavior After This Change
<!-- What changes now, including user-visible and non-user-visible behavior -->
```
--http-proxy http://ip-172-17-1-167.ap-southeast-1.compute.internal:3128/ \
--https-proxy http://ip-172-17-1-167.ap-southeast-1.compute.internal:3128/ \
```
Succeeds.

## How to Test (Step-by-Step)
<!-- Provide reproducible validation instructions -->

Set an `--http-proxy` to `https://proxy.example.com:8443`
Set an `--https-proxy` to `http://proxy.example.com:8080`

Validate that the change succeed. 

### Preconditions
<!-- Required setup, environment, credentials, flags, cluster state, etc. -->

### Test Steps
1.
2.
3.

### Expected Results
<!-- What should happen after running the steps above -->

## Proof of the Fix
<!-- Attach evidence that demonstrates the changed behavior -->
- Screenshots:
- Videos:
- Logs/CLI output:
- Other artifacts:

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
<!-- Required only when breaking changes are introduced -->

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [x] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

### Notes
- `make test` fails in an unrelated/unmodified test.

[OCM-24123]: https://redhat.atlassian.net/browse/OCM-24123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Proxy URL validation refined: HTTPS proxy now accepts http:// and https://; HTTP proxy requires http://. URLs with non-root/extra path components remain rejected. Error messages normalized to list allowed scheme(s).

* **Tests**
  * Unit and end-to-end tests updated to cover allowed-scheme permutations and new error phrasing.

* **Documentation**
  * CLI help text clarified to state allowed proxy schemes (http, https).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->