### PR TITLE
OCM-24070 | chore: Set release version to 1.2.62 on master

### DIFF
--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,7 +18,7 @@ limitations under the License.
 
 package info
 
-const DefaultVersion = "1.2.61"
+const DefaultVersion = "1.2.62"
 
 // Build contains the short Git SHA of the CLI at the point it was build. Set via `-ldflags` at build time
 var Build = "local"


### PR DESCRIPTION
## PR Summary

Bump `pkg/info/info.go` `DefaultVersion` on `master` from `1.2.61` to `1.2.62` so the default CLI version matches the GA **v1.2.62** release after QE sign-off.

## Related

- Jira: [OCM-24070](https://redhat.atlassian.net/browse/OCM-24070)
- GA tag: `v1.2.62`

## Validation

- `make clean rosa`
- `./rosa version` (reports `INFO: 1.2.62`)
- Local pre-push checks (format, build, lint, coverage, tests) passed on push to fork branch.

[OCM-24070]: https://redhat.atlassian.net/browse/OCM-24070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version number to reflect latest release

<!-- end of auto-generated comment: release notes by coderabbit.ai -->