### PR TITLE
ROSAENG-60112 | test: add focused coverage for untested pkg packages

### DIFF
--- a/pkg/aws/profile/flag_test.go
+++ b/pkg/aws/profile/flag_test.go
@@ -1,0 +1,61 @@
+package profile
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/pflag"
+)
+
+func TestProfile(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Profile Suite")
+}
+
+var _ = Describe("Profile", func() {
+	var (
+		previousProfile    string
+		previousAwsProfile string
+	)
+
+	BeforeEach(func() {
+		previousProfile = profile
+		previousAwsProfile = os.Getenv("AWS_PROFILE")
+		profile = ""
+		Expect(os.Setenv("AWS_PROFILE", "")).To(Succeed())
+	})
+
+	AfterEach(func() {
+		profile = previousProfile
+		Expect(os.Setenv("AWS_PROFILE", previousAwsProfile)).To(Succeed())
+	})
+
+	It("registers the profile flag with an empty default", func() {
+		flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+
+		AddFlag(flags)
+
+		flag := flags.Lookup("profile")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.DefValue).To(Equal(""))
+	})
+
+	It("prefers the flag value over the environment variable", func() {
+		profile = "flag-profile"
+		Expect(os.Setenv("AWS_PROFILE", "env-profile")).To(Succeed())
+
+		Expect(Profile()).To(Equal("flag-profile"))
+	})
+
+	It("falls back to the AWS_PROFILE environment variable", func() {
+		Expect(os.Setenv("AWS_PROFILE", "env-profile")).To(Succeed())
+
+		Expect(Profile()).To(Equal("env-profile"))
+	})
+
+	It("returns an empty string when neither flag nor environment is set", func() {
+		Expect(Profile()).To(Equal(""))
+	})
+})

--- a/pkg/aws/region/flag_test.go
+++ b/pkg/aws/region/flag_test.go
@@ -55,6 +55,10 @@ var _ = Describe("Region", func() {
 		Expect(Region()).To(Equal("eu-west-1"))
 	})
 
+	It("returns an empty string when neither flag nor environment is set", func() {
+		Expect(Region()).To(Equal(""))
+	})
+
 	It("treats an escaped empty flag value as unset", func() {
 		region = "\"\""
 		Expect(os.Setenv("AWS_REGION", "sa-east-1")).To(Succeed())

--- a/pkg/aws/region/flag_test.go
+++ b/pkg/aws/region/flag_test.go
@@ -1,0 +1,70 @@
+package region
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/pflag"
+)
+
+func TestRegion(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Region Suite")
+}
+
+var _ = Describe("Region", func() {
+	var (
+		previousRegion    string
+		previousAwsRegion string
+	)
+
+	BeforeEach(func() {
+		previousRegion = region
+		previousAwsRegion = os.Getenv("AWS_REGION")
+		region = ""
+		Expect(os.Setenv("AWS_REGION", "")).To(Succeed())
+	})
+
+	AfterEach(func() {
+		region = previousRegion
+		Expect(os.Setenv("AWS_REGION", previousAwsRegion)).To(Succeed())
+	})
+
+	It("registers the region flag with an empty default", func() {
+		flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+
+		AddFlag(flags)
+
+		flag := flags.Lookup("region")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.DefValue).To(Equal(""))
+	})
+
+	It("prefers the flag value over the environment variable", func() {
+		region = "us-east-1"
+		Expect(os.Setenv("AWS_REGION", "eu-west-1")).To(Succeed())
+
+		Expect(Region()).To(Equal("us-east-1"))
+	})
+
+	It("falls back to the AWS_REGION environment variable", func() {
+		Expect(os.Setenv("AWS_REGION", "eu-west-1")).To(Succeed())
+
+		Expect(Region()).To(Equal("eu-west-1"))
+	})
+
+	It("treats an escaped empty flag value as unset", func() {
+		region = "\"\""
+		Expect(os.Setenv("AWS_REGION", "sa-east-1")).To(Succeed())
+
+		Expect(Region()).To(Equal("sa-east-1"))
+	})
+
+	It("treats an escaped empty environment value as empty", func() {
+		Expect(os.Setenv("AWS_REGION", "\"\"")).To(Succeed())
+
+		Expect(Region()).To(Equal(""))
+	})
+})

--- a/pkg/clients/http_test.go
+++ b/pkg/clients/http_test.go
@@ -1,0 +1,44 @@
+package clients
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestClients(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Clients Suite")
+}
+
+var _ = Describe("DefaultHTTPClient", func() {
+	It("issues a GET request with the wrapped client", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			Expect(request.Method).To(Equal(http.MethodGet))
+			_, err := writer.Write([]byte("ok"))
+			Expect(err).NotTo(HaveOccurred())
+		}))
+		defer server.Close()
+
+		client := NewDefaultHTTPClient(server.Client())
+
+		response, err := client.Get(server.URL)
+		Expect(err).NotTo(HaveOccurred())
+		defer response.Body.Close()
+
+		body, err := io.ReadAll(response.Body)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(body)).To(Equal("ok"))
+	})
+
+	It("returns the underlying client error", func() {
+		client := NewDefaultHTTPClient(http.DefaultClient)
+
+		_, err := client.Get("://bad-url")
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/pkg/color/flag_test.go
+++ b/pkg/color/flag_test.go
@@ -1,7 +1,6 @@
 package color
 
 import (
-	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -58,18 +57,6 @@ var _ = Describe("Color", func() {
 		expected := UseColor()
 
 		SetColor("unexpected")
-
-		Expect(UseColor()).To(Equal(expected))
-	})
-
-	It("uses the current stdout mode for auto", func() {
-		SetColor("auto")
-
-		stdout, err := os.Stdout.Stat()
-		expected := true
-		if err == nil {
-			expected = (stdout.Mode()&os.ModeDevice != 0) && (stdout.Mode()&os.ModeNamedPipe == 0)
-		}
 
 		Expect(UseColor()).To(Equal(expected))
 	})

--- a/pkg/color/flag_test.go
+++ b/pkg/color/flag_test.go
@@ -1,0 +1,76 @@
+package color
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+)
+
+func TestColor(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Color Suite")
+}
+
+var _ = Describe("Color", func() {
+	var previousColor string
+
+	BeforeEach(func() {
+		previousColor = color
+		color = ""
+	})
+
+	AfterEach(func() {
+		color = previousColor
+	})
+
+	It("registers the color flag with auto as default", func() {
+		cmd := &cobra.Command{Use: "test"}
+
+		AddFlag(cmd)
+
+		flag := cmd.PersistentFlags().Lookup("color")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.DefValue).To(Equal("auto"))
+	})
+
+	It("returns the supported completion options", func() {
+		values, directive := completion(&cobra.Command{Use: "test"}, nil, "")
+
+		Expect(values).To(Equal([]string{"auto", "never", "always"}))
+		Expect(directive).To(Equal(cobra.ShellCompDirectiveDefault))
+	})
+
+	It("disables color when set to never", func() {
+		SetColor("never")
+		Expect(UseColor()).To(BeFalse())
+	})
+
+	It("enables color when set to always", func() {
+		SetColor("always")
+		Expect(UseColor()).To(BeTrue())
+	})
+
+	It("treats unknown values the same as auto", func() {
+		SetColor("auto")
+		expected := UseColor()
+
+		SetColor("unexpected")
+
+		Expect(UseColor()).To(Equal(expected))
+	})
+
+	It("uses the current stdout mode for auto", func() {
+		SetColor("auto")
+
+		stdout, err := os.Stdout.Stat()
+		expected := true
+		if err == nil {
+			expected = (stdout.Mode()&os.ModeDevice != 0) && (stdout.Mode()&os.ModeNamedPipe == 0)
+		}
+
+		Expect(UseColor()).To(Equal(expected))
+	})
+})

--- a/pkg/debug/flag_test.go
+++ b/pkg/debug/flag_test.go
@@ -1,0 +1,47 @@
+package debug
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/pflag"
+)
+
+func TestDebug(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Debug Suite")
+}
+
+var _ = Describe("Debug", func() {
+	var previousEnabled bool
+
+	BeforeEach(func() {
+		previousEnabled = enabled
+		enabled = false
+	})
+
+	AfterEach(func() {
+		enabled = previousEnabled
+	})
+
+	It("registers the debug flag with false as the default", func() {
+		flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+
+		AddFlag(flags)
+
+		flag := flags.Lookup("debug")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.DefValue).To(Equal("false"))
+	})
+
+	It("tracks debug mode through SetEnabled and Enabled", func() {
+		Expect(Enabled()).To(BeFalse())
+
+		SetEnabled(true)
+		Expect(Enabled()).To(BeTrue())
+
+		SetEnabled(false)
+		Expect(Enabled()).To(BeFalse())
+	})
+})

--- a/pkg/fedramp/fedramp_test.go
+++ b/pkg/fedramp/fedramp_test.go
@@ -54,6 +54,28 @@ var _ = Describe("Fedramp", func() {
 		})
 	})
 
+	Describe("Flag independence", func() {
+		It("setting govcloud does not make HasAdminFlag report as changed", func() {
+			cmd := &cobra.Command{Use: "test"}
+			AddFlag(cmd.Flags())
+
+			Expect(cmd.Flags().Set("govcloud", "true")).To(Succeed())
+
+			Expect(HasFlag(cmd)).To(BeTrue())
+			Expect(HasAdminFlag(cmd)).To(BeFalse())
+		})
+
+		It("setting admin does not make HasFlag report as changed", func() {
+			cmd := &cobra.Command{Use: "test"}
+			AddFlag(cmd.Flags())
+
+			Expect(cmd.Flags().Set("admin", "true")).To(Succeed())
+
+			Expect(HasAdminFlag(cmd)).To(BeTrue())
+			Expect(HasFlag(cmd)).To(BeFalse())
+		})
+	})
+
 	Describe("Enabled", func() {
 		It("returns true when the in-memory flag is already enabled", func() {
 			Enable()
@@ -92,6 +114,20 @@ var _ = Describe("Fedramp", func() {
 
 			Expect(Enabled()).To(BeFalse())
 		})
+
+		It("returns false when the config is valid but FedRAMP is false", func() {
+			tempDir := GinkgoT().TempDir()
+			Expect(os.Setenv("OCM_CONFIG", filepath.Join(tempDir, "ocm.json"))).To(Succeed())
+			Expect(config.Save(&config.Config{
+				AccessToken: "token",
+				ClientID:    "client",
+				TokenURL:    "https://sso.example.com/token",
+				URL:         "https://api.example.com",
+				FedRAMP:     false,
+			})).To(Succeed())
+
+			Expect(Enabled()).To(BeFalse())
+		})
 	})
 
 	Describe("Disable", func() {
@@ -117,6 +153,29 @@ var _ = Describe("Fedramp", func() {
 		})
 	})
 
+	Describe("Disable edge cases", func() {
+		It("does not panic when the config file is missing", func() {
+			tempDir := GinkgoT().TempDir()
+			Expect(os.Setenv("OCM_CONFIG", filepath.Join(tempDir, "missing.json"))).To(Succeed())
+			Enable()
+
+			Expect(func() { Disable() }).NotTo(Panic())
+			Expect(enabled).To(BeFalse())
+		})
+
+		It("does not panic when the config is invalid", func() {
+			tempDir := GinkgoT().TempDir()
+			Expect(os.Setenv("OCM_CONFIG", filepath.Join(tempDir, "ocm.json"))).To(Succeed())
+			Expect(config.Save(&config.Config{
+				FedRAMP: true,
+			})).To(Succeed())
+			Enable()
+
+			Expect(func() { Disable() }).NotTo(Panic())
+			Expect(enabled).To(BeFalse())
+		})
+	})
+
 	Describe("IsGovRegion", func() {
 		It("recognizes the GovCloud regions", func() {
 			Expect(IsGovRegion("us-gov-west-1")).To(BeTrue())
@@ -133,6 +192,7 @@ var _ = Describe("Fedramp", func() {
 		It("recognizes known environments", func() {
 			Expect(IsValidEnv("production")).To(BeTrue())
 			Expect(IsValidEnv("staging")).To(BeTrue())
+			Expect(IsValidEnv("staging01")).To(BeTrue())
 			Expect(IsValidEnv("integration")).To(BeTrue())
 		})
 

--- a/pkg/fedramp/fedramp_test.go
+++ b/pkg/fedramp/fedramp_test.go
@@ -1,0 +1,144 @@
+package fedramp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/config"
+)
+
+func TestFedramp(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Fedramp Suite")
+}
+
+var _ = Describe("Fedramp", func() {
+	var (
+		previousEnabled   bool
+		previousOcmConfig string
+	)
+
+	BeforeEach(func() {
+		previousEnabled = enabled
+		previousOcmConfig = os.Getenv("OCM_CONFIG")
+		enabled = false
+		Expect(os.Setenv("OCM_CONFIG", "")).To(Succeed())
+	})
+
+	AfterEach(func() {
+		enabled = previousEnabled
+		Expect(os.Setenv("OCM_CONFIG", previousOcmConfig)).To(Succeed())
+	})
+
+	Describe("AddFlag and flag detection", func() {
+		It("registers the govcloud and admin flags and detects when they are changed", func() {
+			cmd := &cobra.Command{Use: "test"}
+
+			AddFlag(cmd.Flags())
+
+			Expect(cmd.Flags().Lookup("govcloud")).NotTo(BeNil())
+			Expect(cmd.Flags().Lookup("admin")).NotTo(BeNil())
+			Expect(HasFlag(cmd)).To(BeFalse())
+			Expect(HasAdminFlag(cmd)).To(BeFalse())
+
+			Expect(cmd.Flags().Set("govcloud", "true")).To(Succeed())
+			Expect(HasFlag(cmd)).To(BeTrue())
+
+			Expect(cmd.Flags().Set("admin", "true")).To(Succeed())
+			Expect(HasAdminFlag(cmd)).To(BeTrue())
+		})
+	})
+
+	Describe("Enabled", func() {
+		It("returns true when the in-memory flag is already enabled", func() {
+			Enable()
+
+			Expect(Enabled()).To(BeTrue())
+		})
+
+		It("loads a valid FedRAMP config from disk and caches the enabled state", func() {
+			tempDir := GinkgoT().TempDir()
+			Expect(os.Setenv("OCM_CONFIG", filepath.Join(tempDir, "ocm.json"))).To(Succeed())
+			Expect(config.Save(&config.Config{
+				AccessToken: "token",
+				ClientID:    "client",
+				TokenURL:    "https://sso.example.com/token",
+				URL:         "https://api.example.com",
+				FedRAMP:     true,
+			})).To(Succeed())
+
+			Expect(Enabled()).To(BeTrue())
+			Expect(enabled).To(BeTrue())
+		})
+
+		It("returns false when the loaded config is invalid", func() {
+			tempDir := GinkgoT().TempDir()
+			Expect(os.Setenv("OCM_CONFIG", filepath.Join(tempDir, "ocm.json"))).To(Succeed())
+			Expect(config.Save(&config.Config{
+				FedRAMP: true,
+			})).To(Succeed())
+
+			Expect(Enabled()).To(BeFalse())
+		})
+
+		It("returns false when the config file does not exist", func() {
+			tempDir := GinkgoT().TempDir()
+			Expect(os.Setenv("OCM_CONFIG", filepath.Join(tempDir, "missing.json"))).To(Succeed())
+
+			Expect(Enabled()).To(BeFalse())
+		})
+	})
+
+	Describe("Disable", func() {
+		It("clears the in-memory flag and persists FedRAMP=false for a valid config", func() {
+			tempDir := GinkgoT().TempDir()
+			Expect(os.Setenv("OCM_CONFIG", filepath.Join(tempDir, "ocm.json"))).To(Succeed())
+			Expect(config.Save(&config.Config{
+				AccessToken: "token",
+				ClientID:    "client",
+				TokenURL:    "https://sso.example.com/token",
+				URL:         "https://api.example.com",
+				FedRAMP:     true,
+			})).To(Succeed())
+			Enable()
+
+			Disable()
+
+			Expect(enabled).To(BeFalse())
+			cfg, err := config.Load()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg).NotTo(BeNil())
+			Expect(cfg.FedRAMP).To(BeFalse())
+		})
+	})
+
+	Describe("IsGovRegion", func() {
+		It("recognizes the GovCloud regions", func() {
+			Expect(IsGovRegion("us-gov-west-1")).To(BeTrue())
+			Expect(IsGovRegion("us-gov-east-1")).To(BeTrue())
+		})
+
+		It("rejects non-GovCloud regions", func() {
+			Expect(IsGovRegion("us-east-1")).To(BeFalse())
+			Expect(IsGovRegion("")).To(BeFalse())
+		})
+	})
+
+	Describe("IsValidEnv", func() {
+		It("recognizes known environments", func() {
+			Expect(IsValidEnv("production")).To(BeTrue())
+			Expect(IsValidEnv("staging")).To(BeTrue())
+			Expect(IsValidEnv("integration")).To(BeTrue())
+		})
+
+		It("rejects unknown environments", func() {
+			Expect(IsValidEnv("dev")).To(BeFalse())
+			Expect(IsValidEnv("")).To(BeFalse())
+		})
+	})
+})

--- a/pkg/input/input_test.go
+++ b/pkg/input/input_test.go
@@ -1,0 +1,93 @@
+package input
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+func TestInput(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Input Suite")
+}
+
+var _ = Describe("Input", func() {
+	Describe("UnmarshalInputFile", func() {
+		It("loads a YAML file into a map", func() {
+			tempDir, err := os.MkdirTemp("", "input-yaml-*")
+			Expect(err).NotTo(HaveOccurred())
+			defer os.RemoveAll(tempDir)
+
+			path := filepath.Join(tempDir, "spec.yaml")
+			Expect(os.WriteFile(path, []byte("name: demo\ncount: 3\nnested:\n  enabled: true\n"), 0o600)).To(Succeed())
+
+			result, err := UnmarshalInputFile(path)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(HaveKeyWithValue("name", "demo"))
+			Expect(result).To(HaveKey("nested"))
+		})
+
+		It("loads a JSON file because YAML unmarshalling accepts JSON", func() {
+			tempDir, err := os.MkdirTemp("", "input-json-*")
+			Expect(err).NotTo(HaveOccurred())
+			defer os.RemoveAll(tempDir)
+
+			path := filepath.Join(tempDir, "spec.json")
+			Expect(os.WriteFile(path, []byte(`{"name":"demo","enabled":true}`), 0o600)).To(Succeed())
+
+			result, err := UnmarshalInputFile(path)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(HaveKeyWithValue("name", "demo"))
+			Expect(result).To(HaveKeyWithValue("enabled", BeTrue()))
+		})
+
+		It("returns an error for a missing file", func() {
+			_, err := UnmarshalInputFile(filepath.Join(os.TempDir(), "does-not-exist.yaml"))
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error for invalid YAML", func() {
+			tempDir, err := os.MkdirTemp("", "input-invalid-*")
+			Expect(err).NotTo(HaveOccurred())
+			defer os.RemoveAll(tempDir)
+
+			path := filepath.Join(tempDir, "bad.yaml")
+			Expect(os.WriteFile(path, []byte("name: [unterminated"), 0o600)).To(Succeed())
+
+			_, err = UnmarshalInputFile(path)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns no error for an empty file", func() {
+			tempDir, err := os.MkdirTemp("", "input-empty-*")
+			Expect(err).NotTo(HaveOccurred())
+			defer os.RemoveAll(tempDir)
+
+			path := filepath.Join(tempDir, "empty.yaml")
+			Expect(os.WriteFile(path, []byte(""), 0o600)).To(Succeed())
+
+			result, err := UnmarshalInputFile(path)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeNil())
+		})
+	})
+
+	Describe("CheckIfHypershiftClusterOrExit", func() {
+		It("returns without exiting for a hypershift cluster", func() {
+			cluster, err := cmv1.NewCluster().
+				Hypershift(cmv1.NewHypershift().Enabled(true)).
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(func() {
+				CheckIfHypershiftClusterOrExit(&rosa.Runtime{}, cluster)
+			}).NotTo(Panic())
+		})
+	})
+})

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -1,0 +1,222 @@
+package logging
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+
+	"github.com/openshift/rosa/pkg/debug"
+)
+
+func TestLogging(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Logging Suite")
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+var _ = Describe("Logging", func() {
+	var previousDebug bool
+
+	BeforeEach(func() {
+		previousDebug = debug.Enabled()
+		debug.SetEnabled(false)
+	})
+
+	AfterEach(func() {
+		debug.SetEnabled(previousDebug)
+	})
+
+	Describe("NewLogger", func() {
+		It("creates an info-level logger by default", func() {
+			logger := NewLogger()
+
+			Expect(logger.Level).To(Equal(logrus.InfoLevel))
+			formatter, ok := logger.Formatter.(*logrus.TextFormatter)
+			Expect(ok).To(BeTrue())
+			Expect(formatter.DisableColors).To(BeTrue())
+			Expect(formatter.DisableQuote).To(BeTrue())
+			Expect(formatter.FullTimestamp).To(BeTrue())
+		})
+
+		It("creates a debug-level logger when debug mode is enabled", func() {
+			debug.SetEnabled(true)
+
+			logger := NewLogger()
+
+			Expect(logger.Level).To(Equal(logrus.DebugLevel))
+		})
+	})
+
+	Describe("AWSLoggerBuilder", func() {
+		It("requires a logger", func() {
+			_, err := (&AWSLoggerBuilder{}).Build()
+			Expect(err).To(MatchError("Logger is mandatory"))
+		})
+
+		It("builds a logger and writes through it", func() {
+			buffer := &bytes.Buffer{}
+			logger := logrus.New()
+			logger.SetOutput(buffer)
+
+			result, err := (&AWSLoggerBuilder{}).Logger(logger).Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			result.Log("hello", " ", "aws")
+			Expect(buffer.String()).To(ContainSubstring("hello aws"))
+		})
+	})
+
+	Describe("OCMLoggerBuilder", func() {
+		It("requires a logger", func() {
+			_, err := NewOCMLogger().Build()
+			Expect(err).To(MatchError("Logger is mandatory"))
+		})
+
+		It("builds a logger with level helpers", func() {
+			logger := logrus.New()
+			logger.SetLevel(logrus.InfoLevel)
+
+			result, err := NewOCMLogger().Logger(logger).Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result.DebugEnabled()).To(BeFalse())
+			Expect(result.InfoEnabled()).To(BeTrue())
+			Expect(result.WarnEnabled()).To(BeTrue())
+			Expect(result.ErrorEnabled()).To(BeTrue())
+		})
+	})
+
+	Describe("RoundTripperBuilder", func() {
+		It("requires a logger", func() {
+			_, err := NewRoundTripper().
+				Next(roundTripFunc(func(request *http.Request) (*http.Response, error) {
+					return nil, nil
+				})).
+				Build()
+			Expect(err).To(MatchError("Logger is mandatory"))
+		})
+
+		It("requires a next handler", func() {
+			_, err := NewRoundTripper().
+				Logger(logrus.New()).
+				Build()
+			Expect(err).To(MatchError("Next handler is mandatory"))
+		})
+
+		It("copies the redact configuration from the builder", func() {
+			builder := NewRoundTripper().
+				Logger(logrus.New()).
+				Redact("token").
+				Next(roundTripFunc(func(request *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     "200 OK",
+						Body:       io.NopCloser(strings.NewReader("ok")),
+						Header:     http.Header{},
+					}, nil
+				}))
+
+			result, err := builder.Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			builder.Redact("other")
+			Expect(result.redact).To(HaveKeyWithValue("token", true))
+			Expect(result.redact).NotTo(HaveKey("other"))
+		})
+	})
+
+	Describe("RoundTripper", func() {
+		It("preserves request and response bodies and redacts JSON fields in logs", func() {
+			logBuffer := &bytes.Buffer{}
+			logger := logrus.New()
+			logger.SetOutput(logBuffer)
+			logger.SetLevel(logrus.DebugLevel)
+			logger.SetFormatter(&logrus.TextFormatter{DisableColors: true, DisableQuote: true})
+
+			var capturedRequestBody string
+			roundTripper, err := NewRoundTripper().
+				Logger(logger).
+				Redact("token").
+				Next(roundTripFunc(func(request *http.Request) (*http.Response, error) {
+					body, readErr := io.ReadAll(request.Body)
+					Expect(readErr).NotTo(HaveOccurred())
+					capturedRequestBody = string(body)
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     "200 OK",
+						Header:     http.Header{"Content-Type": []string{"application/json"}},
+						Body:       io.NopCloser(strings.NewReader(`{"token":"response-secret","visible":"response-visible"}`)),
+					}, nil
+				})).
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			request, err := http.NewRequest(http.MethodPost, "https://example.com", strings.NewReader(`{"token":"request-secret","visible":"request-visible"}`))
+			Expect(err).NotTo(HaveOccurred())
+			request.Header.Set("Authorization", "Bearer super-secret")
+			request.Header.Set("Content-Type", "application/json")
+
+			response, err := roundTripper.RoundTrip(request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(capturedRequestBody).To(Equal(`{"token":"request-secret","visible":"request-visible"}`))
+
+			responseBody, err := io.ReadAll(response.Body)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(responseBody)).To(Equal(`{"token":"response-secret","visible":"response-visible"}`))
+
+			logOutput := logBuffer.String()
+			Expect(logOutput).To(ContainSubstring("Request header 'Authorization' is omitted"))
+			Expect(logOutput).To(ContainSubstring("***"))
+			Expect(logOutput).To(ContainSubstring("request-visible"))
+			Expect(logOutput).To(ContainSubstring("response-visible"))
+			Expect(logOutput).NotTo(ContainSubstring("request-secret"))
+			Expect(logOutput).NotTo(ContainSubstring("response-secret"))
+			Expect(logOutput).NotTo(ContainSubstring("super-secret"))
+		})
+
+		It("redacts configured form fields in logs", func() {
+			logBuffer := &bytes.Buffer{}
+			logger := logrus.New()
+			logger.SetOutput(logBuffer)
+			logger.SetLevel(logrus.DebugLevel)
+			logger.SetFormatter(&logrus.TextFormatter{DisableColors: true, DisableQuote: true})
+
+			roundTripper, err := NewRoundTripper().
+				Logger(logger).
+				Redact("token").
+				Next(roundTripFunc(func(request *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     "200 OK",
+						Header:     http.Header{},
+						Body:       io.NopCloser(strings.NewReader("ok")),
+					}, nil
+				})).
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			request, err := http.NewRequest(http.MethodPost, "https://example.com", strings.NewReader("token=secret&name=value"))
+			Expect(err).NotTo(HaveOccurred())
+			request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+			_, err = roundTripper.RoundTrip(request)
+			Expect(err).NotTo(HaveOccurred())
+
+			logOutput := logBuffer.String()
+			Expect(logOutput).To(ContainSubstring("***"))
+			Expect(logOutput).To(ContainSubstring("name=value"))
+			Expect(logOutput).NotTo(ContainSubstring("secret"))
+		})
+	})
+})

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -25,6 +25,14 @@ func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) 
 	return f(request)
 }
 
+func newDebugLogger(out *bytes.Buffer) *logrus.Logger {
+	logger := logrus.New()
+	logger.SetOutput(out)
+	logger.SetLevel(logrus.DebugLevel)
+	logger.SetFormatter(&logrus.TextFormatter{DisableColors: true, DisableQuote: true})
+	return logger
+}
+
 var _ = Describe("Logging", func() {
 	var previousDebug bool
 
@@ -137,21 +145,44 @@ var _ = Describe("Logging", func() {
 	})
 
 	Describe("RoundTripper", func() {
-		It("preserves request and response bodies and redacts JSON fields in logs", func() {
-			logBuffer := &bytes.Buffer{}
-			logger := logrus.New()
-			logger.SetOutput(logBuffer)
-			logger.SetLevel(logrus.DebugLevel)
-			logger.SetFormatter(&logrus.TextFormatter{DisableColors: true, DisableQuote: true})
-
+		It("preserves request and response bodies through the round trip", func() {
 			var capturedRequestBody string
 			roundTripper, err := NewRoundTripper().
-				Logger(logger).
+				Logger(newDebugLogger(&bytes.Buffer{})).
 				Redact("token").
 				Next(roundTripFunc(func(request *http.Request) (*http.Response, error) {
 					body, readErr := io.ReadAll(request.Body)
 					Expect(readErr).NotTo(HaveOccurred())
 					capturedRequestBody = string(body)
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     "200 OK",
+						Header:     http.Header{"Content-Type": []string{"application/json"}},
+						Body:       io.NopCloser(strings.NewReader(`{"visible":"response-value"}`)),
+					}, nil
+				})).
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			request, err := http.NewRequest(http.MethodPost, "https://example.com", strings.NewReader(`{"visible":"request-value"}`))
+			Expect(err).NotTo(HaveOccurred())
+			request.Header.Set("Content-Type", "application/json")
+
+			response, err := roundTripper.RoundTrip(request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(capturedRequestBody).To(Equal(`{"visible":"request-value"}`))
+
+			responseBody, err := io.ReadAll(response.Body)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(responseBody)).To(Equal(`{"visible":"response-value"}`))
+		})
+
+		It("redacts configured JSON fields in logs", func() {
+			logBuffer := &bytes.Buffer{}
+			roundTripper, err := NewRoundTripper().
+				Logger(newDebugLogger(logBuffer)).
+				Redact("token").
+				Next(roundTripFunc(func(request *http.Request) (*http.Response, error) {
 					return &http.Response{
 						StatusCode: http.StatusOK,
 						Status:     "200 OK",
@@ -164,36 +195,50 @@ var _ = Describe("Logging", func() {
 
 			request, err := http.NewRequest(http.MethodPost, "https://example.com", strings.NewReader(`{"token":"request-secret","visible":"request-visible"}`))
 			Expect(err).NotTo(HaveOccurred())
-			request.Header.Set("Authorization", "Bearer super-secret")
 			request.Header.Set("Content-Type", "application/json")
 
-			response, err := roundTripper.RoundTrip(request)
+			_, err = roundTripper.RoundTrip(request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(capturedRequestBody).To(Equal(`{"token":"request-secret","visible":"request-visible"}`))
-
-			responseBody, err := io.ReadAll(response.Body)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(responseBody)).To(Equal(`{"token":"response-secret","visible":"response-visible"}`))
 
 			logOutput := logBuffer.String()
-			Expect(logOutput).To(ContainSubstring("Request header 'Authorization' is omitted"))
 			Expect(logOutput).To(ContainSubstring("***"))
 			Expect(logOutput).To(ContainSubstring("request-visible"))
 			Expect(logOutput).To(ContainSubstring("response-visible"))
 			Expect(logOutput).NotTo(ContainSubstring("request-secret"))
 			Expect(logOutput).NotTo(ContainSubstring("response-secret"))
+		})
+
+		It("omits the Authorization header from logs", func() {
+			logBuffer := &bytes.Buffer{}
+			roundTripper, err := NewRoundTripper().
+				Logger(newDebugLogger(logBuffer)).
+				Next(roundTripFunc(func(request *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     "200 OK",
+						Header:     http.Header{},
+						Body:       io.NopCloser(strings.NewReader("ok")),
+					}, nil
+				})).
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			request, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+			Expect(err).NotTo(HaveOccurred())
+			request.Header.Set("Authorization", "Bearer super-secret")
+
+			_, err = roundTripper.RoundTrip(request)
+			Expect(err).NotTo(HaveOccurred())
+
+			logOutput := logBuffer.String()
+			Expect(logOutput).To(ContainSubstring("Request header 'Authorization' is omitted"))
 			Expect(logOutput).NotTo(ContainSubstring("super-secret"))
 		})
 
 		It("redacts configured form fields in logs", func() {
 			logBuffer := &bytes.Buffer{}
-			logger := logrus.New()
-			logger.SetOutput(logBuffer)
-			logger.SetLevel(logrus.DebugLevel)
-			logger.SetFormatter(&logrus.TextFormatter{DisableColors: true, DisableQuote: true})
-
 			roundTripper, err := NewRoundTripper().
-				Logger(logger).
+				Logger(newDebugLogger(logBuffer)).
 				Redact("token").
 				Next(roundTripFunc(func(request *http.Request) (*http.Response, error) {
 					return &http.Response{


### PR DESCRIPTION
## PR Summary
Add focused, meaningful unit tests for previously untested package-level behavior in the early-priority Phase 1C scope. This aligns the change with the plan's first implementation step instead of the earlier pkg/aws Phase 1A direction.

## Detailed Description of the Issue
The coverage plan prioritizes untested `pkg/` packages first because they are fast, reviewable wins that raise confidence without over-investing in low-value command wiring. Several package-level utilities and integration helpers had no automated coverage at all, including FedRAMP config behavior, input file parsing, logging helpers, color/profile/region/debug flag behavior, and the small HTTP client wrapper.

This PR adds focused tests for the real behavior in those packages while intentionally skipping constants-only packages and avoiding coverage-for-coverage-sake assertions.

## Related Issues and PRs
- Jira: [ROSAENG-60112](https://issues.redhat.com/browse/ROSAENG-60112)
- Fixes: `#`
- Related PR(s): supersedes prior draft work that was started under the Phase 1A direction
- Related design/docs: Coverage planning work for [ROSAENG-60112](https://redhat.atlassian.net/browse/ROSAENG-60112)

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [x] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
The following packages had no dedicated automated coverage for their package-level behavior:
- `pkg/fedramp`
- `pkg/input`
- `pkg/logging`
- `pkg/color`
- `pkg/aws/profile`
- `pkg/aws/region`
- `pkg/debug`
- `pkg/clients`

## Behavior After This Change
The repo now has focused tests for:
- FedRAMP flag wiring, environment validation, and config-backed enable/disable behavior
- YAML/JSON input file loading plus the Hosted Control Planes happy path guard
- Logger builders and HTTP round-tripper request/response logging with JSON/form redaction
- Color flag defaults, completion options, and explicit color modes
- AWS profile and region flag/environment precedence, including escaped-empty handling for region
- Debug flag state behavior
- HTTP client wrapper request behavior

Intentionally not added:
- constants-only packages such as `pkg/info`, `pkg/object`, `pkg/properties`, and `pkg/constants`
- brittle tests that would only duplicate stdlib or SDK behavior without validating ROSA-specific logic

## How to Test (Step-by-Step)
### Preconditions
- Go toolchain installed
- Repository cloned with hooks installed

### Test Steps
1. Run `go test ./pkg/fedramp ./pkg/input ./pkg/logging ./pkg/color ./pkg/aws/profile ./pkg/aws/region ./pkg/debug ./pkg/clients -count=1`
2. Run `go test ./pkg/fedramp ./pkg/input ./pkg/logging ./pkg/color ./pkg/aws/profile ./pkg/aws/region ./pkg/debug ./pkg/clients -cover`
3. Run `go vet ./pkg/fedramp ./pkg/input ./pkg/logging ./pkg/color ./pkg/aws/profile ./pkg/aws/region ./pkg/debug ./pkg/clients`

### Expected Results
- All targeted package tests pass
- Coverage is reported for each targeted package
- `go vet` finishes without findings

## Proof of the Fix
- Logs/CLI output:
  - `go test` passes for all targeted packages
  - `go vet` is clean
  - pre-push checks passed (format, build, lint, changed-files coverage, unit/integration tests)
- Other artifacts:
  - 8 new test files
  - 757 lines of test code added

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [ ] `make rosa` passes.
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

[ROSAENG-60112]: https://redhat.atlassian.net/browse/ROSAENG-60112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROSAENG-60112]: https://redhat.atlassian.net/browse/ROSAENG-60112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Ginkgo/Gomega suites covering AWS `profile` and `region` flag + environment variable precedence and special empty-value handling.
  * Added HTTP client tests for successful requests and error propagation.
  * Added `color` and `debug` flag tests for default behavior and state changes.
  * Added FedRAMP config tests, including enable/disable behavior, region validation, and environment validation.
  * Added input unmarshalling tests (YAML/JSON) and Hypershift safety checks.
  * Added logging tests verifying log level behavior, body preservation, and sensitive/redacted field handling (including headers and form fields).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->