### PR TITLE
OCM-24858 | fix: update the default machinepool instance type

### DIFF
--- a/cmd/create/machinepool/options.go
+++ b/cmd/create/machinepool/options.go
@@ -5,8 +5,6 @@ import (
 	"github.com/openshift/rosa/pkg/reporter"
 )
 
-const instanceType = "m5.xlarge"
-
 type CreateMachinepoolOptions struct {
 	reporter reporter.Logger
 
@@ -15,7 +13,7 @@ type CreateMachinepoolOptions struct {
 
 func NewCreateMachinepoolUserOptions() *mpOpts.CreateMachinepoolUserOptions {
 	return &mpOpts.CreateMachinepoolUserOptions{
-		InstanceType:          instanceType,
+		InstanceType:          mpOpts.DefaultInstanceType,
 		AutoscalingEnabled:    false,
 		MultiAvailabilityZone: true,
 		Autorepair:            true,

--- a/cmd/create/machinepool/options_test.go
+++ b/cmd/create/machinepool/options_test.go
@@ -21,7 +21,7 @@ var _ = Describe("CreateMachinepoolOptions", func() {
 
 	Context("NewCreateMachinepoolUserOptions", func() {
 		It("should create default user options", func() {
-			Expect(userOptions.InstanceType).To(Equal(instanceType))
+			Expect(userOptions.InstanceType).To(Equal(mpOpts.DefaultInstanceType))
 			Expect(userOptions.AutoscalingEnabled).To(BeFalse())
 			Expect(userOptions.MultiAvailabilityZone).To(BeTrue())
 			Expect(userOptions.Autorepair).To(BeTrue())

--- a/pkg/options/machinepool/create.go
+++ b/pkg/options/machinepool/create.go
@@ -40,16 +40,18 @@ type CreateMachinepoolUserOptions struct {
 }
 
 const (
-	use     = "machinepool"
-	short   = "Add machine pool to cluster"
-	long    = "Add a machine pool to the cluster."
-	example = `  # Interactively add a machine pool to a cluster named "mycluster"
+	// DefaultInstanceType is the default AWS instance type for new machine pools.
+	DefaultInstanceType = "m7i.xlarge"
+	use                 = "machinepool"
+	short               = "Add machine pool to cluster"
+	long                = "Add a machine pool to the cluster."
+	example             = `  # Interactively add a machine pool to a cluster named "mycluster"
   rosa create machinepool --cluster=mycluster --interactive
-  # Add a machine pool mp-1 with 3 replicas of m5.xlarge to a cluster
-  rosa create machinepool --cluster=mycluster --name=mp-1 --replicas=3 --instance-type=m5.xlarge
-  # Add a machine pool mp-1 with autoscaling enabled and 3 to 6 replicas of m5.xlarge to a cluster
+  # Add a machine pool mp-1 with 3 replicas of m7i.xlarge to a cluster
+  rosa create machinepool --cluster=mycluster --name=mp-1 --replicas=3 --instance-type=m7i.xlarge
+  # Add a machine pool mp-1 with autoscaling enabled and 3 to 6 replicas of m7i.xlarge to a cluster
   rosa create machinepool --cluster=mycluster --name=mp-1 --enable-autoscaling \
-	--min-replicas=3 --max-replicas=6 --instance-type=m5.xlarge
+	--min-replicas=3 --max-replicas=6 --instance-type=m7i.xlarge
   # Add a machine pool with labels to a cluster
   rosa create machinepool -c mycluster --name=mp-1 --replicas=2 --instance-type=r5.2xlarge --labels=foo=bar,bar=baz,
   # Add a machine pool with spot instances to a cluster
@@ -64,7 +66,9 @@ type CreateMachinepoolOptions struct {
 }
 
 func NewCreateMachinepoolUserOptions() *CreateMachinepoolUserOptions {
-	return &CreateMachinepoolUserOptions{}
+	return &CreateMachinepoolUserOptions{
+		InstanceType: DefaultInstanceType,
+	}
 }
 
 func (m *CreateMachinepoolOptions) Machinepool() *CreateMachinepoolUserOptions {
@@ -130,7 +134,7 @@ func BuildMachinePoolCreateCommandWithOptions() (*cobra.Command, *CreateMachinep
 	flags.StringVar(
 		&options.InstanceType,
 		"instance-type",
-		"m5.xlarge",
+		DefaultInstanceType,
 		"Instance type that should be used.",
 	)
 

--- a/pkg/options/machinepool/create_test.go
+++ b/pkg/options/machinepool/create_test.go
@@ -31,7 +31,7 @@ var _ = Describe("BuildMachinePoolCreateCommandWithOptions", func() {
 		Expect(options.AutoscalingEnabled).To(Equal(false))
 		Expect(options.MinReplicas).To(Equal(0))
 		Expect(options.MaxReplicas).To(Equal(0))
-		Expect(options.InstanceType).To(Equal("m5.xlarge"))
+		Expect(options.InstanceType).To(Equal(DefaultInstanceType))
 		Expect(options.Labels).To(Equal(""))
 		Expect(options.Taints).To(Equal(""))
 		Expect(options.UseSpotInstances).To(Equal(false))
@@ -70,7 +70,7 @@ var _ = Describe("BuildMachinePoolCreateCommandWithOptions", func() {
 		Expect(maxReplicas).To(Equal(0))
 
 		instanceType, _ := flags.GetString("instance-type")
-		Expect(instanceType).To(Equal("m5.xlarge"))
+		Expect(instanceType).To(Equal(DefaultInstanceType))
 
 		labels, _ := flags.GetString("labels")
 		Expect(labels).To(Equal(""))

--- a/tests/e2e/test_rosacli_machine_pool.go
+++ b/tests/e2e/test_rosacli_machine_pool.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openshift-online/ocm-common/pkg/test/vpc_client"
 
-	mpOpts "github.com/openshift/rosa/pkg/options/machinepool"
 	"github.com/openshift/rosa/tests/ci/labels"
 	"github.com/openshift/rosa/tests/utils/config"
 	"github.com/openshift/rosa/tests/utils/constants"
@@ -20,6 +19,8 @@ import (
 	"github.com/openshift/rosa/tests/utils/helper"
 	"github.com/openshift/rosa/tests/utils/log"
 )
+
+const expectedDefaultMachinePoolInstanceType = "m7i.xlarge"
 
 var _ = Describe("Create machinepool",
 	labels.Feature.Machinepool,
@@ -141,7 +142,7 @@ var _ = Describe("Create machinepool",
 					Expect(err).ToNot(HaveOccurred())
 					if key == "default" {
 						Expect(out.Machinepool(mpID).Replicas).To(Equal("0"))
-						Expect(out.Machinepool(mpID).InstanceType).To(Equal(mpOpts.DefaultInstanceType))
+						Expect(out.Machinepool(mpID).InstanceType).To(Equal(expectedDefaultMachinePoolInstanceType))
 					}
 
 					if key == "advanced" {
@@ -159,7 +160,7 @@ var _ = Describe("Create machinepool",
 						Expect(out.Machinepool(mpID).Replicas).
 							To(
 								Equal(fmt.Sprintf("%s-%s", minReplicas, maxReplicas)))
-						Expect(out.Machinepool(mpID).InstanceType).To(Equal(mpOpts.DefaultInstanceType))
+						Expect(out.Machinepool(mpID).InstanceType).To(Equal(expectedDefaultMachinePoolInstanceType))
 						Expect(out.Machinepool(mpID).Labels).To(
 							Equal(strings.Join(helper.ParseCommaSeparatedStrings(labels_2), ", ")))
 					}

--- a/tests/e2e/test_rosacli_machine_pool.go
+++ b/tests/e2e/test_rosacli_machine_pool.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openshift-online/ocm-common/pkg/test/vpc_client"
 
+	mpOpts "github.com/openshift/rosa/pkg/options/machinepool"
 	"github.com/openshift/rosa/tests/ci/labels"
 	"github.com/openshift/rosa/tests/utils/config"
 	"github.com/openshift/rosa/tests/utils/constants"
@@ -140,7 +141,7 @@ var _ = Describe("Create machinepool",
 					Expect(err).ToNot(HaveOccurred())
 					if key == "default" {
 						Expect(out.Machinepool(mpID).Replicas).To(Equal("0"))
-						Expect(out.Machinepool(mpID).InstanceType).To(Equal("m5.xlarge"))
+						Expect(out.Machinepool(mpID).InstanceType).To(Equal(mpOpts.DefaultInstanceType))
 					}
 
 					if key == "advanced" {
@@ -158,7 +159,7 @@ var _ = Describe("Create machinepool",
 						Expect(out.Machinepool(mpID).Replicas).
 							To(
 								Equal(fmt.Sprintf("%s-%s", minReplicas, maxReplicas)))
-						Expect(out.Machinepool(mpID).InstanceType).To(Equal("m5.xlarge"))
+						Expect(out.Machinepool(mpID).InstanceType).To(Equal(mpOpts.DefaultInstanceType))
 						Expect(out.Machinepool(mpID).Labels).To(
 							Equal(strings.Join(helper.ParseCommaSeparatedStrings(labels_2), ", ")))
 					}


### PR DESCRIPTION
JIRA: [OCM-24858](https://redhat.atlassian.net/browse/OCM-24858)

[OCM-24858]: https://redhat.atlassian.net/browse/OCM-24858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CLI no longer hard-codes a default instance type for machine pool creation; the flag defaults to unspecified so the cluster’s default is used.
  * Help text and tests updated to reflect using the cluster-derived default when no --instance-type is supplied.
* **Bug Fixes**
  * Creation flows now derive and reuse default instance type and root disk size, avoiding redundant lookups.
* **Bug Fixes**
  * Spot price handling treats the “on-demand” value consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->