### PR TITLE
OCM-24479 | ci: configure Renovate for ROSA CLI

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -50,9 +50,13 @@
   },
   "packageRules": [
     {
-      "description": "Enable automerge Konflux tekton task updates",
+      "description": "Enable automerge Konflux .tekton task updates",
       "matchManagers": [
         "tekton"
+      ],
+      "matchFileNames": [
+        ".tekton/**/*.yaml",
+        ".tekton/**/*.yml"
       ],
       "automerge": true
     },

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,165 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":gitSignOff"
+  ],
+  "enabledManagers": [
+    "gomod",
+    "tekton",
+    "dockerfile"
+  ],
+  "commitMessagePrefix": "OCM-00000 | ci: ",
+  "prConcurrentLimit": 2,
+  "prHourlyLimit": 0,
+  "dependencyDashboard": true,
+  "minimumReleaseAge": "3 days",
+  "vulnerabilityAlerts": {
+    "enabled": false
+  },
+  "labels": [
+    "ok-to-test"
+  ],
+  "tekton": {
+    "schedule": [
+      "at any time"
+    ]
+  },
+  "gomod": {
+    "constraints": {
+      "go": "1.25.8"
+    },
+    "managerFilePatterns": [
+      "/(^|/)\\.bingo/[^/]+\\.mod$/"
+    ],
+    "postUpdateOptions": [
+      "gomodUpdateImportPaths",
+      "gomodTidy"
+    ],
+    "packageRules": [
+      {
+        "matchManagers": [
+          "gomod"
+        ],
+        "matchDepTypes": [
+          "indirect"
+        ],
+        "enabled": false
+      }
+    ]
+  },
+  "packageRules": [
+    {
+      "description": "Enable automerge Konflux tekton task updates",
+      "matchManagers": [
+        "tekton"
+      ],
+      "automerge": true
+    },
+    {
+      "description": "Do not bump Go toolchain minor/major versions",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchDatasources": [
+        "golang-version"
+      ],
+      "matchDepTypes": [
+        "toolchain"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "major"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Group Bingo-managed tool modules",
+      "groupName": "bingo-tooling",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchFileNames": [
+        ".bingo/*.mod"
+      ]
+    },
+    {
+      "description": "AWS SDK v2 and smithy",
+      "groupName": "aws-sdk",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "github.com/aws/{/,}**"
+      ]
+    },
+    {
+      "description": "OpenShift OCM libraries",
+      "groupName": "openshift-ocm",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "github.com/openshift-online/{/,}**"
+      ]
+    },
+    {
+      "description": "Cobra CLI stack",
+      "groupName": "spf13-cli",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "github.com/spf13/{/,}**"
+      ]
+    },
+    {
+      "description": "Kubernetes client libraries",
+      "groupName": "kubernetes",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "k8s.io/{/,}**",
+        "sigs.k8s.io/{/,}**"
+      ]
+    },
+    {
+      "description": "Pin k8s.io/apimachinery below the Go 1.26-only line",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "k8s.io/apimachinery"
+      ],
+      "allowedVersions": "< 0.36.0"
+    },
+    {
+      "description": "Test and generator stack",
+      "groupName": "testing",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "github.com/onsi/{/,}**",
+        "go.uber.org/{/,}**"
+      ]
+    },
+    {
+      "description": "CLI helper libraries",
+      "groupName": "helpers",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "github.com/AlecAivazis/survey/v2",
+        "github.com/Masterminds/semver",
+        "github.com/pkg/errors",
+        "github.com/sirupsen/logrus",
+        "github.com/zgalor/weberr",
+        "gopkg.in/yaml.v2",
+        "gopkg.in/yaml.v3"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## PR Summary
Add a MintMaker-compatible `renovate.json` so ROSA CLI dependency updates can be proposed through the repo's existing Konflux/Prow workflow, including the `OCM-24531` requirement to auto-merge Konflux `.tekton` updates.

## Detailed Description of the Issue
The ROSA CLI repo did not have in-repo dependency automation even though it already carries several update surfaces that benefit from regular maintenance, including the root Go module, Bingo-managed tool modules, Dockerfiles, and Tekton bundle references.

This change adds a repo-local Renovate configuration based on the newer provider-repo setup while adapting it to ROSA-specific constraints:
- use the existing `ok-to-test` bot workflow
- keep commit titles compatible with the repo template
- avoid `reviewersFromCodeOwners` because this repo has `OWNERS`, not GitHub `CODEOWNERS`
- cover Bingo's nonstandard `.bingo/*.mod` files with `gomod.managerFilePatterns`
- group high-churn dependency ecosystems to keep PR volume reviewable
- enable auto-merge for Konflux-managed `.tekton` updates, which is the ROSA CLI portion of `OCM-24531`

## Related Issues and PRs
- Jira:
  - [OCM-24479](https://issues.redhat.com/browse/OCM-24479)
  - [OCM-24531](https://redhat.atlassian.net/browse/OCM-24531)
- Fixes: N/A
- Related PR(s):
  - Companion release PR for `OCM-24531`: [openshift/release#79678](https://github.com/openshift/release/pull/79678)
  - Provider reference: [terraform-redhat/terraform-provider-rhcs renovate.json](https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/renovate.json)
- Related design/docs: N/A

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [x] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
The repository had no in-repo Renovate or Dependabot configuration, so dependency update handling for Go modules, Bingo-managed tool modules, Dockerfiles, and Tekton bundle references depended on manual maintenance. Konflux `.tekton` reference PRs also had no repo-local auto-merge policy.

## Behavior After This Change
The repository has a MintMaker-compatible `renovate.json` that:
- enables `gomod`, `dockerfile`, and `tekton` managers
- keeps `ok-to-test` labeling and bot-friendly commit prefixes
- constrains Go updates to the current supported baseline
- groups AWS, OCM, Kubernetes, testing, CLI helper, and Bingo tool updates
- allows Tekton dependency updates to follow the established Konflux path
- auto-merges Konflux `.tekton` updates via the Tekton manager rule, explicitly scoped to `.tekton/**/*.yaml` and `.tekton/**/*.yml`

## How to Test (Step-by-Step)
### Preconditions
- Node.js and `npx` available locally.

### Test Steps
1. Validate JSON syntax:
   ```bash
   python -c "import json; json.load(open('renovate.json')); print('json-ok')"
   ```
2. Validate Renovate configuration:
   ```bash
   npx --yes --package renovate renovate-config-validator renovate.json
   ```
3. Review the config contents and confirm it covers:
   - root `go.mod`
   - `.bingo/*.mod`
   - Dockerfiles
   - `.tekton` dependency references
   - `packageRules` entry enabling automerge for `.tekton` updates

### Expected Results
- JSON syntax validation prints `json-ok`.
- Renovate validator reports `Config validated successfully`.
- The config reflects the ROSA-specific grouping, labels, and manager coverage described above.
- The Tekton manager rule clearly enables auto-merge for Konflux `.tekton` updates.

## Proof of the Fix
- Logs/CLI output: `json-ok` from Python JSON parsing and `Config validated successfully` from `renovate-config-validator`.

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [ ] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

[OCM-24479]: https://redhat.atlassian.net/browse/OCM-24479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ