### PR TITLE
OCM-00000 | chore: Set release version to 1.2.64

### DIFF
--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,7 +18,7 @@ limitations under the License.
 
 package info
 
-const DefaultVersion = "1.2.63"
+const DefaultVersion = "1.2.64"
 
 // Build contains the short Git SHA of the CLI at the point it was build. Set via `-ldflags` at build time
 var Build = "local"


### PR DESCRIPTION
## Description

Bump `DefaultVersion` on `master` to `1.2.64` after the `release_1.2.64` branch was created.

## Links & References

- Release branch: `release_1.2.64`
- RC1: https://github.com/openshift/rosa/releases/tag/v1.2.64-rc1

## How has this been tested?

Version-only change in `pkg/info/info.go`.

```
rosa version → 1.2.64
```

## Checklist

- [x] Subject follows commit-message format
- [x] Build succeeds (`make rosa`)
- [x] This is a version bump; no functional change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 1.2.64

<!-- end of auto-generated comment: release notes by coderabbit.ai -->