### PR TITLE
ROSAENG-000000 | test: Only unlink existing OCM and user roles if they are in the same AWS account

### DIFF
--- a/tests/utils/handler/resources_handler_prepare.go
+++ b/tests/utils/handler/resources_handler_prepare.go
@@ -542,10 +542,14 @@ func (rh *resourcesHandler) PrepareOCMRole(
 	}
 	for _, role := range roles {
 		if role != "" {
-			output, err := ocmResourceService.UnlinkOCMRole("--role-arn", role, "-y")
-			if err != nil {
-				err = fmt.Errorf("error happens when unlinking existing OCM role: %s", output.String())
-				return nil, err
+			// Only unlink the OCM role if the AWS Account ID in the ARN matches the current AWS Account ID
+			if r.AWSClient.ValidateRoleARNAccountIDMatchCallerAccountID(role) == nil {
+				log.Logger.Warnf("Found existing OCM role '%s' that doesn't exist in AWS anymore, unlinking it", role)
+				output, err := ocmResourceService.UnlinkOCMRole("--role-arn", role, "-y")
+				if err != nil {
+					err = fmt.Errorf("error happens when unlinking existing OCM role: %s", output.String())
+					return nil, err
+				}
 			}
 		}
 	}
@@ -628,10 +632,14 @@ func (rh *resourcesHandler) PrepareUserRole(
 	}
 	for _, role := range roles {
 		if role != "" {
-			output, err := ocmResourceService.UnlinkUserRole("--role-arn", role, "-y")
-			if err != nil {
-				err = fmt.Errorf("error happens when unlinking existing user role: %s", output.String())
-				return nil, err
+			// Only unlink the user role if the AWS Account ID in the ARN matches the current AWS Account ID
+			if r.AWSClient.ValidateRoleARNAccountIDMatchCallerAccountID(role) == nil {
+				log.Logger.Warnf("Found existing user role '%s' that doesn't exist in AWS anymore, unlinking it", role)
+				output, err := ocmResourceService.UnlinkUserRole("--role-arn", role, "-y")
+				if err != nil {
+					err = fmt.Errorf("error happens when unlinking existing user role: %s", output.String())
+					return nil, err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
Supported ticket prefixes:
OCM-XXXXX, ROSAENG-XXXX
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For contributor workflow, see: ./CONTRIBUTING.md
For repo-local agent guidance, see: ./AGENTS.md
-->

## PR Summary
Attempts to fix an issue where our OCM role is accidentally getting unlinked automatically

## Detailed Description of the Issue
There's a potential issue where the code first checks `rosa list ocm-roles` for any linked OCM roles, and then checks the AMS API to see if there's any roles marked as linked that may have been deleted from AWS. However, it currently just assumes that if the role is in the API, and not the CLI response, that it must be invalid, and it doesn't check if the extra role is from a different AWS account

## Related Issues and PRs
<!-- Link all tracking items and related code changes -->
- Jira: 
- Fixes: `#`
- Related PR(s):
- Related design/docs:

## Type of Change
<!-- Check the primary type this PR represents -->
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [x] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
<!-- What users or systems experienced before this change -->

## Behavior After This Change
<!-- What changes now, including user-visible and non-user-visible behavior -->

## How to Test (Step-by-Step)
<!-- Provide reproducible validation instructions -->
### Preconditions
<!-- Required setup, environment, credentials, flags, cluster state, etc. -->

### Test Steps
1.
2.
3.

### Expected Results
<!-- What should happen after running the steps above -->

## Proof of the Fix
<!-- Attach evidence that demonstrates the changed behavior -->
- Screenshots:
- Videos:
- Logs/CLI output:
- Other artifacts:

## Breaking Changes
- [ ] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
<!-- Required only when breaking changes are introduced -->

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [x] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced OCM role unlinking with account ID validation to ensure roles are only unlinked when the AWS account ID in the role ARN matches the current caller's account.
  * Improved user role unlinking to include identical account ID verification, preventing unintended cross-account role removals and strengthening operational safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->