### PR TITLE
ROSAENG-60640 | test: Fixing day1-negative test cases

### DIFF
--- a/tests/e2e/test_rosacli_account_roles.go
+++ b/tests/e2e/test_rosacli_account_roles.go
@@ -504,9 +504,12 @@ var _ = Describe("Edit account roles", labels.Feature.AccountRoles, func() {
 			Expect(textData).To(ContainSubstring("WARN: There are no hosted CP account roles to be deleted"))
 		})
 	It("create/delete classic account roles with managed policies - [id:57408]",
-		labels.Critical, labels.Runtime.OCMResources,
+		labels.Critical,
+		labels.Runtime.OCMResources,
+		// Classic account roles with managed policies is a feature that was never fully implemented (never made it prod),
+		// and is being planned to be removed
+		labels.Exclude,
 		func() {
-
 			var (
 				rolePrefixAuto      = helper.GenerateRandomName("ar57408a", 2)
 				rolePrefixManual    = helper.GenerateRandomName("ar57408m", 2)

--- a/tests/e2e/test_rosacli_cluster.go
+++ b/tests/e2e/test_rosacli_cluster.go
@@ -1748,7 +1748,7 @@ var _ = Describe("Classic cluster creation validation",
 				Expect(output.String()).
 					To(
 						ContainSubstring(
-							"invalid label key '%s': name part must be no more than 63 characters", longLabelKey))
+							"invalid label key '%s': name part must be no more than 63 bytes", longLabelKey))
 
 				By("Create ROSA cluster with the --worker-mp-labels flag and >63 character label value")
 				rosalCommand.ReplaceFlagValue(replacingFlags)
@@ -1760,7 +1760,7 @@ var _ = Describe("Classic cluster creation validation",
 				key = longValue[:index]
 				Expect(output.String()).
 					To(
-						ContainSubstring("invalid label value '%s': at key: '%s': must be no more than 63 characters",
+						ContainSubstring("invalid label value '%s': at key: '%s': must be no more than 63 bytes",
 							longLabelValue,
 							key))
 
@@ -1831,12 +1831,10 @@ var _ = Describe("Classic cluster creation validation",
 				By("Create cluster with use-local-credentials flag but with sts")
 				out, err := clusterService.CreateDryRun(
 					clusterName, "--sts",
-					"--mode", "auto",
 					"--role-arn", ar.InstallerRole,
 					"--support-role-arn", ar.SupportRole,
 					"--controlplane-iam-role", ar.ControlPlaneRole,
 					"--worker-iam-role", ar.WorkerRole,
-					"-y", "--dry-run",
 					"--use-local-credentials",
 				)
 				Expect(err).NotTo(BeNil())
@@ -2486,35 +2484,48 @@ var _ = Describe("HCP cluster creation negative testing",
 		var (
 			rosaClient     *rosacli.Client
 			clusterService rosacli.ClusterService
-			profilesMap    map[string]*handler.Profile
-			profile        *handler.Profile
+			customProfile  *handler.Profile
 			command        string
 			rosalCommand   config.Command
 			clusterHandler handler.ClusterHandler
 			err            error
 		)
 		BeforeEach(func() {
-
 			By("Init the client")
 			rosaClient = rosacli.NewClient()
 			clusterService = rosaClient.Cluster
 
-			// Get a random profile
-			profilesMap = handler.ParseProfilesByFile(path.Join(ciConfig.Test.YAMLProfilesDir, "rosa-hcp.yaml"))
-			profilesNames := make([]string, 0, len(profilesMap))
-			for k := range profilesMap {
-				profilesNames = append(profilesNames, k)
+			By("Prepare custom profile")
+			customProfile = &handler.Profile{
+				ClusterConfig: &handler.ClusterConfig{
+					HCP:                   true,
+					MultiAZ:               true,
+					STS:                   true,
+					OIDCConfig:            "managed",
+					NetworkingSet:         true,
+					BYOVPC:                true,
+					Zones:                 "",
+					Autoscale:             false,
+					PrivateLink:           false,
+					DefaultIngressPrivate: false,
+				},
+				AccountRoleConfig: &handler.AccountRoleConfig{
+					Path:               "",
+					PermissionBoundary: "",
+				},
+				Version:      "y-1",
+				ChannelGroup: "stable",
+				Region:       constants.CommonAWSRegion,
 			}
-			profile = profilesMap[profilesNames[helper.RandomInt(len(profilesNames))]]
-			profile.NamePrefix = constants.DefaultNamePrefix
-			clusterHandler, err = handler.NewTempClusterHandler(rosaClient, profile)
+			customProfile.NamePrefix = constants.DefaultNamePrefix
+			clusterHandler, err = handler.NewTempClusterHandler(rosaClient, customProfile)
 			Expect(err).To(BeNil())
 
 			By("Prepare creation command")
 			flags, err := clusterHandler.GenerateClusterCreateFlags()
 			Expect(err).To(BeNil())
 
-			command = "rosa create cluster --cluster-name " + profile.ClusterConfig.Name + " " + strings.Join(flags, " ")
+			command = "rosa create cluster --cluster-name " + customProfile.ClusterConfig.Name + " " + strings.Join(flags, " ")
 			rosalCommand = config.GenerateCommand(command)
 		})
 
@@ -2714,28 +2725,26 @@ var _ = Describe("HCP cluster creation negative testing",
 							"ERR: External authentication configuration is only supported for a Hosted Control Plane cluster."))
 
 				By("Create HCP cluster with --external-auth-providers-enabled and cluster version lower than 4.15")
-				cg := rosalCommand.GetFlagValue("--channel-group", true)
-				if cg == "" {
-					cg = rosacli.VersionChannelGroupStable
-				}
+				cg := rosacli.VersionChannelGroupStable
 				versionList, err := rosaClient.Version.ListAndReflectVersions(cg, rosalCommand.CheckFlagExist("--hosted-cp"))
 				Expect(err).To(BeNil())
 				Expect(versionList).ToNot(BeNil())
 				previousVersionsList, err := versionList.FindNearestBackwardMinorVersion("4.14", 0, true)
 				Expect(err).ToNot(HaveOccurred())
 				foundVersion := previousVersionsList.Version
+
 				replacingFlags := map[string]string{
 					"-c":              clusterName,
 					"--cluster-name":  clusterName,
 					"--domain-prefix": clusterName,
 					"--version":       foundVersion,
+					"--channel-group": cg,
 				}
 				rosalCommand.ReplaceFlagValue(replacingFlags)
 				if !rosalCommand.CheckFlagExist("--external-auth-providers-enabled") {
-					rosalCommand.AddFlags("--dry-run", "--external-auth-providers-enabled", "-y")
-				} else {
-					rosalCommand.AddFlags("--dry-run", "-y")
+					rosalCommand.AddFlags("--external-auth-providers-enabled")
 				}
+				rosalCommand.AddFlags("--dry-run")
 				output, err = rosaClient.Runner.RunCMD(strings.Split(rosalCommand.GetFullCommand(), " "))
 				Expect(err).To(HaveOccurred())
 				Expect(output.String()).
@@ -2804,9 +2813,11 @@ var _ = Describe("HCP cluster creation negative testing",
 				)
 
 				By("Create classic cluster with additional allowed principals")
-				_, err = clusterService.CreateDryRun(clusterName,
+				_, err = clusterService.CreateDryRun(
+					clusterName,
 					"--additional-allowed-principals", "zzzz",
-					"-y", "--debug")
+					"--debug",
+				)
 				helper.ExpectErrorWithMessage(err, "ERR: Additional Allowed Principals is supported only for Hosted Control Planes")
 			})
 
@@ -2840,7 +2851,6 @@ var _ = Describe("HCP cluster creation negative testing",
 				}
 				rosalCommand.ReplaceFlagValue(replacingFlags)
 				rosalCommand.AddFlags("--dry-run", "-y")
-				log.Logger.Debug(profile.Name)
 				log.Logger.Debug(strings.Split(rosalCommand.GetFullCommand(), " "))
 
 				By("Create classic cluster with  audit log arn")
@@ -2848,7 +2858,7 @@ var _ = Describe("HCP cluster creation negative testing",
 					rosalCommand.DeleteFlag("--audit-log-arn", true)
 				}
 
-				output, err := clusterService.CreateDryRun(clusterName, "--audit-log-arn", "-y")
+				output, err := clusterService.CreateDryRun(clusterName, "--audit-log-arn", "dummy-arn")
 				Expect(err).To(HaveOccurred())
 				Expect(output.String()).
 					To(
@@ -2958,7 +2968,7 @@ var _ = Describe("HCP cluster creation negative testing",
 					if rosalCommand.CheckFlagExist(flag) {
 						rosalCommand.DeleteFlag(flag, true)
 					}
-					output, err := clusterService.CreateDryRun(clusterName, flag, "-y")
+					output, err := clusterService.CreateDryRun(clusterName, flag, "dummy-value")
 					Expect(err).To(HaveOccurred())
 					Expect(output.String()).
 						To(
@@ -2974,7 +2984,6 @@ var _ = Describe("HCP cluster creation negative testing",
 				}
 				rosalCommand.ReplaceFlagValue(replacingFlags)
 				rosalCommand.AddFlags("--dry-run", "-y")
-				log.Logger.Debug(profile.Name)
 				log.Logger.Debug(strings.Split(rosalCommand.GetFullCommand(), " "))
 
 				rosalCommand.AddFlags("--registry-config-allowed-registries-for-import", "test.com:invalid")

--- a/tests/e2e/test_rosacli_idp_user.go
+++ b/tests/e2e/test_rosacli_idp_user.go
@@ -1,7 +1,9 @@
 package e2e
 
 import (
+	//nolint:staticcheck
 	. "github.com/onsi/ginkgo/v2"
+	//nolint:staticcheck
 	. "github.com/onsi/gomega"
 	"github.com/openshift-online/ocm-common/pkg/aws/aws_client"
 
@@ -195,18 +197,24 @@ var _ = Describe("Validate user", // TODO could be transformed as day1 negative
 				}
 
 				By("Try to create classic non STS cluster with invalid admin password")
-				output, err := clusterService.CreateDryRun(clusterID, "--cluster-admin-password", invalidPassword,
-					"--region", region, "--mode", "auto", "-y")
+				output, err := clusterService.CreateDryRun(
+					clusterID,
+					"--cluster-admin-password", invalidPassword,
+					"--region", region,
+				)
 				textData := rosaClient.Parser.TextData.Input(output).Parse().Tip()
 				Expect(err).To(HaveOccurred())
 				Expect(textData).Should(ContainSubstring("assword must be at least"))
 
 				By("Try to create cluster with invalid admin password on classic STS cluster")
-				output, err = clusterService.CreateDryRun(clusterID, "--sts", "--cluster-admin-password", invalidPassword,
-					"--region", region, "--mode", "auto", "-y")
+				output, err = clusterService.CreateDryRun(
+					clusterID,
+					"--sts",
+					"--cluster-admin-password", invalidPassword,
+					"--region", region,
+				)
 				textData = rosaClient.Parser.TextData.Input(output).Parse().Tip()
 				Expect(err).To(HaveOccurred())
 				Expect(textData).Should(ContainSubstring("assword must be at least"))
 			})
-
 	})

--- a/tests/utils/exec/rosacli/cluster_service.go
+++ b/tests/utils/exec/rosacli/cluster_service.go
@@ -245,7 +245,7 @@ func (c *clusterService) List() (bytes.Buffer, error) {
 }
 
 func (c *clusterService) CreateDryRun(clusterName string, flags ...string) (bytes.Buffer, error) {
-	combflags := append([]string{"-c", clusterName, "--dry-run"}, flags...)
+	combflags := append([]string{"-c", clusterName, "--dry-run", "--mode=auto", "--yes"}, flags...)
 	createDryRun := c.client.Runner.
 		Cmd("create", "cluster").
 		CmdFlags(combflags...)


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
Supported ticket prefixes:
OCM-XXXXX, ROSAENG-XXXX
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For contributor workflow, see: ./CONTRIBUTING.md
For repo-local agent guidance, see: ./AGENTS.md
-->

## PR Summary
Fixing day1-negative test failures

## Detailed Description of the Issue
<!-- Describe the root problem, scope, impact, and user/business context -->

## Related Issues and PRs
<!-- Link all tracking items and related code changes -->
- Jira: https://redhat.atlassian.net/browse/ROSAENG-60640
- Fixes: `#`
- Related PR(s):
- Related design/docs:

## Type of Change
<!-- Check the primary type this PR represents -->
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [x] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
<!-- What users or systems experienced before this change -->

## Behavior After This Change
<!-- What changes now, including user-visible and non-user-visible behavior -->

## How to Test (Step-by-Step)
<!-- Provide reproducible validation instructions -->
### Preconditions
<!-- Required setup, environment, credentials, flags, cluster state, etc. -->

### Test Steps
1.
2.
3.

### Expected Results
<!-- What should happen after running the steps above -->

## Proof of the Fix
<!-- Attach evidence that demonstrates the changed behavior -->
- Screenshots:
- Videos:
- Logs/CLI output:
- Other artifacts:

- Running all `day1-negative` tests: https://privatebin.corp.redhat.com/?3ba3df823f17a63a#GvKFJanDjJhd1qLHeARBFDXTW9sfaFVFgGTHDwuzKyLA
- Re-running `id:73755` after fixing that test: https://privatebin.corp.redhat.com/?51e973069aee31b8#25zMXYYqrBjp3AfME2mENTqcL9yQgeoHvi8RWJm8TPum

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
<!-- Required only when breaking changes are introduced -->

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [x] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved negative/validation coverage for cluster creation scenarios with more consistent dry-run argument handling and deterministic test setup.
  * Updated dry-run command construction to include the expected automatic mode and confirmation flags.

* **Tests**
  * Refined e2e test label configuration and debug logging for more reliable test selection and troubleshooting.
  * Adjusted IDP user validation dry-run invocations and added a targeted lint suppression for the Ginkgo import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->