### PR TITLE
ROSAENG-61037 | fix: update OCP-75603 assertion for new STS external ID error

### DIFF
--- a/tests/e2e/test_rosacli_cluster.go
+++ b/tests/e2e/test_rosacli_cluster.go
@@ -3979,7 +3979,7 @@ var _ = Describe("Sts cluster creation with external id",
 				stdout, err := rosaClient.Runner.RunCMD(strings.Split(rosalCommand.GetFullCommand(), " "))
 				Expect(err).ToNot(BeNil())
 				Expect(stdout.String()).To(ContainSubstring(
-					"An error occurred while trying to create an AWS client: Failed to assume role with ARN"))
+					"does not match trust policy for installer role"))
 
 				By("Create cluster with external id")
 				rosalCommand.ReplaceFlagValue(map[string]string{


### PR DESCRIPTION
## PR Summary

Update E2E test OCP-75603 assertion to match the new STS external ID mismatch error message produced by the ROSA CLI.

## Detailed Description of the Issue

The CLI now validates the external ID against role trust policies **before** attempting to assume the role. This changed the error path from the old AWS client-level failure (`"An error occurred while trying to create an AWS client: Failed to assume role with ARN"`) to a new, more specific validation error (`"does not match trust policy for installer role"`).

The E2E test `OCP-75603` still asserts the old error substring, causing the test to fail.

## Related Issues and PRs
- Jira: [ROSAENG-61037](https://issues.redhat.com/browse/ROSAENG-61037)

## Type of Change
- [x] fix - resolves an incorrect behavior or bug.

## Previous Behavior

The E2E test assertion checked for the old error string `"An error occurred while trying to create an AWS client: Failed to assume role with ARN"`, which was produced when the AWS SDK attempted to assume a role with a mismatched external ID.

## Behavior After This Change

The assertion now checks for `"does not match trust policy for installer role"`, which matches the new error produced by the `ExternalIDMismatchError` type in the `ststrust` package. The CLI now catches the mismatch earlier during external ID resolution.

## How to Test (Step-by-Step)

### Preconditions
- A ROSA environment with STS account roles configured and an installer role that has an `sts:ExternalId` condition in its trust policy.

### Test Steps
1. Run the E2E test suite targeting test ID 75603.
2. The test creates a cluster with a deliberately mismatched `--external-id` value.
3. The CLI should report the new error message about the trust policy mismatch.

### Expected Results
The assertion matches the CLI output and the test passes.

## Breaking Changes
- [x] No breaking changes

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

[ROSAENG-61037]: https://redhat.atlassian.net/browse/ROSAENG-61037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated an end-to-end validation to check for a clearer, more specific error message when cluster creation fails due to a trust policy mismatch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->