### PR TITLE
OCM-23343 | feat: Added support for --no-console to rosa create ocm-role

### DIFF
--- a/assets/bindata.go
+++ b/assets/bindata.go
@@ -1,5 +1,6 @@
 // Code generated for package assets by go-bindata DO NOT EDIT. (@generated)
 // sources:
+// templates/clibyexample/template
 // templates/cloudformation/iam_user_osdCcsAdmin.json
 package assets
 
@@ -11,6 +12,7 @@ import (
 	"strings"
 	"time"
 )
+
 type asset struct {
 	bytes []byte
 	info  os.FileInfo
@@ -51,6 +53,45 @@ func (fi bindataFileInfo) IsDir() bool {
 // Sys return file is sys mode
 func (fi bindataFileInfo) Sys() interface{} {
 	return nil
+}
+
+var _templatesClibyexampleTemplate = []byte(`// NOTE: The contents of this file are auto-generated
+:_mod-docs-content-type: REFERENCE
+[id="rosa-cli-commands_{context}"]
+= ROSA CLI commands
+
+[role="_abstract"]
+This reference provides descriptions and example commands for ROSA CLI (` + "`" + `rosa` + "`" + `) commands.
+
+Run ` + "`" + `rosa -h` + "`" + ` to list all commands or run ` + "`" + `rosa <command> --help` + "`" + ` to get additional details for a specific command.
+
+{{range .Items}}
+
+== {{.FullName}}
+{{.Description}}
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+{{.Examples}}
+----
+
+{{end}}
+`)
+
+func templatesClibyexampleTemplateBytes() ([]byte, error) {
+	return _templatesClibyexampleTemplate, nil
+}
+
+func templatesClibyexampleTemplate() (*asset, error) {
+	bytes, err := templatesClibyexampleTemplateBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "templates/clibyexample/template", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
 }
 
 var _templatesCloudformationIam_user_osdccsadminJson = []byte(`{
@@ -135,6 +176,7 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
+	"templates/clibyexample/template":                    templatesClibyexampleTemplate,
 	"templates/cloudformation/iam_user_osdCcsAdmin.json": templatesCloudformationIam_user_osdccsadminJson,
 }
 
@@ -142,11 +184,13 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"}
 // AssetDir("data/img") would return []string{"a.png", "b.png"}
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error
@@ -179,9 +223,12 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"templates": &bintree{nil, map[string]*bintree{
-		"cloudformation": &bintree{nil, map[string]*bintree{
-			"iam_user_osdCcsAdmin.json": &bintree{templatesCloudformationIam_user_osdccsadminJson, map[string]*bintree{}},
+	"templates": {nil, map[string]*bintree{
+		"clibyexample": {nil, map[string]*bintree{
+			"template": {templatesClibyexampleTemplate, map[string]*bintree{}},
+		}},
+		"cloudformation": {nil, map[string]*bintree{
+			"iam_user_osdCcsAdmin.json": {templatesCloudformationIam_user_osdccsadminJson, map[string]*bintree{}},
 		}},
 	}},
 }}

--- a/cmd/create/ocmrole/cmd.go
+++ b/cmd/create/ocmrole/cmd.go
@@ -19,6 +19,7 @@ package ocmrole
 import (
 	"fmt"
 	"os"
+	"slices"
 
 	common "github.com/openshift-online/ocm-common/pkg/aws/validations"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -43,6 +44,7 @@ var args struct {
 	admin               bool
 	path                string
 	managed             bool
+	noConsole           bool
 }
 
 var Cmd = &cobra.Command{
@@ -82,6 +84,13 @@ func init() {
 		"Enable admin capabilities for the role",
 	)
 
+	flags.BoolVar(
+		&args.noConsole,
+		"no-console",
+		false,
+		"Create OCM role with minimal permissions (cannot be used with console.redhat.com)",
+	)
+
 	flags.StringVar(
 		&args.path,
 		"path",
@@ -103,6 +112,8 @@ func init() {
 		false,
 		"Attach Classic ROSA AWS managed policies to the account roles. This is an alias for --managed-policies")
 	flags.MarkHidden("mp")
+
+	Cmd.MarkFlagsMutuallyExclusive("admin", "no-console")
 
 	interactive.AddModeFlag(Cmd)
 
@@ -169,19 +180,18 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
-	isAdmin := args.admin
+	profile := determineProfile(args.admin, args.noConsole)
 
-	if interactive.Enabled() && !isAdmin {
-		isAdmin, err = interactive.GetBool(interactive.Input{
-			Question: "Enable admin capabilities for the OCM role",
-			Help:     cmd.Flags().Lookup("admin").Usage,
-			Default:  isAdmin,
-			Required: false,
-		})
+	if interactive.Enabled() && profile == ProfileStandard {
+		profile, err = promptProfile(cmd, profile)
 		if err != nil {
 			r.Reporter.Errorf("Expected a valid --admin value: %s", err)
 			os.Exit(1)
 		}
+	}
+
+	if profile == ProfileNoConsole {
+		r.Reporter.Warnf("This OCM role cannot be used to provision clusters via console.redhat.com")
 	}
 
 	permissionsBoundary := args.permissionsBoundary
@@ -248,7 +258,6 @@ func run(cmd *cobra.Command, _ []string) {
 	roleNameRequested := aws.GetOCMRoleName(prefix, aws.OCMRole, externalID)
 
 	existsOnOCM, _, selectedARN, err := r.OCMClient.CheckRoleExists(orgID, roleNameRequested, r.Creator.AccountID)
-
 	if err != nil {
 		r.Reporter.Errorf("Error checking existing ocm-role: %v", err)
 		os.Exit(1)
@@ -266,11 +275,24 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
+	// Validate no-console policy availability before any operations
+	if profile == ProfileNoConsole {
+		filename := fmt.Sprintf("sts_%s_permission_policy", aws.OCMNoConsoleRolePolicyFile)
+		policy, ok := policies[filename]
+		// For managed policies, validate ARN exists
+		// For customer-managed policies, validate Details exists (ARN is constructed later)
+		if !ok || (managedPolicies && policy.ARN() == "") || (!managedPolicies && policy.Details() == "") {
+			r.Reporter.Errorf("There was an error creating the ocm role: " +
+				"the no-console OCM role profile is not yet enabled for your Organization")
+			os.Exit(1)
+		}
+	}
+
 	switch mode {
 	case interactive.ModeAuto:
 		r.Reporter.Infof("Creating role using '%s'", r.Creator.ARN)
 		roleARN, err := createRoles(r, prefix, roleNameRequested, path, permissionsBoundary,
-			orgID, env, isAdmin, policies, managedPolicies)
+			orgID, env, profile, policies, managedPolicies)
 		if err != nil {
 			r.Reporter.Errorf("There was an error creating the ocm role: %s", err)
 			r.OCMClient.LogEvent("ROSACreateOCMRoleModeAuto", map[string]string{
@@ -286,11 +308,11 @@ func run(cmd *cobra.Command, _ []string) {
 		arguments.DisableRegionDeprecationWarning = false // enable region deprecation again
 	case interactive.ModeManual:
 		r.OCMClient.LogEvent("ROSACreateOCMRoleModeManual", map[string]string{})
-		_, _, err = checkRoleExists(r, roleNameRequested, isAdmin, interactive.ModeManual)
+		_, _, err = checkRoleExists(r, roleNameRequested, profile, interactive.ModeManual, path)
 		if err != nil {
 			r.Reporter.Warnf("Creating ocm role '%s' should fail: %s", roleNameRequested, err)
 		}
-		err = generateOcmRolePolicyFiles(r, env, orgID, isAdmin, policies)
+		err = generateOcmRolePolicyFiles(r, env, orgID, profile, policies)
 		if err != nil {
 			r.Reporter.Errorf("There was an error generating the policy files: %s", err)
 			r.OCMClient.LogEvent("ROSACreateOCMRoleModeManual", map[string]string{
@@ -310,7 +332,7 @@ func run(cmd *cobra.Command, _ []string) {
 			permissionsBoundary,
 			r.Creator,
 			env,
-			isAdmin,
+			profile,
 			managedPolicies,
 			confirm.Yes(),
 			policies,
@@ -327,11 +349,41 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 }
 
+func promptProfile(cmd *cobra.Command, curr RoleProfile) (RoleProfile, error) {
+	isAdmin, err := interactive.GetBool(interactive.Input{
+		Question: "Enable admin capabilities for the OCM role",
+		Help:     cmd.Flags().Lookup("admin").Usage,
+		Default:  curr == ProfileAdmin,
+		Required: false,
+	})
+	if err != nil {
+		return ProfileStandard, fmt.Errorf("expected a valid --admin value: %s", err)
+	}
+	if isAdmin {
+		return ProfileAdmin, nil
+	}
+
+	isNoConsole, err := interactive.GetBool(interactive.Input{
+		Question: "Create OCM role with minimal permissions (no console access)",
+		Help:     cmd.Flags().Lookup("no-console").Usage,
+		Default:  curr == ProfileNoConsole,
+		Required: false,
+	})
+	if err != nil {
+		return ProfileStandard, fmt.Errorf("expected a valid --no-console value: %s", err)
+	}
+	if isNoConsole {
+		return ProfileNoConsole, nil
+	}
+
+	return ProfileStandard, nil
+}
+
 func buildCommands(prefix string, roleName string, rolePath string, permissionsBoundary string,
-	creator *aws.Creator, env string, isAdmin bool, managedPolicies bool, autoConfirmLink bool,
-	policies map[string]*cmv1.AWSSTSPolicy) (string, error) {
+	creator *aws.Creator, env string, profile RoleProfile, managedPolicies bool, autoConfirmLink bool,
+	policies map[string]*cmv1.AWSSTSPolicy,
+) (string, error) {
 	commands := []string{}
-	policyName := aws.GetPolicyName(roleName)
 	iamTags := map[string]string{
 		tags.RolePrefix:    prefix,
 		tags.RoleType:      aws.OCMRole,
@@ -346,6 +398,10 @@ func buildCommands(prefix string, roleName string, rolePath string, permissionsB
 		tags.AdminRole: tags.True,
 	}
 
+	noConsoleTags := map[string]string{
+		tags.NoConsoleRole: tags.True,
+	}
+
 	builder := awscb.NewIAMCommandBuilder().
 		SetCommand(awscb.CreateRole).
 		AddParam(awscb.RoleName, roleName).
@@ -353,9 +409,28 @@ func buildCommands(prefix string, roleName string, rolePath string, permissionsB
 		AddParam(awscb.PermissionsBoundary, permissionsBoundary).
 		AddTags(iamTags).
 		AddParam(awscb.Path, rolePath)
-	if isAdmin {
+
+	var policyFile string
+	var policyName string
+
+	switch profile {
+	case ProfileAdmin:
 		builder.AddTags(adminTags)
+
+		policyFile = aws.OCMRolePolicyFile
+		policyName = aws.GetPolicyName(roleName)
+	case ProfileNoConsole:
+		builder.AddTags(noConsoleTags)
+
+		policyFile = aws.OCMNoConsoleRolePolicyFile
+		policyName = aws.GetNoConsolePolicyName(roleName)
+	case ProfileStandard:
+		// No additional tags
+
+		policyFile = aws.OCMRolePolicyFile
+		policyName = aws.GetPolicyName(roleName)
 	}
+
 	createRole := builder.Build()
 
 	var createPolicy string
@@ -363,7 +438,7 @@ func buildCommands(prefix string, roleName string, rolePath string, permissionsB
 		createPolicy = awscb.NewIAMCommandBuilder().
 			SetCommand(awscb.CreatePolicy).
 			AddParam(awscb.PolicyName, policyName).
-			AddParam(awscb.PolicyDocument, fmt.Sprintf("file://sts_%s_permission_policy.json", aws.OCMRolePolicyFile)).
+			AddParam(awscb.PolicyDocument, fmt.Sprintf("file://sts_%s_permission_policy.json", policyFile)).
 			AddTags(iamTags).
 			AddParam(awscb.Path, rolePath).
 			Build()
@@ -371,13 +446,19 @@ func buildCommands(prefix string, roleName string, rolePath string, permissionsB
 
 	var policyARN string
 	var err error
+	policyKey := fmt.Sprintf("sts_%s_permission_policy", policyFile)
 	if managedPolicies {
-		policyARN, err = aws.GetManagedPolicyARN(policies, "sts_ocm_permission_policy")
+		policyARN, err = aws.GetManagedPolicyARN(policies, policyKey)
 		if err != nil {
 			return "", err
 		}
 	} else {
-		policyARN = aws.GetPolicyArnWithSuffix(creator.Partition, creator.AccountID, roleName, rolePath)
+		switch profile {
+		case ProfileNoConsole:
+			policyARN = aws.GetNoConsolePolicyARN(creator.Partition, creator.AccountID, roleName, rolePath)
+		case ProfileAdmin, ProfileStandard:
+			policyARN = aws.GetPolicyArnWithSuffix(creator.Partition, creator.AccountID, roleName, rolePath)
+		}
 	}
 	attachRolePolicy := awscb.NewIAMCommandBuilder().
 		SetCommand(awscb.AttachRolePolicy).
@@ -390,7 +471,8 @@ func buildCommands(prefix string, roleName string, rolePath string, permissionsB
 	} else {
 		commands = append(commands, createRole, createPolicy, attachRolePolicy)
 	}
-	if isAdmin {
+
+	if profile == ProfileAdmin {
 		policyName := aws.GetAdminPolicyName(roleName)
 
 		var createAdminPolicy string
@@ -438,18 +520,21 @@ func buildCommands(prefix string, roleName string, rolePath string, permissionsB
 }
 
 func createRoles(r *rosa.Runtime, prefix string, roleName string, rolePath string,
-	permissionsBoundary string, orgID string, env string, isAdmin bool,
-	policies map[string]*cmv1.AWSSTSPolicy, managedPolicies bool) (string, error) {
+	permissionsBoundary string, orgID string, env string, profile RoleProfile,
+	policies map[string]*cmv1.AWSSTSPolicy, managedPolicies bool,
+) (string, error) {
 	var policyARN string
 	var err error
 
-	if managedPolicies {
-		policyARN, err = aws.GetManagedPolicyARN(policies, "sts_ocm_permission_policy")
-		if err != nil {
-			return "", err
+	if profile != ProfileNoConsole {
+		if managedPolicies {
+			policyARN, err = aws.GetManagedPolicyARN(policies, fmt.Sprintf("sts_%s_permission_policy", aws.OCMRolePolicyFile))
+			if err != nil {
+				return "", err
+			}
+		} else {
+			policyARN = aws.GetPolicyArnWithSuffix(r.Creator.Partition, r.Creator.AccountID, roleName, rolePath)
 		}
-	} else {
-		policyARN = aws.GetPolicyArnWithSuffix(r.Creator.Partition, r.Creator.AccountID, roleName, rolePath)
 	}
 	if !confirm.Prompt(true, "Create the '%s' role?", roleName) {
 		os.Exit(0)
@@ -462,7 +547,7 @@ func createRoles(r *rosa.Runtime, prefix string, roleName string, rolePath strin
 		"ocm_organization_id": orgID,
 	})
 
-	roleARN, exists, err := checkRoleExists(r, roleName, isAdmin, interactive.ModeAuto)
+	roleARN, exists, err := checkRoleExists(r, roleName, profile, interactive.ModeAuto, rolePath)
 	if err != nil {
 		return "", err
 	}
@@ -480,28 +565,29 @@ func createRoles(r *rosa.Runtime, prefix string, roleName string, rolePath strin
 		iamTags[common.ManagedPolicies] = tags.True
 	}
 
-	if !exists {
-		r.Reporter.Debugf("Creating role '%s'", roleName)
+	r.Reporter.Debugf("Creating role '%s'", roleName)
 
-		roleARN, err = r.AWSClient.EnsureRole(r.Reporter, roleName, policy, permissionsBoundary,
-			"", iamTags, rolePath, false)
-		if err != nil {
-			return "", err
-		}
-		r.Reporter.Infof("Created role '%s' with ARN '%s'", roleName, roleARN)
+	roleARN, err = r.AWSClient.EnsureRole(r.Reporter, roleName, policy, permissionsBoundary,
+		"", iamTags, rolePath, false)
+	if err != nil {
+		return "", err
+	}
+	r.Reporter.Infof("Created role '%s' with ARN '%s'", roleName, roleARN)
 
-		// create and attach the permission policy to the role
+	switch profile {
+	case ProfileStandard:
 		filename = fmt.Sprintf("sts_%s_permission_policy", aws.OCMRolePolicyFile)
 		policyDetail = aws.GetPolicyDetails(policies, filename)
 		err = createPermissionPolicy(r, policyARN, iamTags, roleName, rolePath, policyDetail, managedPolicies)
 		if err != nil {
 			return "", err
 		}
-	}
 
-	if isAdmin {
-		// tag role with admin tag
-		err = r.AWSClient.AddRoleTag(roleName, tags.AdminRole, tags.True)
+	case ProfileAdmin:
+		// standard policy first
+		filename = fmt.Sprintf("sts_%s_permission_policy", aws.OCMRolePolicyFile)
+		policyDetail = aws.GetPolicyDetails(policies, filename)
+		err = createPermissionPolicy(r, policyARN, iamTags, roleName, rolePath, policyDetail, managedPolicies)
 		if err != nil {
 			return "", err
 		}
@@ -522,13 +608,46 @@ func createRoles(r *rosa.Runtime, prefix string, roleName string, rolePath strin
 		if err != nil {
 			return "", err
 		}
+
+		// tag role with admin tag
+		err = r.AWSClient.AddRoleTag(roleName, tags.AdminRole, tags.True)
+		if err != nil {
+			return "", err
+		}
+
+	case ProfileNoConsole:
+		filename = fmt.Sprintf("sts_%s_permission_policy", aws.OCMNoConsoleRolePolicyFile)
+
+		// create and attach the no-console policy to the role
+		if managedPolicies {
+			policyARN, err = aws.GetManagedPolicyARN(policies, filename)
+			if err != nil {
+				return "", err
+			}
+		} else {
+			policyARN = aws.GetNoConsolePolicyARN(r.Creator.Partition, r.Creator.AccountID, roleName, rolePath)
+		}
+		iamTags[tags.NoConsoleRole] = tags.True
+		policyDetail = aws.GetPolicyDetails(policies, filename)
+		err = createPermissionPolicy(r, policyARN, iamTags, roleName, rolePath, policyDetail, managedPolicies)
+		if err != nil {
+			return "", err
+		}
+
+		// tag role with no-console tag
+		err = r.AWSClient.AddRoleTag(roleName, tags.NoConsoleRole, tags.True)
+		if err != nil {
+			return "", err
+		}
+
 	}
 
 	return roleARN, nil
 }
 
-func generateOcmRolePolicyFiles(r *rosa.Runtime, env string, orgID string, isAdmin bool,
-	policies map[string]*cmv1.AWSSTSPolicy) error {
+func generateOcmRolePolicyFiles(r *rosa.Runtime, env string, orgID string, profile RoleProfile,
+	policies map[string]*cmv1.AWSSTSPolicy,
+) error {
 	filename := fmt.Sprintf("sts_%s_trust_policy", aws.OCMRolePolicyFile)
 
 	policyDetail := aws.GetPolicyDetails(policies, filename)
@@ -543,7 +662,17 @@ func generateOcmRolePolicyFiles(r *rosa.Runtime, env string, orgID string, isAdm
 	if err != nil {
 		return err
 	}
-	filename = fmt.Sprintf("sts_%s_permission_policy", aws.OCMRolePolicyFile)
+
+	var policyFile string
+	switch profile {
+	case ProfileNoConsole:
+		policyFile = aws.OCMNoConsoleRolePolicyFile
+	case ProfileAdmin, ProfileStandard:
+		policyFile = aws.OCMRolePolicyFile
+	}
+
+	filename = fmt.Sprintf("sts_%s_permission_policy", policyFile)
+
 	policyDetail = aws.GetPolicyDetails(policies, filename)
 	filename = aws.GetFormattedFileName(filename)
 	r.Reporter.Debugf("Saving '%s' to the current directory", filename)
@@ -552,7 +681,7 @@ func generateOcmRolePolicyFiles(r *rosa.Runtime, env string, orgID string, isAdm
 		return err
 	}
 
-	if isAdmin {
+	if profile == ProfileAdmin {
 		filename = fmt.Sprintf("sts_%s_admin_permission_policy", aws.OCMRolePolicyFile)
 		policyDetail = aws.GetPolicyDetails(policies, filename)
 		filename = aws.GetFormattedFileName(filename)
@@ -566,8 +695,8 @@ func generateOcmRolePolicyFiles(r *rosa.Runtime, env string, orgID string, isAdm
 }
 
 func createPermissionPolicy(r *rosa.Runtime, policyARN string,
-	iamTags map[string]string, roleName string, rolePath string, policyDetail string, managedPolicies bool) error {
-
+	iamTags map[string]string, roleName string, rolePath string, policyDetail string, managedPolicies bool,
+) error {
 	r.Reporter.Debugf("Creating permission policy '%s'", policyARN)
 	if !managedPolicies {
 		var err error
@@ -586,8 +715,9 @@ func createPermissionPolicy(r *rosa.Runtime, policyARN string,
 	return nil
 }
 
-func checkRoleExists(r *rosa.Runtime, roleName string, isAdmin bool,
-	mode string) (string, bool, error) {
+func checkRoleExists(r *rosa.Runtime, roleName string, profile RoleProfile,
+	mode string, rolePath string,
+) (string, bool, error) {
 	exists, roleARN, err := r.AWSClient.CheckRoleExists(roleName)
 	if err != nil {
 		return "", false, err
@@ -597,23 +727,103 @@ func checkRoleExists(r *rosa.Runtime, roleName string, isAdmin bool,
 		if err != nil {
 			return "", true, err
 		}
+		isExistingRoleNoConsole, err := r.AWSClient.IsNoConsoleRole(roleName)
+		if err != nil {
+			return "", true, err
+		}
+
 		r.Reporter.Warnf("Role '%s' already exists", roleName)
 
-		if !isAdmin {
+		switch profile {
+		case ProfileStandard:
 			if isExistingRoleAdmin {
 				return "", true, fmt.Errorf("the existing role is an admin role."+
 					" To remove admin capabilities please delete the admin policy and the '%s' tag",
 					tags.AdminRole)
 			}
+			if isExistingRoleNoConsole {
+				return "", true, fmt.Errorf("the existing role is a no-console role." +
+					" To use standard permissions please delete the role and recreate it")
+			}
 			return roleARN, true, nil
-		}
 
-		if isExistingRoleAdmin {
-			return roleARN, true, nil
-		}
+		case ProfileAdmin:
+			if isExistingRoleNoConsole {
+				return "", true, fmt.Errorf("the existing role is a no-console role." +
+					" To use admin permissions please delete the role and recreate it")
+			}
 
-		if mode == interactive.ModeAuto && !confirm.Prompt(true, "Add admin policies to '%s' role?", roleName) {
-			return roleARN, true, nil
+			if isExistingRoleAdmin {
+				return roleARN, true, nil
+			}
+
+			// Role appears to be standard - check if admin policy is actually attached (self-healing)
+			attachedPolicies, err := r.AWSClient.ListAttachedRolePolicies(roleName)
+			if err != nil {
+				return "", true, err
+			}
+
+			// Check if admin policy is attached (exact ARN match)
+			expectedAdminPolicyARN := aws.GetAdminPolicyARN(r.Creator.Partition, r.Creator.AccountID, roleName, "")
+			if slices.Contains(attachedPolicies, expectedAdminPolicyARN) {
+				// Self-heal: admin policy exists but tag is missing
+				r.Reporter.Debugf("Admin policy found but tag missing - adding tag")
+				err = r.AWSClient.AddRoleTag(roleName, tags.AdminRole, "true")
+				if err != nil {
+					return "", true, fmt.Errorf("failed to add admin role tag: %v", err)
+				}
+				return roleARN, true, nil
+			}
+
+			if mode == interactive.ModeAuto && !confirm.Prompt(true, "Add admin policies to '%s' role?", roleName) {
+				return roleARN, true, nil
+			}
+
+		case ProfileNoConsole:
+			if isExistingRoleAdmin {
+				return "", true, fmt.Errorf("the existing role is an admin role." +
+					" To use no-console permissions please delete the role and recreate it")
+			}
+
+			if isExistingRoleNoConsole {
+				// Verify no-console policy is actually attached
+				attachedPolicies, err := r.AWSClient.ListAttachedRolePolicies(roleName)
+				if err != nil {
+					return "", true, err
+				}
+
+				expectedNoConsolePolicyARN := aws.GetNoConsolePolicyARN(
+					r.Creator.Partition, r.Creator.AccountID, roleName, rolePath)
+				if !slices.Contains(attachedPolicies, expectedNoConsolePolicyARN) {
+					// Tag exists but policy is missing - incomplete manual run
+					return "", true, fmt.Errorf("the role has the no-console tag but the no-console policy is not attached." +
+						" Please attach the policy or remove the tag and recreate the role")
+				}
+
+				return roleARN, true, nil
+			}
+
+			// Role appears to be standard - check if no-console policy is actually attached (self-healing)
+			attachedPolicies, err := r.AWSClient.ListAttachedRolePolicies(roleName)
+			if err != nil {
+				return "", true, err
+			}
+
+			// Check if no-console policy is attached (exact ARN match)
+			expectedNoConsolePolicyARN := aws.GetNoConsolePolicyARN(r.Creator.Partition, r.Creator.AccountID, roleName, rolePath)
+			if slices.Contains(attachedPolicies, expectedNoConsolePolicyARN) {
+				// Self-heal: no-console policy exists but tag is missing
+				r.Reporter.Debugf("No-console policy found but tag missing - adding tag")
+				err = r.AWSClient.AddRoleTag(roleName, tags.NoConsoleRole, "true")
+				if err != nil {
+					return "", true, fmt.Errorf("failed to add no-console role tag: %v", err)
+				}
+				return roleARN, true, nil
+			}
+
+			// Existing is standard, cannot convert
+			return "", true, fmt.Errorf("the existing role is a standard role." +
+				" To use no-console permissions please delete the role and recreate it")
 		}
 	}
 

--- a/cmd/create/ocmrole/cmd_test.go
+++ b/cmd/create/ocmrole/cmd_test.go
@@ -1,0 +1,559 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ocmrole
+
+import (
+	"fmt"
+	"os"
+
+	"go.uber.org/mock/gomock"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
+	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/reporter"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+var _ = Describe("buildCommands", func() {
+	var (
+		creator  *aws.Creator
+		policies map[string]*cmv1.AWSSTSPolicy
+	)
+
+	BeforeEach(func() {
+		creator = &aws.Creator{
+			ARN:       "arn:aws:iam::123456789012:user/test",
+			AccountID: "123456789012",
+			Partition: "aws",
+		}
+
+		standardPolicy, err := (&cmv1.AWSSTSPolicyBuilder{}).
+			ARN("arn:aws:iam::123456789012:policy/standard").
+			Details(`{"Version":"2012-10-17","Statement":[]}`).
+			Build()
+		Expect(err).NotTo(HaveOccurred())
+		adminPolicy, err := (&cmv1.AWSSTSPolicyBuilder{}).
+			ARN("arn:aws:iam::123456789012:policy/admin").
+			Details(`{"Version":"2012-10-17","Statement":[]}`).
+			Build()
+		Expect(err).NotTo(HaveOccurred())
+		noConsolePolicy, err := (&cmv1.AWSSTSPolicyBuilder{}).
+			ARN("arn:aws:iam::123456789012:policy/no-console").
+			Details(`{"Version":"2012-10-17","Statement":[]}`).
+			Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		policies = map[string]*cmv1.AWSSTSPolicy{
+			"sts_ocm_permission_policy":            standardPolicy,
+			"sts_ocm_admin_permission_policy":      adminPolicy,
+			"sts_ocm_no_console_permission_policy": noConsolePolicy,
+		}
+	})
+
+	Context("Manual mode command generation", func() {
+		It("should include no-console tag when profile is no-console", func() {
+			commands, err := buildCommands(
+				"test",
+				"test-OCM-Role",
+				"",
+				"",
+				creator,
+				"production",
+				ProfileNoConsole,
+				true, // managedPolicies
+				false,
+				policies,
+			)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(commands).ToNot(BeEmpty())
+			Expect(commands).To(ContainSubstring("Key=rosa_no_console_role,Value=true"))
+			Expect(commands).To(ContainSubstring("test-OCM-Role"))
+		})
+
+		It("should not generate admin tag when profile is no-console", func() {
+			commands, err := buildCommands(
+				"test",
+				"test-OCM-Role",
+				"",
+				"",
+				creator,
+				"production",
+				ProfileNoConsole,
+				true, // managedPolicies
+				false,
+				policies,
+			)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(commands).ToNot(BeEmpty())
+			Expect(commands).ToNot(ContainSubstring("Key=rosa_admin_role,Value=true"))
+		})
+
+		It("should generate admin tag commands when profile is admin", func() {
+			commands, err := buildCommands(
+				"test",
+				"test-OCM-Role",
+				"",
+				"",
+				creator,
+				"production",
+				ProfileAdmin,
+				true, // managedPolicies
+				false,
+				policies,
+			)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(commands).ToNot(BeEmpty())
+			Expect(commands).To(ContainSubstring("Key=rosa_admin_role,Value=true"))
+			Expect(commands).To(ContainSubstring("test-OCM-Role"))
+		})
+
+		It("should not generate no-console tag when profile is admin", func() {
+			commands, err := buildCommands(
+				"test",
+				"test-OCM-Role",
+				"",
+				"",
+				creator,
+				"production",
+				ProfileAdmin,
+				true, // managedPolicies
+				false,
+				policies,
+			)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(commands).ToNot(BeEmpty())
+			Expect(commands).ToNot(ContainSubstring("Key=rosa_no_console_role,Value=true"))
+		})
+
+		It("should not generate special tags for standard role", func() {
+			commands, err := buildCommands(
+				"test",
+				"test-OCM-Role",
+				"",
+				"",
+				creator,
+				"production",
+				ProfileStandard,
+				true, // managedPolicies
+				false,
+				policies,
+			)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(commands).ToNot(BeEmpty())
+			Expect(commands).ToNot(ContainSubstring("Key=rosa_admin_role,Value=true"))
+			Expect(commands).ToNot(ContainSubstring("Key=rosa_no_console_role,Value=true"))
+		})
+
+		It("should generate attach-role-policy command for no-console role", func() {
+			commands, err := buildCommands(
+				"test",
+				"test-OCM-Role",
+				"",
+				"",
+				creator,
+				"production",
+				ProfileNoConsole,
+				true, // managedPolicies
+				false,
+				policies,
+			)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(commands).ToNot(BeEmpty())
+			Expect(commands).To(ContainSubstring("attach-role-policy"))
+			Expect(commands).To(ContainSubstring("arn:aws:iam::123456789012:policy/no-console"))
+		})
+	})
+})
+
+var _ = Describe("generateOcmRolePolicyFiles", func() {
+	var (
+		r          *rosa.Runtime
+		env        string
+		orgID      string
+		policies   map[string]*cmv1.AWSSTSPolicy
+		tempDir    string
+		originalWd string
+	)
+
+	BeforeEach(func() {
+		var err error
+		tempDir, err = os.MkdirTemp("", "rosa-test-*")
+		Expect(err).ToNot(HaveOccurred())
+
+		// Save current directory and change to temp
+		originalWd, err = os.Getwd()
+		Expect(err).ToNot(HaveOccurred())
+		err = os.Chdir(tempDir)
+		Expect(err).ToNot(HaveOccurred())
+
+		env = "production"
+		orgID = "test-org-123"
+
+		trustPolicy, err := (&cmv1.AWSSTSPolicyBuilder{}).
+			Details(`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::710019948333:root"},"Action":"sts:AssumeRole"}]}`).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		standardPolicy, err := (&cmv1.AWSSTSPolicyBuilder{}).
+			Details(`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"sts:AssumeRole","Resource":"*"}]}`).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		adminPolicy, err := (&cmv1.AWSSTSPolicyBuilder{}).
+			Details(`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}`).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		noConsolePolicy, err := (&cmv1.AWSSTSPolicyBuilder{}).
+			Details(`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"ec2:Describe*","Resource":"*"}]}`).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		policies = map[string]*cmv1.AWSSTSPolicy{
+			"sts_ocm_trust_policy":                 trustPolicy,
+			"sts_ocm_permission_policy":            standardPolicy,
+			"sts_ocm_admin_permission_policy":      adminPolicy,
+			"sts_ocm_no_console_permission_policy": noConsolePolicy,
+		}
+
+		r = rosa.NewRuntime()
+		r.Creator = &aws.Creator{
+			Partition: "aws",
+			AccountID: "123456789012",
+		}
+	})
+
+	AfterEach(func() {
+		// Clean up temp directory
+		err := os.Chdir(originalWd)
+		Expect(err).ToNot(HaveOccurred())
+		err = os.RemoveAll(tempDir)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should generate no-console permission policy file when profile is no-console", func() {
+		err := generateOcmRolePolicyFiles(r, env, orgID, ProfileNoConsole, policies)
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = os.Stat("sts_ocm_no_console_permission_policy.json")
+		Expect(err).ToNot(HaveOccurred(), "no-console policy file should exist")
+
+		_, err = os.Stat("sts_ocm_permission_policy.json")
+		Expect(os.IsNotExist(err)).To(BeTrue(), "standard policy file should not exist")
+
+		_, err = os.Stat("sts_ocm_trust_policy.json")
+		Expect(err).ToNot(HaveOccurred(), "trust policy file should exist")
+
+		_, err = os.Stat("sts_ocm_admin_permission_policy.json")
+		Expect(os.IsNotExist(err)).To(BeTrue(), "admin policy file should not exist")
+	})
+
+	It("should generate standard permission policy file when profile is standard", func() {
+		err := generateOcmRolePolicyFiles(r, env, orgID, ProfileStandard, policies)
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = os.Stat("sts_ocm_permission_policy.json")
+		Expect(err).ToNot(HaveOccurred(), "standard policy file should exist")
+
+		_, err = os.Stat("sts_ocm_no_console_permission_policy.json")
+		Expect(os.IsNotExist(err)).To(BeTrue(), "no-console policy file should not exist")
+
+		_, err = os.Stat("sts_ocm_trust_policy.json")
+		Expect(err).ToNot(HaveOccurred(), "trust policy file should exist")
+
+		_, err = os.Stat("sts_ocm_admin_permission_policy.json")
+		Expect(os.IsNotExist(err)).To(BeTrue(), "admin policy file should not exist")
+	})
+
+	It("should generate admin policy file when profile is admin", func() {
+		err := generateOcmRolePolicyFiles(r, env, orgID, ProfileAdmin, policies)
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = os.Stat("sts_ocm_admin_permission_policy.json")
+		Expect(err).ToNot(HaveOccurred(), "admin policy file should exist")
+
+		_, err = os.Stat("sts_ocm_permission_policy.json")
+		Expect(err).ToNot(HaveOccurred(), "standard policy file should exist")
+
+		_, err = os.Stat("sts_ocm_trust_policy.json")
+		Expect(err).ToNot(HaveOccurred(), "trust policy file should exist")
+
+		_, err = os.Stat("sts_ocm_no_console_permission_policy.json")
+		Expect(os.IsNotExist(err)).To(BeTrue(), "no-console policy file should not exist")
+	})
+
+	It("should generate no-console files successfully when policy is available", func() {
+		err := generateOcmRolePolicyFiles(r, env, orgID, ProfileNoConsole, policies)
+
+		Expect(err).NotTo(HaveOccurred())
+		// Verify no-console permission policy file was created
+		fileContent, err := os.ReadFile("sts_ocm_no_console_permission_policy.json")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(fileContent).NotTo(BeEmpty())
+	})
+})
+
+var _ = Describe("checkRoleExists", func() {
+	var (
+		r          *rosa.Runtime
+		roleName   string
+		ctrl       *gomock.Controller
+		mockClient *aws.MockClient
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockClient = aws.NewMockClient(ctrl)
+		r = rosa.NewRuntime()
+		r.AWSClient = mockClient
+		r.Reporter = reporter.CreateReporter()
+		r.Creator = &aws.Creator{
+			ARN:       "arn:aws:iam::123456789012:user/test",
+			AccountID: "123456789012",
+			Partition: "aws",
+		}
+		roleName = "test-role"
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Context("when requesting standard profile", func() {
+		It("should succeed if existing role is standard", func() {
+			mockClient.EXPECT().CheckRoleExists(roleName).Return(true, "arn:aws:iam::123456789012:role/test-role", nil)
+			mockClient.EXPECT().IsAdminRole(roleName).Return(false, nil)
+			mockClient.EXPECT().IsNoConsoleRole(roleName).Return(false, nil)
+
+			arn, exists, err := checkRoleExists(r, roleName, ProfileStandard, "auto", "")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeTrue())
+			Expect(arn).To(Equal("arn:aws:iam::123456789012:role/test-role"))
+		})
+
+		It("should error if existing role is admin", func() {
+			mockClient.EXPECT().CheckRoleExists(roleName).Return(true, "arn:aws:iam::123456789012:role/test-role", nil)
+			mockClient.EXPECT().IsAdminRole(roleName).Return(true, nil)
+			mockClient.EXPECT().IsNoConsoleRole(roleName).Return(false, nil)
+
+			_, exists, err := checkRoleExists(r, roleName, ProfileStandard, "auto", "")
+
+			Expect(err).To(HaveOccurred())
+			Expect(exists).To(BeTrue())
+			Expect(err.Error()).To(ContainSubstring("the existing role is an admin role"))
+		})
+
+		It("should error if existing role is no-console", func() {
+			mockClient.EXPECT().CheckRoleExists(roleName).Return(true, "arn:aws:iam::123456789012:role/test-role", nil)
+			mockClient.EXPECT().IsAdminRole(roleName).Return(false, nil)
+			mockClient.EXPECT().IsNoConsoleRole(roleName).Return(true, nil)
+
+			_, exists, err := checkRoleExists(r, roleName, ProfileStandard, "auto", "")
+
+			Expect(err).To(HaveOccurred())
+			Expect(exists).To(BeTrue())
+			Expect(err.Error()).To(ContainSubstring("the existing role is a no-console role"))
+		})
+	})
+
+	Context("when requesting admin profile", func() {
+		It("should succeed if existing role is admin (idempotent)", func() {
+			mockClient.EXPECT().CheckRoleExists(roleName).Return(true, "arn:aws:iam::123456789012:role/test-role", nil)
+			mockClient.EXPECT().IsAdminRole(roleName).Return(true, nil)
+			mockClient.EXPECT().IsNoConsoleRole(roleName).Return(false, nil)
+
+			arn, exists, err := checkRoleExists(r, roleName, ProfileAdmin, "auto", "")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeTrue())
+			Expect(arn).To(Equal("arn:aws:iam::123456789012:role/test-role"))
+		})
+
+		It("should error if existing role is no-console", func() {
+			mockClient.EXPECT().CheckRoleExists(roleName).Return(true, "arn:aws:iam::123456789012:role/test-role", nil)
+			mockClient.EXPECT().IsAdminRole(roleName).Return(false, nil)
+			mockClient.EXPECT().IsNoConsoleRole(roleName).Return(true, nil)
+
+			_, exists, err := checkRoleExists(r, roleName, ProfileAdmin, "auto", "")
+
+			Expect(err).To(HaveOccurred())
+			Expect(exists).To(BeTrue())
+			Expect(err.Error()).To(ContainSubstring("the existing role is a no-console role"))
+		})
+
+		// Note: Admin → Standard upgrade scenario with prompt is harder to test
+		// because it requires mocking confirm.Prompt which exits on 'No'
+	})
+
+	Context("when requesting no-console profile", func() {
+		It("should succeed if existing role is no-console", func() {
+			mockClient.EXPECT().CheckRoleExists(roleName).Return(true, "arn:aws:iam::123456789012:role/test-role", nil)
+			mockClient.EXPECT().IsAdminRole(roleName).Return(false, nil)
+			mockClient.EXPECT().IsNoConsoleRole(roleName).Return(true, nil)
+			mockClient.EXPECT().ListAttachedRolePolicies(roleName).Return([]string{
+				"arn:aws:iam::123456789012:policy/test-role-NoConsole-Policy",
+			}, nil)
+
+			arn, exists, err := checkRoleExists(r, roleName, ProfileNoConsole, "auto", "")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeTrue())
+			Expect(arn).To(Equal("arn:aws:iam::123456789012:role/test-role"))
+		})
+
+		It("should error if existing role is admin", func() {
+			mockClient.EXPECT().CheckRoleExists(roleName).Return(true, "arn:aws:iam::123456789012:role/test-role", nil)
+			mockClient.EXPECT().IsAdminRole(roleName).Return(true, nil)
+			mockClient.EXPECT().IsNoConsoleRole(roleName).Return(false, nil)
+
+			_, exists, err := checkRoleExists(r, roleName, ProfileNoConsole, "auto", "")
+
+			Expect(err).To(HaveOccurred())
+			Expect(exists).To(BeTrue())
+			Expect(err.Error()).To(ContainSubstring("the existing role is an admin role"))
+		})
+
+		It("should error if existing role is standard", func() {
+			mockClient.EXPECT().CheckRoleExists(roleName).Return(true, "arn:aws:iam::123456789012:role/test-role", nil)
+			mockClient.EXPECT().IsAdminRole(roleName).Return(false, nil)
+			mockClient.EXPECT().IsNoConsoleRole(roleName).Return(false, nil)
+			mockClient.EXPECT().ListAttachedRolePolicies(roleName).Return([]string{
+				"arn:aws:iam::123456789012:policy/ManagedOpenShift-OCM-Role-Policy",
+			}, nil)
+
+			_, exists, err := checkRoleExists(r, roleName, ProfileNoConsole, "auto", "")
+
+			Expect(err).To(HaveOccurred())
+			Expect(exists).To(BeTrue())
+			Expect(err.Error()).To(ContainSubstring("the existing role is a standard role"))
+		})
+
+		It("should self-heal when no-console policy exists but tag is missing", func() {
+			noConsolePolicyARN := "arn:aws:iam::123456789012:policy/test-role-NoConsole-Policy"
+			mockClient.EXPECT().CheckRoleExists(roleName).Return(true, "arn:aws:iam::123456789012:role/test-role", nil)
+			mockClient.EXPECT().IsAdminRole(roleName).Return(false, nil)
+			mockClient.EXPECT().IsNoConsoleRole(roleName).Return(false, nil)
+			mockClient.EXPECT().ListAttachedRolePolicies(roleName).Return([]string{
+				noConsolePolicyARN,
+			}, nil)
+			mockClient.EXPECT().AddRoleTag(roleName, "rosa_no_console_role", "true").Return(nil)
+
+			arn, exists, err := checkRoleExists(r, roleName, ProfileNoConsole, "auto", "")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeTrue())
+			Expect(arn).To(Equal("arn:aws:iam::123456789012:role/test-role"))
+		})
+
+		It("should error when self-healing tag addition fails", func() {
+			noConsolePolicyARN := "arn:aws:iam::123456789012:policy/test-role-NoConsole-Policy"
+			mockClient.EXPECT().CheckRoleExists(roleName).Return(true, "arn:aws:iam::123456789012:role/test-role", nil)
+			mockClient.EXPECT().IsAdminRole(roleName).Return(false, nil)
+			mockClient.EXPECT().IsNoConsoleRole(roleName).Return(false, nil)
+			mockClient.EXPECT().ListAttachedRolePolicies(roleName).Return([]string{
+				noConsolePolicyARN,
+			}, nil)
+			mockClient.EXPECT().AddRoleTag(roleName, "rosa_no_console_role", "true").Return(
+				fmt.Errorf("tag operation failed"))
+
+			_, exists, err := checkRoleExists(r, roleName, ProfileNoConsole, "auto", "")
+
+			Expect(err).To(HaveOccurred())
+			Expect(exists).To(BeTrue())
+			Expect(err.Error()).To(ContainSubstring("failed to add no-console role tag"))
+		})
+
+		It("should error when no-console tag exists but policy is not attached", func() {
+			mockClient.EXPECT().CheckRoleExists(roleName).Return(true, "arn:aws:iam::123456789012:role/test-role", nil)
+			mockClient.EXPECT().IsAdminRole(roleName).Return(false, nil)
+			mockClient.EXPECT().IsNoConsoleRole(roleName).Return(true, nil)
+			mockClient.EXPECT().ListAttachedRolePolicies(roleName).Return([]string{
+				"arn:aws:iam::123456789012:policy/test-role-Policy", // standard policy, not no-console
+			}, nil)
+
+			_, exists, err := checkRoleExists(r, roleName, ProfileNoConsole, "auto", "")
+
+			Expect(err).To(HaveOccurred())
+			Expect(exists).To(BeTrue())
+			Expect(err.Error()).To(ContainSubstring("the role has the no-console tag but the no-console policy is not attached"))
+		})
+	})
+
+	Context("when requesting admin profile with self-healing", func() {
+		It("should self-heal when admin policy exists but tag is missing", func() {
+			adminPolicyARN := "arn:aws:iam::123456789012:policy/test-role-Admin-Policy"
+			mockClient.EXPECT().CheckRoleExists(roleName).Return(true, "arn:aws:iam::123456789012:role/test-role", nil)
+			mockClient.EXPECT().IsAdminRole(roleName).Return(false, nil)
+			mockClient.EXPECT().IsNoConsoleRole(roleName).Return(false, nil)
+			mockClient.EXPECT().ListAttachedRolePolicies(roleName).Return([]string{
+				"arn:aws:iam::123456789012:policy/test-role-Policy",
+				adminPolicyARN,
+			}, nil)
+			mockClient.EXPECT().AddRoleTag(roleName, "rosa_admin_role", "true").Return(nil)
+
+			arn, exists, err := checkRoleExists(r, roleName, ProfileAdmin, "auto", "")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeTrue())
+			Expect(arn).To(Equal("arn:aws:iam::123456789012:role/test-role"))
+		})
+
+		It("should error when self-healing tag addition fails for admin", func() {
+			adminPolicyARN := "arn:aws:iam::123456789012:policy/test-role-Admin-Policy"
+			mockClient.EXPECT().CheckRoleExists(roleName).Return(true, "arn:aws:iam::123456789012:role/test-role", nil)
+			mockClient.EXPECT().IsAdminRole(roleName).Return(false, nil)
+			mockClient.EXPECT().IsNoConsoleRole(roleName).Return(false, nil)
+			mockClient.EXPECT().ListAttachedRolePolicies(roleName).Return([]string{
+				"arn:aws:iam::123456789012:policy/test-role-Policy",
+				adminPolicyARN,
+			}, nil)
+			mockClient.EXPECT().AddRoleTag(roleName, "rosa_admin_role", "true").Return(
+				fmt.Errorf("tag operation failed"))
+
+			_, exists, err := checkRoleExists(r, roleName, ProfileAdmin, "auto", "")
+
+			Expect(err).To(HaveOccurred())
+			Expect(exists).To(BeTrue())
+			Expect(err.Error()).To(ContainSubstring("failed to add admin role tag"))
+		})
+
+		It("should self-heal no-console with custom rolePath", func() {
+			customPath := "/custom/path/"
+			noConsolePolicyARN := "arn:aws:iam::123456789012:policy/custom/path/test-role-NoConsole-Policy"
+			mockClient.EXPECT().CheckRoleExists(roleName).Return(true, "arn:aws:iam::123456789012:role/custom/path/test-role", nil)
+			mockClient.EXPECT().IsAdminRole(roleName).Return(false, nil)
+			mockClient.EXPECT().IsNoConsoleRole(roleName).Return(false, nil)
+			mockClient.EXPECT().ListAttachedRolePolicies(roleName).Return([]string{
+				noConsolePolicyARN,
+			}, nil)
+			mockClient.EXPECT().AddRoleTag(roleName, "rosa_no_console_role", "true").Return(nil)
+
+			arn, exists, err := checkRoleExists(r, roleName, ProfileNoConsole, "auto", customPath)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeTrue())
+			Expect(arn).To(Equal("arn:aws:iam::123456789012:role/custom/path/test-role"))
+		})
+	})
+})

--- a/cmd/create/ocmrole/ocmrole.go
+++ b/cmd/create/ocmrole/ocmrole.go
@@ -1,0 +1,36 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ocmrole
+
+type RoleProfile string
+
+const (
+	ProfileStandard  RoleProfile = "standard"
+	ProfileAdmin     RoleProfile = "admin"
+	ProfileNoConsole RoleProfile = "no-console"
+)
+
+func determineProfile(isAdmin, isNoConsole bool) RoleProfile {
+	switch {
+	case isAdmin:
+		return ProfileAdmin
+	case isNoConsole:
+		return ProfileNoConsole
+	default:
+		return ProfileStandard
+	}
+}

--- a/cmd/create/ocmrole/ocmrole_test.go
+++ b/cmd/create/ocmrole/ocmrole_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ocmrole
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestOCMRole(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "OCM Role suite")
+}
+
+var _ = Describe("RoleProfile constants", func() {
+	It("Should have correct profile values", func() {
+		Expect(ProfileStandard).To(Equal(RoleProfile("standard")))
+		Expect(ProfileAdmin).To(Equal(RoleProfile("admin")))
+		Expect(ProfileNoConsole).To(Equal(RoleProfile("no-console")))
+	})
+})
+
+var _ = Describe("determineProfile", func() {
+	It("should return ProfileAdmin when isAdmin is true", func() {
+		profile := determineProfile(true, false)
+		Expect(profile).To(Equal(ProfileAdmin))
+	})
+
+	It("should return ProfileAdmin when both isAdmin and isNoConsole are true", func() {
+		// Admin takes precedence
+		profile := determineProfile(true, true)
+		Expect(profile).To(Equal(ProfileAdmin))
+	})
+
+	It("should return ProfileNoConsole when isNoConsole is true and isAdmin is false", func() {
+		profile := determineProfile(false, true)
+		Expect(profile).To(Equal(ProfileNoConsole))
+	})
+
+	It("should return ProfileStandard when both are false", func() {
+		profile := determineProfile(false, false)
+		Expect(profile).To(Equal(ProfileStandard))
+	})
+})

--- a/cmd/rosa/structure_test/command_args/rosa/create/ocm-role/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/create/ocm-role/command_args.yml
@@ -3,6 +3,7 @@
 - name: managed-policies
 - name: mode
 - name: mp
+- name: no-console
 - name: path
 - name: permissions-boundary
 - name: prefix

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -193,6 +193,7 @@ type Client interface {
 	IsPolicyExists(policyARN string) (*iam.GetPolicyOutput, error)
 	IsRolePolicyExists(roleName string, policyName string) (*iam.GetRolePolicyOutput, error)
 	IsAdminRole(roleName string) (bool, error)
+	IsNoConsoleRole(roleName string) (bool, error)
 	DeleteInlineRolePolicies(roleName string) error
 	IsUserRole(roleName *string) (bool, error)
 	GetRoleARNPath(prefix string) (string, error)
@@ -296,7 +297,6 @@ func New(
 	iamQuotaClient client.ServiceQuotasApiClient,
 	awsAccessKeys *AccessKey,
 	useLocalCredentials bool,
-
 ) Client {
 	return &awsClient{
 		cfg,
@@ -374,7 +374,8 @@ func (b *ClientBuilder) ExternalConfig(value *aws.Config) *ClientBuilder {
 
 // Create AWS session with a specific set of credentials
 func (b *ClientBuilder) BuildSessionWithOptionsCredentials(value *AccessKey,
-	logLevel aws.ClientLogMode) (aws.Config, error) {
+	logLevel aws.ClientLogMode,
+) (aws.Config, error) {
 	cfg, err := config.LoadDefaultConfig(context.TODO(),
 		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(value.AccessKeyID,
 			value.SecretAccessKey, "")),
@@ -586,7 +587,6 @@ func (c *awsClient) FetchPublicSubnetMap(subnets []ec2types.Subnet) (map[string]
 }
 
 func (c *awsClient) ListSubnets(subnetIds ...string) ([]ec2types.Subnet, error) {
-
 	if len(subnetIds) == 0 {
 		return c.getSubnetIDs(&ec2.DescribeSubnetsInput{})
 	}
@@ -721,7 +721,8 @@ func (c *awsClient) isPublicSubnet(subnetID *string, routeTables []ec2types.Rout
 }
 
 func (c *awsClient) getSubnetRouteTable(subnetID *string,
-	routeTables []ec2types.RouteTable) (*ec2types.RouteTable, error) {
+	routeTables []ec2types.RouteTable,
+) (*ec2types.RouteTable, error) {
 	// Subnet route table — A route table that's associated with a subnet
 	for _, routeTable := range routeTables {
 		for _, association := range routeTable.Associations {
@@ -1463,7 +1464,8 @@ func (c *awsClient) ListServiceAccountRoles(clusterName string) ([]iamtypes.Role
 
 // GetServiceAccountRoleDetails gets detailed information about a service account role using existing methods
 func (c *awsClient) GetServiceAccountRoleDetails(roleName string) (
-	*iamtypes.Role, []iamtypes.AttachedPolicy, []string, error) {
+	*iamtypes.Role, []iamtypes.AttachedPolicy, []string, error,
+) {
 	// Use existing GetRoleByName method
 	role, err := c.GetRoleByName(roleName)
 	if err != nil {

--- a/pkg/aws/client_mock.go
+++ b/pkg/aws/client_mock.go
@@ -1207,6 +1207,21 @@ func (mr *MockClientMockRecorder) IsLocalAvailabilityZone(availabilityZoneName a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsLocalAvailabilityZone", reflect.TypeOf((*MockClient)(nil).IsLocalAvailabilityZone), availabilityZoneName)
 }
 
+// IsNoConsoleRole mocks base method.
+func (m *MockClient) IsNoConsoleRole(roleName string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsNoConsoleRole", roleName)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsNoConsoleRole indicates an expected call of IsNoConsoleRole.
+func (mr *MockClientMockRecorder) IsNoConsoleRole(roleName any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsNoConsoleRole", reflect.TypeOf((*MockClient)(nil).IsNoConsoleRole), roleName)
+}
+
 // IsPolicyCompatible mocks base method.
 func (m *MockClient) IsPolicyCompatible(policyArn, version string) (bool, error) {
 	m.ctrl.T.Helper()

--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -42,13 +42,16 @@ var RoleNameRE = regexp.MustCompile(`^[\w+=,.@-]+$`)
 var RoleArnRE = regexp.MustCompile(
 	`^arn:aws[\w-]*:iam::\d{12}:role(?:\/+[\w+=,.@-]+)+$`,
 )
+
 var PolicyArnRE = regexp.MustCompile(
 	`^arn:aws[\w-]*:iam::(\d{12}|aws):policy(?:\/+[\w+=,.@-]+)+$`,
 )
 
 // UserTagKeyRE , UserTagValueRE - https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html#tag-conventions
-var UserTagKeyRE = regexp.MustCompile(`^[\pL\pZ\pN_.:/=+\-@]{1,128}$`)
-var UserTagValueRE = regexp.MustCompile(`^[\pL\pZ\pN_.:/=+\-@]{0,256}$`)
+var (
+	UserTagKeyRE   = regexp.MustCompile(`^[\pL\pZ\pN_.:/=+\-@]{1,128}$`)
+	UserTagValueRE = regexp.MustCompile(`^[\pL\pZ\pN_.:/=+\-@]{0,256}$`)
+)
 
 // the following regex defines five different patterns:
 // first pattern is to validate IPv4 address
@@ -220,7 +223,7 @@ func GetAWSClientForUserRegion(reporter rprtr.Logger, logger *logrus.Logger,
 			os.Exit(1)
 		}
 		// Create the AWS client with the region used in the init
-		//So we can check for the stack in that region
+		// So we can check for the stack in that region
 		awsClient, err := NewClient().
 			Logger(logger).
 			Region(regionUsedForInit).
@@ -436,6 +439,10 @@ func GetOperatorPolicyName(prefix string, namespace string, name string) string 
 	return awsCommonUtils.TruncateRoleName(policy)
 }
 
+func GetNoConsolePolicyName(name string) string {
+	return fmt.Sprintf("%s-NoConsole-Policy", name)
+}
+
 func GetAdminPolicyName(name string) string {
 	return fmt.Sprintf("%s-Admin-Policy", name)
 }
@@ -445,8 +452,13 @@ func GetPolicyName(name string) string {
 }
 
 func GetOperatorPolicyARN(partition string, accountID string,
-	prefix string, namespace string, name string, path string) string {
+	prefix string, namespace string, name string, path string,
+) string {
 	return getPolicyARN(partition, accountID, GetOperatorPolicyName(prefix, namespace, name), path)
+}
+
+func GetNoConsolePolicyARN(partition string, accountID string, name string, path string) string {
+	return getPolicyARN(partition, accountID, GetNoConsolePolicyName(name), path)
 }
 
 func GetAdminPolicyARN(partition string, accountID string, name string, path string) string {
@@ -598,7 +610,7 @@ func GetOperatorRolePolicyPrefixFromCluster(cluster *cmv1.Cluster, awsClient Cli
 		return rankedPolicyPrefix[0], nil
 	}
 
-	//If no standard prefix is found, tries to look for the longest common prefix
+	// If no standard prefix is found, tries to look for the longest common prefix
 	// TODO: check if it makes sense to only use this and remove "-openshift" later
 	policyPrefix := helper.LongestCommonPrefixBySorting(policyNames)
 	if policyPrefix != "" {
@@ -645,7 +657,7 @@ func GenerateOperatorRolePolicyFiles(reporter rprtr.Logger, policies map[string]
 				"shared_vpc_role_arn": sharedVpcRoleArn,
 			})
 		}
-		//In case any missing policy we don't want to block the user.This might not happen
+		// In case any missing policy we don't want to block the user.This might not happen
 		if policyDetail == "" {
 			continue
 		}
@@ -661,9 +673,10 @@ func GenerateOperatorRolePolicyFiles(reporter rprtr.Logger, policies map[string]
 }
 
 func GenerateAccountRolePolicyFiles(reporter rprtr.Logger, env string, policies map[string]*cmv1.AWSSTSPolicy,
-	skipPermissionFiles bool, accountRoles map[string]AccountRole, partition string) error {
+	skipPermissionFiles bool, accountRoles map[string]AccountRole, partition string,
+) error {
 	for file := range accountRoles {
-		//Get trust policy
+		// Get trust policy
 		filename := fmt.Sprintf("sts_%s_trust_policy", file)
 		policyDetail := GetPolicyDetails(policies, filename)
 		policy := InterpolatePolicyDocument(partition, policyDetail, map[string]string{
@@ -677,7 +690,7 @@ func GenerateAccountRolePolicyFiles(reporter rprtr.Logger, env string, policies 
 			return err
 		}
 
-		//Get the permission policy
+		// Get the permission policy
 		if !skipPermissionFiles {
 			err = generatePermissionPolicyFile(reporter, file, policies)
 			if err != nil {
@@ -695,7 +708,7 @@ func generatePermissionPolicyFile(reporter rprtr.Logger, file string, policies m
 	if policyDetail == "" {
 		return nil
 	}
-	//Check and save it as json file
+	// Check and save it as json file
 	filename = GetFormattedFileName(filename)
 	reporter.Debugf("Saving '%s' to the current directory", filename)
 
@@ -703,7 +716,7 @@ func generatePermissionPolicyFile(reporter rprtr.Logger, file string, policies m
 }
 
 func GetFormattedFileName(filename string) string {
-	//Check and save it as json file
+	// Check and save it as json file
 	ext := filepath.Ext(filename)
 	if ext != ".json" {
 		filename = fmt.Sprintf("%s.json", filename)
@@ -712,7 +725,8 @@ func GetFormattedFileName(filename string) string {
 }
 
 func BuildOperatorRolePolicies(prefix string, accountID string, partition string, awsClient Client, commands []string,
-	defaultPolicyVersion string, credRequests map[string]*cmv1.STSOperator, path string) []string {
+	defaultPolicyVersion string, credRequests map[string]*cmv1.STSOperator, path string,
+) []string {
 	for credrequest, operator := range credRequests {
 		policyARN := GetOperatorPolicyARN(partition, accountID, prefix, operator.Namespace(), operator.Name(), path)
 		_, err := awsClient.IsPolicyExists(policyARN)
@@ -856,7 +870,6 @@ func ParseOption(option string) string {
 // if resource-id is empty then error is returned
 func GetResourceIdFromARN(stringARN string) (string, error) {
 	parsedARN, err := arn.Parse(stringARN)
-
 	if err != nil {
 		return "", fmt.Errorf("couldn't parse arn '%s': %v", stringARN, err)
 	}
@@ -876,7 +889,6 @@ func GetResourceIdFromARN(stringARN string) (string, error) {
 
 func GetResourceIdFromOidcProviderARN(stringARN string) (string, error) {
 	parsedARN, err := arn.Parse(stringARN)
-
 	if err != nil {
 		return "", fmt.Errorf("couldn't parse arn '%s': %v", stringARN, err)
 	}
@@ -896,7 +908,6 @@ func GetResourceIdFromOidcProviderARN(stringARN string) (string, error) {
 
 func GetResourceIdFromSecretArn(secretArn string) (string, error) {
 	parsedARN, err := arn.Parse(secretArn)
-
 	if err != nil {
 		return "", err
 	}
@@ -1033,7 +1044,6 @@ func waitForStackUpdateComplete(ctx context.Context, cfClient client.CloudFormat
 	return waiter.Wait(ctx, params, maxWaitDur, func(o *cloudformation.StackUpdateCompleteWaiterOptions) {
 		// Optionally set MinDelay, MaxDelay, and other options here
 	})
-
 }
 
 func waitForStackDeleteComplete(ctx context.Context, cfClient client.CloudFormationApiClient, stackName string) error {

--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -159,9 +159,12 @@ var HCPAccountRoles = map[string]AccountRole{
 	HCPWorkerRole:    {Name: fmt.Sprintf("%s-Worker", HCPSuffixPattern), Flag: "worker-iam-role"},
 }
 
-var OCMUserRolePolicyFile = "ocm_user"
-var OCMRolePolicyFile = "ocm"
-var OCMAdminRolePolicyFile = "ocm_admin"
+var (
+	OCMUserRolePolicyFile      = "ocm_user"
+	OCMRolePolicyFile          = "ocm"
+	OCMAdminRolePolicyFile     = "ocm_admin"
+	OCMNoConsoleRolePolicyFile = "ocm_no_console"
+)
 
 var roleTypeMap = map[string]string{
 	InstallerAccountRole:    InstallerAccountRoleType,
@@ -171,7 +174,8 @@ var roleTypeMap = map[string]string{
 }
 
 func (c *awsClient) EnsureRole(reporter reporter.Logger, name string, policy string, permissionsBoundary string,
-	version string, tagList map[string]string, path string, managedPolicies bool) (string, error) {
+	version string, tagList map[string]string, path string, managedPolicies bool,
+) (string, error) {
 	output, err := c.iamClient.GetRole(context.Background(), &iam.GetRoleInput{
 		RoleName: aws.String(name),
 	})
@@ -265,7 +269,8 @@ func (c *awsClient) ValidateRoleNameAvailable(name string) (err error) {
 }
 
 func (c *awsClient) createRole(reporter reporter.Logger, name string, policy string,
-	permissionsBoundary string, tagList map[string]string, path string) (string, error) {
+	permissionsBoundary string, tagList map[string]string, path string,
+) (string, error) {
 	if !RoleNameRE.MatchString(name) {
 		return "", fmt.Errorf("Role name is invalid")
 	}
@@ -319,17 +324,20 @@ func (c *awsClient) PutRolePolicy(roleName string, policyName string, policy str
 }
 
 func (c *awsClient) ForceEnsurePolicy(policyArn string, document string,
-	version string, tagList map[string]string, path string) (string, error) {
+	version string, tagList map[string]string, path string,
+) (string, error) {
 	return c.ensurePolicyHelper(policyArn, document, version, tagList, path, true, "")
 }
 
 func (c *awsClient) EnsurePolicy(policyArn string, document string,
-	version string, tagList map[string]string, path string) (string, error) {
+	version string, tagList map[string]string, path string,
+) (string, error) {
 	return c.ensurePolicyHelper(policyArn, document, version, tagList, path, false, "")
 }
 
 func (c *awsClient) ensurePolicyHelper(policyArn string, document string,
-	version string, tagList map[string]string, path string, force bool, policyName string) (string, error) {
+	version string, tagList map[string]string, path string, force bool, policyName string,
+) (string, error) {
 	output, err := c.IsPolicyExists(policyArn)
 	if err != nil {
 		var policyArnLocal string
@@ -406,7 +414,8 @@ func (c *awsClient) IsRolePolicyExists(roleName string, policyName string) (*iam
 }
 
 func (c *awsClient) createPolicy(policyArn string, document string, tagList map[string]string,
-	path string, policyName string) (string, error) {
+	path string, policyName string,
+) (string, error) {
 	var err error
 	if policyName == "" {
 		policyName, err = GetResourceIdFromARN(policyArn)
@@ -424,7 +433,6 @@ func (c *awsClient) createPolicy(policyArn string, document string, tagList map[
 	}
 
 	output, err := c.iamClient.CreatePolicy(context.Background(), createPolicyInput)
-
 	if err != nil {
 		return "", err
 	}
@@ -577,7 +585,8 @@ func (c *awsClient) FindRoleARNsHostedCp(roleType string, version string) ([]str
 
 // FIXME: refactor similar calls to use this instead
 func (c *awsClient) ValidateAccountRoleVersionCompatibility(
-	roleName string, roleType string, minVersion string) (bool, error) {
+	roleName string, roleType string, minVersion string,
+) (bool, error) {
 	listRoleTagsOutput, err := c.iamClient.ListRoleTags(context.Background(), &iam.ListRoleTagsInput{
 		RoleName: aws.String(roleName),
 	})
@@ -589,7 +598,8 @@ func (c *awsClient) ValidateAccountRoleVersionCompatibility(
 }
 
 func validateAccountRoleVersionCompatibilityClassic(roleType string, minVersion string,
-	tagList []iamtypes.Tag) (bool, error) {
+	tagList []iamtypes.Tag,
+) (bool, error) {
 	isCompatible, err := isAccountRoleVersionCompatible(tagList, roleType, minVersion)
 	if err != nil {
 		return false, err
@@ -607,7 +617,8 @@ func validateAccountRoleVersionCompatibilityClassic(roleType string, minVersion 
 }
 
 func validateAccountRoleVersionCompatibilityHostedCp(roleType string, minVersion string,
-	tagsList []iamtypes.Tag) (bool, error) {
+	tagsList []iamtypes.Tag,
+) (bool, error) {
 	isCompatible, err := isAccountRoleVersionCompatible(tagsList, roleType, minVersion)
 	if err != nil {
 		return false, err
@@ -621,7 +632,8 @@ func validateAccountRoleVersionCompatibilityHostedCp(roleType string, minVersion
 }
 
 func isAccountRoleVersionCompatible(tagsList []iamtypes.Tag, roleType string,
-	minVersion string) (bool, error) {
+	minVersion string,
+) (bool, error) {
 	skip := false
 	isTagged := false
 
@@ -838,7 +850,6 @@ func (c *awsClient) GetAccountRoleByArn(arn string) (Role, error) {
 	}
 
 	accountRole, err := c.mapToAccountRole("", role)
-
 	if err != nil {
 		return Role{}, err
 	}
@@ -919,8 +930,8 @@ func (c *awsClient) ListAccountRoles(version string) ([]Role, error) {
 }
 
 func (c *awsClient) ListOperatorRoles(targetVersion string,
-	targetClusterId string, targetPrefix string) (map[string][]OperatorRoleDetail, error) {
-
+	targetClusterId string, targetPrefix string,
+) (map[string][]OperatorRoleDetail, error) {
 	operatorMap := map[string][]OperatorRoleDetail{}
 	roles, err := c.ListRoles()
 	if err != nil {
@@ -1043,7 +1054,8 @@ func (c *awsClient) ListOperatorRoles(targetVersion string,
 }
 
 func (c *awsClient) ValidateIfRosaOperatorRole(role iamtypes.Role,
-	credRequest map[string]*cmv1.STSOperator) (bool, error) {
+	credRequest map[string]*cmv1.STSOperator,
+) (bool, error) {
 	listRoleTags, err := c.iamClient.ListRoleTags(context.Background(), &iam.ListRoleTagsInput{
 		RoleName: role.RoleName,
 	})
@@ -1102,7 +1114,8 @@ func (c *awsClient) GetPolicyDetailsFromRole(role *string) ([]*iam.GetPolicyOutp
 }
 
 func (c *awsClient) DeleteOperatorRole(roleName string, managedPolicies bool,
-	deleteHcpSharedVpcPolicies bool) (map[string]bool, error) {
+	deleteHcpSharedVpcPolicies bool,
+) (map[string]bool, error) {
 	role := aws.String(roleName)
 	sharedVpcPoliciesNotDeleted := make(map[string]bool)
 	tagFilter, err := getOperatorRolePolicyTags(c.iamClient, roleName)
@@ -1209,7 +1222,8 @@ func (c *awsClient) GetInstanceProfilesForRole(r string) ([]string, error) {
 }
 
 func (c *awsClient) DeleteAccountRole(roleName string, prefix string, managedPolicies bool,
-	deleteHcpSharedVpcPolicies bool) error {
+	deleteHcpSharedVpcPolicies bool,
+) error {
 	role := aws.String(roleName)
 	err := c.DeleteInlineRolePolicies(aws.ToString(role))
 	if err != nil {
@@ -1430,7 +1444,8 @@ func (c *awsClient) deletePolicyVersions(policyArn string) error {
 }
 
 func (c *awsClient) GetAttachedPolicyWithTags(role *string,
-	tagFilter map[string]string) ([]PolicyDetail, []PolicyDetail, error) {
+	tagFilter map[string]string,
+) ([]PolicyDetail, []PolicyDetail, error) {
 	policies := []PolicyDetail{}
 	excludedPolicies := []PolicyDetail{}
 	attachedPoliciesOutput, err := c.iamClient.ListAttachedRolePolicies(
@@ -1503,7 +1518,8 @@ func (c *awsClient) detachOperatorRolePolicies(role *string) error {
 }
 
 func (c *awsClient) GetOperatorRolesFromAccountByClusterID(clusterID string,
-	credRequest map[string]*cmv1.STSOperator) ([]string, error) {
+	credRequest map[string]*cmv1.STSOperator,
+) ([]string, error) {
 	var roleList []string
 	roles, err := c.ListRoles()
 	if err != nil {
@@ -1543,7 +1559,8 @@ func (c *awsClient) GetOperatorRolesFromAccountByClusterID(clusterID string,
 }
 
 func (c *awsClient) GetOperatorRolesFromAccountByPrefix(prefix string,
-	credRequest map[string]*cmv1.STSOperator) ([]string, error) {
+	credRequest map[string]*cmv1.STSOperator,
+) ([]string, error) {
 	var roleList []string
 	roles, err := c.ListRoles()
 	if err != nil {
@@ -1668,8 +1685,8 @@ func (c *awsClient) checkInstallerRoleExists(roleName string) (*iamtypes.Role, e
 	installerRole := fmt.Sprintf("%s%s-Role", rolePrefix, "Installer")
 	installerRoleResponse, err := c.iamClient.GetRole(context.Background(),
 		&iam.GetRoleInput{RoleName: aws.String(installerRole)})
-	//We try our best to determine the environment based on the trust policy in the installer
-	//If the installer role is deleted we can assume that there is no cluster using the role
+	// We try our best to determine the environment based on the trust policy in the installer
+	// If the installer role is deleted we can assume that there is no cluster using the role
 	if err != nil {
 		if awserr.IsNoSuchEntityException(err) {
 			return nil, nil
@@ -1681,7 +1698,8 @@ func (c *awsClient) checkInstallerRoleExists(roleName string) (*iamtypes.Role, e
 }
 
 func (c *awsClient) GetAccountRoleForCurrentEnvWithPrefix(env string, rolePrefix string,
-	accountRolesMap map[string]AccountRole) ([]Role, error) {
+	accountRolesMap map[string]AccountRole,
+) ([]Role, error) {
 	roleList := []Role{}
 	for _, prefix := range accountRolesMap {
 		role, err := c.GetAccountRoleForCurrentEnv(env, fmt.Sprintf("%s-%s-Role", rolePrefix, prefix.Name))
@@ -1723,7 +1741,8 @@ func (c *awsClient) buildRoles(roleName string, accountID string) ([]Role, error
 }
 
 func (c *awsClient) GetAccountRolePolicies(roles []string, prefix string) (map[string][]PolicyDetail,
-	map[string][]PolicyDetail, error) {
+	map[string][]PolicyDetail, error,
+) {
 	rolePolicies := make(map[string][]PolicyDetail)
 	roleExcludedPolicies := make(map[string][]PolicyDetail)
 	for _, role := range roles {
@@ -1842,7 +1861,6 @@ func (c *awsClient) IsUpgradedNeededForAccountRolePolicies(prefix string, versio
 		}
 		isCompatible, err := c.validateRolePolicyUpgradeVersionCompatibility(aws.ToString(role.Role.RoleName),
 			version)
-
 		if err != nil {
 			return false, err
 		}
@@ -1880,7 +1898,8 @@ func (c *awsClient) HasManagedPolicies(roleARN string) (bool, error) {
 }
 
 func (c *awsClient) IsUpgradedNeededForAccountRolePoliciesUsingCluster(
-	cluster *cmv1.Cluster, version string) (bool, error) {
+	cluster *cmv1.Cluster, version string,
+) (bool, error) {
 	for _, role := range AccountRoles {
 		roleName, err := GetAccountRoleName(cluster, role.Name)
 		if err != nil {
@@ -1890,7 +1909,6 @@ func (c *awsClient) IsUpgradedNeededForAccountRolePoliciesUsingCluster(
 			continue
 		}
 		isCompatible, err := c.validateRolePolicyUpgradeVersionCompatibility(aws.ToString(&roleName), version)
-
 		if err != nil {
 			return false, err
 		}
@@ -1981,7 +1999,8 @@ func (c *awsClient) IsUpgradedNeededForOperatorRolePoliciesUsingCluster(
 }
 
 func (c *awsClient) validateRolePolicyUpgradeVersionCompatibility(roleName string,
-	version string) (bool, error) {
+	version string,
+) (bool, error) {
 	attachedPolicies, _, err := c.GetAttachedPolicyWithTags(aws.String(roleName),
 		map[string]string{tags.RedHatManaged: TrueString})
 	if err != nil {
@@ -1997,7 +2016,8 @@ func (c *awsClient) validateRolePolicyUpgradeVersionCompatibility(roleName strin
 }
 
 func (c *awsClient) IsUpgradedNeededForOperatorRolePoliciesUsingPrefix(prefix string, partition string,
-	accountID string, version string, credRequests map[string]*cmv1.STSOperator, path string) (bool, error) {
+	accountID string, version string, credRequests map[string]*cmv1.STSOperator, path string,
+) (bool, error) {
 	for _, operator := range credRequests {
 		policyARN := GetOperatorPolicyARN(partition, accountID, prefix, operator.Namespace(), operator.Name(), path)
 		existsAndUpToDate, err := c.checkPolicyExistsAndUpToDate(policyARN, version)
@@ -2072,6 +2092,23 @@ func (c *awsClient) IsAdminRole(roleName string) (bool, error) {
 	return false, nil
 }
 
+func (c *awsClient) IsNoConsoleRole(roleName string) (bool, error) {
+	role, err := c.iamClient.GetRole(context.Background(), &iam.GetRoleInput{
+		RoleName: aws.String(roleName),
+	})
+	if err != nil {
+		return false, err
+	}
+
+	for _, tag := range role.Role.Tags {
+		if aws.ToString(tag.Key) == tags.NoConsoleRole && aws.ToString(tag.Value) == TrueString {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 func (c *awsClient) GetAccountRoleARN(prefix string, roleType string) (string, error) {
 	output, err := c.iamClient.GetRole(context.Background(), &iam.GetRoleInput{
 		RoleName: aws.String(common.GetRoleName(prefix, roleType)),
@@ -2093,7 +2130,8 @@ func (c *awsClient) GetAccountRoleARN(prefix string, roleType string) (string, e
 
 func (c *awsClient) ValidateOperatorRolesManagedPolicies(cluster *cmv1.Cluster,
 	operatorRoles map[string]*cmv1.STSOperator, policies map[string]*cmv1.AWSSTSPolicy,
-	hostedCPPolicies bool) error {
+	hostedCPPolicies bool,
+) error {
 	for key, operatorRole := range operatorRoles {
 		roleName, exist := FindOperatorRoleNameBySTSOperator(cluster, operatorRole)
 		if exist {
@@ -2108,7 +2146,8 @@ func (c *awsClient) ValidateOperatorRolesManagedPolicies(cluster *cmv1.Cluster,
 }
 
 func (c *awsClient) ValidateAccountRolesManagedPolicies(prefix string,
-	policies map[string]*cmv1.AWSSTSPolicy) error {
+	policies map[string]*cmv1.AWSSTSPolicy,
+) error {
 	for roleType, accountRole := range AccountRoles {
 		roleName := common.GetRoleName(prefix, accountRole.Name)
 
@@ -2125,7 +2164,8 @@ func (c *awsClient) ValidateAccountRolesManagedPolicies(prefix string,
 }
 
 func (c *awsClient) ValidateHCPAccountRolesManagedPolicies(prefix string,
-	policies map[string]*cmv1.AWSSTSPolicy) error {
+	policies map[string]*cmv1.AWSSTSPolicy,
+) error {
 	for roleType, accountRole := range HCPAccountRoles {
 		roleName := common.GetRoleName(prefix, accountRole.Name)
 
@@ -2190,7 +2230,8 @@ func (c *awsClient) GetOperatorRoleDefaultPolicy(roleName string) (string, error
 }
 
 func (c *awsClient) validateManagedPolicy(policies map[string]*cmv1.AWSSTSPolicy, policyKey string,
-	roleName string) error {
+	roleName string,
+) error {
 	managedPolicyARN, err := GetManagedPolicyARN(policies, policyKey)
 	if err != nil {
 		return err
@@ -2266,7 +2307,8 @@ func doesPolicyHaveTags(c client.IamApiClient, policyArn *string, tagFilter map[
 }
 
 func getAttachedPolicies(c client.IamApiClient, role string,
-	tagFilter map[string]string) ([]string, []string, error) {
+	tagFilter map[string]string,
+) ([]string, []string, error) {
 	policyArr := []string{}
 	excludedPolicyArr := []string{}
 	policiesOutput, err := c.ListAttachedRolePolicies(context.Background(),

--- a/pkg/aws/policies_test.go
+++ b/pkg/aws/policies_test.go
@@ -135,7 +135,8 @@ var _ = Describe("ListOperatorRoles", func() {
 					{
 						Key:   aws.String(common.ManagedPolicies),
 						Value: aws.String("true"),
-					}},
+					},
+				},
 			}, nil)
 		mockIamAPI.EXPECT().ListAttachedRolePolicies(gomock.Any(), gomock.Any()).Return(
 			&iam.ListAttachedRolePoliciesOutput{
@@ -224,7 +225,6 @@ var _ = Describe("mapToAccountRoles", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(roles).To(HaveLen(2))
 	})
-
 })
 
 var _ = Describe("Is Policy Compatible", func() {
@@ -273,6 +273,79 @@ var _ = Describe("Is Policy Compatible", func() {
 			isCompatible, err := client.IsPolicyCompatible("fakearn", "")
 			Expect(err).To(BeNil())
 			Expect(isCompatible).To(BeTrue())
+		})
+	})
+})
+
+var _ = Describe("Test IsNoConsoleRole function", func() {
+	var (
+		client     awsClient
+		mockIamAPI *mocks.MockIamApiClient
+		mockCtrl   *gomock.Controller
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockIamAPI = mocks.NewMockIamApiClient(mockCtrl)
+		client = awsClient{
+			iamClient: mockIamAPI,
+		}
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	When("Role has the no-console tag", func() {
+		It("Should return true", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				&iam.GetRoleOutput{
+					Role: &iamtypes.Role{
+						Tags: []iamtypes.Tag{
+							{
+								Key:   aws.String(tags.NoConsoleRole),
+								Value: aws.String(TrueString),
+							},
+						},
+					},
+				},
+				nil,
+			)
+
+			isNoConsoleRole, err := client.IsNoConsoleRole("test-role")
+			Expect(err).To(BeNil())
+			Expect(isNoConsoleRole).To(BeTrue())
+		})
+	})
+
+	When("Role does not have the no-console tag", func() {
+		It("Should return false", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				&iam.GetRoleOutput{
+					Role: &iamtypes.Role{
+						Tags: []iamtypes.Tag{},
+					},
+				},
+				nil,
+			)
+
+			isNoConsoleRole, err := client.IsNoConsoleRole("test-role")
+			Expect(err).To(BeNil())
+			Expect(isNoConsoleRole).To(BeFalse())
+		})
+	})
+
+	When("GetRole returns an error", func() {
+		It("Should return the error", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				nil,
+				fmt.Errorf("IAM error"),
+			)
+
+			isNoConsoleRole, err := client.IsNoConsoleRole("test-role")
+			Expect(err).NotTo(BeNil())
+			Expect(err.Error()).To(Equal("IAM error"))
+			Expect(isNoConsoleRole).To(BeFalse())
 		})
 	})
 })
@@ -371,7 +444,6 @@ var _ = Describe("Is Account Role Version Compatible", func() {
 })
 
 var _ = Describe("DeleteRole Validation", func() {
-
 	var (
 		client     awsClient
 		mockIamAPI *mocks.MockIamApiClient
@@ -415,7 +487,6 @@ var _ = Describe("DeleteRole Validation", func() {
 })
 
 var _ = Describe("Cluster Roles/Policies", func() {
-
 	var (
 		client     awsClient
 		mockIamAPI *mocks.MockIamApiClient
@@ -632,7 +703,6 @@ var _ = Describe("Validates isAwsManagedPolicy function", func() {
 })
 
 var _ = Describe("CheckIfROSAOperatorRole", func() {
-
 	var (
 		credRequest map[string]*cmv1.STSOperator
 		role        iamtypes.Role
@@ -854,10 +924,12 @@ var _ = Describe("validateManagedPolicy", func() {
 		}
 	},
 		Entry("fails if ECR policy does not exist", map[string]*cmv1.AWSSTSPolicy{
-			"sts_hcp_instance_worker_permission_policy": workerPolicy},
+			"sts_hcp_instance_worker_permission_policy": workerPolicy,
+		},
 			"sts_hcp_ec2_registry_permission_policy", "worker", "failed to find policy ARN for 'sts_hcp_ec2_registry_permission_policy'"),
 		Entry("fails to find worker policy", map[string]*cmv1.AWSSTSPolicy{
-			"sts_hcp_ec2_registry_permission_policy": ec2ContainerPolicy},
+			"sts_hcp_ec2_registry_permission_policy": ec2ContainerPolicy,
+		},
 			"sts_hcp_instance_worker_permission_policy", "worker",
 			"failed to find policy ARN for 'sts_hcp_instance_worker_permission_policy'"),
 	)

--- a/pkg/aws/tags/tags.go
+++ b/pkg/aws/tags/tags.go
@@ -43,6 +43,7 @@ const Environment = prefix + "environment"
 // AdminRole tags the role as admin (true/false)
 const AdminRole = prefix + "admin_role"
 
+// NoConsoleRole tags the role as no-console role
 const NoConsoleRole = prefix + "no_console_role"
 
 // RedHatManaged tags the role as red_hat_managed


### PR DESCRIPTION
## PR Summary
Adds `--no-console` flag to `rosa create ocm-role` for creating OCM roles with minimal permissions for customers not using console.redhat.com.

## Detailed Description of the Issue
This PR adds support for creating OCM roles with minimal permissions (`no-console`).

 ## Related Issues and PRs
  - Jira: [OCM-23880](https://issues.redhat.com/browse/OCM-23880)
  - Related: [OCM-23336](https://issues.redhat.com/browse/OCM-23336) (backend support)
  - Related PR(s): 
      - #3250 (rosa list ocm-role console access column)
      - [OCM-25298](https://issues.redhat.com/browse/OCM-25298) (linter fixes)
  - Related design/docs:  [design doc](https://github.com/openshift-online/rosa-enhancements/blob/main/enhancements/no-console-ocm-role.md)


## Type of Change
<!-- Check the primary type this PR represents -->
- [x] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
<!-- What users or systems experienced before this change -->

Users could only create standard or admin OCM roles. All OCM roles had permissions suitable for console.redhat.com usage.

## Behavior After This Change
<!-- What changes now, including user-visible and non-user-visible behavior -->

 Users can create three OCM role profiles:
  - **Standard** (default): Full OCM permissions for console and CLI usage
  - **Admin** (`--admin`): Enhanced permissions for administrative operations
  - **No-console** (`--no-console`): Minimal permissions

The `--admin` and `--no-console` flags are mutually exclusive. No-console roles are tagged with `rosa_no_console_role:true` and attach the `sts_ocm_no_console_permission_policy` instead of the standard policy.

## User-Facing Changes

 ### New --no-console flag for OCM role creation:
  - Customers can now create OCM roles with minimal permissions using `rosa create ocm-role --no-console`
  - The `--no-console` and `--admin` flags are mutually exclusive
  - When creating a no-console role, a warning is displayed: "This OCM role cannot be used to provision clusters via console.redhat.com"

###  Interactive mode behavior:
  - In interactive mode, users are first asked if they want an admin role
  - If they decline admin, they're then asked if they want a no-console role
  - This ensures users understand they have three options: standard, admin, or no-console

 ### Role conflict detection:
  - If a role already exists, the CLI provides clear guidance on what to do based on the requested vs. existing role type
  - Users cannot convert between role types - they must delete and recreate

###  Manual mode (--mode manual):
  - Generates the correct policy files and AWS CLI commands for no-console roles
  - Policy file: `sts_ocm_no_console_permission_policy.json` instead of the standard policy file

###  Graceful degradation:
  - If the no-console policy is not yet available from the OCM API, users get a clear error: "no-console OCM role is not yet enabled"

## How to Test (Step-by-Step)

### Preconditions
- AWS credentials configured with appropriate IAM permissions
- ROSA CLI built from this branch: `make rosa`
- OCM login configured: `rosa login`

### Test Results

#### Test 1: Mutual Exclusivity
**Command:**
```bash
./rosa create ocm-role --prefix test --admin --no-console
```
**Expected:** Error about mutually exclusive flags

**Result:** PASS
```
Error: if any flags in the group [admin no-console] are set none of the others can be; 
[admin no-console] were all set
```

---

#### Test 2: Standard Role Creation
**Command:**
```bash
./rosa create ocm-role --prefix test-standard --mode auto
```
**Expected:** Role created with no special tags (no admin, no no-console)

**Result:** PASS
```
I: Created role 'test-standard-OCM-Role-13829321'
I: Attached policy 'test-standard-OCM-Role-13829321-Policy'

Tags: rosa_role_type:OCM, red-hat-managed:true, rosa_environment:production
NO rosa_admin_role or rosa_no_console_role tags 
```

---

#### Test 3: Admin Role Creation
**Command:**
```bash
./rosa create ocm-role --prefix test-admin --admin --mode auto
```
**Expected:** Admin tag present, two policies attached

**Result:** PASS
```
I: Created role 'test-admin-OCM-Role-13829321'
I: Attached policy 'test-admin-OCM-Role-13829321-Policy'
I: Attached policy 'test-admin-OCM-Role-13829321-Admin-Policy'

Tags: rosa_admin_role:true 
Policies: Standard + Admin (2 total) 
```

---

#### Test 4: No-Console - Graceful Degradation (Production OCM)
**Command:**
```bash
./rosa create ocm-role --prefix test-noconsole --no-console --mode auto
```
**Expected:** Warning + error when policy not available, no AWS resources created

**Result:** PASS
```
W: This OCM role cannot be used to provision clusters via console.redhat.com 
I: Created role 'test-noconsole-OCM-Role-13829321'
E: There was an error creating the ocm role: no-console OCM role is not yet enabled 

Graceful error handling works correctly 
No partial resources created 
```

---

#### Test 5: No-Console - Full End-to-End (Local OCM with Policy)
**Command:**
```bash
./rosa create ocm-role --prefix test-noconsole-local --no-console --mode auto
```
**Expected:** Warning + full role creation with no-console policy

**Result:** PASS
```
W: This OCM role cannot be used to provision clusters via console.redhat.com 
I: Created role 'test-noconsole-local-OCM-Role-12541229'
I: Attached policy 'test-noconsole-local-OCM-Role-12541229-NoConsole-Policy' 

Tags: rosa_no_console_role:true 
Policy: Only NoConsole-Policy (NOT standard) 
Policy Content: {"Action":"iam:GetRole", "Condition":{...tags...}} 
```

---

#### Test 6: Manual Mode - Graceful Degradation (Production OCM)
**Command:**
```bash
mkdir /tmp/rosa-test && cd /tmp/rosa-test
./rosa create ocm-role --prefix test-manual --no-console --mode manual
```
**Expected:** Warning + error, no empty files

**Result:** PASS
```
W: This OCM role cannot be used to provision clusters via console.redhat.com 
E: There was an error creating the ocm role: no-console OCM role is not yet enabled 

No empty policy files generated 
Consistent with auto mode 
```

---

#### Test 7: Manual Mode - Full Success (Local OCM with Policy)
**Command:**
```bash
mkdir /tmp/rosa-manual && cd /tmp/rosa-manual
./rosa create ocm-role --prefix test-manual-noconsole --no-console --mode manual
```
**Expected:** Policy files with content, correct commands

**Result:** PASS
```
W: This OCM role cannot be used to provision clusters via console.redhat.com 
I: All policy files saved to the current directory

Files Generated:
 sts_ocm_trust_policy.json (has content)
 sts_ocm_no_console_permission_policy.json (has content, NOT empty!)

Commands Include:
 Key=rosa_no_console_role,Value=true
 --policy-name test-manual-noconsole-OCM-Role-12541229-NoConsole-Policy
 file://sts_ocm_no_console_permission_policy.json
```

---

#### Test 8: Interactive Mode - No Console
**Command:**
```bash
./rosa create ocm-role --prefix test-interactive -i
# Prompts: admin=No, no-console=Yes, mode=auto
```
**Expected:** No-console prompt shown after admin=No

**Result:** PASS
```
? Enable admin capabilities for the OCM role: No 
? Create OCM role with minimal permissions (no console access): Yes 
W: This OCM role cannot be used to provision clusters via console.redhat.com 
I: Created role 'test-no-console-interactive-OCM-Role-12541229'

Interactive flow correct: asked admin first, then no-console 
Tags: rosa_no_console_role:true 
```

---

#### Test 9: Interactive Mode - Admin
**Command:**
```bash
./rosa create ocm-role --prefix test-admin-interactive -i
# Prompts: admin=Yes, mode=auto
```
**Expected:** No-console prompt skipped (mutual exclusivity)

**Result:** PASS
```
? Enable admin capabilities for the OCM role: Yes 
[NO no-console prompt - correctly skipped] 
I: Created role 'test-admin-interactive-OCM-Role-12541229'
I: Attached policy 'test-admin-interactive-OCM-Role-12541229-Policy'
I: Attached policy 'test-admin-interactive-OCM-Role-12541229-Admin-Policy'

Tags: rosa_admin_role:true (NO rosa_no_console_role) 
Policies: Standard + Admin (2 total) 
```

---

#### Test 10: Conflict Detection - Standard → No Console
**Command:**
```bash
./rosa create ocm-role --prefix test-conflict --mode auto
./rosa create ocm-role --prefix test-conflict --no-console --mode auto
```
**Expected:** Error preventing conversion

**Result:** PASS
```
W: Role 'test-conflict-OCM-Role-13829321' already exists
E: There was an error creating the ocm role: the existing role is a standard role. 
   To use no-console permissions please delete the role and recreate it 

Clear, actionable error message 
No AWS resources modified 
```

---

#### Test 11: Conflict Detection - Admin → No Console
**Command:**
```bash
./rosa create ocm-role --prefix test-conflict2 --admin --mode auto
./rosa create ocm-role --prefix test-conflict2 --no-console --mode auto
```
**Expected:** Error preventing conversion

**Result:** PASS
```
W: Role 'test-conflict2-OCM-Role-13829321' already exists
E: There was an error creating the ocm role: the existing role is an admin role. 
   To use no-console permissions please delete the role and recreate it 

Clear, actionable error message 
No AWS resources modified 
```

---

#### Test 12: Upgrade Path - Standard → Admin
**Command:**
```bash
./rosa create ocm-role --prefix test-conflict3 --mode auto
./rosa create ocm-role --prefix test-conflict3 --admin --mode auto
```
**Expected:** Idempotent upgrade allowed

**Result:** PASS
```
W: Role 'test-conflict3-OCM-Role-13829321' already exists
? Add admin policies to 'test-conflict3-OCM-Role-13829321' role? Yes
I: Attached policy 'test-conflict3-OCM-Role-13829321-Admin-Policy' 

Tags: rosa_admin_role:true (added) 
Policies: Standard + Admin (both present) 
Idempotent upgrade works correctly 
```

---

#### Test 13: Custom Path
**Command:**
```bash
./rosa create ocm-role --prefix test-path --no-console --path /rosa/ --mode auto
```
**Expected:** Custom path in both role and policy ARNs

**Result:** PASS
```
I: Created role 'test-path-OCM-Role-12541229' with ARN 
   'arn:aws:iam::471112697682:role/rosa/test-path-OCM-Role-12541229' 
I: Attached policy 
   'arn:aws:iam::471112697682:policy/rosa/test-path-OCM-Role-12541229-NoConsole-Policy' 

Custom path /rosa/ correctly applied to both role and policy 
```

---

### Summary

**Automated Tests:** 11/11 passing
```bash
cd cmd/create/ocmrole && ginkgo
SUCCESS! -- 11 Passed | 0 Failed
```

**Manual Tests:** 13/13 passed
- All core functionality working correctly
- Graceful degradation verified (production OCM without policy)
- Full end-to-end flow verified (local OCM with policy)
- Interactive mode, conflict detection, and edge cases validated

**Key Validations:**
- --no-console flag works and is mutually exclusive with --admin
- Warning message displays correctly
- Correct tags: `rosa_no_console_role:true`
- Correct policy: Only NoConsole-Policy (not standard)
- Policy content: Minimal permissions (iam:GetRole with tag conditions)
- Graceful error when policy unavailable
- No empty files in manual mode
- Conflict detection prevents invalid conversions
- Custom paths work correctly


## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
<!-- Required only when breaking changes are introduced -->

N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

[OCM-23880]: https://redhat.atlassian.net/browse/OCM-23880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OCM-23336]: https://redhat.atlassian.net/browse/OCM-23336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OCM-25298]: https://redhat.atlassian.net/browse/OCM-25298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --no-console option to create OCM roles without console access (mutually exclusive with --admin)
  * OCM role profiles now include standard, admin, and no-console with guided interactive selection

* **Improvements**
  * Enhanced validation to prevent reusing roles with incompatible variants and ensure correct policy selection

* **Tests**
  * Added tests for profile constants, no-console behavior, and policy-file generation/validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->