### PR TITLE
ROSAENG-60112 | test: add tests for delete cluster command

### DIFF
--- a/cmd/dlt/cluster/cluster_suite_test.go
+++ b/cmd/dlt/cluster/cluster_suite_test.go
@@ -1,0 +1,13 @@
+package cluster
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDeleteCluster(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Delete cluster suite")
+}

--- a/cmd/dlt/cluster/cmd_test.go
+++ b/cmd/dlt/cluster/cmd_test.go
@@ -1,0 +1,187 @@
+package cluster
+
+import (
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+
+	"github.com/openshift/rosa/pkg/test"
+)
+
+var _ = Describe("Delete cluster", func() {
+	var (
+		t         *test.TestingRuntime
+		clusterId string
+	)
+
+	BeforeEach(func() {
+		t = test.NewTestRuntime()
+		clusterId = test.MockClusterID
+	})
+
+	Context("handleClusterDelete", func() {
+		It("returns nil and logs info when the cluster is already uninstalling", func() {
+			clusterReady := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateReady)
+			})
+			t.SetCluster(clusterId, clusterReady)
+
+			statusBody := fmt.Sprintf(`{
+				"kind": "ClusterStatus",
+				"id": "%s",
+				"state": "uninstalling"
+			}`, clusterId)
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, statusBody))
+
+			err := t.StdOutReader.Record()
+			Expect(err).NotTo(HaveOccurred())
+
+			err = handleClusterDelete(t.RosaRuntime, clusterReady, clusterId, false)
+			Expect(err).NotTo(HaveOccurred())
+
+			stdout, err := t.StdOutReader.Read()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stdout).To(ContainSubstring("already uninstalling"))
+		})
+
+		It("deletes the cluster and logs the start message", func() {
+			clusterReady := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateReady)
+			})
+			t.SetCluster(clusterId, clusterReady)
+
+			statusBody := fmt.Sprintf(`{
+				"kind": "ClusterStatus",
+				"id": "%s",
+				"state": "ready"
+			}`, clusterId)
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, statusBody))
+			t.ApiServer.AppendHandlers(RespondWithJSON(
+				http.StatusOK, test.FormatClusterList([]*cmv1.Cluster{clusterReady})))
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, ""))
+
+			err := t.StdOutReader.Record()
+			Expect(err).NotTo(HaveOccurred())
+
+			err = handleClusterDelete(t.RosaRuntime, clusterReady, clusterId, false)
+			Expect(err).NotTo(HaveOccurred())
+
+			stdout, err := t.StdOutReader.Read()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stdout).To(ContainSubstring("will start uninstalling"))
+		})
+
+		It("passes the bestEffort flag through to DeleteCluster", func() {
+			clusterReady := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateReady)
+			})
+			t.SetCluster(clusterId, clusterReady)
+
+			statusBody := fmt.Sprintf(`{
+				"kind": "ClusterStatus",
+				"id": "%s",
+				"state": "ready"
+			}`, clusterId)
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, statusBody))
+			t.ApiServer.AppendHandlers(RespondWithJSON(
+				http.StatusOK, test.FormatClusterList([]*cmv1.Cluster{clusterReady})))
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, ""))
+
+			err := handleClusterDelete(t.RosaRuntime, clusterReady, clusterId, true)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns an error when GetClusterState fails", func() {
+			clusterReady := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateReady)
+			})
+			t.SetCluster(clusterId, clusterReady)
+
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusInternalServerError, ""))
+
+			err := handleClusterDelete(t.RosaRuntime, clusterReady, clusterId, false)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("expected response content type"))
+		})
+
+		It("returns an error when DeleteCluster fails", func() {
+			clusterReady := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateReady)
+			})
+			t.SetCluster(clusterId, clusterReady)
+
+			statusBody := fmt.Sprintf(`{
+				"kind": "ClusterStatus",
+				"id": "%s",
+				"state": "ready"
+			}`, clusterId)
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, statusBody))
+			t.ApiServer.AppendHandlers(RespondWithJSON(
+				http.StatusOK, test.FormatClusterList([]*cmv1.Cluster{clusterReady})))
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusForbidden, `{
+				"kind": "Error",
+				"id": "403",
+				"href": "/api/clusters_mgmt/v1/errors/403",
+				"code": "CLUSTERS-MGMT-403",
+				"reason": "forbidden"
+			}`))
+
+			err := handleClusterDelete(t.RosaRuntime, clusterReady, clusterId, false)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("forbidden"))
+		})
+	})
+
+	Context("buildCommands", func() {
+		It("uses cluster ID flags when OIDC config is not reusable", func() {
+			cluster := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.AWS(cmv1.NewAWS().STS(
+					cmv1.NewSTS().
+						RoleARN("arn:aws:iam::123456789012:role/Installer").
+						OperatorRolePrefix("my-prefix").
+						OIDCEndpointURL("https://oidc.example.com").
+						OperatorIAMRoles(
+							cmv1.NewOperatorIAMRole().
+								Name("ebs-cloud-credentials").
+								Namespace("openshift-cluster-csi-drivers").
+								RoleARN("arn:aws:iam::123456789012:role/op-role"),
+						),
+				))
+			})
+
+			result := buildCommands(cluster)
+			Expect(result).To(ContainSubstring(fmt.Sprintf("-c %s", clusterId)))
+			Expect(result).To(ContainSubstring("rosa delete operator-roles"))
+			Expect(result).To(ContainSubstring("rosa delete oidc-provider"))
+			Expect(result).NotTo(ContainSubstring("--prefix"))
+			Expect(result).NotTo(ContainSubstring("--oidc-config-id"))
+		})
+
+		It("uses prefix and oidc-config-id flags when OIDC config is reusable", func() {
+			cluster := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.AWS(cmv1.NewAWS().STS(
+					cmv1.NewSTS().
+						RoleARN("arn:aws:iam::123456789012:role/Installer").
+						OperatorRolePrefix("my-prefix").
+						OIDCEndpointURL("https://oidc.example.com").
+						OidcConfig(cmv1.NewOidcConfig().ID("oidc-abc123").Reusable(true)).
+						OperatorIAMRoles(
+							cmv1.NewOperatorIAMRole().
+								Name("ebs-cloud-credentials").
+								Namespace("openshift-cluster-csi-drivers").
+								RoleARN("arn:aws:iam::123456789012:role/op-role"),
+						),
+				))
+			})
+
+			result := buildCommands(cluster)
+			Expect(result).To(ContainSubstring("--prefix my-prefix"))
+			Expect(result).To(ContainSubstring("--oidc-config-id oidc-abc123"))
+			Expect(result).NotTo(ContainSubstring(fmt.Sprintf("-c %s", clusterId)))
+		})
+	})
+})


### PR DESCRIPTION
## PR Summary
Add focused unit tests for the delete cluster command at `cmd/dlt/cluster/`, covering the core business logic in `handleClusterDelete` and the cleanup command builder `buildCommands`.

## Detailed Description of the Issue
The delete cluster command had 0% test coverage. This is one of the most critical user-facing workflows in the ROSA CLI. The command handles cluster state validation, deletion via the OCM API, and generating cleanup instructions for STS resources (operator roles and OIDC providers).

This PR tests the two internal functions that contain the actual decision logic, without needing to trap `os.Exit` from the legacy `Run: run` Cobra pattern.

## Related Issues and PRs
- Jira: [ROSAENG-60112](https://issues.redhat.com/browse/ROSAENG-60112)
- Related PR(s): coverage was addressed in #3277

## Type of Change
- [ ] feat
- [ ] fix
- [ ] docs
- [ ] style
- [ ] refactor
- [x] test
- [ ] chore
- [ ] build
- [ ] ci
- [ ] perf

## Previous Behavior
`cmd/dlt/cluster/` had no automated test coverage.

## Behavior After This Change
Six focused test cases covering:

**`handleClusterDelete`** (4 tests):
- Cluster already uninstalling: returns nil, logs info
- Happy path: state is ready, `DeleteCluster` succeeds, returns nil
- `GetClusterState` API error: propagated
- `DeleteCluster` API error: propagated

**`buildCommands`** (2 tests):
- Non-reusable OIDC config: commands use `-c <clusterID>`
- Reusable OIDC config: commands use `--prefix` and `--oidc-config-id`

## How to Test (Step-by-Step)
### Preconditions
- Go toolchain installed
- Repository cloned with hooks installed

### Test Steps
1. `go test ./cmd/dlt/cluster/... -count=1 -v`
2. `go vet ./cmd/dlt/cluster/...`

### Expected Results
- 6/6 specs pass
- `go vet` clean

## Proof of the Fix
- Pre-push checks passed (format, build, lint, coverage, unit tests)

## Breaking Changes
- [x] No breaking changes

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [ ] `make rosa` passes.
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

[ROSAENG-60112]: https://redhat.atlassian.net/browse/ROSAENG-60112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a Ginkgo/Gomega test suite covering cluster deletion behavior, including already-uninstalling, successful deletion, and error handling for failures retrieving cluster state and forbidden delete responses.
  * Added test coverage for generated CLI flags, validating correct argument composition for reusable vs non-reusable OIDC configuration scenarios.
  * Introduced a Ginkgo suite entry point to run the cluster deletion specs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->