### PR TITLE
ROSAENG-61034 | test: align machinepool edit e2e assertion

### DIFF
--- a/tests/e2e/test_rosacli_machine_pool.go
+++ b/tests/e2e/test_rosacli_machine_pool.go
@@ -1528,7 +1528,7 @@ var _ = Describe("Edit machinepool",
 					clusterID, mpName, "--min-replicas", "9",
 					"--max-replicas", "3", "--enable-autoscaling",
 				)
-				helper.ExpectErrorWithMessage(err, "Min replicas must be less than max replicas")
+				helper.ExpectErrorWithMessage(err, "max-replicas must be greater or equal to min-replicas")
 
 				By("Edit with min-replicas not multiple 3 for multi-az")
 				_, err = machinePoolService.EditMachinePool(


### PR DESCRIPTION
## PR Summary
JIRA: [ROSAENG-61034](https://redhat.atlassian.net/browse/ROSAENG-61034)

Update the stale classic machinepool edit E2E assertion so OCP-44776 matches the current CLI validation wording and no longer fails on string drift.

## Detailed Description of the Issue
The classic multi-AZ `edit machinepool` E2E expected an outdated error string even though the current CLI validation already returns `max-replicas must be greater or equal to min-replicas`.

That mismatch caused a false-negative CI failure for OCP-44776. This change keeps the fix ticket-scoped by updating only the E2E expectation to match current behavior.

## Related Issues and PRs
- Jira: [ROSAENG-61034](https://redhat.atlassian.net/browse/ROSAENG-61034)
- Fixes: N/A
- Related PR(s): N/A
- Related design/docs: N/A

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [x] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
The E2E case `OCP-44776` in `tests/e2e/test_rosacli_machine_pool.go` expected `Min replicas must be less than max replicas`, which no longer matched the current CLI validation text.

## Behavior After This Change
The E2E case now expects `max-replicas must be greater or equal to min-replicas`, which matches the current CLI behavior already covered by related unit tests.

## How to Test (Step-by-Step)
### Preconditions
- ROSA CLI repository checked out locally
- Git hooks installed for the clone

### Test Steps
1. Run `go test ./cmd/edit/machinepool ./pkg/machinepool`
2. Run `make pre-push-checks`
3. Confirm the `OCP-44776` path in CI no longer fails due to the stale assertion text

### Expected Results
- The targeted machinepool Go test packages pass
- Pre-push validation passes on the committed change
- The shared-vpc day2 E2E no longer fails because of the outdated message expectation

## Proof of the Fix
- Screenshots: N/A
- Videos: N/A
- Logs/CLI output:
  - `go test ./cmd/edit/machinepool ./pkg/machinepool`
  - `git push -u upstream HEAD` completed successfully and its pre-push checks passed
- Other artifacts:
  - The branch diff contains a single one-line assertion update in `tests/e2e/test_rosacli_machine_pool.go`

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [x] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

[ROSAENG-61034]: https://redhat.atlassian.net/browse/ROSAENG-61034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated an end-to-end validation check to expect the current error message when `min-replicas` is set higher than `max-replicas` for machine pool edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->