### PR TITLE
ROSAENG-61176 | test: add tests for list cluster command

### DIFF
--- a/cmd/list/cluster/cluster_suite_test.go
+++ b/cmd/list/cluster/cluster_suite_test.go
@@ -1,0 +1,13 @@
+package cluster
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestListCluster(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "List Cluster Suite")
+}

--- a/cmd/list/cluster/cmd.go
+++ b/cmd/list/cluster/cmd.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/output"
 	"github.com/openshift/rosa/pkg/rosa"
 )
@@ -111,13 +112,7 @@ func run(_ *cobra.Command, _ []string) {
 	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	fmt.Fprintf(writer, "ID\tNAME\tSTATE\tTOPOLOGY\n")
 	for _, cluster := range clusters {
-		typeOutput := "Classic"
-		if cluster.AWS() != nil && cluster.AWS().STS() != nil && cluster.AWS().STS().Enabled() {
-			typeOutput = "Classic (STS)"
-		}
-		if cluster.Hypershift().Enabled() {
-			typeOutput = "Hosted CP"
-		}
+		typeOutput := clusterTopology(cluster)
 		fmt.Fprintf(
 			writer,
 			"%s\t%s\t%s\t%s\n",
@@ -128,4 +123,14 @@ func run(_ *cobra.Command, _ []string) {
 		)
 	}
 	writer.Flush()
+}
+
+func clusterTopology(cluster *v1.Cluster) string {
+	if ocm.IsHyperShiftCluster(cluster) {
+		return "Hosted CP"
+	}
+	if cluster.AWS() != nil && cluster.AWS().STS() != nil && cluster.AWS().STS().Enabled() {
+		return "Classic (STS)"
+	}
+	return "Classic"
 }

--- a/cmd/list/cluster/cmd_test.go
+++ b/cmd/list/cluster/cmd_test.go
@@ -1,0 +1,113 @@
+package cluster
+
+import (
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+
+	awsClient "github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/test"
+)
+
+var _ = Describe("List clusters", func() {
+	Context("clusterTopology", func() {
+		It("returns Classic for a cluster without STS or Hypershift", func() {
+			cluster := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.Hypershift(cmv1.NewHypershift().Enabled(false))
+			})
+			Expect(clusterTopology(cluster)).To(Equal("Classic"))
+		})
+
+		It("returns Classic (STS) when AWS STS is enabled", func() {
+			cluster := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.AWS(cmv1.NewAWS().STS(cmv1.NewSTS().Enabled(true).RoleARN("arn:aws:iam::123:role/Installer")))
+				c.Hypershift(cmv1.NewHypershift().Enabled(false))
+			})
+			Expect(clusterTopology(cluster)).To(Equal("Classic (STS)"))
+		})
+
+		It("returns Hosted CP when Hypershift is enabled", func() {
+			cluster := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.Hypershift(cmv1.NewHypershift().Enabled(true))
+			})
+			Expect(clusterTopology(cluster)).To(Equal("Hosted CP"))
+		})
+
+		It("returns Hosted CP when both Hypershift and STS are enabled", func() {
+			cluster := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.AWS(cmv1.NewAWS().STS(cmv1.NewSTS().Enabled(true).RoleARN("arn:aws:iam::123:role/Installer")))
+				c.Hypershift(cmv1.NewHypershift().Enabled(true))
+			})
+			Expect(clusterTopology(cluster)).To(Equal("Hosted CP"))
+		})
+	})
+
+	Context("listClustersUsingAccountRole", func() {
+		var t *test.TestingRuntime
+
+		BeforeEach(func() {
+			t = test.NewTestRuntime()
+		})
+
+		It("returns clusters when AWS role lookup and OCM query succeed", func() {
+			args.accountRoleArn = "arn:aws:iam::123456789012:role/ManagedOpenShift-Installer-Role"
+
+			mockAWS := t.RosaRuntime.AWSClient.(*awsClient.MockClient)
+			mockAWS.EXPECT().GetAccountRoleByArn(args.accountRoleArn).Return(awsClient.Role{
+				RoleName: "ManagedOpenShift-Installer-Role",
+				RoleARN:  args.accountRoleArn,
+				RoleType: "Installer",
+			}, nil)
+
+			mockCluster := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateReady)
+			})
+			t.ApiServer.AppendHandlers(RespondWithJSON(
+				http.StatusOK, test.FormatClusterList([]*cmv1.Cluster{mockCluster})))
+
+			clusters, err := listClustersUsingAccountRole(t.RosaRuntime.Creator, t.RosaRuntime)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(clusters).To(HaveLen(1))
+			Expect(clusters[0].ID()).To(Equal(test.MockClusterID))
+		})
+
+		It("returns error when GetAccountRoleByArn fails", func() {
+			args.accountRoleArn = "arn:aws:iam::123456789012:role/NonExistent"
+
+			mockAWS := t.RosaRuntime.AWSClient.(*awsClient.MockClient)
+			mockAWS.EXPECT().GetAccountRoleByArn(args.accountRoleArn).Return(
+				awsClient.Role{}, fmt.Errorf("role not found"))
+
+			_, err := listClustersUsingAccountRole(t.RosaRuntime.Creator, t.RosaRuntime)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("role not found"))
+		})
+
+		It("returns error when GetClustersUsingAccountRole fails", func() {
+			args.accountRoleArn = "arn:aws:iam::123456789012:role/ManagedOpenShift-Installer-Role"
+
+			mockAWS := t.RosaRuntime.AWSClient.(*awsClient.MockClient)
+			mockAWS.EXPECT().GetAccountRoleByArn(args.accountRoleArn).Return(awsClient.Role{
+				RoleName: "ManagedOpenShift-Installer-Role",
+				RoleARN:  args.accountRoleArn,
+				RoleType: "Installer",
+			}, nil)
+
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusInternalServerError, `{
+				"kind": "Error",
+				"id": "500",
+				"href": "/api/clusters_mgmt/v1/errors/500",
+				"code": "CLUSTERS-MGMT-500",
+				"reason": "internal error"
+			}`))
+
+			_, err := listClustersUsingAccountRole(t.RosaRuntime.Creator, t.RosaRuntime)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("expected response content type"))
+		})
+	})
+})


### PR DESCRIPTION
## PR Summary
Add focused tests for the list cluster command, previously at 0% coverage. Extract the topology display logic into a testable pure function.

## Detailed Description of the Issue
The list cluster command had no automated test coverage. This PR extracts the topology branching logic (Classic / Classic STS / Hosted CP) into a `clusterTopology` pure function and adds tests for both it and the `listClustersUsingAccountRole` helper.

## Related Issues and PRs
- Jira: [ROSAENG-60112](https://issues.redhat.com/browse/ROSAENG-60112) / [ROSAENG-61176](https://issues.redhat.com/browse/ROSAENG-61176)

## Type of Change
- [x] test
- [x] refactor

## Previous Behavior
Topology display logic was inline in `run()`, untestable without stdout capture.

## Behavior After This Change
7 new test cases:
- `clusterTopology`: Classic, Classic (STS), Hosted CP, Hosted CP priority over STS
- `listClustersUsingAccountRole`: happy path with AWS + OCM mocks, GetAccountRoleByArn error, GetClustersUsingAccountRole error

No behavior change in the command itself, only a refactor to extract the pure function.

## How to Test (Step-by-Step)
1. `go test ./cmd/list/cluster/... -count=1 -v`
2. `go vet ./cmd/list/cluster/...`

## Breaking Changes
- [x] No breaking changes

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] Any risk, limitation, or follow-up work is documented.

[ROSAENG-60112]: https://redhat.atlassian.net/browse/ROSAENG-60112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROSAENG-61176]: https://redhat.atlassian.net/browse/ROSAENG-61176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster listing to display the correct topology label for Classic, Classic (STS), and Hosted CP clusters.
* **Tests**
  * Added automated coverage for cluster listing behavior across multiple cluster configurations.
  * Added tests for role lookup and cluster query success and failure scenarios.
  * Added a test suite entrypoint for the cluster listing suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->