### PR TITLE
OCM-24429 | feat: Updated rosa list ocm-role to display console access

### DIFF
--- a/cmd/list/ocmroles/cmd.go
+++ b/cmd/list/ocmroles/cmd.go
@@ -18,6 +18,7 @@ package ocmroles
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"text/tabwriter"
 	"time"
@@ -86,18 +87,24 @@ func run(_ *cobra.Command, _ []string) {
 
 	// Create the writer that will be used to print the tabulated results:
 	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprint(writer, "ROLE NAME\tROLE ARN\tLINKED\tADMIN\tAWS Managed\n")
-	for _, ocmRole := range ocmRoles {
-		var awsManaged string
-		if ocmRole.ManagedPolicy {
-			awsManaged = "Yes"
-		} else {
-			awsManaged = "No"
-		}
-		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\n", ocmRole.RoleName, ocmRole.RoleARN, ocmRole.Linked, ocmRole.Admin,
-			awsManaged)
-	}
+	printOCMRoles(writer, ocmRoles)
 	writer.Flush()
+}
+
+func printOCMRoles(writer io.Writer, ocmRoles []aws.Role) {
+	fmt.Fprint(writer, "ROLE NAME\tROLE ARN\tLINKED\tADMIN\tAWS Managed\tCONSOLE ACCESS\n")
+	for _, ocmRole := range ocmRoles {
+		awsManaged := output.No
+		if ocmRole.ManagedPolicy {
+			awsManaged = output.Yes
+		}
+		consoleAccess := output.Yes
+		if ocmRole.NoConsole == output.Yes {
+			consoleAccess = output.No
+		}
+		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\t%s\n", ocmRole.RoleName, ocmRole.RoleARN, ocmRole.Linked,
+			ocmRole.Admin, awsManaged, consoleAccess)
+	}
 }
 
 func listOCMRoles(r *rosa.Runtime) ([]aws.Role, error) {
@@ -126,9 +133,9 @@ func listOCMRoles(r *rosa.Runtime) ([]aws.Role, error) {
 	for i := range ocmRoles {
 		_, exist := linkedRolesMap[ocmRoles[i].RoleARN]
 		if exist {
-			ocmRoles[i].Linked = "Yes"
+			ocmRoles[i].Linked = output.Yes
 		} else {
-			ocmRoles[i].Linked = "No"
+			ocmRoles[i].Linked = output.No
 		}
 	}
 

--- a/cmd/list/ocmroles/cmd_test.go
+++ b/cmd/list/ocmroles/cmd_test.go
@@ -1,0 +1,257 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package ocmroles
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+
+	"github.com/openshift/rosa/pkg/aws"
+	mock "github.com/openshift/rosa/pkg/aws"
+	. "github.com/openshift/rosa/pkg/test"
+)
+
+func TestListOCMRoles(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "rosa list ocm-roles")
+}
+
+var _ = Describe("rosa list ocm-roles", func() {
+	Context("printOCMRoles", func() {
+		It("Prints header and rows with all columns", func() {
+			roles := []aws.Role{
+				{
+					RoleName:      "my-OCM-Role",
+					RoleARN:       "arn:aws:iam::111111111111:role/my-OCM-Role",
+					Linked:        "Yes",
+					Admin:         "Yes",
+					ManagedPolicy: true,
+					NoConsole:     "No",
+				},
+			}
+			var buf bytes.Buffer
+			printOCMRoles(&buf, roles)
+			lines := strings.Split(buf.String(), "\n")
+			Expect(len(lines)).To(BeNumerically(">=", 2))
+
+			header := strings.Split(lines[0], "\t")
+			Expect(header).To(HaveLen(6))
+			Expect(header[4]).To(Equal("AWS Managed"))
+			Expect(header[5]).To(Equal("CONSOLE ACCESS"))
+
+			cols := strings.Split(lines[1], "\t")
+			Expect(cols).To(HaveLen(6))
+			Expect(cols[0]).To(Equal("my-OCM-Role"))
+			Expect(cols[1]).To(Equal("arn:aws:iam::111111111111:role/my-OCM-Role"))
+			Expect(cols[2]).To(Equal("Yes"))
+			Expect(cols[3]).To(Equal("Yes"))
+			Expect(cols[4]).To(Equal("Yes"))
+			Expect(cols[5]).To(Equal("Yes"))
+		})
+
+		It("Shows No in CONSOLE ACCESS when NoConsole is Yes", func() {
+			roles := []aws.Role{
+				{
+					RoleName:  "no-console-OCM-Role",
+					RoleARN:   "arn:aws:iam::111111111111:role/no-console-OCM-Role",
+					Linked:    "No",
+					Admin:     "No",
+					NoConsole: "Yes",
+				},
+			}
+			var buf bytes.Buffer
+			printOCMRoles(&buf, roles)
+			lines := strings.Split(buf.String(), "\n")
+			Expect(len(lines)).To(BeNumerically(">=", 2))
+			cols := strings.Split(lines[1], "\t")
+			Expect(cols).To(HaveLen(6))
+			Expect(cols[4]).To(Equal("No"))
+			Expect(cols[5]).To(Equal("No"))
+		})
+
+		It("Shows Yes in CONSOLE ACCESS when NoConsole is No", func() {
+			roles := []aws.Role{
+				{
+					RoleName:  "console-OCM-Role",
+					RoleARN:   "arn:aws:iam::111111111111:role/console-OCM-Role",
+					Linked:    "No",
+					Admin:     "No",
+					NoConsole: "No",
+				},
+			}
+			var buf bytes.Buffer
+			printOCMRoles(&buf, roles)
+			lines := strings.Split(buf.String(), "\n")
+			Expect(len(lines)).To(BeNumerically(">=", 2))
+			cols := strings.Split(lines[1], "\t")
+			Expect(cols).To(HaveLen(6))
+			Expect(cols[4]).To(Equal("No"))
+			Expect(cols[5]).To(Equal("Yes"))
+		})
+
+		It("Shows AWS Managed correctly", func() {
+			roles := []aws.Role{
+				{
+					RoleName:      "managed-OCM-Role",
+					RoleARN:       "arn:aws:iam::111111111111:role/managed-OCM-Role",
+					Linked:        "No",
+					Admin:         "No",
+					ManagedPolicy: true,
+					NoConsole:     "No",
+				},
+				{
+					RoleName:      "unmanaged-OCM-Role",
+					RoleARN:       "arn:aws:iam::111111111111:role/unmanaged-OCM-Role",
+					Linked:        "No",
+					Admin:         "No",
+					ManagedPolicy: false,
+					NoConsole:     "Yes",
+				},
+			}
+			var buf bytes.Buffer
+			printOCMRoles(&buf, roles)
+			lines := strings.Split(buf.String(), "\n")
+			Expect(len(lines)).To(BeNumerically(">=", 3))
+
+			managedCols := strings.Split(lines[1], "\t")
+			Expect(managedCols).To(HaveLen(6))
+			Expect(managedCols[4]).To(Equal("Yes"))
+			Expect(managedCols[5]).To(Equal("Yes"))
+
+			unmanagedCols := strings.Split(lines[2], "\t")
+			Expect(unmanagedCols).To(HaveLen(6))
+			Expect(unmanagedCols[4]).To(Equal("No"))
+			Expect(unmanagedCols[5]).To(Equal("No"))
+		})
+
+		It("Shows NoConsole overriding Admin in display", func() {
+			roles := []aws.Role{
+				{
+					RoleName:  "both-tags-OCM-Role",
+					RoleARN:   "arn:aws:iam::111111111111:role/both-tags-OCM-Role",
+					Linked:    "No",
+					Admin:     "No",
+					NoConsole: "Yes",
+				},
+			}
+			var buf bytes.Buffer
+			printOCMRoles(&buf, roles)
+			lines := strings.Split(buf.String(), "\n")
+			Expect(len(lines)).To(BeNumerically(">=", 2))
+			cols := strings.Split(lines[1], "\t")
+			Expect(cols).To(HaveLen(6))
+			Expect(cols[0]).To(Equal("both-tags-OCM-Role"))
+			Expect(cols[3]).To(Equal("No"))
+			Expect(cols[5]).To(Equal("No"))
+		})
+
+		It("Prints only the header for empty roles", func() {
+			var buf bytes.Buffer
+			printOCMRoles(&buf, []aws.Role{})
+			output := buf.String()
+			Expect(output).To(ContainSubstring("ROLE NAME"))
+			Expect(output).To(ContainSubstring("CONSOLE ACCESS"))
+			lines := bytes.Split(buf.Bytes(), []byte("\n"))
+			Expect(len(lines)).To(Equal(2))
+		})
+	})
+
+	Context("listOCMRoles", func() {
+		var (
+			t          *TestingRuntime
+			mockClient *mock.MockClient
+		)
+
+		BeforeEach(func() {
+			t = NewTestRuntime()
+			mockCtrl := gomock.NewController(GinkgoT())
+			mockClient = mock.NewMockClient(mockCtrl)
+			t.RosaRuntime.AWSClient = mockClient
+		})
+
+		It("Returns empty slice when no roles exist", func() {
+			mockClient.EXPECT().ListOCMRoles().Return([]aws.Role{}, nil)
+			roles, err := listOCMRoles(t.RosaRuntime)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(roles).To(BeEmpty())
+		})
+
+		It("Returns error when AWS ListOCMRoles fails", func() {
+			mockClient.EXPECT().ListOCMRoles().Return(nil, fmt.Errorf("aws error"))
+			roles, err := listOCMRoles(t.RosaRuntime)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("aws error"))
+			Expect(roles).To(BeNil())
+		})
+
+		It("Sets linked status and preserves NoConsole field", func() {
+			awsRoles := []aws.Role{
+				{
+					RoleName:  "linked-OCM-Role",
+					RoleARN:   "arn:aws:iam::111111111111:role/linked-OCM-Role",
+					Admin:     "Yes",
+					NoConsole: "Yes",
+				},
+				{
+					RoleName:  "unlinked-OCM-Role",
+					RoleARN:   "arn:aws:iam::222222222222:role/unlinked-OCM-Role",
+					Admin:     "No",
+					NoConsole: "No",
+				},
+			}
+			mockClient.EXPECT().ListOCMRoles().Return(awsRoles, nil)
+
+			// GET /api/accounts_mgmt/v1/current_account
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusOK, `{
+					"kind": "Account",
+					"organization": {
+						"id": "org123",
+						"kind": "Organization"
+					}
+				}`),
+			)
+			// GET /api/accounts_mgmt/v1/organizations/org123/labels/sts_ocm_role
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusOK, `{
+					"kind": "Label",
+					"key": "sts_ocm_role",
+					"value": "arn:aws:iam::111111111111:role/linked-OCM-Role"
+				}`),
+			)
+
+			roles, err := listOCMRoles(t.RosaRuntime)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(roles).To(HaveLen(2))
+			// Linked roles sort first
+			Expect(roles[0].RoleName).To(Equal("linked-OCM-Role"))
+			Expect(roles[0].Linked).To(Equal("Yes"))
+			Expect(roles[0].NoConsole).To(Equal("Yes"))
+			Expect(roles[1].RoleName).To(Equal("unlinked-OCM-Role"))
+			Expect(roles[1].Linked).To(Equal("No"))
+			Expect(roles[1].NoConsole).To(Equal("No"))
+		})
+	})
+})

--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -76,6 +76,7 @@ type Role struct {
 	Linked        string `json:"Linked,omitempty"`
 	Admin         string `json:"Admin,omitempty"`
 	ManagedPolicy bool   `json:"ManagedPolicy,omitempty"`
+	NoConsole     string `json:"NoConsole,omitempty"`
 	ClusterID     string `json:"ClusterID,omitempty"`
 }
 
@@ -134,6 +135,9 @@ const (
 		"\"Action\": \"sts:AssumeRole\",\n    \"Resource\": [\n    \"%{shared_vpc_role_arn}\"\n    ]\n  }\n}\n"
 
 	TrueString = "true"
+
+	RoleYes = "Yes"
+	RoleNo  = "No"
 )
 
 const (
@@ -806,12 +810,18 @@ func (c *awsClient) ListOCMRoles() ([]Role, error) {
 			}
 			v2Tags := roleTags.Tags
 			if common.IamResourceHasTag(v2Tags, tags.AdminRole, tags.True) {
-				ocmRole.Admin = "Yes"
+				ocmRole.Admin = RoleYes
 			} else {
-				ocmRole.Admin = "No"
+				ocmRole.Admin = RoleNo
 			}
 			if common.IamResourceHasTag(v2Tags, common.ManagedPolicies, tags.True) {
 				ocmRole.ManagedPolicy = true
+			}
+			if common.IamResourceHasTag(v2Tags, tags.NoConsoleRole, tags.True) {
+				ocmRole.NoConsole = RoleYes
+				ocmRole.Admin = RoleNo
+			} else {
+				ocmRole.NoConsole = RoleNo
 			}
 
 			ocmRoles = append(ocmRoles, ocmRole)

--- a/pkg/aws/sts.go
+++ b/pkg/aws/sts.go
@@ -144,7 +144,7 @@ func (c *awsClient) deleteOCMRolePolicies(roleName string, managedPolicies bool)
 
 func SortRolesByLinkedRole(roles []Role) {
 	sort.SliceStable(roles, func(i, j int) bool {
-		return roles[i].Linked == "Yes" && roles[j].Linked == "No"
+		return roles[i].Linked == RoleYes && roles[j].Linked == RoleNo
 	})
 }
 

--- a/pkg/aws/tags/tags.go
+++ b/pkg/aws/tags/tags.go
@@ -43,6 +43,8 @@ const Environment = prefix + "environment"
 // AdminRole tags the role as admin (true/false)
 const AdminRole = prefix + "admin_role"
 
+const NoConsoleRole = prefix + "no_console_role"
+
 // RedHatManaged tags the role as red_hat_managed
 const RedHatManaged = "red-hat-managed"
 


### PR DESCRIPTION
Adds to the output of `rosa list ocm-role` a field that allows customers to see if the `OCM Role` they have configured has the `no-console` profile.

Example output

```
rblake@rblake-mac rosa % rosa list ocm-role
I: Fetching ocm roles
ROLE NAME                                 ROLE ARN                                                                      LINKED  ADMIN  AWS Managed  CONSOLE ACCESS
rblake-OCM-Role-123456789                  arn:aws:iam::123456789:role/rblake-OCM-Role-123456789                       No      No     No           No
```

## PR Summary

This PR updates the `rosa list ocm-role` command to show if the `OCM Role` the customer has configured has can be used to deploy clusters via `console.redhat.com`. This field is captured via the `CONSOLE ACCESS` column in the output, which displays `No` if the user has a `--no-console` version of the `OCM Role` configured, and `yes` otherwise

Examples of the various forms of role showing in the output:

```
Admin Profile:

rblake@rblake-mac rosa % rosa list ocm-role
I: Fetching ocm roles
ROLE NAME                                 ROLE ARN                                                                      LINKED  ADMIN  AWS Managed  CONSOLE ACCESS
rblake-OCM-Role-123456789                  arn:aws:iam::123456789:role/rblake-OCM-Role-123456789                       No      Yes    No           Yes

Standard Profile:

rblake@rblake-mac rosa % rosa list ocm-role
I: Fetching ocm roles
ROLE NAME                                 ROLE ARN                                                                      LINKED  ADMIN  AWS Managed  CONSOLE ACCESS
rblake-OCM-Role-123456789                  arn:aws:iam::123456789:role/rblake-OCM-Role-123456789                       No      No     No           Yes

No Console profile:

rblake@rblake-mac rosa % rosa list ocm-role
I: Fetching ocm roles
ROLE NAME                                 ROLE ARN                                                                      LINKED  ADMIN  AWS Managed  CONSOLE ACCESS
rblake-OCM-Role-123456789                  arn:aws:iam::123456789:role/rblake-OCM-Role-123456789                       No      No     No           No
```

## Related Issues and PRs
<!-- Link all tracking items and related code changes -->
- Jira: https://redhat.atlassian.net/browse/OCM-24429
- Related design/docs: https://github.com/openshift-online/rosa-enhancements/pull/50/changes

## Type of Change
<!-- Check the primary type this PR represents -->
- [X] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior

Prior to this behavior, there was no column indicating if the `OCM Role` had console access

## Behavior After This Change

The column is now present if the user has configured a no-console `OCM Role`

## How to Test (Step-by-Step)

The easiest way to test is to manually apply Tags to your IAM role for the `OCM Role`.

### Test Steps
1. Tag an existing `OCM Role` with `rosa_no_console_role:true`. Run `rosa list ocm-role` and see that the `CONSOLE ACCESS` column displays `No`
2. Remove the `rosa_no_console_role` tag from the `OCM Role`. Run `rosa list ocm-role` again and see that the `CONSOLE_ACCESS` column displays `Yes`


### Expected Results

Described above

## Proof of the Fix

```
rblake@rblake-mac rosa % rosa list ocm-role
I: Fetching ocm roles
ROLE NAME                                 ROLE ARN                                                                      LINKED  ADMIN  AWS Managed  CONSOLE ACCESS
rblake-OCM-Role-123456789                  arn:aws:iam::123456789:role/rblake-OCM-Role-123456789                       No      No     No           No
```

## PR Summary

This PR updates the `rosa list ocm-role` command to show if the `OCM Role` the customer has configured has can be used to deploy clusters via `console.redhat.com`. This field is captured via the `CONSOLE ACCESS` column in the output, which displays `No` if the user has a `--no-console` version of the `OCM Role` configured, and `yes` otherwise

Examples of the various forms of role showing in the output:

```
Admin Profile:

rblake@rblake-mac rosa % rosa list ocm-role
I: Fetching ocm roles
ROLE NAME                                 ROLE ARN                                                                      LINKED  ADMIN  AWS Managed  CONSOLE ACCESS
rblake-OCM-Role-123456789                  arn:aws:iam::123456789:role/rblake-OCM-Role-123456789                       No      Yes    No           Yes

Standard Profile:

rblake@rblake-mac rosa % rosa list ocm-role
I: Fetching ocm roles
ROLE NAME                                 ROLE ARN                                                                      LINKED  ADMIN  AWS Managed  CONSOLE ACCESS
rblake-OCM-Role-123456789                  arn:aws:iam::123456789:role/rblake-OCM-Role-123456789                       No      No     No           Yes

No Console profile:

rblake@rblake-mac rosa % rosa list ocm-role
I: Fetching ocm roles
ROLE NAME                                 ROLE ARN                                                                      LINKED  ADMIN  AWS Managed  CONSOLE ACCESS
rblake-OCM-Role-123456789                  arn:aws:iam::123456789:role/rblake-OCM-Role-123456789                       No      No     No           No
```

Additionally, JSON output for various commands where the internal struct is deserialized:

```
# OCM Role
rblake@rblake-mac rosa % rosa list ocm-role -o json
I: Fetching ocm roles
[
  {
    "RoleName": "ManagedOpenShift-OCM-Role-12541229",
    "RoleARN": "arn:aws:iam::765374464689:role/ManagedOpenShift-OCM-Role-12541229",
    "Linked": "Yes",
    "Admin": "Yes",
    "NoConsole": "No"
  },
  {
    "RoleName": "AG-OCM-Role-5318290",
    "RoleARN": "arn:aws:iam::765374464689:role/AG-OCM-Role-5318290",
    "Linked": "No",
    "Admin": "No",
    "NoConsole": "No"
  },

# User Role

rblake@rblake-mac rosa % rosa list user-role -o json
I: Fetching user roles
[
  {
    "RoleName": "ManagedOpenShift-User-ocmqe-aaraj-Role",
    "RoleARN": "arn:aws:iam::765374464689:role/ManagedOpenShift-User-ocmqe-aaraj-Role",
    "Linked": "No"
  }
]

# Account Roles
rblake@rblake-mac rosa % rosa list account-role -o json
I: Fetching account roles
[
  {
    "RoleType": "Installer",
    "Version": "4.13",
    "RoleName": "CSE2ETests-HCP-ROSA-Installer-Role",
    "RoleARN": "arn:aws:iam::765374464689:role/CSE2ETests-HCP-ROSA-Installer-Role",
    "ManagedPolicy": true
  },

```


## Breaking Changes
- [X] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
<!-- Required only when breaking changes are introduced -->

## Developer Verification Checklist
- [X ] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [X] PR description clearly explains both **what** changed and **why**.
- [X] Relevant Jira/GitHub issues and related PRs are linked.
- [X] `make install-hooks` has been run in this clone.
- [X] Tests were added/updated where appropriate.
- [X] I manually tested the change.
- [X] `make test` passes.
- [X] `make lint` passes.
- [X] `make rosa` passes.
- [X] Documentation or repo-local agent guidance was added/updated where appropriate.
- [X] Any risk, limitation, or follow-up work is documented.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded OCM roles listing with a new CONSOLE ACCESS column, clearer AWS-managed/linked indicators, and improved ordering so linked roles appear first; roles marked as no-console now show as having no console access and are treated as non-admin in the listing.
* **Tests**
  * Added comprehensive tests for the OCM roles command covering table formatting, console-access logic, role enrichment and ordering, and API/error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->