### PR TITLE
ROSAENG-6719 | fix: clarify machine pool image type messaging

### DIFF
--- a/pkg/machinepool/create_image_type_test.go
+++ b/pkg/machinepool/create_image_type_test.go
@@ -1,0 +1,24 @@
+package machinepool
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
+	mpHelpers "github.com/openshift/rosa/pkg/helper/machinepools"
+	mpOpts "github.com/openshift/rosa/pkg/options/machinepool"
+)
+
+var _ = Describe("buildMachinePoolImageTypeInput", func() {
+	It("builds a clearer hosted image type prompt", func() {
+		cmd, _ := mpOpts.BuildMachinePoolCreateCommandWithOptions()
+
+		input := buildMachinePoolImageTypeInput(cmd)
+
+		Expect(input.Question).To(Equal("Machine pool image type"))
+		Expect(input.Help).To(Equal(cmd.Flags().Lookup("type").Usage))
+		Expect(input.Default).To(Equal(cmv1.ImageTypeDefault))
+		Expect(input.Required).To(BeFalse())
+		Expect(input.Options).To(Equal(mpHelpers.ImageTypes))
+	})
+})

--- a/pkg/machinepool/machinepool.go
+++ b/pkg/machinepool/machinepool.go
@@ -73,6 +73,23 @@ func NewMachinePoolService() MachinePoolService {
 	return &machinePool{}
 }
 
+func buildMachinePoolImageTypeInput(cmd *cobra.Command) interactive.Input {
+	help := ""
+	if cmd != nil {
+		if flag := cmd.Flags().Lookup("type"); flag != nil {
+			help = flag.Usage
+		}
+	}
+
+	return interactive.Input{
+		Question: "Machine pool image type",
+		Help:     help,
+		Default:  cmv1.ImageTypeDefault,
+		Required: false,
+		Options:  mpHelpers.ImageTypes,
+	}
+}
+
 // Create machine pool based on cluster type
 func (m machinePool) CreateMachinePoolBasedOnClusterType(r *rosa.Runtime,
 	cmd *cobra.Command, clusterKey string, cluster *cmv1.Cluster, clusterAutoscaler *cmv1.ClusterAutoscaler,
@@ -550,14 +567,9 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 		imageType = args.Type
 	}
 
-	// Image type (supports things such as WinLI // Windows VMs)
+	// Machine pool image type
 	if interactive.Enabled() && cluster.Hypershift().Enabled() && !fedramp.Enabled() {
-		imageType, err = interactive.GetOption(interactive.Input{
-			Question: "Image Type",
-			Default:  cmv1.ImageTypeDefault,
-			Required: false,
-			Options:  mpHelpers.ImageTypes,
-		})
+		imageType, err = interactive.GetOption(buildMachinePoolImageTypeInput(cmd))
 		if err != nil {
 			return fmt.Errorf("expected a valid image type: '%s'", err)
 		}

--- a/pkg/options/machinepool/create.go
+++ b/pkg/options/machinepool/create.go
@@ -283,8 +283,8 @@ func BuildMachinePoolCreateCommandWithOptions() (*cobra.Command, *CreateMachinep
 	flags.StringVar(&options.Type,
 		"type",
 		"",
-		"Specifies the type of AMI this machinepool uses. You may supply '--type Windows' for example if you want "+
-			"support for Windows VMs.")
+		"Specifies the image type used by Hosted Control Plane machine pools. "+
+			"Use '--type Windows' to create a machine pool that uses a Windows image.")
 
 	flags.StringVar(&options.CapacityReservationPreference,
 		"capacity-reservation-preference",

--- a/pkg/options/machinepool/create_test.go
+++ b/pkg/options/machinepool/create_test.go
@@ -18,6 +18,15 @@ var _ = Describe("BuildMachinePoolCreateCommandWithOptions", func() {
 		cmd, options = BuildMachinePoolCreateCommandWithOptions()
 	})
 
+	It("describes the image type flag for hosted control plane machine pools", func() {
+		flag := cmd.Flags().Lookup("type")
+		Expect(flag).ToNot(BeNil())
+		Expect(flag.Usage).To(Equal(
+			"Specifies the image type used by Hosted Control Plane machine pools. " +
+				"Use '--type Windows' to create a machine pool that uses a Windows image.",
+		))
+	})
+
 	It("should create a command with the expected use, short, long, and example descriptions", func() {
 		Expect(cmd.Use).To(Equal(use))
 		Expect(cmd.Short).To(Equal(short))


### PR DESCRIPTION
## PR Summary
Clarify the Hosted Control Plane machine-pool image type wording during `rosa create machinepool` so users understand that `Windows` is an image selection, not a different machine-pool kind.

Add focused tests that lock the updated `--type` help text and the interactive image-type prompt configuration.

## Detailed Description of the Issue
`ROSAENG-6719` reports that machine-pool creation via the CLI has confusing messaging around image type selection. The previous `--type` help text and interactive `Image Type` prompt did not clearly communicate that the choice controls the image used by the Hosted Control Plane machine pool, which could make `Windows` read like a different machine-pool type.

This change keeps the fix intentionally narrow by updating only the create-time wording and adding focused regression coverage for the changed copy.

## Related Issues and PRs
- Jira: [ROSAENG-6719](https://issues.redhat.com/browse/ROSAENG-6719)
- Fixes: N/A
- Related PR(s): N/A
- Related design/docs: N/A

## Type of Change
- [x] fix - resolves an incorrect behavior or bug.
- [ ] feat - adds a new user-facing capability.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
`rosa create machinepool` used a generic `Image Type` prompt and a `--type` help string that referred to the AMI type and Windows VMs without clearly stating that the choice selects the image used by a Hosted Control Plane machine pool.

## Behavior After This Change
The `--type` flag now says it selects the image type used by Hosted Control Plane machine pools, and the interactive prompt now asks for `Machine pool image type` while reusing the same help text.

## How to Test (Step-by-Step)
### Preconditions
- Go toolchain and repo dependencies are installed.
- Work from this branch.

### Test Steps
1. Run `make fmt`.
2. Run `go test ./pkg/options/machinepool ./pkg/machinepool`.
3. Run `make generate-docs`.
4. Run `make lint`.
5. Run `make test`.
6. Run `make rosa`.

### Expected Results
- All commands pass.
- `rosa create machinepool --help` shows the updated `--type` description.
- The HCP machine-pool create flow uses the clearer `Machine pool image type` prompt.

## Proof of the Fix
- Screenshots: N/A
- Videos: N/A
- Logs/CLI output: `make lint`, `make test`, `make rosa`, and `git push -u upstream HEAD` all passed; the push also passed the repo pre-push checks.
- Other artifacts: `pkg/options/machinepool/create_test.go`, `pkg/machinepool/create_image_type_test.go`

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [x] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

[ROSAENG-6719]: https://redhat.atlassian.net/browse/ROSAENG-6719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the interactive machine pool setup flow for Hosted Control Plane clusters by using clearer image type prompt text and defaults.

* **Documentation**
  * Updated the `--type` command help to better describe image type selection, including Windows images.

* **Bug Fixes**
  * Aligned the interactive prompt help with the command’s usage text for a more consistent CLI experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->