### PR TITLE
ROSAENG-60386 | test: Fixing id:84981

### DIFF
--- a/tests/ci/data/resources/autonode_policy.json
+++ b/tests/ci/data/resources/autonode_policy.json
@@ -1,0 +1,243 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ReadPermissions",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeCapacityReservations",
+        "ec2:DescribeImages",
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceTypeOfferings",
+        "ec2:DescribeInstanceTypes",
+        "ec2:DescribeLaunchTemplates",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSnapshots",
+        "ec2:DescribeSpotPriceHistory",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeVpcs"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "PricingReadActions",
+      "Effect": "Allow",
+      "Action": [
+        "pricing:GetProducts"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "KMSPermissions",
+      "Effect": "Allow",
+      "Action": [
+        "kms:DescribeKey",
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*"
+      ],
+      "Resource": "arn:aws:kms:*:*:key/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/red-hat": "true"
+        }
+      }
+    },
+    {
+      "Sid": "KMSGrantPermissions",
+      "Effect": "Allow",
+      "Action": [
+        "kms:CreateGrant",
+        "kms:ListGrants",
+        "kms:RevokeGrant"
+      ],
+      "Resource": "arn:aws:kms:*:*:key/*",
+      "Condition": {
+        "Bool": {
+          "kms:GrantIsForAWSResource": true
+        },
+        "StringLike": {
+          "kms:ViaService": "ec2.*.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Sid": "CreateEC2Resources",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:RunInstances",
+        "ec2:CreateFleet"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:*:security-group/*",
+        "arn:aws:ec2:*:*:subnet/*",
+        "arn:aws:ec2:*:*:capacity-reservation/*"
+      ]
+    },
+    {
+      "Sid": "CreateEC2ResourcesWithApprovedAMIs",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:RunInstances",
+        "ec2:CreateFleet"
+      ],
+      "Resource": "arn:aws:ec2:*::image/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:Owner": [
+            "531415883065",
+            "251351625822",
+            "210686502322"
+          ]
+        }
+      }
+    },
+    {
+      "Sid": "CreateEC2ResourcesWithTags",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:RunInstances",
+        "ec2:CreateFleet",
+        "ec2:CreateLaunchTemplate"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:*:fleet/*",
+        "arn:aws:ec2:*:*:instance/*",
+        "arn:aws:ec2:*:*:volume/*",
+        "arn:aws:ec2:*:*:network-interface/*",
+        "arn:aws:ec2:*:*:launch-template/*",
+        "arn:aws:ec2:*:*:spot-instances-request/*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/red-hat-managed": "true"
+        }
+      }
+    },
+    {
+      "Sid": "CreateEC2ResourcesLaunchTemplate",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:RunInstances",
+        "ec2:CreateFleet"
+      ],
+      "Resource": "arn:aws:ec2:*:*:launch-template/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/red-hat-managed": "true"
+        }
+      }
+    },
+    {
+      "Sid": "CreateTagsOnResources",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateTags"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:*:fleet/*",
+        "arn:aws:ec2:*:*:instance/*",
+        "arn:aws:ec2:*:*:volume/*",
+        "arn:aws:ec2:*:*:network-interface/*",
+        "arn:aws:ec2:*:*:launch-template/*",
+        "arn:aws:ec2:*:*:spot-instances-request/*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "ec2:CreateAction": [
+            "RunInstances",
+            "CreateFleet",
+            "CreateLaunchTemplate"
+          ],
+          "aws:RequestTag/red-hat-managed": "true"
+        }
+      }
+    },
+    {
+      "Sid": "ManageTagsOnManagedResources",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateTags"
+      ],
+      "Resource": "arn:aws:ec2:*:*:instance/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/red-hat-managed": "true"
+        }
+      }
+    },
+    {
+      "Sid": "TerminateManagedResources",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:TerminateInstances",
+        "ec2:DeleteLaunchTemplate"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:*:instance/*",
+        "arn:aws:ec2:*:*:launch-template/*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/red-hat-managed": "true"
+        }
+      }
+    },
+    {
+      "Sid": "PassInstanceRole",
+      "Effect": "Allow",
+      "Action": [
+        "iam:PassRole"
+      ],
+      "Resource": "arn:aws:iam::*:role/*",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": [
+            "ec2.amazonaws.com"
+          ]
+        }
+      }
+    },
+    {
+      "Sid": "ManageInstanceProfiles",
+      "Effect": "Allow",
+      "Action": [
+        "iam:AddRoleToInstanceProfile",
+        "iam:RemoveRoleFromInstanceProfile",
+        "iam:DeleteInstanceProfile"
+      ],
+      "Resource": [
+        "arn:aws:iam::*:instance-profile/rosa-service-managed-*",
+        "arn:aws:iam::*:instance-profile/*-worker"
+      ]
+    },
+    {
+      "Sid": "CreateInstanceProfiles",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateInstanceProfile",
+        "iam:TagInstanceProfile"
+      ],
+      "Resource": [
+        "arn:aws:iam::*:instance-profile/rosa-service-managed-*",
+        "arn:aws:iam::*:instance-profile/*-worker"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/red-hat-managed": "true"
+        }
+      }
+    },
+    {
+      "Sid": "ReadInstanceProfiles",
+      "Effect": "Allow",
+      "Action": [
+        "iam:ListInstanceProfiles",
+        "iam:GetInstanceProfile"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/tests/ci/data/resources/autonode_trust_policy_template.json
+++ b/tests/ci/data/resources/autonode_trust_policy_template.json
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::{AWS_ACCOUNT_ID}:oidc-provider/{OIDC_PROVIDER_URL}"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "{OIDC_PROVIDER_URL}:sub": "system:serviceaccount:kube-system:karpenter"
+        }
+      }
+    }
+  ]
+}

--- a/tests/e2e/hcp_cluster_test.go
+++ b/tests/e2e/hcp_cluster_test.go
@@ -782,14 +782,35 @@ var _ = Describe("HCP cluster testing",
 		It("edit ROSA HCP with autonode configuration via rosa cli  - [id:84981]",
 			labels.High, labels.Runtime.Day2,
 			func() {
-				By("Get the installer role arn")
+				By("Create the autonode IAM role")
+
 				rosaClient.Runner.JsonFormat()
 				jsonOutput, err := clusterService.DescribeCluster(clusterID)
-				Expect(err).To(BeNil())
 				rosaClient.Runner.UnsetFormat()
+				Expect(err).To(BeNil())
 				jsonData := rosaClient.Parser.JsonData.Input(jsonOutput).Parse()
-				installRoleArn := jsonData.DigString("aws", "sts", "role_arn")
-				supportRoleArn := jsonData.DigString("aws", "sts", "support_role_arn")
+
+				autonodeEnabled := jsonData.DigString("auto_node", "mode")
+				if autonodeEnabled == "enabled" {
+					Skip("Autonode is already enabled on this cluster (and currently can't be disabled)")
+				}
+
+				oidcProviderURL := jsonData.DigString("aws", "sts", "oidc_config", "issuer_url")
+				autonodePrefix1 := clusterID + "-1"
+				autonodePrefix2 := clusterID + "-2"
+				autonodeRoleARN, err := config.PrepareAutonodeRoleAndPolicy(autonodePrefix1, oidcProviderURL, profile.Region)
+				defer func() {
+					err := config.DeleteAutonodeRoleAndPolicy(autonodePrefix1, profile.Region)
+					Expect(err).ToNot(HaveOccurred())
+				}()
+				Expect(err).ToNot(HaveOccurred())
+
+				autonodeRoleARN2, err := config.PrepareAutonodeRoleAndPolicy(autonodePrefix2, oidcProviderURL, profile.Region)
+				defer func() {
+					err := config.DeleteAutonodeRoleAndPolicy(autonodePrefix2, profile.Region)
+					Expect(err).ToNot(HaveOccurred())
+				}()
+				Expect(err).ToNot(HaveOccurred())
 
 				By("Edit cluster autonode configuration with invalid flag value")
 				out, err := clusterService.EditCluster(
@@ -811,7 +832,7 @@ var _ = Describe("HCP cluster testing",
 				By("Edit role arn when autonode configuration is not enabled")
 				out, err = clusterService.EditCluster(
 					clusterID,
-					"--autonode-iam-role-arn", installRoleArn,
+					"--autonode-iam-role-arn", autonodeRoleARN,
 				)
 				Expect(err).To(HaveOccurred())
 				Expect(out.String()).To(ContainSubstring("cannot update IAM role ARN when AutoNode is not enabled"))
@@ -820,7 +841,7 @@ var _ = Describe("HCP cluster testing",
 				out, err = clusterService.EditCluster(
 					clusterID,
 					"--autonode=enabled",
-					"--autonode-iam-role-arn", installRoleArn,
+					"--autonode-iam-role-arn", autonodeRoleARN,
 				)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(out.String()).To(ContainSubstring("Updated cluster"))
@@ -828,12 +849,12 @@ var _ = Describe("HCP cluster testing",
 				jsonData, err = clusterService.GetJSONClusterDescription(clusterID)
 				Expect(err).To(BeNil())
 				Expect(jsonData.DigString("auto_node", "mode")).To(Equal("enabled"))
-				Expect(jsonData.DigString("aws", "auto_node", "role_arn")).To(Equal(installRoleArn))
+				Expect(jsonData.DigString("aws", "auto_node", "role_arn")).To(Equal(autonodeRoleARN))
 
 				By("Update the autonode configuration on cluster")
 				out, err = clusterService.EditCluster(
 					clusterID,
-					"--autonode-iam-role-arn", supportRoleArn,
+					"--autonode-iam-role-arn", autonodeRoleARN2,
 				)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(out.String()).To(ContainSubstring("Updated cluster"))
@@ -841,7 +862,7 @@ var _ = Describe("HCP cluster testing",
 				jsonData, err = clusterService.GetJSONClusterDescription(clusterID)
 				Expect(err).To(BeNil())
 				Expect(jsonData.DigString("auto_node", "mode")).To(Equal("enabled"))
-				Expect(jsonData.DigString("aws", "auto_node", "role_arn")).To(Equal(supportRoleArn))
+				Expect(jsonData.DigString("aws", "auto_node", "role_arn")).To(Equal(autonodeRoleARN2))
 			})
 	})
 var _ = Describe("hosted-cp cluster creation",

--- a/tests/utils/config/autonode.go
+++ b/tests/utils/config/autonode.go
@@ -1,0 +1,190 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+	"time"
+
+	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/openshift-online/ocm-common/pkg/aws/aws_client"
+
+	"github.com/openshift/rosa/tests/ci/config"
+	"github.com/openshift/rosa/tests/utils/helper"
+	"github.com/openshift/rosa/tests/utils/log"
+)
+
+// Takes a given prefix and generates the role and policy names
+func generateNames(prefix string) (string, string) {
+	roleName := prefix + "-autonode-operator-role"
+	policyName := prefix + "-autonode-private-preview"
+	return roleName, policyName
+}
+
+// Takes a given policy name and returns the expected ARN for that policy
+func generatePolicyARN(awsclient *aws_client.AWSClient, policyName string) string {
+	return fmt.Sprintf(
+		"arn:%s:iam::%s:policy/%s",
+		awsclient.GetAWSPartition(),
+		awsclient.AccountID,
+		policyName,
+	)
+}
+
+func PrepareAutonodeRoleAndPolicy(prefix string, oidcProviderURL string, region string) (string, error) {
+	var err error
+	roleName, policyName := generateNames(prefix)
+	var tags = map[string]string{
+		"rosa_cli_testing": "true",
+		"rosa_cli_prefix":  prefix,
+	}
+	var alreadyExists *iamTypes.EntityAlreadyExistsException
+	var createdPolicy = false
+	var createdRole = false
+
+	awsclient, err := aws_client.CreateAWSClient("", region)
+	if err != nil {
+		return "", err
+	}
+
+	policyDocument, err := helper.ReadFileContent(path.Join(config.Test.ResourcesDir, "autonode_policy.json"))
+	if err != nil {
+		return "", err
+	}
+	log.Logger.Infof("Creating AutoNode IAM Policy '%s'", policyName)
+	policy, err := awsclient.CreateIAMPolicy(policyName, policyDocument, tags)
+	if errors.As(err, &alreadyExists) {
+		log.Logger.Warnf("AutoNode IAM Policy '%s' already exists. Reusing existing IAM Policy", policyName)
+		policy, err = awsclient.GetIAMPolicy(generatePolicyARN(awsclient, policyName))
+		if err != nil {
+			return "", err
+		}
+	} else if err != nil {
+		log.Logger.Error("Failed to create AutoNode IAM Policy, cleaning up resources...")
+		deleteError := DeleteAutonodeRoleAndPolicy(prefix, region)
+		if deleteError != nil {
+			return "", errors.Join(err, deleteError)
+		}
+		return "", err
+	} else {
+		createdPolicy = true
+	}
+	log.Logger.Infof("Waiting upto 15 seconds for IAM Policy '%s' to exist...", *policy.Arn)
+	err = awsclient.WaitForResourceExisting("policy-"+*policy.Arn, 15)
+	if err != nil {
+		if createdPolicy {
+			log.Logger.Error("Failed to wait for AutoNode IAM Policy to exist, cleaning up resources...")
+			deleteError := DeleteAutonodeRoleAndPolicy(prefix, region)
+			if deleteError != nil {
+				return "", errors.Join(err, deleteError)
+			}
+		}
+		return "", err
+	}
+
+	assumeRolePolicyDocument, err := helper.ReadFileContent(
+		path.Join(config.Test.ResourcesDir, "autonode_trust_policy_template.json"),
+	)
+	if err != nil {
+		if createdPolicy {
+			log.Logger.Error("Failed to get AutoNode IAM Role trust policy, cleaning up resources...")
+			deleteError := DeleteAutonodeRoleAndPolicy(prefix, region)
+			if deleteError != nil {
+				return "", errors.Join(err, deleteError)
+			}
+		}
+		return "", err
+	}
+	oidcProviderURL, err = helper.ExtractOIDCProviderFromOidcUrl(oidcProviderURL)
+	if err != nil {
+		if createdPolicy {
+			log.Logger.Error("Failed to get OIDC Provider for AutoNode IAM Role trust policy, cleaning up resources...")
+			deleteError := DeleteAutonodeRoleAndPolicy(prefix, region)
+			if deleteError != nil {
+				return "", errors.Join(err, deleteError)
+			}
+		}
+		return "", err
+	}
+	assumeRolePolicyDocument = strings.ReplaceAll(assumeRolePolicyDocument, "{AWS_ACCOUNT_ID}", awsclient.AccountID)
+	assumeRolePolicyDocument = strings.ReplaceAll(assumeRolePolicyDocument, "{OIDC_PROVIDER_URL}", oidcProviderURL)
+	log.Logger.Infof("Creating AutoNode IAM Role '%s'", roleName)
+	role, err := awsclient.CreateRoleAndAttachPolicy(roleName, assumeRolePolicyDocument, "", tags, "", *policy.Arn)
+	if errors.As(err, &alreadyExists) {
+		log.Logger.Warnf("AutoNode IAM Role '%s' already exists. Reusing existing IAM Role", roleName)
+		roleTemp, err := awsclient.GetRole(roleName)
+		if err != nil {
+			if createdPolicy {
+				log.Logger.Error("Failed to get existing AutoNode IAM Role, cleaning up resources...")
+				deleteError := DeleteAutonodeRoleAndPolicy(prefix, region)
+				if deleteError != nil {
+					return "", errors.Join(err, deleteError)
+				}
+			}
+			return "", err
+		}
+		role = *roleTemp
+	} else if err != nil {
+		log.Logger.Error("Failed to create for AutoNode IAM Role, cleaning up resources...")
+		deleteError := DeleteAutonodeRoleAndPolicy(prefix, region)
+		if deleteError != nil {
+			return "", errors.Join(err, deleteError)
+		}
+		return "", err
+	} else {
+		createdRole = true
+	}
+	log.Logger.Infof("Waiting upto 15 seconds for IAM Role '%s' to exist...", roleName)
+	err = awsclient.WaitForResourceExisting("role-"+*role.RoleName, 15)
+	if err != nil {
+		if createdPolicy || createdRole {
+			log.Logger.Error("Failed to wait for AutoNode IAM Role to exist, cleaning up resources...")
+			deleteError := DeleteAutonodeRoleAndPolicy(prefix, region)
+			if deleteError != nil {
+				return "", errors.Join(err, deleteError)
+			}
+		}
+		return "", err
+	}
+
+	log.Logger.Info("Waiting 3 seconds for AWS consistency...")
+	time.Sleep(3 * time.Second)
+
+	return *role.Arn, nil
+}
+
+func DeleteAutonodeRoleAndPolicy(prefix string, region string) error {
+	var err error
+
+	roleName, policyName := generateNames(prefix)
+
+	awsclient, err := aws_client.CreateAWSClient("", region)
+	if err != nil {
+		return err
+	}
+
+	policyARN := generatePolicyARN(awsclient, policyName)
+	var errs []error
+
+	if detachErr := awsclient.DetachIAMPolicy(roleName, policyARN); detachErr != nil {
+		var noSuchEntity *iamTypes.NoSuchEntityException
+		if !errors.As(detachErr, &noSuchEntity) && !strings.Contains(detachErr.Error(), "is not attached") {
+			errs = append(errs, fmt.Errorf("detach policy %s from role %s: %w", policyARN, roleName, detachErr))
+		}
+	}
+	if deletePolErr := awsclient.DeleteIAMPolicy(policyARN); deletePolErr != nil {
+		var noSuchEntity *iamTypes.NoSuchEntityException
+		if !errors.As(deletePolErr, &noSuchEntity) {
+			errs = append(errs, fmt.Errorf("delete policy %s: %w", policyARN, deletePolErr))
+		}
+	}
+	if deleteRoleErr := awsclient.DeleteRole(roleName); deleteRoleErr != nil {
+		var noSuchEntity *iamTypes.NoSuchEntityException
+		if !errors.As(deleteRoleErr, &noSuchEntity) {
+			errs = append(errs, fmt.Errorf("delete role %s: %w", roleName, deleteRoleErr))
+		}
+	}
+
+	return errors.Join(errs...)
+}

--- a/tests/utils/exec/rosacli/cluster_service.go
+++ b/tests/utils/exec/rosacli/cluster_service.go
@@ -73,6 +73,22 @@ type ClusterList struct {
 	Clusters []ClusterListItem `yaml:"Clusters,omitempty"`
 }
 
+type AutoNodeDescription struct {
+	Mode string `yaml:"Mode,omitempty"`
+	ARN  string `yaml:"IAM Role ARN,omitempty"`
+}
+
+func (an *AutoNodeDescription) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.ScalarNode {
+		return value.Decode(&an.Mode)
+	}
+	if value.Kind == yaml.MappingNode {
+		type plain AutoNodeDescription
+		return value.Decode((*plain)(an))
+	}
+	return fmt.Errorf("unexpected YAML node kind %d for AutoNode", value.Kind)
+}
+
 // Struct for the 'rosa describe cluster' output
 type ClusterDescription struct {
 	Name                  string                   `yaml:"Name,omitempty"`
@@ -123,7 +139,7 @@ type ClusterDescription struct {
 	EnableEtcdEncryption     string                   `yaml:"Etcd Encryption,omitempty"`
 	EtcdKmsKeyARN            string                   `yaml:"Etcd KMS key ARN,omitempty"`
 	RegistryConfiguration    []map[string]interface{} `yaml:"Registry Configuration,omitempty"`
-	AutoNode                 string                   `yaml:"AutoNode,omitempty"`
+	AutoNode                 AutoNodeDescription      `yaml:"AutoNode,omitempty"`
 	ZeroEgress               string                   `yaml:"Zero Egress,omitempty"`
 	SharedVPCConfig          []map[string]string      `yaml:"Shared VPC Config,omitempty"`
 }

--- a/tests/utils/handler/cluster_handler.go
+++ b/tests/utils/handler/cluster_handler.go
@@ -970,7 +970,11 @@ func (ch *clusterHandler) GenerateClusterCreateFlags() ([]string, error) {
 		if err != nil {
 			return flags, err
 		}
-		oidcProvider := strings.TrimPrefix(oidcConfig.IssuerUrl, "https://")
+
+		oidcProvider, err := helper.ExtractOIDCProviderFromOidcUrl(oidcConfig.IssuerUrl)
+		if err != nil {
+			return flags, err
+		}
 		_, err = resourcesHandler.PrepareLogForwardRole(oidcProvider, "log_forward")
 		if err != nil {
 			return flags, err


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
Supported ticket prefixes:
OCM-XXXXX, ROSAENG-XXXX
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For contributor workflow, see: ./CONTRIBUTING.md
For repo-local agent guidance, see: ./AGENTS.md
-->

## PR Summary
Fixes id:84981 by creating properly configured IAM roles and policies for autonode support

## Detailed Description of the Issue
<!-- Describe the root problem, scope, impact, and user/business context -->

## Related Issues and PRs
<!-- Link all tracking items and related code changes -->
- Jira: https://redhat.atlassian.net/browse/ROSAENG-60386
- Fixes: `#`
- Related PR(s):
- Related design/docs:

## Type of Change
<!-- Check the primary type this PR represents -->
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [x] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
id:84981 would always fail, and describing a cluster (which is done during the cleanup phase) would also fail to parse the output when autonode is properly enabled

## Behavior After This Change
id:84891 creates 2 IAM roles and policies and passes. You can also delete a cluster after running this test since the code can properly parse the autonode description now

## How to Test (Step-by-Step)
<!-- Provide reproducible validation instructions -->
### Preconditions
<!-- Required setup, environment, credentials, flags, cluster state, etc. -->

### Test Steps
1.
2.
3.

### Expected Results
<!-- What should happen after running the steps above -->

## Proof of the Fix
### test case passing
```
TEST_PROFILE="rosa-hcp-basic" go run github.com/onsi/ginkgo/v2/ginkgo run --timeout 2h --focus "id:84981" tests/e2e/
Running Suite: ROSA CLI e2e tests suite - /home/jericho/work/repos/rosa/tests/e2e
=================================================================================
Random Seed: 1782396173

Will run 1 of 282 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSStime="2026-06-25 10:02:57" level=info msg="Got file path: /home/jericho/.aws/credentials from env variable AWS_SHARED_CREDENTIALS_FILE\n"
time="2026-06-25 10:03:02" level=info msg="Got file path: /home/jericho/.aws/credentials from env variable AWS_SHARED_CREDENTIALS_FILE\n"
time="2026-06-25 10:03:14" level=info msg="Got file path: /home/jericho/.aws/credentials from env variable AWS_SHARED_CREDENTIALS_FILE\n"
time="2026-06-25 10:03:15" level=info msg="Got file path: /home/jericho/.aws/credentials from env variable AWS_SHARED_CREDENTIALS_FILE\n"
•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 282 Specs in 20.045 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 281 Skipped
PASS

Ginkgo ran 1 suite in 23.02350855s
Test Suite Passed
```

### running the test case again 
- The test is skipped cause you can't disable autonode support on a cluster, so you can't test enabling it if it's already enabled
```
TEST_PROFILE="rosa-hcp-basic" go run github.com/onsi/ginkgo/v2/ginkgo run --timeout 2h --focus "id:84981" tests/e2e/
Running Suite: ROSA CLI e2e tests suite - /home/jericho/work/repos/rosa/tests/e2e
=================================================================================
Random Seed: 1782319488

Will run 1 of 282 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 0 of 282 Specs in 1.246 seconds
SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 282 Skipped
PASS

Ginkgo ran 1 suite in 3.220235106s
Test Suite Passed
```

### Can delete cluster
```
TEST_PROFILE="rosa-hcp-basic" go run github.com/onsi/ginkgo/v2/ginkgo run --label-filter destroy --timeout 2h tests/e2e/
Running Suite: ROSA CLI e2e tests suite - /home/jericho/work/repos/rosa/tests/e2e
=================================================================================
Random Seed: 1782319495

Will run 1 of 282 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSStime="2026-06-24 12:57:22" level=info msg="Got aws shared credential file path: /home/jericho/.aws/credentials "
time="2026-06-24 12:57:22" level=info msg="Going to delete the vpc and follow resources by ID: vpc-0f6e7acf6832f02f2"
time="2026-06-24 12:57:22" level=info msg="Going to terminate proxy instances if exists"
time="2026-06-24 12:57:22" level=info msg="Got no instances to terminate."
time="2026-06-24 12:57:22" level=info msg="Terminating instances  successfully"
time="2026-06-24 12:57:22" level=info msg="No key pairs found for VPC vpc-0f6e7acf6832f02f2"
time="2026-06-24 12:57:22" level=info msg="Delete vpc instances successfully"
time="2026-06-24 12:57:22" level=info msg="Going to delete proxy security group"
time="2026-06-24 12:57:23" level=info msg="Delete vpc proxy security group successfully"
time="2026-06-24 12:57:23" level=info msg="Got custom rt rtb-05b7eed5cda8c2b88 "
time="2026-06-24 12:57:23" level=info msg="Got custom rt rtb-0178939ba85d65ccf "
time="2026-06-24 12:57:23" level=info msg="Got main association for rt rtb-00f12e762b71a6f45"
time="2026-06-24 12:57:23" level=info msg="Disassociate route table success rtbassoc-0044eaa86877532fe"
time="2026-06-24 12:57:24" level=info msg="Disassociate route table success rtbassoc-0a0d2c96ae1f2c3c3"
time="2026-06-24 12:57:24" level=info msg="Delete vpc route tables successfully"
time="2026-06-24 12:57:24" level=info msg="Deleting nat gateway nat-03cc50a492bcf9090"
time="2026-06-24 12:57:25" level=info msg="Current NAT gateway 'nat-03cc50a492bcf9090' status: deleting"
time="2026-06-24 12:57:27" level=info msg="Current NAT gateway 'nat-03cc50a492bcf9090' status: deleting"
time="2026-06-24 12:57:29" level=info msg="Current NAT gateway 'nat-03cc50a492bcf9090' status: deleting"
time="2026-06-24 12:57:31" level=info msg="Current NAT gateway 'nat-03cc50a492bcf9090' status: deleting"
time="2026-06-24 12:57:33" level=info msg="Current NAT gateway 'nat-03cc50a492bcf9090' status: deleting"
time="2026-06-24 12:57:36" level=info msg="Current NAT gateway 'nat-03cc50a492bcf9090' status: deleting"
time="2026-06-24 12:57:38" level=info msg="Current NAT gateway 'nat-03cc50a492bcf9090' status: deleting"
time="2026-06-24 12:57:40" level=info msg="Current NAT gateway 'nat-03cc50a492bcf9090' status: deleting"
time="2026-06-24 12:57:42" level=info msg="Current NAT gateway 'nat-03cc50a492bcf9090' status: deleting"
time="2026-06-24 12:57:44" level=info msg="Current NAT gateway 'nat-03cc50a492bcf9090' status: deleting"
time="2026-06-24 12:57:46" level=info msg="Current NAT gateway 'nat-03cc50a492bcf9090' status: deleting"
time="2026-06-24 12:57:48" level=info msg="Current NAT gateway 'nat-03cc50a492bcf9090' status: deleting"
time="2026-06-24 12:57:50" level=info msg="Current NAT gateway 'nat-03cc50a492bcf9090' status: deleting"
time="2026-06-24 12:57:53" level=info msg="Current NAT gateway 'nat-03cc50a492bcf9090' status: deleting"
time="2026-06-24 12:57:55" level=info msg="Current NAT gateway 'nat-03cc50a492bcf9090' status: deleting"
time="2026-06-24 12:57:57" level=info msg="Current NAT gateway 'nat-03cc50a492bcf9090' status: deleting"
time="2026-06-24 12:57:59" level=info msg="Current NAT gateway 'nat-03cc50a492bcf9090' status: deleting"
time="2026-06-24 12:58:01" level=info msg="Current NAT gateway 'nat-03cc50a492bcf9090' status: deleting"
time="2026-06-24 12:58:03" level=info msg="Current NAT gateway 'nat-03cc50a492bcf9090' status: deleting"
time="2026-06-24 12:58:05" level=info msg="Current NAT gateway 'nat-03cc50a492bcf9090' status: deleting"
time="2026-06-24 12:58:07" level=info msg="Current NAT gateway 'nat-03cc50a492bcf9090' status: deleting"
time="2026-06-24 12:58:09" level=info msg="Current NAT gateway 'nat-03cc50a492bcf9090' status: deleting"
time="2026-06-24 12:58:12" level=info msg="Current NAT gateway 'nat-03cc50a492bcf9090' status: deleting"
time="2026-06-24 12:58:14" level=info msg="Current NAT gateway 'nat-03cc50a492bcf9090' status: deleting"
time="2026-06-24 12:58:16" level=info msg="Current NAT gateway 'nat-03cc50a492bcf9090' status: deleting"
time="2026-06-24 12:58:18" level=info msg="Current NAT gateway 'nat-03cc50a492bcf9090' status: deleting"
time="2026-06-24 12:58:20" level=info msg="Current NAT gateway 'nat-03cc50a492bcf9090' status: deleting"
time="2026-06-24 12:58:22" level=info msg="Current NAT gateway 'nat-03cc50a492bcf9090' status: deleting"
time="2026-06-24 12:58:24" level=info msg="Current NAT gateway 'nat-03cc50a492bcf9090' status: deleted"
time="2026-06-24 12:58:24" level=info msg="Delete Nat Gateway success nat-03cc50a492bcf9090"
time="2026-06-24 12:58:25" level=info msg="Release EIP eipalloc-063e445d3da8c62a6 successsully "
time="2026-06-24 12:58:25" level=info msg="Delete vpc nat gateways successfully"
time="2026-06-24 12:58:25" level=info msg="Got total clean set, going to delete other possible resource leak"
time="2026-06-24 12:58:25" level=info msg="Going to terminate the leak instances if exist"
time="2026-06-24 12:58:25" level=info msg="Got no instances to terminate."
time="2026-06-24 12:58:25" level=info msg="Terminating instances  successfully"
time="2026-06-24 12:58:25" level=info msg="No key pairs found for VPC vpc-0f6e7acf6832f02f2"
time="2026-06-24 12:58:26" level=info msg="Release rules successfully for SG sg-0c99f8d6054642c55"
time="2026-06-24 12:58:27" level=info msg="Delete security group sg-0c99f8d6054642c55 success "
time="2026-06-24 12:58:27" level=info msg="Detach igw igw-09356c735363c12b4 success from vpc vpc-0f6e7acf6832f02f2"
time="2026-06-24 12:58:28" level=info msg="Delete igw success: igw-09356c735363c12b4"
time="2026-06-24 12:58:28" level=info msg="Delete subnet subnet-06b14597990c5df7c successfully "
time="2026-06-24 12:58:29" level=info msg="Delete subnet subnet-02a582092d0d39fec successfully "
time="2026-06-24 12:58:29" level=info msg="Delete vpc vpc-0f6e7acf6832f02f2 successfuly "
•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 282 Specs in 823.976 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 281 Skipped
PASS

Ginkgo ran 1 suite in 13m45.991731593s
Test Suite Passed
```

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
<!-- Required only when breaking changes are introduced -->

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [x] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enhanced AutoNode configuration handling to support richer IAM role details when present.
* **Bug Fixes**
  * Improved OIDC provider extraction and error handling when preparing AutoNode-related cluster create settings.
* **Tests**
  * Updated end-to-end coverage and CI test resources to provision per-prefix AutoNode IAM roles/policies and validate role updates reflected in cluster configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->