### PR TITLE
ROSAENG-11735 | fix: fall back to m5.xlarge when m7i.xlarge is unavailable in region

### DIFF
--- a/pkg/machinepool/machinepool.go
+++ b/pkg/machinepool/machinepool.go
@@ -302,6 +302,11 @@ func (m *machinePool) CreateMachinePool(r *rosa.Runtime, cmd *cobra.Command, clu
 		spin.Stop()
 	}
 
+	instanceType, err = resolveInstanceTypeFallback(cmd, instanceType, instanceTypeList, cluster.Region().ID(), r)
+	if err != nil {
+		return err
+	}
+
 	if interactive.Enabled() {
 		if instanceType == "" {
 			instanceType = instanceTypeList.Items[0].MachineType.ID()
@@ -737,6 +742,11 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 
 	if spin != nil {
 		spin.Stop()
+	}
+
+	instanceType, err = resolveInstanceTypeFallback(cmd, instanceType, instanceTypeList, cluster.Region().ID(), r)
+	if err != nil {
+		return err
 	}
 
 	if interactive.Enabled() {
@@ -2454,4 +2464,28 @@ func manageReplicas(cmd *cobra.Command, args *mpOpts.CreateMachinepoolUserOption
 		}
 	}
 	return minReplicas, maxReplicas, replicas, autoscaling, nil
+}
+
+func resolveInstanceTypeFallback(
+	cmd *cobra.Command,
+	instanceType string,
+	instanceTypeList ocm.MachineTypeList,
+	region string,
+	r *rosa.Runtime,
+) (string, error) {
+	if cmd.Flags().Changed("instance-type") || instanceTypeList.Find(instanceType) != nil {
+		return instanceType, nil
+	}
+	if instanceTypeList.Find(mpOpts.FallbackInstanceType) != nil {
+		r.Reporter.Warnf(
+			"Default instance type '%s' is not available in region '%s', using '%s'",
+			mpOpts.DefaultInstanceType, region, mpOpts.FallbackInstanceType,
+		)
+		return mpOpts.FallbackInstanceType, nil
+	}
+	return "", fmt.Errorf(
+		"default instance type '%s' is not available in region '%s'"+
+			" and fallback '%s' is also unavailable, please specify --instance-type",
+		mpOpts.DefaultInstanceType, region, mpOpts.FallbackInstanceType,
+	)
 }

--- a/pkg/machinepool/machinepool_test.go
+++ b/pkg/machinepool/machinepool_test.go
@@ -1425,6 +1425,96 @@ var _ = Describe("MachinePools", func() {
 			err = machinePool.CreateMachinePool(t.RosaRuntime, cmd, clusterKey, cluster, &args)
 			Expect(err).ToNot(HaveOccurred())
 		})
+		It("Should fall back to FallbackInstanceType when default is not available in region", func() {
+			machinePool := &machinePool{}
+			args.Subnet = subnet
+			cluster = returnMockCluster(version)
+
+			cmd.Flags().StringVar(&args.Name, "name", "", "Name of the machine pool")
+			cmd.Flags().Set("name", "mp-1")
+			cmd.Flags().Bool("multi-availability-zone", true, "")
+			cmd.Flags().Set("multi-availability-zone", "true")
+			cmd.Flags().Bool("enable-autoscaling", true, "")
+			cmd.Flags().Set("enable-autoscaling", "true")
+			cmd.Flags().Int32("min-replicas", 1, "Replicas of the machine pool")
+			cmd.Flags().Set("min-replicas", "1")
+			cmd.Flags().Int32("max-replicas", 3, "Replicas of the machine pool")
+			cmd.Flags().Set("max-replicas", "3")
+			args.MinReplicas = 1
+			args.MaxReplicas = 3
+			args.AutoscalingEnabled = true
+			// Use the default instance type but do NOT mark the flag as changed
+			args.InstanceType = mpOpts.DefaultInstanceType
+			cmd.Flags().StringVar(new(string), "instance-type", mpOpts.DefaultInstanceType, "")
+			args.UseSpotInstances = true
+			args.SpotMaxPrice = "1.00"
+			// Return only m5.xlarge in the available types — m7i.xlarge is absent
+			mt, err := cmv1.NewMachineType().ID(mpOpts.FallbackInstanceType).
+				Name(mpOpts.FallbackInstanceType).Build()
+			Expect(err).ToNot(HaveOccurred())
+			acc, err := amsv1.NewAccount().ID("123456789012").Build()
+			Expect(err).ToNot(HaveOccurred())
+			qc, err := amsv1.NewQuotaCost().QuotaID("test-quota").OrganizationID("123456789012").
+				Version("4.15.0").Build()
+			Expect(err).ToNot(HaveOccurred())
+			machinePoolObj, err := cmv1.NewMachinePool().ID("mp-1").
+				InstanceType(mpOpts.FallbackInstanceType).Build()
+			Expect(err).ToNot(HaveOccurred())
+			mockClient.EXPECT().GetSubnetAvailabilityZone(subnet).Return(region, nil)
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusOK,
+					test.FormatMachineTypeList([]*cmv1.MachineType{mt})))
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusOK,
+					test.FormatMachineTypeList([]*cmv1.MachineType{mt})))
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, FormatResources(acc)))
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusOK,
+					test.FormatQuotaCostList([]*amsv1.QuotaCost{qc})))
+			mockClient.EXPECT().IsLocalAvailabilityZone(region).Return(false, nil)
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusOK, FormatResources(machinePoolObj)))
+			err = machinePool.CreateMachinePool(t.RosaRuntime, cmd, clusterKey, cluster, &args)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("Should error when both default and fallback instance types are unavailable", func() {
+			machinePool := &machinePool{}
+			args.Subnet = subnet
+			cluster = returnMockCluster(version)
+
+			cmd.Flags().StringVar(&args.Name, "name", "", "Name of the machine pool")
+			cmd.Flags().Set("name", "mp-1")
+			cmd.Flags().Bool("multi-availability-zone", true, "")
+			cmd.Flags().Set("multi-availability-zone", "true")
+			cmd.Flags().IntVar(&args.Replicas, "replicas", 3, "Replicas of the machine pool")
+			cmd.Flags().Set("replicas", "3")
+			args.Replicas = 3
+			args.InstanceType = mpOpts.DefaultInstanceType
+			cmd.Flags().StringVar(new(string), "instance-type", mpOpts.DefaultInstanceType, "")
+			// Return only t3.small — neither m7i.xlarge nor m5.xlarge available
+			mt, err := cmv1.NewMachineType().ID("t3.small").Name("t3.small").Build()
+			Expect(err).ToNot(HaveOccurred())
+			acc, err := amsv1.NewAccount().ID("123456789012").Build()
+			Expect(err).ToNot(HaveOccurred())
+			qc, err := amsv1.NewQuotaCost().QuotaID("test-quota").OrganizationID("123456789012").
+				Version("4.15.0").Build()
+			Expect(err).ToNot(HaveOccurred())
+			mockClient.EXPECT().GetSubnetAvailabilityZone(subnet).Return(region, nil)
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusOK,
+					test.FormatMachineTypeList([]*cmv1.MachineType{mt})))
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusOK,
+					test.FormatMachineTypeList([]*cmv1.MachineType{mt})))
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, FormatResources(acc)))
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusOK,
+					test.FormatQuotaCostList([]*amsv1.QuotaCost{qc})))
+			err = machinePool.CreateMachinePool(t.RosaRuntime, cmd, clusterKey, cluster, &args)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("default instance type"))
+			Expect(err.Error()).To(ContainSubstring("fallback"))
+		})
 	})
 })
 
@@ -1929,6 +2019,137 @@ var _ = Describe("NodePools", func() {
 			Expect(err).To(HaveOccurred())
 
 			Expect(err.Error()).To(ContainSubstring("expected a valid node pool root disk size value"))
+		})
+		It("Should fall back to FallbackInstanceType when default is not available in region", func() {
+			machinePool := &machinePool{}
+			version := "4.15.0"
+			az := "a1"
+
+			cluster = returnMockCluster(version)
+			privateSubnets := []ec2types.Subnet{
+				{AvailabilityZone: &az, SubnetId: &subnet},
+			}
+
+			cmd.Flags().StringVar(&args.Name, "name", "", "Name of the machine pool")
+			cmd.Flags().Set("name", "test")
+
+			cmd.Flags().StringVar(&args.Version, "version", "", "Version of the machine pool")
+			cmd.Flags().Set("version", version)
+
+			cmd.Flags().Bool("enable-autoscaling", true, "")
+			cmd.Flags().Set("enable-autoscaling", "true")
+			cmd.Flags().Int32("min-replicas", 1, "Replicas of the machine pool")
+			cmd.Flags().Set("min-replicas", "1")
+			cmd.Flags().Int32("max-replicas", 3, "Replicas of the machine pool")
+			cmd.Flags().Set("max-replicas", "3")
+			args.AutoscalingEnabled = true
+			args.MinReplicas = 1
+			args.MaxReplicas = 3
+			// Use the default instance type but do NOT mark the flag as changed
+			args.InstanceType = mpOpts.DefaultInstanceType
+			cmd.Flags().StringVar(new(string), "instance-type", mpOpts.DefaultInstanceType, "")
+			args.TuningConfigs = "test"
+			args.KubeletConfigs = "test"
+			args.NodeDrainGracePeriod = "30"
+
+			v := cmv1.VersionBuilder{}
+			v.ID(version).ChannelGroup("stable").RawID(version).Default(true).
+				Enabled(true).ROSAEnabled(true).HostedControlPlaneDefault(true)
+			versionObj, err := v.Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatVersionList(
+				[]*cmv1.Version{versionObj})))
+			mockClient.EXPECT().GetVPCPrivateSubnets(gomock.Any()).Return(privateSubnets, nil)
+			mockClient.EXPECT().GetSubnetAvailabilityZone(subnet).Return(az, nil)
+			// Return only m5.xlarge — m7i.xlarge is absent from this region
+			mt, err := cmv1.NewMachineType().ID(mpOpts.FallbackInstanceType).
+				Name(mpOpts.FallbackInstanceType).Build()
+			Expect(err).ToNot(HaveOccurred())
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatMachineTypeList(
+				[]*cmv1.MachineType{mt})))
+			acc, err := amsv1.NewAccount().ID("123456789012").Build()
+			Expect(err).ToNot(HaveOccurred())
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, FormatResources(acc)))
+			qc, err := amsv1.NewQuotaCost().QuotaID("test-quota").
+				OrganizationID("123456789012").Version("4.15.0").Build()
+			Expect(err).ToNot(HaveOccurred())
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatQuotaCostList([]*amsv1.QuotaCost{qc})))
+			tuningConfig, err := cmv1.NewTuningConfig().ID("test").Build()
+			Expect(err).ToNot(HaveOccurred())
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatTuningConfigList(
+				[]*cmv1.TuningConfig{tuningConfig})))
+			kubeConfig, err := cmv1.NewKubeletConfig().Name("test").ID("test").PodPidsLimit(5000).Build()
+			Expect(err).ToNot(HaveOccurred())
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatKubeletConfigList(
+				[]*cmv1.KubeletConfig{kubeConfig})))
+			flavour, err := cmv1.NewFlavour().AWS(cmv1.NewAWSFlavour().ComputeInstanceType("x-large").
+				WorkerVolume(cmv1.NewAWSVolume().Size(100))).
+				Network(cmv1.NewNetwork().MachineCIDR("").PodCIDR("").ServiceCIDR("").HostPrefix(1)).Build()
+			Expect(err).ToNot(HaveOccurred())
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, FormatResources(flavour)))
+			nodePoolObj, err := cmv1.NewNodePool().ID("np-1").Build()
+			Expect(err).ToNot(HaveOccurred())
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, FormatResources(nodePoolObj)))
+			nodePoolResponse := test.FormatNodePoolList([]*cmv1.NodePool{nodePoolObj})
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, nodePoolResponse))
+			err = machinePool.CreateNodePools(t.RosaRuntime, cmd, clusterKey, cluster, nil, &args)
+			Expect(err).To(Not(HaveOccurred()))
+		})
+		It("Should error when both default and fallback instance types are unavailable", func() {
+			machinePool := &machinePool{}
+			version := "4.15.0"
+			az := "a1"
+
+			cluster = returnMockCluster(version)
+			privateSubnets := []ec2types.Subnet{
+				{AvailabilityZone: &az, SubnetId: &subnet},
+			}
+
+			cmd.Flags().StringVar(&args.Name, "name", "", "Name of the machine pool")
+			cmd.Flags().Set("name", "test")
+
+			cmd.Flags().StringVar(&args.Version, "version", "", "Version of the machine pool")
+			cmd.Flags().Set("version", version)
+
+			cmd.Flags().Bool("enable-autoscaling", true, "")
+			cmd.Flags().Set("enable-autoscaling", "true")
+			cmd.Flags().Int32("min-replicas", 1, "Replicas of the machine pool")
+			cmd.Flags().Set("min-replicas", "1")
+			cmd.Flags().Int32("max-replicas", 3, "Replicas of the machine pool")
+			cmd.Flags().Set("max-replicas", "3")
+			args.AutoscalingEnabled = true
+			args.MinReplicas = 1
+			args.MaxReplicas = 3
+			args.InstanceType = mpOpts.DefaultInstanceType
+			cmd.Flags().StringVar(new(string), "instance-type", mpOpts.DefaultInstanceType, "")
+
+			v := cmv1.VersionBuilder{}
+			v.ID(version).ChannelGroup("stable").RawID(version).Default(true).
+				Enabled(true).ROSAEnabled(true).HostedControlPlaneDefault(true)
+			versionObj, err := v.Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatVersionList(
+				[]*cmv1.Version{versionObj})))
+			mockClient.EXPECT().GetVPCPrivateSubnets(gomock.Any()).Return(privateSubnets, nil)
+			mockClient.EXPECT().GetSubnetAvailabilityZone(subnet).Return(az, nil)
+			// Return only t3.small — neither m7i.xlarge nor m5.xlarge available
+			mt, err := cmv1.NewMachineType().ID("t3.small").Name("t3.small").Build()
+			Expect(err).ToNot(HaveOccurred())
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatMachineTypeList(
+				[]*cmv1.MachineType{mt})))
+			acc, err := amsv1.NewAccount().ID("123456789012").Build()
+			Expect(err).ToNot(HaveOccurred())
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, FormatResources(acc)))
+			qc, err := amsv1.NewQuotaCost().QuotaID("test-quota").
+				OrganizationID("123456789012").Version("4.15.0").Build()
+			Expect(err).ToNot(HaveOccurred())
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatQuotaCostList([]*amsv1.QuotaCost{qc})))
+			err = machinePool.CreateNodePools(t.RosaRuntime, cmd, clusterKey, cluster, nil, &args)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("default instance type"))
+			Expect(err.Error()).To(ContainSubstring("fallback"))
 		})
 	})
 })

--- a/pkg/options/machinepool/create.go
+++ b/pkg/options/machinepool/create.go
@@ -42,10 +42,12 @@ type CreateMachinepoolUserOptions struct {
 const (
 	// DefaultInstanceType is the default AWS instance type for new machine pools.
 	DefaultInstanceType = "m7i.xlarge"
-	use                 = "machinepool"
-	short               = "Add machine pool to cluster"
-	long                = "Add a machine pool to the cluster."
-	example             = `  # Interactively add a machine pool to a cluster named "mycluster"
+	// FallbackInstanceType is used when DefaultInstanceType is not available in the cluster's region.
+	FallbackInstanceType = "m5.xlarge"
+	use                  = "machinepool"
+	short                = "Add machine pool to cluster"
+	long                 = "Add a machine pool to the cluster."
+	example              = `  # Interactively add a machine pool to a cluster named "mycluster"
   rosa create machinepool --cluster=mycluster --interactive
   # Add a machine pool mp-1 with 3 replicas of m7i.xlarge to a cluster
   rosa create machinepool --cluster=mycluster --name=mp-1 --replicas=3 --instance-type=m7i.xlarge


### PR DESCRIPTION
## PR Summary

Fall back to m5.xlarge when the default m7i.xlarge instance type is not available in the cluster's region during machinepool/nodepool creation.

## Detailed Description of the Issue

PR #3241 ([OCM-24858](https://redhat.atlassian.net/browse/OCM-24858), v1.2.63) changed the `rosa create machinepool` default instance type from `m5.xlarge` to `m7i.xlarge`. However, m7i.xlarge is not available in all ROSA-supported AWS regions — specifically ca-west-1 (Canada West, Calgary) does not offer any m7i instance types. In that region, creating a machinepool without explicitly specifying `--instance-type` sends an invalid default to CS, which rejects it.

The CLI already fetches the region-filtered available instance type list via `GetAvailableMachineTypesInRegion()` before validation but did not use it to adjust the default.

## Related Issues and PRs

- Jira: [ROSAENG-11735](https://redhat.atlassian.net/browse/ROSAENG-11735)
- Parent epic: [ROSAENG-6780](https://redhat.atlassian.net/browse/ROSAENG-6780)
- Related: [OCM-24831](https://redhat.atlassian.net/browse/OCM-24831) (epic for m7i default change)
- Related: [OCM-24858](https://redhat.atlassian.net/browse/OCM-24858) / PR #3241 (original m7i default change)

## Type of Change

- [x] fix - resolves an incorrect behavior or bug.

## Previous Behavior

In regions where m7i.xlarge is not available (e.g. ca-west-1), `rosa create machinepool` without `--instance-type` would send `m7i.xlarge` to CS, which would reject it server-side with a validation error.

## Behavior After This Change

After fetching the available instance types for the cluster's region, if the user did not explicitly set `--instance-type` and `m7i.xlarge` is not in the available list, the CLI falls back to `m5.xlarge` and emits a warning:

```
W: Default instance type 'm7i.xlarge' is not available in region 'ca-west-1', using 'm5.xlarge'
```

If the user explicitly passed `--instance-type m7i.xlarge`, the behavior is unchanged — the existing validation path handles it.

The fix applies to both the Classic machinepool path and the HCP nodepool path.

## How to Test (Step-by-Step)

### Preconditions

- A ROSA cluster in ca-west-1 (the only ROSA-enabled region currently missing m7i.xlarge)
- Alternatively, verify via unit tests (no cluster needed)

### Test Steps

1. Build the CLI from this branch: `make rosa`
2. Create a machinepool without specifying instance type:
   ```
   rosa create machinepool --cluster=<cluster-in-ca-west-1> --name=test-mp --replicas=1
   ```
3. Verify the warning is printed and m5.xlarge is used
4. Create a machinepool with explicit instance type in a supported region:
   ```
   rosa create machinepool --cluster=<cluster-in-us-east-1> --name=test-mp --replicas=1
   ```
5. Verify m7i.xlarge is used with no warning

### Expected Results

- Step 2: Warning printed, machinepool created with m5.xlarge
- Step 4: No warning, machinepool created with m7i.xlarge

## Proof of the Fix

- `make fmt` — clean
- `make lint` — 0 issues
- `ginkgo ./pkg/machinepool/` — 241 tests pass (includes 2 new fallback tests)
- Regional availability verified via `aws ec2 describe-instance-type-offerings` across all 17 opt-in regions + GovCloud; ca-west-1 confirmed as the only ROSA-enabled region without m7i.xlarge

## Breaking Changes

- [x] No breaking changes

## Developer Verification Checklist

- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

[ROSAENG-11735]: https://redhat.atlassian.net/browse/ROSAENG-11735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROSAENG-6780]: https://redhat.atlassian.net/browse/ROSAENG-6780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OCM-24831]: https://redhat.atlassian.net/browse/OCM-24831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OCM-24858]: https://redhat.atlassian.net/browse/OCM-24858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Machine pool and node pool creation now automatically fall back to an alternative instance type when the default isn't available in the selected region, issuing a warning and prompting the user to specify an instance type if no fallback exists.

* **Documentation**
  * CLI help and examples rewritten into a clearer multi-step interactive walkthrough explaining instance-type behavior.

* **Tests**
  * Added tests covering successful fallback and error scenarios when default and fallback instance types are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->