### PR TITLE
ROSA-745: per-repo dependency automation config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    labels:
+      - "area/dependency"
+      - "ok-to-test"
+      - "lgtm"
+      - "approved"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "ubi9/go-toolset"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>openshift/boilerplate//.github/renovate.json"
+  ],
+  "enabledManagers": [
+    "tekton",
+    "gomod"
+  ]
+}


### PR DESCRIPTION
## Summary
[ROSA-745](https://redhat.atlassian.net/browse/ROSA-745) — **rosa** per-repo MintMaker + Dependabot (not on boilerplate).

- `.github/renovate.json` — extends boilerplate MintMaker rules (`tekton` + `gomod`)
- `.github/dependabot.yml` — docker only; pre-labels `lgtm`/`approved` for tide on UBI bumps

**Draft** — merge after [openshift/release#80263](https://github.com/openshift/release/pull/80263) is live (~6h).

## Depends on
- [openshift/release#80263](https://github.com/openshift/release/pull/80263) — Konflux `rosa-on-pull-request` + EC + mandatory prow image contexts

## Test plan
- [ ] MintMaker grouped gomod PR opens on schedule
- [ ] Merge gated by Konflux + prow (no merge on partial green)
- [ ] Major gomod stays manual

[ROSA-745]: https://redhat.atlassian.net/browse/ROSA-745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a Dependabot configuration to automatically check Docker dependencies weekly, with PR labeling, a cap on concurrently open Dependabot PRs, and a selected exclusion.
  * Added a Renovate configuration that validates the config schema and limits automated updates to specific dependency managers only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->