### PR TITLE
ROSAENG-60112 | test: add focused coverage for untested pkg packages (Phase 1C)

### DIFF
--- a/pkg/aws/client_additional_test.go
+++ b/pkg/aws/client_additional_test.go
@@ -1,0 +1,260 @@
+package aws
+
+import (
+	"fmt"
+
+	gomock "go.uber.org/mock/gomock"
+
+	awsSdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	secretsmanagertypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+
+	"github.com/openshift/rosa/pkg/aws/mocks"
+)
+
+var _ = Describe("Client Additional", func() {
+	var (
+		client   Client
+		mockCtrl *gomock.Controller
+
+		mockIamAPI            *mocks.MockIamApiClient
+		mockSecretsManagerAPI *mocks.MockSecretsManagerApiClient
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockIamAPI = mocks.NewMockIamApiClient(mockCtrl)
+		mockSecretsManagerAPI = mocks.NewMockSecretsManagerApiClient(mockCtrl)
+		client = New(
+			awsSdk.Config{},
+			NewLoggerWrapper(logrus.New(), nil),
+			mockIamAPI,
+			mocks.NewMockEc2ApiClient(mockCtrl),
+			mocks.NewMockOrganizationsApiClient(mockCtrl),
+			mocks.NewMockS3ApiClient(mockCtrl),
+			mockSecretsManagerAPI,
+			mocks.NewMockStsApiClient(mockCtrl),
+			mocks.NewMockCloudFormationApiClient(mockCtrl),
+			mocks.NewMockServiceQuotasApiClient(mockCtrl),
+			mocks.NewMockServiceQuotasApiClient(mockCtrl),
+			&AccessKey{},
+			false,
+		)
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	Context("CheckRoleExists", func() {
+		var (
+			roleName string
+			roleARN  string
+		)
+
+		BeforeEach(func() {
+			roleName = "test-role"
+			roleARN = "arn:aws:iam::123456789012:role/test-role"
+		})
+
+		It("Returns true with ARN when the role exists", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), &iam.GetRoleInput{
+				RoleName: awsSdk.String(roleName),
+			}).Return(&iam.GetRoleOutput{
+				Role: &iamtypes.Role{
+					Arn:      awsSdk.String(roleARN),
+					RoleName: awsSdk.String(roleName),
+				},
+			}, nil)
+
+			exists, arn, err := client.CheckRoleExists(roleName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeTrue())
+			Expect(arn).To(Equal(roleARN))
+		})
+
+		It("Returns false when the role does not exist", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), &iam.GetRoleInput{
+				RoleName: awsSdk.String(roleName),
+			}).Return(nil, &iamtypes.NoSuchEntityException{
+				Message: awsSdk.String("not found"),
+			})
+
+			exists, arn, err := client.CheckRoleExists(roleName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeFalse())
+			Expect(arn).To(BeEmpty())
+		})
+
+		It("Returns error for non-NoSuchEntity API failures", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), &iam.GetRoleInput{
+				RoleName: awsSdk.String(roleName),
+			}).Return(nil, fmt.Errorf("access denied"))
+
+			exists, arn, err := client.CheckRoleExists(roleName)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("access denied"))
+			Expect(exists).To(BeFalse())
+			Expect(arn).To(BeEmpty())
+		})
+	})
+
+	Context("GetRoleByARN", func() {
+		It("Returns the role for a valid role ARN", func() {
+			roleName := "MyRole"
+			roleARN := "arn:aws:iam::123456789012:role/MyRole"
+
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), &iam.GetRoleInput{
+				RoleName: awsSdk.String(roleName),
+			}).Return(&iam.GetRoleOutput{
+				Role: &iamtypes.Role{
+					Arn:      awsSdk.String(roleARN),
+					RoleName: awsSdk.String(roleName),
+				},
+			}, nil)
+
+			role, err := client.GetRoleByARN(roleARN)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*role.RoleName).To(Equal(roleName))
+			Expect(*role.Arn).To(Equal(roleARN))
+		})
+
+		It("Returns error for an invalid ARN string", func() {
+			role, err := client.GetRoleByARN("not-an-arn")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("expected 'not-an-arn' to be a valid IAM role ARN"))
+			Expect(role).To(Equal(iamtypes.Role{}))
+		})
+
+		It("Returns error when ARN is for a non-role resource", func() {
+			userARN := "arn:aws:iam::123456789012:user/Bob"
+
+			role, err := client.GetRoleByARN(userARN)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("expected ARN"))
+			Expect(err.Error()).To(ContainSubstring("to be IAM role resource"))
+			Expect(role).To(Equal(iamtypes.Role{}))
+		})
+
+		It("Extracts role name correctly from ARN with path", func() {
+			roleARN := "arn:aws:iam::123456789012:role/path/to/MyRole"
+
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), &iam.GetRoleInput{
+				RoleName: awsSdk.String("MyRole"),
+			}).Return(&iam.GetRoleOutput{
+				Role: &iamtypes.Role{
+					Arn:      awsSdk.String(roleARN),
+					RoleName: awsSdk.String("MyRole"),
+				},
+			}, nil)
+
+			role, err := client.GetRoleByARN(roleARN)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*role.RoleName).To(Equal("MyRole"))
+		})
+	})
+
+	Context("GetRoleByName", func() {
+		It("Returns the role on success", func() {
+			roleName := "test-role"
+			roleARN := "arn:aws:iam::123456789012:role/test-role"
+
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), &iam.GetRoleInput{
+				RoleName: awsSdk.String(roleName),
+			}).Return(&iam.GetRoleOutput{
+				Role: &iamtypes.Role{
+					Arn:      awsSdk.String(roleARN),
+					RoleName: awsSdk.String(roleName),
+				},
+			}, nil)
+
+			role, err := client.GetRoleByName(roleName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*role.RoleName).To(Equal(roleName))
+			Expect(*role.Arn).To(Equal(roleARN))
+		})
+
+		It("Returns error on API failure", func() {
+			roleName := "nonexistent-role"
+
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), &iam.GetRoleInput{
+				RoleName: awsSdk.String(roleName),
+			}).Return(nil, fmt.Errorf("api error"))
+
+			role, err := client.GetRoleByName(roleName)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("api error"))
+			Expect(role).To(Equal(iamtypes.Role{}))
+		})
+	})
+
+	Context("CreateSecretInSecretsManager", func() {
+		It("Returns the secret ARN on success", func() {
+			secretName := "my-secret"
+			secretValue := "super-secret-value"
+			secretARN := "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret-AbCdEf"
+
+			mockSecretsManagerAPI.EXPECT().CreateSecret(gomock.Any(), gomock.Any()).Return(
+				&secretsmanager.CreateSecretOutput{
+					ARN: awsSdk.String(secretARN),
+				}, nil)
+
+			resultARN, err := client.CreateSecretInSecretsManager(secretName, secretValue)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resultARN).To(Equal(secretARN))
+		})
+
+		It("Returns error on API failure", func() {
+			mockSecretsManagerAPI.EXPECT().CreateSecret(gomock.Any(), gomock.Any()).Return(
+				nil, fmt.Errorf("secret creation failed"))
+
+			_, err := client.CreateSecretInSecretsManager("my-secret", "value")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("secret creation failed"))
+		})
+	})
+
+	Context("DeleteSecretInSecretsManager", func() {
+		var secretARN string
+
+		BeforeEach(func() {
+			secretARN = "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret-AbCdEf"
+		})
+
+		It("Deletes the secret when it exists", func() {
+			mockSecretsManagerAPI.EXPECT().DescribeSecret(gomock.Any(), gomock.Any()).Return(
+				&secretsmanager.DescribeSecretOutput{}, nil)
+			mockSecretsManagerAPI.EXPECT().DeleteSecret(gomock.Any(), gomock.Any()).Return(
+				&secretsmanager.DeleteSecretOutput{}, nil)
+
+			err := client.DeleteSecretInSecretsManager(secretARN)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Returns nil when the secret is not found", func() {
+			mockSecretsManagerAPI.EXPECT().DescribeSecret(gomock.Any(), gomock.Any()).Return(
+				nil, &secretsmanagertypes.ResourceNotFoundException{
+					Message: awsSdk.String("not found"),
+				})
+
+			err := client.DeleteSecretInSecretsManager(secretARN)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Returns error when DeleteSecret fails", func() {
+			mockSecretsManagerAPI.EXPECT().DescribeSecret(gomock.Any(), gomock.Any()).Return(
+				&secretsmanager.DescribeSecretOutput{}, nil)
+			mockSecretsManagerAPI.EXPECT().DeleteSecret(gomock.Any(), gomock.Any()).Return(
+				nil, fmt.Errorf("delete failed"))
+
+			err := client.DeleteSecretInSecretsManager(secretARN)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("delete failed"))
+		})
+	})
+})

--- a/pkg/aws/cloudformation_test.go
+++ b/pkg/aws/cloudformation_test.go
@@ -1,0 +1,432 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+
+	gomock "go.uber.org/mock/gomock"
+
+	awsSdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
+	cloudformationtypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+	"github.com/aws/smithy-go"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+
+	"github.com/openshift/rosa/pkg/aws/mocks"
+)
+
+var _ = Describe("CloudFormation", func() {
+	var (
+		client    Client
+		mockCtrl  *gomock.Controller
+		mockCfAPI *mocks.MockCloudFormationApiClient
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockCfAPI = mocks.NewMockCloudFormationApiClient(mockCtrl)
+		client = New(
+			awsSdk.Config{},
+			NewLoggerWrapper(logrus.New(), nil),
+			mocks.NewMockIamApiClient(mockCtrl),
+			mocks.NewMockEc2ApiClient(mockCtrl),
+			mocks.NewMockOrganizationsApiClient(mockCtrl),
+			mocks.NewMockS3ApiClient(mockCtrl),
+			mocks.NewMockSecretsManagerApiClient(mockCtrl),
+			mocks.NewMockStsApiClient(mockCtrl),
+			mockCfAPI,
+			mocks.NewMockServiceQuotasApiClient(mockCtrl),
+			mocks.NewMockServiceQuotasApiClient(mockCtrl),
+			&AccessKey{},
+			false,
+		)
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	Context("CheckStackReadyOrNotExisting", func() {
+		stackName := "test-stack"
+
+		It("Returns ready when stack is CREATE_COMPLETE", func() {
+			mockCfAPI.EXPECT().ListStacks(gomock.Any(), gomock.Any()).Return(
+				&cloudformation.ListStacksOutput{
+					StackSummaries: []cloudformationtypes.StackSummary{
+						{
+							StackName:   awsSdk.String(stackName),
+							StackStatus: cloudformationtypes.StackStatusCreateComplete,
+						},
+					},
+				}, nil)
+
+			ready, status, err := client.CheckStackReadyOrNotExisting(stackName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ready).To(BeTrue())
+			Expect(*status).To(Equal("CREATE_COMPLETE"))
+		})
+
+		It("Returns ready when stack is UPDATE_COMPLETE", func() {
+			mockCfAPI.EXPECT().ListStacks(gomock.Any(), gomock.Any()).Return(
+				&cloudformation.ListStacksOutput{
+					StackSummaries: []cloudformationtypes.StackSummary{
+						{
+							StackName:   awsSdk.String(stackName),
+							StackStatus: cloudformationtypes.StackStatusUpdateComplete,
+						},
+					},
+				}, nil)
+
+			ready, status, err := client.CheckStackReadyOrNotExisting(stackName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ready).To(BeTrue())
+			Expect(*status).To(Equal("UPDATE_COMPLETE"))
+		})
+
+		It("Skips DELETE_COMPLETE stacks (treated as non-existing)", func() {
+			mockCfAPI.EXPECT().ListStacks(gomock.Any(), gomock.Any()).Return(
+				&cloudformation.ListStacksOutput{
+					StackSummaries: []cloudformationtypes.StackSummary{
+						{
+							StackName:   awsSdk.String(stackName),
+							StackStatus: cloudformationtypes.StackStatusDeleteComplete,
+						},
+					},
+				}, nil)
+
+			ready, status, err := client.CheckStackReadyOrNotExisting(stackName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ready).To(BeFalse())
+			Expect(status).To(BeNil())
+		})
+
+		It("Returns error with suggestion for ROLLBACK_COMPLETE stack", func() {
+			mockCfAPI.EXPECT().ListStacks(gomock.Any(), gomock.Any()).Return(
+				&cloudformation.ListStacksOutput{
+					StackSummaries: []cloudformationtypes.StackSummary{
+						{
+							StackName:   awsSdk.String(stackName),
+							StackStatus: cloudformationtypes.StackStatusRollbackComplete,
+						},
+					},
+				}, nil)
+
+			ready, status, err := client.CheckStackReadyOrNotExisting(stackName)
+			Expect(err).To(HaveOccurred())
+			Expect(ready).To(BeFalse())
+			Expect(*status).To(Equal("ROLLBACK_COMPLETE"))
+			Expect(err.Error()).To(ContainSubstring(
+				"exists with status ROLLBACK_COMPLETE. Expected status is CREATE_COMPLETE"))
+			Expect(err.Error()).To(ContainSubstring("rosa init --delete-stack"))
+		})
+
+		It("Returns not found when no stacks match", func() {
+			mockCfAPI.EXPECT().ListStacks(gomock.Any(), gomock.Any()).Return(
+				&cloudformation.ListStacksOutput{
+					StackSummaries: []cloudformationtypes.StackSummary{
+						{
+							StackName:   awsSdk.String("other-stack"),
+							StackStatus: cloudformationtypes.StackStatusCreateComplete,
+						},
+					},
+				}, nil)
+
+			ready, status, err := client.CheckStackReadyOrNotExisting(stackName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ready).To(BeFalse())
+			Expect(status).To(BeNil())
+		})
+
+		It("Returns not found when stack list is empty", func() {
+			mockCfAPI.EXPECT().ListStacks(gomock.Any(), gomock.Any()).Return(
+				&cloudformation.ListStacksOutput{
+					StackSummaries: []cloudformationtypes.StackSummary{},
+				}, nil)
+
+			ready, status, err := client.CheckStackReadyOrNotExisting(stackName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ready).To(BeFalse())
+			Expect(status).To(BeNil())
+		})
+
+		It("Propagates ListStacks API error", func() {
+			mockCfAPI.EXPECT().ListStacks(gomock.Any(), gomock.Any()).Return(
+				nil, fmt.Errorf("access denied"))
+
+			ready, status, err := client.CheckStackReadyOrNotExisting(stackName)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("access denied"))
+			Expect(ready).To(BeFalse())
+			Expect(status).To(BeNil())
+		})
+	})
+
+	Context("GetCFStack", func() {
+		stackName := "test-stack"
+		ctx := context.Background()
+
+		It("Returns the first stack on success", func() {
+			expected := cloudformationtypes.Stack{
+				StackName:   awsSdk.String(stackName),
+				StackStatus: cloudformationtypes.StackStatusCreateComplete,
+			}
+			mockCfAPI.EXPECT().DescribeStacks(gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, input *cloudformation.DescribeStacksInput,
+					_ ...func(*cloudformation.Options)) (*cloudformation.DescribeStacksOutput, error) {
+					Expect(*input.StackName).To(Equal(stackName))
+					return &cloudformation.DescribeStacksOutput{
+						Stacks: []cloudformationtypes.Stack{expected},
+					}, nil
+				})
+
+			stack, err := client.GetCFStack(ctx, stackName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*stack.StackName).To(Equal(stackName))
+			Expect(stack.StackStatus).To(Equal(cloudformationtypes.StackStatusCreateComplete))
+		})
+
+		It("Returns error when no stacks found", func() {
+			mockCfAPI.EXPECT().DescribeStacks(gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, _ *cloudformation.DescribeStacksInput,
+					_ ...func(*cloudformation.Options)) (*cloudformation.DescribeStacksOutput, error) {
+					return &cloudformation.DescribeStacksOutput{
+						Stacks: []cloudformationtypes.Stack{},
+					}, nil
+				})
+
+			stack, err := client.GetCFStack(ctx, stackName)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("No CF stacks with name"))
+			Expect(err.Error()).To(ContainSubstring(stackName))
+			Expect(stack).To(BeNil())
+		})
+
+		It("Propagates DescribeStacks API error", func() {
+			mockCfAPI.EXPECT().DescribeStacks(gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, _ *cloudformation.DescribeStacksInput,
+					_ ...func(*cloudformation.Options)) (*cloudformation.DescribeStacksOutput, error) {
+					return nil, fmt.Errorf("stack not found")
+				})
+
+			stack, err := client.GetCFStack(ctx, stackName)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("stack not found"))
+			Expect(stack).To(BeNil())
+		})
+	})
+
+	Context("DescribeCFStackResources", func() {
+		stackName := "test-stack"
+		ctx := context.Background()
+
+		It("Returns stack resources on success", func() {
+			resources := []cloudformationtypes.StackResource{
+				{
+					LogicalResourceId: awsSdk.String("AdminUser"),
+					ResourceType:      awsSdk.String("AWS::IAM::User"),
+					ResourceStatus:    cloudformationtypes.ResourceStatusCreateComplete,
+				},
+				{
+					LogicalResourceId: awsSdk.String("AdminPolicy"),
+					ResourceType:      awsSdk.String("AWS::IAM::Policy"),
+					ResourceStatus:    cloudformationtypes.ResourceStatusCreateComplete,
+				},
+			}
+			mockCfAPI.EXPECT().DescribeStackResources(gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, input *cloudformation.DescribeStackResourcesInput,
+					_ ...func(*cloudformation.Options)) (*cloudformation.DescribeStackResourcesOutput, error) {
+					Expect(*input.StackName).To(Equal(stackName))
+					return &cloudformation.DescribeStackResourcesOutput{
+						StackResources: resources,
+					}, nil
+				})
+
+			result, err := client.DescribeCFStackResources(ctx, stackName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*result).To(HaveLen(2))
+			Expect(*(*result)[0].LogicalResourceId).To(Equal("AdminUser"))
+		})
+
+		It("Propagates DescribeStackResources API error", func() {
+			mockCfAPI.EXPECT().DescribeStackResources(gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, _ *cloudformation.DescribeStackResourcesInput,
+					_ ...func(*cloudformation.Options)) (*cloudformation.DescribeStackResourcesOutput, error) {
+					return nil, fmt.Errorf("access denied")
+				})
+
+			result, err := client.DescribeCFStackResources(ctx, stackName)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("access denied"))
+			Expect(result).To(BeNil())
+		})
+	})
+
+	Context("DeleteCFStack", func() {
+		stackName := "test-stack"
+		ctx := context.Background()
+
+		It("Succeeds when DeleteStack returns no error", func() {
+			mockCfAPI.EXPECT().DeleteStack(gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, input *cloudformation.DeleteStackInput,
+					_ ...func(*cloudformation.Options)) (*cloudformation.DeleteStackOutput, error) {
+					Expect(*input.StackName).To(Equal(stackName))
+					return &cloudformation.DeleteStackOutput{}, nil
+				})
+
+			err := client.DeleteCFStack(ctx, stackName)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Propagates DeleteStack API error", func() {
+			mockCfAPI.EXPECT().DeleteStack(gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, _ *cloudformation.DeleteStackInput,
+					_ ...func(*cloudformation.Options)) (*cloudformation.DeleteStackOutput, error) {
+					return nil, fmt.Errorf("stack in use")
+				})
+
+			err := client.DeleteCFStack(ctx, stackName)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("stack in use"))
+		})
+	})
+
+	Context("DeleteOsdCcsAdminUser", func() {
+		stackName := "test-stack"
+
+		It("Returns nil on TokenAlreadyExistsException", func() {
+			mockCfAPI.EXPECT().DeleteStack(gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, _ *cloudformation.DeleteStackInput,
+					_ ...func(*cloudformation.Options)) (*cloudformation.DeleteStackOutput, error) {
+					return nil, &cloudformationtypes.TokenAlreadyExistsException{
+						Message: awsSdk.String("token exists"),
+					}
+				})
+
+			err := client.DeleteOsdCcsAdminUser(stackName)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Propagates non-TokenAlreadyExistsException errors", func() {
+			mockCfAPI.EXPECT().DeleteStack(gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, _ *cloudformation.DeleteStackInput,
+					_ ...func(*cloudformation.Options)) (*cloudformation.DeleteStackOutput, error) {
+					return nil, fmt.Errorf("internal server error")
+				})
+
+			err := client.DeleteOsdCcsAdminUser(stackName)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("internal server error"))
+		})
+	})
+
+	Context("UpdateStack", func() {
+		stackName := "test-stack"
+		templateBody := `{"AWSTemplateFormatVersion":"2010-09-09"}`
+
+		It("Returns nil when 'No updates are to be performed'", func() {
+			mockCfAPI.EXPECT().UpdateStack(gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, input *cloudformation.UpdateStackInput,
+					_ ...func(*cloudformation.Options)) (*cloudformation.UpdateStackOutput, error) {
+					Expect(*input.StackName).To(Equal(stackName))
+					Expect(*input.TemplateBody).To(Equal(templateBody))
+					return nil, &smithy.GenericAPIError{
+						Code:    "ValidationError",
+						Message: "No updates are to be performed",
+					}
+				})
+
+			awsC := client.(*awsClient)
+			err := awsC.UpdateStack(templateBody, stackName)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Returns error for non-no-op ValidationError", func() {
+			mockCfAPI.EXPECT().UpdateStack(gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, _ *cloudformation.UpdateStackInput,
+					_ ...func(*cloudformation.Options)) (*cloudformation.UpdateStackOutput, error) {
+					return nil, &smithy.GenericAPIError{
+						Code:    "ValidationError",
+						Message: "Template format error",
+					}
+				})
+
+			awsC := client.(*awsClient)
+			err := awsC.UpdateStack(templateBody, stackName)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Template format error"))
+		})
+
+		It("Returns error for non-ValidationError API error", func() {
+			mockCfAPI.EXPECT().UpdateStack(gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, _ *cloudformation.UpdateStackInput,
+					_ ...func(*cloudformation.Options)) (*cloudformation.UpdateStackOutput, error) {
+					return nil, fmt.Errorf("throttling exception")
+				})
+
+			awsC := client.(*awsClient)
+			err := awsC.UpdateStack(templateBody, stackName)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("throttling exception"))
+		})
+	})
+
+	Context("buildCreateStackInput", func() {
+		It("Sets correct capabilities, name, and template", func() {
+			body := `{"Resources":{}}`
+			name := "my-stack"
+			params := []cloudformationtypes.Parameter{
+				{ParameterKey: awsSdk.String("Env"), ParameterValue: awsSdk.String("prod")},
+			}
+			tags := []cloudformationtypes.Tag{
+				{Key: awsSdk.String("team"), Value: awsSdk.String("platform")},
+			}
+
+			input := buildCreateStackInput(body, name, params, tags)
+
+			Expect(*input.StackName).To(Equal(name))
+			Expect(*input.TemplateBody).To(Equal(body))
+			Expect(input.Capabilities).To(HaveLen(3))
+			Expect(input.Capabilities).To(ContainElements(
+				cloudformationtypes.CapabilityCapabilityIam,
+				cloudformationtypes.CapabilityCapabilityNamedIam,
+				cloudformationtypes.CapabilityCapabilityAutoExpand,
+			))
+			Expect(input.Parameters).To(HaveLen(1))
+			Expect(*input.Parameters[0].ParameterKey).To(Equal("Env"))
+			Expect(*input.Parameters[0].ParameterValue).To(Equal("prod"))
+			Expect(input.Tags).To(HaveLen(1))
+			Expect(*input.Tags[0].Key).To(Equal("team"))
+			Expect(*input.Tags[0].Value).To(Equal("platform"))
+		})
+
+		It("Handles empty params and tags", func() {
+			input := buildCreateStackInput("body", "stack", nil, nil)
+
+			Expect(*input.StackName).To(Equal("stack"))
+			Expect(*input.TemplateBody).To(Equal("body"))
+			Expect(input.Capabilities).To(HaveLen(3))
+			Expect(input.Parameters).To(BeNil())
+			Expect(input.Tags).To(BeNil())
+		})
+	})
+
+	Context("buildUpdateStackInput", func() {
+		It("Sets correct capabilities, name, and template", func() {
+			body := `{"Resources":{}}`
+			name := "my-stack"
+
+			input := buildUpdateStackInput(body, name)
+
+			Expect(*input.StackName).To(Equal(name))
+			Expect(*input.TemplateBody).To(Equal(body))
+			Expect(input.Capabilities).To(HaveLen(3))
+			Expect(input.Capabilities).To(ContainElements(
+				cloudformationtypes.CapabilityCapabilityIam,
+				cloudformationtypes.CapabilityCapabilityNamedIam,
+				cloudformationtypes.CapabilityCapabilityAutoExpand,
+			))
+		})
+	})
+})

--- a/pkg/aws/helpers_additional_test.go
+++ b/pkg/aws/helpers_additional_test.go
@@ -1,0 +1,379 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ARNValidator", func() {
+	When("input is a valid IAM role ARN", func() {
+		It("should return nil", func() {
+			err := ARNValidator("arn:aws:iam::123456789012:role/MyRole")
+			Expect(err).To(BeNil())
+		})
+
+		It("should return nil for a role with a path", func() {
+			err := ARNValidator("arn:aws:iam::123456789012:role/path/to/MyRole")
+			Expect(err).To(BeNil())
+		})
+
+		It("should return nil for a GovCloud ARN", func() {
+			err := ARNValidator("arn:aws-us-gov:iam::123456789012:role/MyRole")
+			Expect(err).To(BeNil())
+		})
+	})
+
+	When("input is an empty string", func() {
+		It("should return nil", func() {
+			err := ARNValidator("")
+			Expect(err).To(BeNil())
+		})
+	})
+
+	When("input is not a valid ARN", func() {
+		It("should return an error for a random string", func() {
+			err := ARNValidator("not-an-arn")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid ARN"))
+		})
+
+		It("should return an error for a malformed ARN", func() {
+			err := ARNValidator("arn:aws:iam:role/MyRole")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid ARN"))
+		})
+	})
+
+	When("input is not a string", func() {
+		It("should return an error for an integer", func() {
+			err := ARNValidator(42)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("can only validate strings"))
+		})
+
+		It("should return an error for a slice", func() {
+			err := ARNValidator([]string{"arn:aws:iam::123456789012:role/MyRole"})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("can only validate strings"))
+		})
+	})
+})
+
+var _ = Describe("SecretManagerArnValidator", func() {
+	When("input is a valid Secrets Manager ARN", func() {
+		It("should return nil", func() {
+			err := SecretManagerArnValidator("arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret-AbCdEf")
+			Expect(err).To(BeNil())
+		})
+	})
+
+	When("input is an empty string", func() {
+		It("should return nil", func() {
+			err := SecretManagerArnValidator("")
+			Expect(err).To(BeNil())
+		})
+	})
+
+	When("input is not a valid ARN", func() {
+		It("should return an error", func() {
+			err := SecretManagerArnValidator("not-an-arn")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("is not a valid ARN"))
+		})
+	})
+
+	When("input is an ARN for a different service", func() {
+		It("should return an error for an IAM ARN", func() {
+			err := SecretManagerArnValidator("arn:aws:iam::123456789012:role/MyRole")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("is not a valid secrets manager ARN"))
+		})
+
+		It("should return an error for an S3 ARN", func() {
+			err := SecretManagerArnValidator("arn:aws:s3:::my-bucket")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("is not a valid secrets manager ARN"))
+		})
+	})
+
+	When("input is not a string", func() {
+		It("should return an error", func() {
+			err := SecretManagerArnValidator(42)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("can only validate strings"))
+		})
+	})
+})
+
+var _ = Describe("GetPathFromARN", func() {
+	When("the ARN has a path", func() {
+		It("should return the path", func() {
+			path, err := GetPathFromARN("arn:aws:iam::123456789012:role/path/to/MyRole")
+			Expect(err).To(BeNil())
+			Expect(path).To(Equal("/path/to/"))
+		})
+
+		It("should return a single-segment path", func() {
+			path, err := GetPathFromARN("arn:aws:iam::123456789012:role/mypath/MyRole")
+			Expect(err).To(BeNil())
+			Expect(path).To(Equal("/mypath/"))
+		})
+	})
+
+	When("the ARN has no path", func() {
+		It("should return an empty string", func() {
+			path, err := GetPathFromARN("arn:aws:iam::123456789012:role/MyRole")
+			Expect(err).To(BeNil())
+			Expect(path).To(Equal(""))
+		})
+	})
+
+	When("the ARN is invalid", func() {
+		It("should return an error", func() {
+			_, err := GetPathFromARN("not-an-arn")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})
+
+var _ = Describe("GetResourceIdFromARN", func() {
+	When("the ARN has a simple resource", func() {
+		It("should return the resource name", func() {
+			id, err := GetResourceIdFromARN("arn:aws:iam::123456789012:role/MyRole")
+			Expect(err).To(BeNil())
+			Expect(id).To(Equal("MyRole"))
+		})
+	})
+
+	When("the ARN has a path", func() {
+		It("should return only the last segment", func() {
+			id, err := GetResourceIdFromARN("arn:aws:iam::123456789012:role/path/to/MyRole")
+			Expect(err).To(BeNil())
+			Expect(id).To(Equal("MyRole"))
+		})
+	})
+
+	When("the ARN is invalid", func() {
+		It("should return an error", func() {
+			_, err := GetResourceIdFromARN("not-an-arn")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("couldn't parse arn"))
+		})
+	})
+
+	When("the resource has no slash separator", func() {
+		It("should return an error", func() {
+			_, err := GetResourceIdFromARN("arn:aws:s3:::my-bucket")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("can't find resource-id"))
+		})
+	})
+})
+
+var _ = Describe("GetResourceIdFromOidcProviderARN", func() {
+	When("the ARN is a valid OIDC provider", func() {
+		It("should return the provider URL portion", func() {
+			id, err := GetResourceIdFromOidcProviderARN(
+				"arn:aws:iam::123456789012:oidc-provider/oidc.example.com/id")
+			Expect(err).To(BeNil())
+			Expect(id).To(Equal("oidc.example.com/id"))
+		})
+
+		It("should return the provider URL without extra path", func() {
+			id, err := GetResourceIdFromOidcProviderARN(
+				"arn:aws:iam::123456789012:oidc-provider/oidc.example.com")
+			Expect(err).To(BeNil())
+			Expect(id).To(Equal("oidc.example.com"))
+		})
+	})
+
+	When("the ARN is invalid", func() {
+		It("should return an error", func() {
+			_, err := GetResourceIdFromOidcProviderARN("not-an-arn")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("couldn't parse arn"))
+		})
+	})
+
+	When("the resource has no slash separator", func() {
+		It("should return an error", func() {
+			_, err := GetResourceIdFromOidcProviderARN("arn:aws:s3:::my-bucket")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("can't find resource-id"))
+		})
+	})
+})
+
+var _ = Describe("GetRoleARN", func() {
+	It("should build an ARN without a path", func() {
+		result := GetRoleARN("123456789012", "MyRole", "", "aws")
+		Expect(result).To(Equal("arn:aws:iam::123456789012:role/MyRole"))
+	})
+
+	It("should build an ARN with a path", func() {
+		result := GetRoleARN("123456789012", "MyRole", "/my/path/", "aws")
+		Expect(result).To(Equal("arn:aws:iam::123456789012:role/my/path/MyRole"))
+	})
+
+	It("should support GovCloud partition", func() {
+		result := GetRoleARN("123456789012", "MyRole", "", "aws-us-gov")
+		Expect(result).To(Equal("arn:aws-us-gov:iam::123456789012:role/MyRole"))
+	})
+})
+
+var _ = Describe("GetOIDCProviderARN", func() {
+	It("should build a valid OIDC provider ARN", func() {
+		result := GetOIDCProviderARN("aws", "123456789012", "oidc.eks.us-east-1.amazonaws.com/id/EXAMPLE")
+		Expect(result).To(Equal("arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/EXAMPLE"))
+	})
+
+	It("should support GovCloud partition", func() {
+		result := GetOIDCProviderARN("aws-us-gov", "123456789012", "oidc.example.com")
+		Expect(result).To(Equal("arn:aws-us-gov:iam::123456789012:oidc-provider/oidc.example.com"))
+	})
+})
+
+var _ = Describe("SetSubnetOption", func() {
+	It("should format a subnet with a Name tag", func() {
+		subnet := ec2types.Subnet{
+			SubnetId:         aws.String("subnet-12345"),
+			VpcId:            aws.String("vpc-abc"),
+			AvailabilityZone: aws.String("us-east-1a"),
+			OwnerId:          aws.String("111222333444"),
+			Tags: []ec2types.Tag{
+				{Key: aws.String("Name"), Value: aws.String("my-subnet")},
+			},
+		}
+		result := SetSubnetOption(subnet)
+		Expect(result).To(Equal(
+			fmt.Sprintf("subnet-12345 ('my-subnet','vpc-abc','us-east-1a', Owner ID: '111222333444')")))
+	})
+
+	It("should format a subnet without a Name tag", func() {
+		subnet := ec2types.Subnet{
+			SubnetId:         aws.String("subnet-67890"),
+			VpcId:            aws.String("vpc-def"),
+			AvailabilityZone: aws.String("us-west-2b"),
+			OwnerId:          aws.String("555666777888"),
+			Tags:             []ec2types.Tag{},
+		}
+		result := SetSubnetOption(subnet)
+		Expect(result).To(Equal(
+			fmt.Sprintf("subnet-67890 ('','vpc-def','us-west-2b', Owner ID: '555666777888')")))
+	})
+
+	It("should use Name tag when multiple tags exist", func() {
+		subnet := ec2types.Subnet{
+			SubnetId:         aws.String("subnet-multi"),
+			VpcId:            aws.String("vpc-xyz"),
+			AvailabilityZone: aws.String("eu-west-1c"),
+			OwnerId:          aws.String("999000111222"),
+			Tags: []ec2types.Tag{
+				{Key: aws.String("Environment"), Value: aws.String("prod")},
+				{Key: aws.String("Name"), Value: aws.String("prod-subnet")},
+				{Key: aws.String("Team"), Value: aws.String("platform")},
+			},
+		}
+		result := SetSubnetOption(subnet)
+		Expect(result).To(ContainSubstring("prod-subnet"))
+		Expect(result).To(ContainSubstring("subnet-multi"))
+	})
+})
+
+var _ = Describe("ParseOption", func() {
+	It("should return the first token", func() {
+		Expect(ParseOption("subnet-123 (us-east-1a)")).To(Equal("subnet-123"))
+	})
+
+	It("should return the whole string when there are no spaces", func() {
+		Expect(ParseOption("subnet-123")).To(Equal("subnet-123"))
+	})
+
+	It("should return empty string for empty input", func() {
+		Expect(ParseOption("")).To(Equal(""))
+	})
+})
+
+var _ = Describe("HasDuplicates", func() {
+	When("there are no duplicates", func() {
+		It("should return false", func() {
+			dup, found := HasDuplicates([]string{"a", "b", "c"})
+			Expect(found).To(BeFalse())
+			Expect(dup).To(Equal(""))
+		})
+	})
+
+	When("there are duplicates", func() {
+		It("should return the duplicate and true", func() {
+			dup, found := HasDuplicates([]string{"a", "b", "a"})
+			Expect(found).To(BeTrue())
+			Expect(dup).To(Equal("a"))
+		})
+
+		It("should find the first duplicate", func() {
+			dup, found := HasDuplicates([]string{"x", "y", "x", "y"})
+			Expect(found).To(BeTrue())
+			Expect(dup).To(Equal("x"))
+		})
+	})
+
+	When("the slice is empty", func() {
+		It("should return false", func() {
+			_, found := HasDuplicates([]string{})
+			Expect(found).To(BeFalse())
+		})
+	})
+
+	When("the slice has one element", func() {
+		It("should return false", func() {
+			_, found := HasDuplicates([]string{"only"})
+			Expect(found).To(BeFalse())
+		})
+	})
+})
+
+var _ = Describe("TrimRoleSuffix", func() {
+	When("the full suffix is present", func() {
+		It("should trim it", func() {
+			result := TrimRoleSuffix("my-prefix-Installer-Role", "-Installer-Role")
+			Expect(result).To(Equal("my-prefix"))
+		})
+	})
+
+	When("the suffix is partially present due to truncation", func() {
+		It("should trim the partial suffix", func() {
+			result := TrimRoleSuffix("my-prefix-Installer-Ro", "-Installer-Role")
+			Expect(result).To(Equal("my-prefix"))
+		})
+
+		It("should trim even a single-char partial suffix", func() {
+			result := TrimRoleSuffix("my-prefix-", "-Installer-Role")
+			Expect(result).To(Equal("my-prefix"))
+		})
+	})
+
+	When("the suffix is not present at all", func() {
+		It("should return the original string", func() {
+			result := TrimRoleSuffix("something-else", "-Installer-Role")
+			Expect(result).To(Equal("something-else"))
+		})
+	})
+
+	When("the name equals the suffix", func() {
+		It("should return an empty string", func() {
+			result := TrimRoleSuffix("-Installer-Role", "-Installer-Role")
+			Expect(result).To(Equal(""))
+		})
+	})
+
+	When("the suffix is empty", func() {
+		It("should return the original string", func() {
+			result := TrimRoleSuffix("my-role", "")
+			Expect(result).To(Equal("my-role"))
+		})
+	})
+})

--- a/pkg/aws/helpers_additional_test.go
+++ b/pkg/aws/helpers_additional_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -374,6 +375,246 @@ var _ = Describe("TrimRoleSuffix", func() {
 		It("should return the original string", func() {
 			result := TrimRoleSuffix("my-role", "")
 			Expect(result).To(Equal("my-role"))
+		})
+	})
+})
+
+var _ = Describe("ARNPathValidator", func() {
+	When("input is a valid path", func() {
+		It("should return nil", func() {
+			err := ARNPathValidator("/my/path/")
+			Expect(err).To(BeNil())
+		})
+	})
+
+	When("input is an empty string", func() {
+		It("should return nil", func() {
+			err := ARNPathValidator("")
+			Expect(err).To(BeNil())
+		})
+	})
+
+	When("input is an invalid path", func() {
+		It("should return an error for a path without slashes", func() {
+			err := ARNPathValidator("noslash")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("must begin and end with /"))
+		})
+	})
+
+	When("input is not a string", func() {
+		It("should return an error", func() {
+			err := ARNPathValidator(42)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("can only validate strings"))
+		})
+	})
+})
+
+var _ = Describe("UserNoProxyValidator", func() {
+	When("input is a valid single IP", func() {
+		It("should return nil", func() {
+			err := UserNoProxyValidator("10.0.0.1")
+			Expect(err).To(BeNil())
+		})
+	})
+
+	When("input is a valid CIDR", func() {
+		It("should return nil", func() {
+			err := UserNoProxyValidator("10.0.0.0/16")
+			Expect(err).To(BeNil())
+		})
+	})
+
+	When("input is a valid domain", func() {
+		It("should return nil", func() {
+			err := UserNoProxyValidator(".example.com")
+			Expect(err).To(BeNil())
+		})
+	})
+
+	When("input is an empty string", func() {
+		It("should return nil", func() {
+			err := UserNoProxyValidator("")
+			Expect(err).To(BeNil())
+		})
+	})
+
+	When("input is invalid", func() {
+		It("should return an error", func() {
+			err := UserNoProxyValidator("not a valid proxy")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("expected a valid user no-proxy value"))
+		})
+	})
+
+	When("input has multiple comma-separated valid values", func() {
+		It("should return nil", func() {
+			err := UserNoProxyValidator("10.0.0.1,10.0.0.2")
+			Expect(err).To(BeNil())
+		})
+	})
+
+	When("input has one invalid value in comma-separated list", func() {
+		It("should return an error", func() {
+			err := UserNoProxyValidator("10.0.0.1,not valid")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("expected a valid user no-proxy value"))
+		})
+	})
+
+	When("input is not a string", func() {
+		It("should return an error", func() {
+			err := UserNoProxyValidator(42)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("can only validate strings"))
+		})
+	})
+})
+
+var _ = Describe("UserNoProxyDuplicateValidator", func() {
+	When("values are unique", func() {
+		It("should return nil", func() {
+			err := UserNoProxyDuplicateValidator("a.com,b.com")
+			Expect(err).To(BeNil())
+		})
+	})
+
+	When("values have duplicates", func() {
+		It("should return an error", func() {
+			err := UserNoProxyDuplicateValidator("a.com,b.com,a.com")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("duplicate key"))
+		})
+	})
+
+	When("input is an empty string", func() {
+		It("should return nil", func() {
+			err := UserNoProxyDuplicateValidator("")
+			Expect(err).To(BeNil())
+		})
+	})
+
+	When("input is not a string", func() {
+		It("should return an error", func() {
+			err := UserNoProxyDuplicateValidator(42)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("can only validate strings"))
+		})
+	})
+})
+
+var _ = Describe("GetOCMRoleName", func() {
+	It("should build the correct OCM role name", func() {
+		result := GetOCMRoleName("ManagedOpenShift", "OCM", "12345")
+		Expect(result).To(Equal("ManagedOpenShift-OCM-Role-12345"))
+	})
+})
+
+var _ = Describe("GetUserRoleName", func() {
+	It("should build the correct user role name", func() {
+		result := GetUserRoleName("ManagedOpenShift", "User", "testuser")
+		Expect(result).To(Equal("ManagedOpenShift-User-testuser-Role"))
+	})
+})
+
+var _ = Describe("GetOperatorPolicyName", func() {
+	It("should build the correct operator policy name", func() {
+		result := GetOperatorPolicyName("my-prefix", "openshift-ingress", "cloud-credentials")
+		Expect(result).To(Equal("my-prefix-openshift-ingress-cloud-credentials"))
+	})
+})
+
+var _ = Describe("GetPolicyArn", func() {
+	It("should build a policy ARN without path", func() {
+		result := GetPolicyArn("aws", "123456789012", "MyPolicy", "")
+		Expect(result).To(Equal("arn:aws:iam::123456789012:policy/MyPolicy"))
+	})
+
+	It("should build a policy ARN with path", func() {
+		result := GetPolicyArn("aws", "123456789012", "MyPolicy", "/my/path/")
+		Expect(result).To(Equal("arn:aws:iam::123456789012:policy/my/path/MyPolicy"))
+	})
+})
+
+var _ = Describe("GetOperatorPolicyARN", func() {
+	It("should build an operator policy ARN without path", func() {
+		result := GetOperatorPolicyARN(
+			"aws", "123456789012", "my-prefix", "openshift-ingress", "cloud-credentials", "")
+		Expect(result).To(Equal(
+			"arn:aws:iam::123456789012:policy/my-prefix-openshift-ingress-cloud-credentials"))
+	})
+})
+
+var _ = Describe("IsStandardNamedAccountRole", func() {
+	When("the role name follows the standard pattern", func() {
+		It("should return true and the prefix", func() {
+			isStandard, prefix := IsStandardNamedAccountRole("my-prefix-Installer-Role", "Installer")
+			Expect(isStandard).To(BeTrue())
+			Expect(prefix).To(Equal("my-prefix"))
+		})
+	})
+
+	When("the role name does not follow the standard pattern", func() {
+		It("should return false and the original name", func() {
+			isStandard, prefix := IsStandardNamedAccountRole("some-other-name", "Installer")
+			Expect(isStandard).To(BeFalse())
+			Expect(prefix).To(Equal("some-other-name"))
+		})
+	})
+})
+
+var _ = Describe("isSTS", func() {
+	When("the ARN is an STS assumed-role", func() {
+		It("should return true", func() {
+			stsARN := arn.ARN{
+				Partition: "aws",
+				Service:   "sts",
+				AccountID: "123456789012",
+				Resource:  "assumed-role/MyRole/session",
+			}
+			Expect(isSTS(stsARN)).To(BeTrue())
+		})
+	})
+
+	When("the ARN is an IAM user", func() {
+		It("should return false", func() {
+			iamARN := arn.ARN{
+				Partition: "aws",
+				Service:   "iam",
+				AccountID: "123456789012",
+				Resource:  "user/MyUser",
+			}
+			Expect(isSTS(iamARN)).To(BeFalse())
+		})
+	})
+})
+
+var _ = Describe("resolveSTSRole", func() {
+	When("the ARN is a valid STS assumed-role", func() {
+		It("should return the corresponding IAM role ARN", func() {
+			stsARN := arn.ARN{
+				Partition: "aws",
+				Service:   "sts",
+				AccountID: "123456789012",
+				Resource:  "assumed-role/MyRole/session",
+			}
+			result, err := resolveSTSRole(stsARN)
+			Expect(err).To(BeNil())
+			Expect(*result).To(Equal("arn:aws:iam::123456789012:role/MyRole"))
+		})
+	})
+
+	When("the ARN is not an STS ARN", func() {
+		It("should return an error", func() {
+			iamARN := arn.ARN{
+				Partition: "aws",
+				Service:   "iam",
+				AccountID: "123456789012",
+				Resource:  "user/MyUser",
+			}
+			_, err := resolveSTSRole(iamARN)
+			Expect(err).To(HaveOccurred())
 		})
 	})
 })

--- a/pkg/aws/idps_test.go
+++ b/pkg/aws/idps_test.go
@@ -1,0 +1,226 @@
+package aws
+
+import (
+	"fmt"
+
+	gomock "go.uber.org/mock/gomock"
+
+	awsSdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+
+	"github.com/openshift/rosa/pkg/aws/mocks"
+	"github.com/openshift/rosa/pkg/aws/tags"
+)
+
+var _ = Describe("OIDC Provider", func() {
+	var (
+		client     Client
+		mockCtrl   *gomock.Controller
+		mockIamAPI *mocks.MockIamApiClient
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockIamAPI = mocks.NewMockIamApiClient(mockCtrl)
+		client = New(
+			awsSdk.Config{},
+			NewLoggerWrapper(logrus.New(), nil),
+			mockIamAPI,
+			mocks.NewMockEc2ApiClient(mockCtrl),
+			mocks.NewMockOrganizationsApiClient(mockCtrl),
+			mocks.NewMockS3ApiClient(mockCtrl),
+			mocks.NewMockSecretsManagerApiClient(mockCtrl),
+			mocks.NewMockStsApiClient(mockCtrl),
+			mocks.NewMockCloudFormationApiClient(mockCtrl),
+			mocks.NewMockServiceQuotasApiClient(mockCtrl),
+			mocks.NewMockServiceQuotasApiClient(mockCtrl),
+			&AccessKey{},
+			false,
+		)
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	Context("CreateOpenIDConnectProvider", func() {
+		var (
+			providerURL string
+			thumbprint  string
+			expectedARN string
+		)
+
+		BeforeEach(func() {
+			providerURL = "https://oidc.example.com/some-id"
+			thumbprint = "a]cfef"
+			expectedARN = "arn:aws:iam::123456789012:oidc-provider/oidc.example.com/some-id"
+		})
+
+		It("Returns the ARN when created with a clusterID tag", func() {
+			clusterID := "test-cluster-123"
+			mockIamAPI.EXPECT().CreateOpenIDConnectProvider(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ interface{}, input *iam.CreateOpenIDConnectProviderInput,
+					_ ...interface{}) (*iam.CreateOpenIDConnectProviderOutput, error) {
+					Expect(input.Url).To(Equal(&providerURL))
+					Expect(input.ThumbprintList).To(Equal([]string{thumbprint}))
+					Expect(input.ClientIDList).To(ConsistOf(OIDCClientIDOpenShift, OIDCClientIDSTSAWS))
+					Expect(input.Tags).To(HaveLen(2))
+					Expect(input.Tags).To(ContainElement(iamtypes.Tag{
+						Key:   awsSdk.String(tags.RedHatManaged),
+						Value: awsSdk.String(tags.True),
+					}))
+					Expect(input.Tags).To(ContainElement(iamtypes.Tag{
+						Key:   awsSdk.String(tags.ClusterID),
+						Value: awsSdk.String(clusterID),
+					}))
+					return &iam.CreateOpenIDConnectProviderOutput{
+						OpenIDConnectProviderArn: awsSdk.String(expectedARN),
+					}, nil
+				})
+
+			arn, err := client.CreateOpenIDConnectProvider(providerURL, thumbprint, clusterID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(arn).To(Equal(expectedARN))
+		})
+
+		It("Only includes RedHatManaged tag when clusterID is empty", func() {
+			mockIamAPI.EXPECT().CreateOpenIDConnectProvider(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ interface{}, input *iam.CreateOpenIDConnectProviderInput,
+					_ ...interface{}) (*iam.CreateOpenIDConnectProviderOutput, error) {
+					Expect(input.Tags).To(HaveLen(1))
+					Expect(input.Tags[0]).To(Equal(iamtypes.Tag{
+						Key:   awsSdk.String(tags.RedHatManaged),
+						Value: awsSdk.String(tags.True),
+					}))
+					return &iam.CreateOpenIDConnectProviderOutput{
+						OpenIDConnectProviderArn: awsSdk.String(expectedARN),
+					}, nil
+				})
+
+			arn, err := client.CreateOpenIDConnectProvider(providerURL, thumbprint, "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(arn).To(Equal(expectedARN))
+		})
+
+		It("Returns error when IAM API fails", func() {
+			mockIamAPI.EXPECT().CreateOpenIDConnectProvider(gomock.Any(), gomock.Any()).
+				Return(nil, fmt.Errorf("iam api error"))
+
+			arn, err := client.CreateOpenIDConnectProvider(providerURL, thumbprint, "cluster-1")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("iam api error"))
+			Expect(arn).To(BeEmpty())
+		})
+	})
+
+	Context("HasOpenIDConnectProvider", func() {
+		var (
+			issuerURL string
+			partition string
+			accountID string
+		)
+
+		BeforeEach(func() {
+			issuerURL = "https://oidc.example.com/some-id"
+			partition = "aws"
+			accountID = "123456789012"
+		})
+
+		It("Returns true when the provider exists and URL matches", func() {
+			expectedProviderURL := "oidc.example.com/some-id"
+			mockIamAPI.EXPECT().GetOpenIDConnectProvider(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ interface{}, input *iam.GetOpenIDConnectProviderInput,
+					_ ...interface{}) (*iam.GetOpenIDConnectProviderOutput, error) {
+					expectedARN := GetOIDCProviderARN(partition, accountID, expectedProviderURL)
+					Expect(awsSdk.ToString(input.OpenIDConnectProviderArn)).To(Equal(expectedARN))
+					return &iam.GetOpenIDConnectProviderOutput{
+						Url: awsSdk.String(expectedProviderURL),
+					}, nil
+				})
+
+			exists, err := client.HasOpenIDConnectProvider(issuerURL, partition, accountID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeTrue())
+		})
+
+		It("Returns false with no error when provider does not exist (NoSuchEntity)", func() {
+			mockIamAPI.EXPECT().GetOpenIDConnectProvider(gomock.Any(), gomock.Any()).
+				Return(nil, &iamtypes.NoSuchEntityException{Message: awsSdk.String("not found")})
+
+			exists, err := client.HasOpenIDConnectProvider(issuerURL, partition, accountID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeFalse())
+		})
+
+		It("Returns false with error for an invalid issuer URL", func() {
+			exists, err := client.HasOpenIDConnectProvider("not-a-valid-url", partition, accountID)
+			Expect(err).To(HaveOccurred())
+			Expect(exists).To(BeFalse())
+		})
+
+		It("Returns false with error on non-NoSuchEntity IAM error", func() {
+			mockIamAPI.EXPECT().GetOpenIDConnectProvider(gomock.Any(), gomock.Any()).
+				Return(nil, fmt.Errorf("access denied"))
+
+			exists, err := client.HasOpenIDConnectProvider(issuerURL, partition, accountID)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("access denied"))
+			Expect(exists).To(BeFalse())
+		})
+
+		It("Returns false with error when provider exists but URL is misconfigured", func() {
+			mockIamAPI.EXPECT().GetOpenIDConnectProvider(gomock.Any(), gomock.Any()).
+				Return(&iam.GetOpenIDConnectProviderOutput{
+					Url: awsSdk.String("different.host.com/other-id"),
+				}, nil)
+
+			exists, err := client.HasOpenIDConnectProvider(issuerURL, partition, accountID)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("misconfigured"))
+			Expect(exists).To(BeFalse())
+		})
+	})
+
+	Context("DeleteOpenIDConnectProvider", func() {
+		var oidcProviderARN string
+
+		BeforeEach(func() {
+			oidcProviderARN = "arn:aws:iam::123456789012:oidc-provider/oidc.example.com/some-id"
+		})
+
+		It("Deletes the provider successfully", func() {
+			mockIamAPI.EXPECT().DeleteOpenIDConnectProvider(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ interface{}, input *iam.DeleteOpenIDConnectProviderInput,
+					_ ...interface{}) (*iam.DeleteOpenIDConnectProviderOutput, error) {
+					Expect(awsSdk.ToString(input.OpenIDConnectProviderArn)).To(Equal(oidcProviderARN))
+					return &iam.DeleteOpenIDConnectProviderOutput{}, nil
+				})
+
+			err := client.DeleteOpenIDConnectProvider(oidcProviderARN)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Returns a specific error when provider does not exist", func() {
+			mockIamAPI.EXPECT().DeleteOpenIDConnectProvider(gomock.Any(), gomock.Any()).
+				Return(nil, &iamtypes.NoSuchEntityException{Message: awsSdk.String("not found")})
+
+			err := client.DeleteOpenIDConnectProvider(oidcProviderARN)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(
+				fmt.Sprintf("the OIDC provider '%s' does not exist", oidcProviderARN)))
+		})
+
+		It("Returns the raw error for other IAM failures", func() {
+			mockIamAPI.EXPECT().DeleteOpenIDConnectProvider(gomock.Any(), gomock.Any()).
+				Return(nil, fmt.Errorf("service unavailable"))
+
+			err := client.DeleteOpenIDConnectProvider(oidcProviderARN)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("service unavailable"))
+		})
+	})
+})

--- a/pkg/aws/policies_additional_test.go
+++ b/pkg/aws/policies_additional_test.go
@@ -1,0 +1,169 @@
+package aws
+
+import (
+	"fmt"
+
+	gomock "go.uber.org/mock/gomock"
+
+	awsSdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	common "github.com/openshift-online/ocm-common/pkg/aws/validations"
+
+	"github.com/openshift/rosa/pkg/aws/mocks"
+)
+
+var _ = Describe("hasCompatibleMajorMinorVersionTags", func() {
+	var client awsClient
+
+	BeforeEach(func() {
+		client = awsClient{}
+	})
+
+	It("Returns true for exact version match", func() {
+		tags := []iamtypes.Tag{
+			{Key: awsSdk.String(common.OpenShiftVersion), Value: awsSdk.String("4.14.0")},
+		}
+		result, err := client.hasCompatibleMajorMinorVersionTags(tags, "4.14.0")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(BeTrue())
+	})
+
+	It("Returns true when tag version has higher minor than input", func() {
+		tags := []iamtypes.Tag{
+			{Key: awsSdk.String(common.OpenShiftVersion), Value: awsSdk.String("4.15.0")},
+		}
+		result, err := client.hasCompatibleMajorMinorVersionTags(tags, "4.14.0")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(BeTrue())
+	})
+
+	It("Returns false when tag version has lower minor than input", func() {
+		tags := []iamtypes.Tag{
+			{Key: awsSdk.String(common.OpenShiftVersion), Value: awsSdk.String("4.13.0")},
+		}
+		result, err := client.hasCompatibleMajorMinorVersionTags(tags, "4.14.0")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(BeFalse())
+	})
+
+	It("Returns true when same major.minor with different patch", func() {
+		tags := []iamtypes.Tag{
+			{Key: awsSdk.String(common.OpenShiftVersion), Value: awsSdk.String("4.14.5")},
+		}
+		result, err := client.hasCompatibleMajorMinorVersionTags(tags, "4.14.0")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(BeTrue())
+	})
+
+	It("Returns false when tags are empty", func() {
+		result, err := client.hasCompatibleMajorMinorVersionTags([]iamtypes.Tag{}, "4.14.0")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(BeFalse())
+	})
+
+	It("Returns false when no OpenShiftVersion tag exists", func() {
+		tags := []iamtypes.Tag{
+			{Key: awsSdk.String("some-other-key"), Value: awsSdk.String("4.14.0")},
+		}
+		result, err := client.hasCompatibleMajorMinorVersionTags(tags, "4.14.0")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(BeFalse())
+	})
+
+	It("Returns error when tag version string is invalid", func() {
+		tags := []iamtypes.Tag{
+			{Key: awsSdk.String(common.OpenShiftVersion), Value: awsSdk.String("not-a-version")},
+		}
+		_, err := client.hasCompatibleMajorMinorVersionTags(tags, "4.14.0")
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("Returns error when input version string is invalid", func() {
+		tags := []iamtypes.Tag{
+			{Key: awsSdk.String(common.OpenShiftVersion), Value: awsSdk.String("4.14.0")},
+		}
+		_, err := client.hasCompatibleMajorMinorVersionTags(tags, "not-a-version")
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("IsPolicyCompatible", func() {
+	var (
+		client     awsClient
+		mockIamAPI *mocks.MockIamApiClient
+		mockCtrl   *gomock.Controller
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockIamAPI = mocks.NewMockIamApiClient(mockCtrl)
+		client = awsClient{iamClient: mockIamAPI}
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	It("Returns true when version is empty", func() {
+		result, err := client.IsPolicyCompatible("arn:aws:iam::123456789:policy/test", "")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(BeTrue())
+	})
+
+	It("Returns true when policy tags have compatible version", func() {
+		mockIamAPI.EXPECT().ListPolicyTags(gomock.Any(), gomock.Any()).Return(
+			&iam.ListPolicyTagsOutput{
+				Tags: []iamtypes.Tag{
+					{Key: awsSdk.String(common.OpenShiftVersion), Value: awsSdk.String("4.14.0")},
+				},
+			}, nil)
+		result, err := client.IsPolicyCompatible("arn:aws:iam::123456789:policy/test", "4.14.0")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(BeTrue())
+	})
+
+	It("Returns true when policy tags have higher version", func() {
+		mockIamAPI.EXPECT().ListPolicyTags(gomock.Any(), gomock.Any()).Return(
+			&iam.ListPolicyTagsOutput{
+				Tags: []iamtypes.Tag{
+					{Key: awsSdk.String(common.OpenShiftVersion), Value: awsSdk.String("4.15.0")},
+				},
+			}, nil)
+		result, err := client.IsPolicyCompatible("arn:aws:iam::123456789:policy/test", "4.14.0")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(BeTrue())
+	})
+
+	It("Returns false when policy tags have incompatible version", func() {
+		mockIamAPI.EXPECT().ListPolicyTags(gomock.Any(), gomock.Any()).Return(
+			&iam.ListPolicyTagsOutput{
+				Tags: []iamtypes.Tag{
+					{Key: awsSdk.String(common.OpenShiftVersion), Value: awsSdk.String("4.13.0")},
+				},
+			}, nil)
+		result, err := client.IsPolicyCompatible("arn:aws:iam::123456789:policy/test", "4.14.0")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(BeFalse())
+	})
+
+	It("Returns false when policy has no tags", func() {
+		mockIamAPI.EXPECT().ListPolicyTags(gomock.Any(), gomock.Any()).Return(
+			&iam.ListPolicyTagsOutput{
+				Tags: []iamtypes.Tag{},
+			}, nil)
+		result, err := client.IsPolicyCompatible("arn:aws:iam::123456789:policy/test", "4.14.0")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(BeFalse())
+	})
+
+	It("Returns error when ListPolicyTags fails", func() {
+		mockIamAPI.EXPECT().ListPolicyTags(gomock.Any(), gomock.Any()).Return(
+			nil, fmt.Errorf("access denied"))
+		_, err := client.IsPolicyCompatible("arn:aws:iam::123456789:policy/test", "4.14.0")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("access denied"))
+	})
+})

--- a/pkg/aws/policy_document_test.go
+++ b/pkg/aws/policy_document_test.go
@@ -1,0 +1,324 @@
+package aws
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("PolicyDocument", func() {
+
+	Describe("NewPolicyDocument", func() {
+		It("returns a document with Version 2012-10-17 and empty Statement", func() {
+			doc := NewPolicyDocument()
+			Expect(doc.Version).To(Equal("2012-10-17"))
+			Expect(doc.Statement).To(BeEmpty())
+		})
+	})
+
+	Describe("ParsePolicyDocument", func() {
+		Context("with valid JSON", func() {
+			It("parses a simple policy", func() {
+				raw := `{
+					"Version": "2012-10-17",
+					"Statement": [{
+						"Effect": "Allow",
+						"Action": "s3:GetObject",
+						"Resource": "*"
+					}]
+				}`
+				doc, err := ParsePolicyDocument(raw)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(doc.Version).To(Equal("2012-10-17"))
+				Expect(doc.Statement).To(HaveLen(1))
+				Expect(doc.Statement[0].Effect).To(Equal("Allow"))
+			})
+
+			It("parses a policy with multiple statements", func() {
+				raw := `{
+					"Version": "2012-10-17",
+					"Statement": [
+						{"Sid": "AllowS3", "Effect": "Allow", "Action": "s3:GetObject", "Resource": "*"},
+						{"Sid": "DenyEC2", "Effect": "Deny", "Action": "ec2:TerminateInstances", "Resource": "*"}
+					]
+				}`
+				doc, err := ParsePolicyDocument(raw)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(doc.Statement).To(HaveLen(2))
+				Expect(doc.Statement[0].Sid).To(Equal("AllowS3"))
+				Expect(doc.Statement[1].Sid).To(Equal("DenyEC2"))
+			})
+		})
+
+		Context("with invalid input", func() {
+			It("returns an error for malformed JSON", func() {
+				_, err := ParsePolicyDocument(`{not json}`)
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("returns an error for an empty string", func() {
+				_, err := ParsePolicyDocument("")
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("GetAWSPrincipals", func() {
+		It("returns a single principal when AWS is a string", func() {
+			stmt := PolicyStatement{
+				Principal: &PolicyStatementPrincipal{
+					AWS: "arn:aws:iam::123456:root",
+				},
+			}
+			Expect(stmt.GetAWSPrincipals()).To(Equal([]string{"arn:aws:iam::123456:root"}))
+		})
+
+		It("returns all principals when AWS is a slice", func() {
+			stmt := PolicyStatement{
+				Principal: &PolicyStatementPrincipal{
+					AWS: []interface{}{"arn:aws:iam::111:root", "arn:aws:iam::222:root"},
+				},
+			}
+			Expect(stmt.GetAWSPrincipals()).To(ConsistOf(
+				"arn:aws:iam::111:root",
+				"arn:aws:iam::222:root",
+			))
+		})
+
+		It("returns an empty slice when AWS is nil", func() {
+			stmt := PolicyStatement{
+				Principal: &PolicyStatementPrincipal{AWS: nil},
+			}
+			Expect(stmt.GetAWSPrincipals()).To(BeEmpty())
+		})
+
+		It("handles a single-element slice from unmarshalled JSON", func() {
+			raw := `{"Principal":{"AWS":["arn:aws:iam::999:role/foo"]}}`
+			var stmt PolicyStatement
+			Expect(json.Unmarshal([]byte(raw), &stmt)).To(Succeed())
+			Expect(stmt.GetAWSPrincipals()).To(Equal([]string{"arn:aws:iam::999:role/foo"}))
+		})
+
+		It("handles a string from unmarshalled JSON", func() {
+			raw := `{"Principal":{"AWS":"arn:aws:iam::888:role/bar"}}`
+			var stmt PolicyStatement
+			Expect(json.Unmarshal([]byte(raw), &stmt)).To(Succeed())
+			Expect(stmt.GetAWSPrincipals()).To(Equal([]string{"arn:aws:iam::888:role/bar"}))
+		})
+	})
+
+	Describe("AllowActions", func() {
+		It("creates an Allow statement with Resource *", func() {
+			doc := NewPolicyDocument()
+			doc.AllowActions("s3:GetObject", "s3:PutObject")
+
+			Expect(doc.Statement).To(HaveLen(1))
+			stmt := doc.Statement[0]
+			Expect(stmt.Effect).To(Equal("Allow"))
+			Expect(stmt.Action).To(Equal([]string{"s3:GetObject", "s3:PutObject"}))
+			Expect(stmt.Resource).To(Equal("*"))
+		})
+
+		It("appends a new statement on each call", func() {
+			doc := NewPolicyDocument()
+			doc.AllowActions("s3:GetObject")
+			doc.AllowActions("ec2:DescribeInstances")
+
+			Expect(doc.Statement).To(HaveLen(2))
+			Expect(doc.Statement[0].Action).To(Equal([]string{"s3:GetObject"}))
+			Expect(doc.Statement[1].Action).To(Equal([]string{"ec2:DescribeInstances"}))
+		})
+	})
+
+	Describe("IsActionAllowed", func() {
+		It("returns true when the action is a matching string", func() {
+			doc := &PolicyDocument{
+				Statement: []PolicyStatement{
+					{Effect: "Allow", Action: "s3:GetObject"},
+				},
+			}
+			Expect(doc.IsActionAllowed("s3:GetObject")).To(BeTrue())
+		})
+
+		It("returns true when the action is in an array", func() {
+			doc := &PolicyDocument{
+				Statement: []PolicyStatement{
+					{Effect: "Allow", Action: []interface{}{"s3:GetObject", "s3:PutObject"}},
+				},
+			}
+			Expect(doc.IsActionAllowed("s3:PutObject")).To(BeTrue())
+		})
+
+		It("returns false when the action is not present", func() {
+			doc := &PolicyDocument{
+				Statement: []PolicyStatement{
+					{Effect: "Allow", Action: "s3:GetObject"},
+				},
+			}
+			Expect(doc.IsActionAllowed("ec2:RunInstances")).To(BeFalse())
+		})
+
+		It("skips Deny statements", func() {
+			doc := &PolicyDocument{
+				Statement: []PolicyStatement{
+					{Effect: "Deny", Action: "s3:GetObject"},
+				},
+			}
+			Expect(doc.IsActionAllowed("s3:GetObject")).To(BeFalse())
+		})
+
+		It("returns false with an empty document", func() {
+			doc := NewPolicyDocument()
+			Expect(doc.IsActionAllowed("s3:GetObject")).To(BeFalse())
+		})
+
+		It("finds the action across multiple statements", func() {
+			doc := &PolicyDocument{
+				Statement: []PolicyStatement{
+					{Effect: "Deny", Action: "s3:GetObject"},
+					{Effect: "Allow", Action: []interface{}{"ec2:RunInstances"}},
+				},
+			}
+			Expect(doc.IsActionAllowed("ec2:RunInstances")).To(BeTrue())
+		})
+	})
+
+	Describe("GetAllowedActions", func() {
+		It("returns all allowed actions from Allow statements", func() {
+			doc := &PolicyDocument{
+				Statement: []PolicyStatement{
+					{Effect: "Allow", Action: "s3:GetObject"},
+					{Effect: "Allow", Action: []interface{}{"ec2:RunInstances", "ec2:DescribeInstances"}},
+				},
+			}
+			Expect(doc.GetAllowedActions()).To(Equal([]string{
+				"s3:GetObject",
+				"ec2:RunInstances",
+				"ec2:DescribeInstances",
+			}))
+		})
+
+		It("skips Deny statements", func() {
+			doc := &PolicyDocument{
+				Statement: []PolicyStatement{
+					{Effect: "Allow", Action: "s3:GetObject"},
+					{Effect: "Deny", Action: "s3:DeleteObject"},
+				},
+			}
+			Expect(doc.GetAllowedActions()).To(Equal([]string{"s3:GetObject"}))
+		})
+
+		It("handles both string and array Action types", func() {
+			doc := &PolicyDocument{
+				Statement: []PolicyStatement{
+					{Effect: "Allow", Action: "iam:CreateRole"},
+					{Effect: "Allow", Action: []interface{}{"iam:DeleteRole"}},
+				},
+			}
+			Expect(doc.GetAllowedActions()).To(Equal([]string{"iam:CreateRole", "iam:DeleteRole"}))
+		})
+
+		It("returns nil for an empty document", func() {
+			doc := NewPolicyDocument()
+			Expect(doc.GetAllowedActions()).To(BeNil())
+		})
+	})
+
+	Describe("InterpolatePolicyDocument", func() {
+		It("replaces template variables", func() {
+			tmpl := `{"Statement":[{"Resource":"arn:aws:iam::%{account_id}:oidc-provider/%{oidc_provider_arn}"}]}`
+			result := InterpolatePolicyDocument("aws", tmpl, map[string]string{
+				"account_id":        "123456789012",
+				"oidc_provider_arn": "oidc.example.com",
+			})
+			Expect(result).To(ContainSubstring("123456789012"))
+			Expect(result).To(ContainSubstring("oidc.example.com"))
+			Expect(result).ToNot(ContainSubstring("%{account_id}"))
+			Expect(result).ToNot(ContainSubstring("%{oidc_provider_arn}"))
+		})
+
+		It("replaces arn:aws: with the given partition", func() {
+			tmpl := `{"Resource":"arn:aws:iam::123456:role/MyRole"}`
+			result := InterpolatePolicyDocument("aws", tmpl, nil)
+			Expect(result).To(Equal(`{"Resource":"arn:aws:iam::123456:role/MyRole"}`))
+		})
+
+		It("converts arn:aws: to arn:aws-us-gov: for GovCloud", func() {
+			tmpl := `{"Resource":"arn:aws:iam::123456:role/MyRole"}`
+			result := InterpolatePolicyDocument("aws-us-gov", tmpl, nil)
+			Expect(result).To(Equal(`{"Resource":"arn:aws-us-gov:iam::123456:role/MyRole"}`))
+		})
+
+		It("handles multiple arn:aws: occurrences", func() {
+			tmpl := `{"Resource":["arn:aws:s3:::bucket","arn:aws:iam::123:role/R"]}`
+			result := InterpolatePolicyDocument("aws-cn", tmpl, nil)
+			Expect(result).ToNot(ContainSubstring("arn:aws:"))
+			Expect(result).To(ContainSubstring("arn:aws-cn:s3"))
+			Expect(result).To(ContainSubstring("arn:aws-cn:iam"))
+		})
+
+		It("is a no-op when no replacements are needed", func() {
+			tmpl := `{"Effect":"Allow"}`
+			result := InterpolatePolicyDocument("aws", tmpl, nil)
+			Expect(result).To(Equal(`{"Effect":"Allow"}`))
+		})
+	})
+
+	Describe("GenerateRolePolicyDoc", func() {
+		const policyTemplate = `{
+			"Version": "2012-10-17",
+			"Statement": [{
+				"Effect": "Allow",
+				"Principal": {"Federated": "arn:aws:iam::%{oidc_provider_arn}"},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": {
+					"StringEquals": {
+						"%{issuer_url}:sub": "system:serviceaccount:%{service_accounts}"
+					}
+				}
+			}]
+		}`
+
+		It("generates a policy with correct OIDC provider ARN and issuer URL", func() {
+			result, err := GenerateRolePolicyDoc(
+				"aws",
+				"https://oidc.example.com/path",
+				"123456789012",
+				"my-namespace:my-sa",
+				policyTemplate,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(ContainSubstring("oidc.example.com/path"))
+			Expect(result).To(ContainSubstring("123456789012"))
+			Expect(result).To(ContainSubstring("my-namespace:my-sa"))
+			Expect(result).ToNot(ContainSubstring("%{oidc_provider_arn}"))
+			Expect(result).ToNot(ContainSubstring("%{issuer_url}"))
+			Expect(result).ToNot(ContainSubstring("%{service_accounts}"))
+		})
+
+		It("returns an error for an invalid OIDC endpoint URL", func() {
+			_, err := GenerateRolePolicyDoc(
+				"aws",
+				"not-a-valid-url",
+				"123456789012",
+				"ns:sa",
+				policyTemplate,
+			)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("applies the partition to arn:aws: in the template", func() {
+			result, err := GenerateRolePolicyDoc(
+				"aws-us-gov",
+				"https://oidc.example.com",
+				"123456789012",
+				"ns:sa",
+				policyTemplate,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(ContainSubstring("arn:aws-us-gov:iam::"))
+			Expect(result).ToNot(ContainSubstring("arn:aws:"))
+		})
+	})
+})

--- a/pkg/aws/quota_test.go
+++ b/pkg/aws/quota_test.go
@@ -1,0 +1,181 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+
+	gomock "go.uber.org/mock/gomock"
+
+	awsSdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/servicequotas"
+	servicequotastypes "github.com/aws/aws-sdk-go-v2/service/servicequotas/types"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+
+	"github.com/openshift/rosa/pkg/aws/mocks"
+)
+
+var _ = Describe("Quota", func() {
+
+	Context("GetServiceQuota", func() {
+		It("Returns matching quota when found", func() {
+			quotaCode := "L-12345678"
+			quotas := []servicequotastypes.ServiceQuota{
+				{
+					QuotaCode: awsSdk.String(quotaCode),
+					QuotaName: awsSdk.String("Test Quota"),
+					Value:     awsSdk.Float64(100.0),
+				},
+			}
+
+			result, err := GetServiceQuota(quotas, quotaCode)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*result.QuotaCode).To(Equal(quotaCode))
+			Expect(*result.Value).To(Equal(100.0))
+		})
+
+		It("Returns error when quota is not found", func() {
+			quotas := []servicequotastypes.ServiceQuota{
+				{
+					QuotaCode: awsSdk.String("L-AAAAAAAA"),
+					QuotaName: awsSdk.String("Other Quota"),
+					Value:     awsSdk.Float64(50.0),
+				},
+			}
+
+			_, err := GetServiceQuota(quotas, "L-NOTFOUND")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Unable to find quota with service code"))
+		})
+
+		It("Returns error for an empty slice", func() {
+			_, err := GetServiceQuota([]servicequotastypes.ServiceQuota{}, "L-12345678")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Unable to find quota with service code"))
+		})
+
+		It("Finds the correct quota among multiple entries", func() {
+			targetCode := "L-BBBBBBBB"
+			quotas := []servicequotastypes.ServiceQuota{
+				{
+					QuotaCode: awsSdk.String("L-AAAAAAAA"),
+					QuotaName: awsSdk.String("First Quota"),
+					Value:     awsSdk.Float64(10.0),
+				},
+				{
+					QuotaCode: awsSdk.String(targetCode),
+					QuotaName: awsSdk.String("Target Quota"),
+					Value:     awsSdk.Float64(200.0),
+				},
+				{
+					QuotaCode: awsSdk.String("L-CCCCCCCC"),
+					QuotaName: awsSdk.String("Third Quota"),
+					Value:     awsSdk.Float64(300.0),
+				},
+			}
+
+			result, err := GetServiceQuota(quotas, targetCode)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*result.QuotaCode).To(Equal(targetCode))
+			Expect(*result.QuotaName).To(Equal("Target Quota"))
+			Expect(*result.Value).To(Equal(200.0))
+		})
+
+		It("Returns the first match when duplicates exist", func() {
+			code := "L-DUPDUP00"
+			quotas := []servicequotastypes.ServiceQuota{
+				{
+					QuotaCode: awsSdk.String(code),
+					QuotaName: awsSdk.String("First Duplicate"),
+					Value:     awsSdk.Float64(10.0),
+				},
+				{
+					QuotaCode: awsSdk.String(code),
+					QuotaName: awsSdk.String("Second Duplicate"),
+					Value:     awsSdk.Float64(99.0),
+				},
+			}
+
+			result, err := GetServiceQuota(quotas, code)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*result.QuotaName).To(Equal("First Duplicate"))
+			Expect(*result.Value).To(Equal(10.0))
+		})
+	})
+
+	Context("GetIAMServiceQuota", func() {
+		var (
+			client          Client
+			mockCtrl        *gomock.Controller
+			mockIAMQuotaAPI *mocks.MockServiceQuotasApiClient
+		)
+
+		BeforeEach(func() {
+			mockCtrl = gomock.NewController(GinkgoT())
+			mockIAMQuotaAPI = mocks.NewMockServiceQuotasApiClient(mockCtrl)
+			client = New(
+				awsSdk.Config{},
+				NewLoggerWrapper(logrus.New(), nil),
+				mocks.NewMockIamApiClient(mockCtrl),
+				mocks.NewMockEc2ApiClient(mockCtrl),
+				mocks.NewMockOrganizationsApiClient(mockCtrl),
+				mocks.NewMockS3ApiClient(mockCtrl),
+				mocks.NewMockSecretsManagerApiClient(mockCtrl),
+				mocks.NewMockStsApiClient(mockCtrl),
+				mocks.NewMockCloudFormationApiClient(mockCtrl),
+				mocks.NewMockServiceQuotasApiClient(mockCtrl),
+				mockIAMQuotaAPI,
+				&AccessKey{},
+				false,
+			)
+		})
+
+		AfterEach(func() {
+			mockCtrl.Finish()
+		})
+
+		It("Returns quota output from iamQuotaClient", func() {
+			quotaCode := "L-F4A5425F"
+			expectedOutput := &servicequotas.GetServiceQuotaOutput{
+				Quota: &servicequotastypes.ServiceQuota{
+					QuotaCode:   awsSdk.String(quotaCode),
+					QuotaName:   awsSdk.String("Roles"),
+					ServiceCode: awsSdk.String(IAMServiceCode),
+					Value:       awsSdk.Float64(1000.0),
+				},
+			}
+
+			mockIAMQuotaAPI.EXPECT().GetServiceQuota(
+				context.Background(),
+				&servicequotas.GetServiceQuotaInput{
+					ServiceCode: awsSdk.String(IAMServiceCode),
+					QuotaCode:   awsSdk.String(quotaCode),
+				},
+			).Return(expectedOutput, nil)
+
+			result, err := client.GetIAMServiceQuota(quotaCode)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(expectedOutput))
+			Expect(*result.Quota.QuotaCode).To(Equal(quotaCode))
+			Expect(*result.Quota.Value).To(Equal(1000.0))
+		})
+
+		It("Returns error when the client call fails", func() {
+			quotaCode := "L-F4A5425F"
+
+			mockIAMQuotaAPI.EXPECT().GetServiceQuota(
+				context.Background(),
+				&servicequotas.GetServiceQuotaInput{
+					ServiceCode: awsSdk.String(IAMServiceCode),
+					QuotaCode:   awsSdk.String(quotaCode),
+				},
+			).Return(nil, fmt.Errorf("access denied"))
+
+			result, err := client.GetIAMServiceQuota(quotaCode)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("access denied"))
+			Expect(result).To(BeNil())
+		})
+	})
+})

--- a/pkg/aws/sts_test.go
+++ b/pkg/aws/sts_test.go
@@ -273,4 +273,161 @@ var _ = Describe("STS", func() {
 			Expect(roles[4].RoleName).To(Equal("unlinked-3"))
 		})
 	})
+
+	Context("DeleteUserRole", func() {
+		It("succeeds when no attached policies and no boundary", func() {
+			mockIamAPI.EXPECT().ListAttachedRolePolicies(gomock.Any(), gomock.Any()).Return(
+				&iam.ListAttachedRolePoliciesOutput{AttachedPolicies: []iamtypes.AttachedPolicy{}}, nil,
+			)
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				&iam.GetRoleOutput{Role: &iamtypes.Role{RoleName: awsSdk.String("test-role")}}, nil,
+			)
+			mockIamAPI.EXPECT().DeleteRole(gomock.Any(), gomock.Any()).Return(&iam.DeleteRoleOutput{}, nil)
+
+			err := client.DeleteUserRole("test-role")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("succeeds when role has attached policies and a permissions boundary", func() {
+			mockIamAPI.EXPECT().ListAttachedRolePolicies(gomock.Any(), gomock.Any()).Return(
+				&iam.ListAttachedRolePoliciesOutput{
+					AttachedPolicies: []iamtypes.AttachedPolicy{
+						{PolicyArn: awsSdk.String("arn:aws:iam::123:policy/Policy1"), PolicyName: awsSdk.String("Policy1")},
+						{PolicyArn: awsSdk.String("arn:aws:iam::123:policy/Policy2"), PolicyName: awsSdk.String("Policy2")},
+					},
+				}, nil,
+			)
+			mockIamAPI.EXPECT().DetachRolePolicy(gomock.Any(), gomock.Any()).Return(&iam.DetachRolePolicyOutput{}, nil).Times(2)
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				&iam.GetRoleOutput{
+					Role: &iamtypes.Role{
+						RoleName: awsSdk.String("test-role"),
+						PermissionsBoundary: &iamtypes.AttachedPermissionsBoundary{
+							PermissionsBoundaryArn: awsSdk.String("arn:aws:iam::123:policy/boundary"),
+						},
+					},
+				}, nil,
+			)
+			mockIamAPI.EXPECT().DeleteRolePermissionsBoundary(gomock.Any(), gomock.Any()).Return(
+				&iam.DeleteRolePermissionsBoundaryOutput{}, nil,
+			)
+			mockIamAPI.EXPECT().DeleteRole(gomock.Any(), gomock.Any()).Return(&iam.DeleteRoleOutput{}, nil)
+
+			err := client.DeleteUserRole("test-role")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns error when ListAttachedRolePolicies fails", func() {
+			mockIamAPI.EXPECT().ListAttachedRolePolicies(gomock.Any(), gomock.Any()).Return(
+				nil, fmt.Errorf("list policies failed"),
+			)
+
+			err := client.DeleteUserRole("test-role")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("list policies failed"))
+		})
+
+		It("returns error when DetachRolePolicy fails", func() {
+			mockIamAPI.EXPECT().ListAttachedRolePolicies(gomock.Any(), gomock.Any()).Return(
+				&iam.ListAttachedRolePoliciesOutput{
+					AttachedPolicies: []iamtypes.AttachedPolicy{
+						{PolicyArn: awsSdk.String("arn:aws:iam::123:policy/Policy1"), PolicyName: awsSdk.String("Policy1")},
+					},
+				}, nil,
+			)
+			mockIamAPI.EXPECT().DetachRolePolicy(gomock.Any(), gomock.Any()).Return(
+				nil, fmt.Errorf("detach failed"),
+			)
+
+			err := client.DeleteUserRole("test-role")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("detach failed"))
+		})
+
+		It("returns error when DeleteRole fails", func() {
+			mockIamAPI.EXPECT().ListAttachedRolePolicies(gomock.Any(), gomock.Any()).Return(
+				&iam.ListAttachedRolePoliciesOutput{AttachedPolicies: []iamtypes.AttachedPolicy{}}, nil,
+			)
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				&iam.GetRoleOutput{Role: &iamtypes.Role{RoleName: awsSdk.String("test-role")}}, nil,
+			)
+			mockIamAPI.EXPECT().DeleteRole(gomock.Any(), gomock.Any()).Return(
+				nil, fmt.Errorf("delete role failed"),
+			)
+
+			err := client.DeleteUserRole("test-role")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("delete role failed"))
+		})
+	})
+
+	Context("DeleteOCMRole", func() {
+		It("detaches but does not delete policies when managedPolicies is true", func() {
+			mockIamAPI.EXPECT().ListAttachedRolePolicies(gomock.Any(), gomock.Any()).Return(
+				&iam.ListAttachedRolePoliciesOutput{
+					AttachedPolicies: []iamtypes.AttachedPolicy{
+						{PolicyArn: awsSdk.String("arn:aws:iam::123:policy/TestPolicy"), PolicyName: awsSdk.String("TestPolicy")},
+					},
+				}, nil,
+			)
+			mockIamAPI.EXPECT().DetachRolePolicy(gomock.Any(), gomock.Any()).Return(&iam.DetachRolePolicyOutput{}, nil)
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				&iam.GetRoleOutput{Role: &iamtypes.Role{RoleName: awsSdk.String("ocm-role")}}, nil,
+			)
+			mockIamAPI.EXPECT().DeleteRole(gomock.Any(), gomock.Any()).Return(&iam.DeleteRoleOutput{}, nil)
+
+			err := client.DeleteOCMRole("ocm-role", true)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("detaches and deletes policies when managedPolicies is false", func() {
+			mockIamAPI.EXPECT().ListAttachedRolePolicies(gomock.Any(), gomock.Any()).Return(
+				&iam.ListAttachedRolePoliciesOutput{
+					AttachedPolicies: []iamtypes.AttachedPolicy{
+						{PolicyArn: awsSdk.String("arn:aws:iam::123:policy/TestPolicy"), PolicyName: awsSdk.String("TestPolicy")},
+					},
+				}, nil,
+			)
+			mockIamAPI.EXPECT().DetachRolePolicy(gomock.Any(), gomock.Any()).Return(&iam.DetachRolePolicyOutput{}, nil)
+			mockIamAPI.EXPECT().DeletePolicy(gomock.Any(), gomock.Any()).Return(&iam.DeletePolicyOutput{}, nil)
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				&iam.GetRoleOutput{Role: &iamtypes.Role{RoleName: awsSdk.String("ocm-role")}}, nil,
+			)
+			mockIamAPI.EXPECT().DeleteRole(gomock.Any(), gomock.Any()).Return(&iam.DeleteRoleOutput{}, nil)
+
+			err := client.DeleteOCMRole("ocm-role", false)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("continues when DeletePolicy returns DeleteConflictException", func() {
+			mockIamAPI.EXPECT().ListAttachedRolePolicies(gomock.Any(), gomock.Any()).Return(
+				&iam.ListAttachedRolePoliciesOutput{
+					AttachedPolicies: []iamtypes.AttachedPolicy{
+						{PolicyArn: awsSdk.String("arn:aws:iam::123:policy/TestPolicy"), PolicyName: awsSdk.String("TestPolicy")},
+					},
+				}, nil,
+			)
+			mockIamAPI.EXPECT().DetachRolePolicy(gomock.Any(), gomock.Any()).Return(&iam.DetachRolePolicyOutput{}, nil)
+			mockIamAPI.EXPECT().DeletePolicy(gomock.Any(), gomock.Any()).Return(
+				nil, &iamtypes.DeleteConflictException{Message: awsSdk.String("conflict")},
+			)
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				&iam.GetRoleOutput{Role: &iamtypes.Role{RoleName: awsSdk.String("ocm-role")}}, nil,
+			)
+			mockIamAPI.EXPECT().DeleteRole(gomock.Any(), gomock.Any()).Return(&iam.DeleteRoleOutput{}, nil)
+
+			err := client.DeleteOCMRole("ocm-role", false)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns error when ListAttachedRolePolicies fails", func() {
+			mockIamAPI.EXPECT().ListAttachedRolePolicies(gomock.Any(), gomock.Any()).Return(
+				nil, fmt.Errorf("list attached policies failed"),
+			)
+
+			err := client.DeleteOCMRole("ocm-role", true)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("list attached policies failed"))
+		})
+	})
 })

--- a/pkg/aws/sts_test.go
+++ b/pkg/aws/sts_test.go
@@ -1,0 +1,276 @@
+package aws
+
+import (
+	"fmt"
+
+	gomock "go.uber.org/mock/gomock"
+
+	awsSdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+
+	"github.com/openshift/rosa/pkg/aws/mocks"
+)
+
+var _ = Describe("STS", func() {
+	var (
+		client     Client
+		mockCtrl   *gomock.Controller
+		mockSTSApi *mocks.MockStsApiClient
+		mockIamAPI *mocks.MockIamApiClient
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockIamAPI = mocks.NewMockIamApiClient(mockCtrl)
+		mockSTSApi = mocks.NewMockStsApiClient(mockCtrl)
+		client = New(
+			awsSdk.Config{},
+			NewLoggerWrapper(logrus.New(), nil),
+			mockIamAPI,
+			mocks.NewMockEc2ApiClient(mockCtrl),
+			mocks.NewMockOrganizationsApiClient(mockCtrl),
+			mocks.NewMockS3ApiClient(mockCtrl),
+			mocks.NewMockSecretsManagerApiClient(mockCtrl),
+			mockSTSApi,
+			mocks.NewMockCloudFormationApiClient(mockCtrl),
+			mocks.NewMockServiceQuotasApiClient(mockCtrl),
+			mocks.NewMockServiceQuotasApiClient(mockCtrl),
+			&AccessKey{},
+			false,
+		)
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	Context("ValidateRoleARNAccountIDMatchCallerAccountID", func() {
+		It("returns nil when role ARN account matches caller account", func() {
+			mockSTSApi.EXPECT().GetCallerIdentity(gomock.Any(), gomock.Any()).Return(
+				&sts.GetCallerIdentityOutput{
+					Arn:     awsSdk.String("arn:aws:iam::123456789012:user/TestUser"),
+					Account: awsSdk.String("123456789012"),
+				}, nil,
+			)
+
+			err := client.ValidateRoleARNAccountIDMatchCallerAccountID(
+				"arn:aws:iam::123456789012:role/MyRole",
+			)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns error when role ARN account differs from caller account", func() {
+			mockSTSApi.EXPECT().GetCallerIdentity(gomock.Any(), gomock.Any()).Return(
+				&sts.GetCallerIdentityOutput{
+					Arn:     awsSdk.String("arn:aws:iam::123456789012:user/TestUser"),
+					Account: awsSdk.String("123456789012"),
+				}, nil,
+			)
+
+			err := client.ValidateRoleARNAccountIDMatchCallerAccountID(
+				"arn:aws:iam::999999999999:role/OtherRole",
+			)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("doesn't match the user's account ID"))
+			Expect(err.Error()).To(ContainSubstring("999999999999"))
+			Expect(err.Error()).To(ContainSubstring("123456789012"))
+		})
+
+		It("returns error for an invalid ARN string", func() {
+			mockSTSApi.EXPECT().GetCallerIdentity(gomock.Any(), gomock.Any()).Return(
+				&sts.GetCallerIdentityOutput{
+					Arn:     awsSdk.String("arn:aws:iam::123456789012:user/TestUser"),
+					Account: awsSdk.String("123456789012"),
+				}, nil,
+			)
+
+			err := client.ValidateRoleARNAccountIDMatchCallerAccountID("not-a-valid-arn")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid prefix"))
+		})
+
+		It("returns error when GetCreator (GetCallerIdentity) fails", func() {
+			mockSTSApi.EXPECT().GetCallerIdentity(gomock.Any(), gomock.Any()).Return(
+				nil, fmt.Errorf("STS service unavailable"),
+			)
+
+			err := client.ValidateRoleARNAccountIDMatchCallerAccountID(
+				"arn:aws:iam::123456789012:role/MyRole",
+			)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to get AWS creator"))
+			Expect(err.Error()).To(ContainSubstring("STS service unavailable"))
+		})
+
+		It("works with GovCloud ARNs when accounts match", func() {
+			mockSTSApi.EXPECT().GetCallerIdentity(gomock.Any(), gomock.Any()).Return(
+				&sts.GetCallerIdentityOutput{
+					Arn:     awsSdk.String("arn:aws-us-gov:iam::111222333444:user/GovUser"),
+					Account: awsSdk.String("111222333444"),
+				}, nil,
+			)
+
+			err := client.ValidateRoleARNAccountIDMatchCallerAccountID(
+				"arn:aws-us-gov:iam::111222333444:role/GovRole",
+			)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns mismatch error with GovCloud ARNs when accounts differ", func() {
+			mockSTSApi.EXPECT().GetCallerIdentity(gomock.Any(), gomock.Any()).Return(
+				&sts.GetCallerIdentityOutput{
+					Arn:     awsSdk.String("arn:aws-us-gov:iam::111222333444:user/GovUser"),
+					Account: awsSdk.String("111222333444"),
+				}, nil,
+			)
+
+			err := client.ValidateRoleARNAccountIDMatchCallerAccountID(
+				"arn:aws-us-gov:iam::555666777888:role/OtherGovRole",
+			)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("doesn't match the user's account ID"))
+		})
+	})
+
+	Context("HasPermissionsBoundary", func() {
+		It("returns true when role has a permissions boundary", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				&iam.GetRoleOutput{
+					Role: &iamtypes.Role{
+						RoleName: awsSdk.String("test-role"),
+						PermissionsBoundary: &iamtypes.AttachedPermissionsBoundary{
+							PermissionsBoundaryArn: awsSdk.String("arn:aws:iam::123456789012:policy/boundary"),
+						},
+					},
+				}, nil,
+			)
+
+			hasBoundary, err := client.HasPermissionsBoundary("test-role")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hasBoundary).To(BeTrue())
+		})
+
+		It("returns false when role has no permissions boundary", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				&iam.GetRoleOutput{
+					Role: &iamtypes.Role{
+						RoleName:            awsSdk.String("test-role"),
+						PermissionsBoundary: nil,
+					},
+				}, nil,
+			)
+
+			hasBoundary, err := client.HasPermissionsBoundary("test-role")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hasBoundary).To(BeFalse())
+		})
+
+		It("returns error when GetRole API call fails", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				nil, fmt.Errorf("NoSuchEntity: role not found"),
+			)
+
+			hasBoundary, err := client.HasPermissionsBoundary("nonexistent-role")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("NoSuchEntity"))
+			Expect(hasBoundary).To(BeFalse())
+		})
+	})
+
+	Context("SortRolesByLinkedRole", func() {
+		It("puts linked roles before unlinked roles", func() {
+			roles := []Role{
+				{RoleName: "unlinked-1", Linked: RoleNo},
+				{RoleName: "linked-1", Linked: RoleYes},
+				{RoleName: "unlinked-2", Linked: RoleNo},
+				{RoleName: "linked-2", Linked: RoleYes},
+			}
+
+			SortRolesByLinkedRole(roles)
+
+			Expect(roles[0].Linked).To(Equal(RoleYes))
+			Expect(roles[1].Linked).To(Equal(RoleYes))
+			Expect(roles[2].Linked).To(Equal(RoleNo))
+			Expect(roles[3].Linked).To(Equal(RoleNo))
+		})
+
+		It("preserves relative order within linked roles (stable sort)", func() {
+			roles := []Role{
+				{RoleName: "linked-A", Linked: RoleYes},
+				{RoleName: "linked-B", Linked: RoleYes},
+				{RoleName: "linked-C", Linked: RoleYes},
+			}
+
+			SortRolesByLinkedRole(roles)
+
+			Expect(roles[0].RoleName).To(Equal("linked-A"))
+			Expect(roles[1].RoleName).To(Equal("linked-B"))
+			Expect(roles[2].RoleName).To(Equal("linked-C"))
+		})
+
+		It("preserves relative order within unlinked roles (stable sort)", func() {
+			roles := []Role{
+				{RoleName: "unlinked-X", Linked: RoleNo},
+				{RoleName: "unlinked-Y", Linked: RoleNo},
+				{RoleName: "unlinked-Z", Linked: RoleNo},
+			}
+
+			SortRolesByLinkedRole(roles)
+
+			Expect(roles[0].RoleName).To(Equal("unlinked-X"))
+			Expect(roles[1].RoleName).To(Equal("unlinked-Y"))
+			Expect(roles[2].RoleName).To(Equal("unlinked-Z"))
+		})
+
+		It("does not panic on an empty slice", func() {
+			roles := []Role{}
+			Expect(func() { SortRolesByLinkedRole(roles) }).NotTo(Panic())
+			Expect(roles).To(BeEmpty())
+		})
+
+		It("handles a single linked role", func() {
+			roles := []Role{
+				{RoleName: "only-role", Linked: RoleYes},
+			}
+
+			SortRolesByLinkedRole(roles)
+
+			Expect(roles).To(HaveLen(1))
+			Expect(roles[0].RoleName).To(Equal("only-role"))
+		})
+
+		It("handles a single unlinked role", func() {
+			roles := []Role{
+				{RoleName: "only-role", Linked: RoleNo},
+			}
+
+			SortRolesByLinkedRole(roles)
+
+			Expect(roles).To(HaveLen(1))
+			Expect(roles[0].RoleName).To(Equal("only-role"))
+		})
+
+		It("preserves stability when linked and unlinked are interleaved", func() {
+			roles := []Role{
+				{RoleName: "unlinked-1", Linked: RoleNo},
+				{RoleName: "linked-1", Linked: RoleYes},
+				{RoleName: "unlinked-2", Linked: RoleNo},
+				{RoleName: "linked-2", Linked: RoleYes},
+				{RoleName: "unlinked-3", Linked: RoleNo},
+			}
+
+			SortRolesByLinkedRole(roles)
+
+			Expect(roles[0].RoleName).To(Equal("linked-1"))
+			Expect(roles[1].RoleName).To(Equal("linked-2"))
+			Expect(roles[2].RoleName).To(Equal("unlinked-1"))
+			Expect(roles[3].RoleName).To(Equal("unlinked-2"))
+			Expect(roles[4].RoleName).To(Equal("unlinked-3"))
+		})
+	})
+})


### PR DESCRIPTION
## PR Summary
Add focused, meaningful unit tests for previously untested package-level behavior in the early-priority Phase 1C scope. This updates the branch/PR away from the earlier pkg/aws Phase 1A direction and aligns it with the plan's first implementation step.

## Detailed Description of the Issue
The coverage plan prioritizes untested `pkg/` packages first because they are fast, reviewable wins that raise confidence without over-investing in low-value command wiring. Several package-level utilities and integration helpers had no automated coverage at all, including FedRAMP config behavior, input file parsing, logging helpers, color/profile/region/debug flag behavior, and the small HTTP client wrapper.

This PR adds focused tests for the real behavior in those packages while intentionally skipping constants-only packages and avoiding coverage-for-coverage-sake assertions.

## Related Issues and PRs
- Jira: [ROSAENG-60112](https://issues.redhat.com/browse/ROSAENG-60112)
- Fixes: `#`
- Related PR(s): N/A
- Related design/docs: Coverage planning work for [ROSAENG-60112](https://redhat.atlassian.net/browse/ROSAENG-60112)

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [x] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
The following packages had no dedicated automated coverage for their package-level behavior:
- `pkg/fedramp`
- `pkg/input`
- `pkg/logging`
- `pkg/color`
- `pkg/aws/profile`
- `pkg/aws/region`
- `pkg/debug`
- `pkg/clients`

## Behavior After This Change
The repo now has focused tests for:
- FedRAMP flag wiring, environment validation, and config-backed enable/disable behavior
- YAML/JSON input file loading plus the Hosted Control Planes happy path guard
- Logger builders and HTTP round-tripper request/response logging with JSON/form redaction
- Color flag defaults, completion options, and explicit color modes
- AWS profile and region flag/environment precedence, including escaped-empty handling for region
- Debug flag state behavior
- HTTP client wrapper request behavior

Intentionally not added:
- constants-only packages such as `pkg/info`, `pkg/object`, `pkg/properties`, and `pkg/constants`
- brittle tests that would only duplicate stdlib or SDK behavior without validating ROSA-specific logic

## How to Test (Step-by-Step)
### Preconditions
- Go toolchain installed
- Repository cloned with hooks installed

### Test Steps
1. Run `go test ./pkg/fedramp ./pkg/input ./pkg/logging ./pkg/color ./pkg/aws/profile ./pkg/aws/region ./pkg/debug ./pkg/clients -count=1`
2. Run `go test ./pkg/fedramp ./pkg/input ./pkg/logging ./pkg/color ./pkg/aws/profile ./pkg/aws/region ./pkg/debug ./pkg/clients -cover`
3. Run `go vet ./pkg/fedramp ./pkg/input ./pkg/logging ./pkg/color ./pkg/aws/profile ./pkg/aws/region ./pkg/debug ./pkg/clients`

### Expected Results
- All targeted package tests pass
- Coverage is reported for each targeted package
- `go vet` finishes without findings

## Proof of the Fix
- Logs/CLI output:
  - `go test` passes for all targeted packages
  - `go vet` is clean
  - pre-push checks passed (format, build, lint, changed-files coverage, unit/integration tests)
- Other artifacts:
  - 8 new test files
  - 757 lines of test code added

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [ ] `make rosa` passes.
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

[ROSAENG-60112]: https://redhat.atlassian.net/browse/ROSAENG-60112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ