### PR TITLE
OCM-24551 | ci: align CodeRabbit review coverage for the CLI

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -26,6 +26,18 @@ reviews:
         - Treat Cobra wiring, flags, command UX, and error handling as high-signal review areas.
         - Flag changes that add commands or flags without matching updates to `cmd/rosa/structure_test/command_structure.yml` or the matching `command_args.yml`.
         - Prefer thin command files and business logic in `pkg/`.
+    - path: "**/*.sh"
+      instructions: |
+        - Review shell scripts for portable bash usage, strict-mode safety, quoting, and robust temporary-file or pipe handling.
+        - Keep script behavior aligned with `Makefile`, `hack/run-checks.sh`, and the git hooks instead of introducing parallel workflows.
+    - path: "**/Dockerfile*"
+      instructions: |
+        - Keep build and runtime image changes aligned with the repo's Go toolchain, release flow, and static-binary expectations.
+        - Flag unpinned downloads, secret-bearing build arguments, or image changes that drift from Tekton/Konflux assumptions without justification.
+    - path: ".tekton/**/*.{yml,yaml}"
+      instructions: |
+        - Treat Konflux/Tekton pipeline steps, required scan stages, and fail-fast behavior as high-signal review areas.
+        - Flag changes that bypass validation gates, artifact flow, or image/security checks without matching workflow updates.
     - path: "pkg/aws/**/*.go"
       instructions: |
         - Cross-check AWS behavior and user-facing wording against the official ROSA and AWS references called out in `AGENTS.md`.
@@ -42,20 +54,42 @@ reviews:
       instructions: |
         - Check commands, workflow steps, and product terminology against `AGENTS.md`, `CONTRIBUTING.md`, `guidelines/ARCHITECTURE.md`, and official ROSA/AWS docs.
         - Flag stale file paths, placeholder Jira links, or wording that conflicts with the real repository workflow.
+    - path: "cmd/rosa/structure_test/**/*.{yml,yaml}"
+      instructions: |
+        - Ensure command structure and flag expectations stay exactly aligned with the CLI tree and supported Cobra flags.
+        - Flag command or flag changes in Go code that are not reflected here, and vice versa.
+    - path: "cmd/create/network/templates/**/*.yaml"
+      instructions: |
+        - Review CloudFormation and network template changes against the ROSA and AWS guidance referenced from `AGENTS.md`.
+        - Flag unsupported AWS assumptions, risky networking defaults, or stale CLI-version/template compatibility notes.
     - path: ".github/**/*"
       instructions: |
         - Keep issue and PR metadata aligned with repo-local agent guidance and contributor workflow.
   tools:
+    checkov:
+      enabled: false
+    gitleaks:
+      enabled: true
     golangci-lint:
       enabled: true
-    gitleaks:
+    hadolint:
+      enabled: true
+    markdownlint:
+      enabled: false
+    shellcheck:
+      enabled: true
+    trivy:
+      enabled: false
+    yamllint:
       enabled: true
 
 knowledge_base:
   code_guidelines:
     enabled: true
     filePatterns:
+      - AGENTS.md
       - CONTRIBUTING.md
+      - .cursor/rules/*.mdc
       - guidelines/ARCHITECTURE.md
       - guidelines/*-guidelines.md
       - .claude/SKILLS.md


### PR DESCRIPTION
## PR Summary

Align the ROSA CLI repository's CodeRabbit configuration with CLI-specific review surfaces instead of Terraform-provider defaults by extending path instructions for shell, Docker, Tekton, command-structure YAML, and CloudFormation paths, and by explicitly enabling only the review tools that fit this repo.

## Detailed Description of the Issue

The Jira points to the Terraform provider's `.coderabbit.yaml` as reference material, but the ROSA CLI repository has different code and configuration surfaces. The CLI already had a strong CodeRabbit baseline for Go code and docs, but it lacked targeted review guidance for important non-Go paths like shell scripts, Dockerfiles, Tekton pipelines, command structure YAML, and CloudFormation templates. This change keeps the provider as precedent while tailoring the final configuration to ROSA CLI standards, existing contributor workflow, and current CI/security reality.

## Related Issues and PRs
- Jira: [OCM-24551](https://redhat.atlassian.net/browse/OCM-24551)
- Fixes: N/A
- Related PR(s):
  - Provider reference: [terraform-redhat/terraform-provider-rhcs#1107](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1107)
  - Provider reference: [terraform-redhat/terraform-provider-rhcs#1138](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1138)
- Related design/docs: N/A

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [x] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior

The repo-specific CodeRabbit configuration focused on Go, AWS-sensitive code, tests, docs, and GitHub metadata, and only explicitly enabled `golangci-lint` and `gitleaks`. It did not provide targeted review instructions for shell scripts, Dockerfiles, Tekton YAML, command-structure YAML, or CloudFormation templates, and it did not make local tool choices explicit for several inherited scanner options.

## Behavior After This Change

CodeRabbit review guidance now explicitly covers the ROSA CLI repo's high-signal non-Go surfaces:
- `**/*.sh` for hook and helper scripts
- `**/Dockerfile*` for build/runtime image changes
- `.tekton/**/*.{yml,yaml}` for Konflux/Tekton workflows
- `cmd/rosa/structure_test/**/*.{yml,yaml}` for command/flag contract files
- `cmd/create/network/templates/**/*.yaml` for CloudFormation/network templates

The config also explicitly keeps the local tool set CLI-specific by enabling `hadolint`, `shellcheck`, and `yamllint`, while leaving `checkov`, `trivy`, and `markdownlint` disabled.

## How to Test (Step-by-Step)
### Preconditions
- Repository checkout on branch `OCM-24551`
- Python available with `yaml` import support in the local environment

### Test Steps
1. Validate the repository CodeRabbit config parses as YAML:
   ```bash
   python - <<'PY'
   import yaml
   from pathlib import Path
   data = yaml.safe_load(Path('.coderabbit.yaml').read_text())
   assert isinstance(data, dict)
   print(sorted(data.keys()))
   print(sorted(data.get('reviews', {}).get('tools', {}).keys()))
   PY
   ```
2. Run the repository verification flow:
   ```bash
   make pre-push-checks
   ```
3. Inspect `.coderabbit.yaml` and confirm the new path instructions and tool toggles are tailored to ROSA CLI paths rather than copied from the Terraform provider.

### Expected Results
- `.coderabbit.yaml` parses successfully.
- `make pre-push-checks` passes.
- The configuration explicitly covers ROSA CLI shell, Docker, Tekton, structure-test, and CloudFormation paths.

## Proof of the Fix
- Screenshots: N/A
- Videos: N/A
- Logs/CLI output:
  - YAML parse succeeded with top-level keys `inheritance`, `knowledge_base`, `language`, `reviews`
  - `make pre-push-checks` passed: format check, build, lint, changed-files coverage, and unit/integration tests
- Other artifacts: N/A

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [ ] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

[OCM-24551]: https://redhat.atlassian.net/browse/OCM-24551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review configuration settings to enhance automated review processes for shell scripts, Docker configurations, and template files.
  * Expanded code guidelines documentation patterns for better reference during development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->