### PR TITLE
ROSAENG-60031 | fix(ci): bootstrap jq for govulncheck in Prow builder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,10 +84,13 @@ When a vulnerability has no fix available, or a fix cannot be adopted yet (for e
 a stdlib fix that requires a newer Go toolchain), add an entry to `.govulncheck-ignore.yaml`
 with the GO ID, exact module path, and reason. Remove entries once the fix is adopted.
 
-The ignore wrapper requires `jq` to parse govulncheck JSON output. ROSA Prow jobs use the
-same OCP builder image as `lint` (`container: from: src`), which includes `jq` as a system
-package. For local runs, install `jq` if it is not already available. `yq` is optional; the
-wrapper falls back to awk when `yq` is not installed.
+The ignore wrapper requires `jq` to parse govulncheck JSON output. The OCP builder image
+used by ROSA Prow jobs (`container: from: src`) does not include `jq`; `make govulncheck`
+downloads a static `jq` binary (currently pinned in `hack/govulncheck.sh`, monitored by
+Renovate) to a versioned temp directory when it is not already on `PATH`, and verifies the
+download against the upstream `sha256sum.txt` for that release. For local runs, install `jq`
+or rely on that bootstrap. `yq` is optional; the wrapper falls back to awk when `yq` is not
+installed.
 
 Commit message checks are performed by the `commit-msg` hook during commits.
 

--- a/hack/govulncheck.sh
+++ b/hack/govulncheck.sh
@@ -7,8 +7,83 @@
 
 set -euo pipefail
 
+# renovate: datasource=github-releases depName=jqlang/jq extractVersion=^jq-(?<version>.+)$
+readonly jq_version="1.8.2"
+
+verify_jq_checksum() {
+	local jq_dir=$1
+	local jq_asset=$2
+	local jq_bin=$3
+	local sha256_file="${jq_dir}/sha256sum.txt"
+	local expected actual
+
+	curl -fsSL --retry 5 --retry-delay 2 \
+		-o "$sha256_file" \
+		"https://github.com/jqlang/jq/releases/download/jq-${jq_version}/sha256sum.txt"
+
+	expected=$(grep -F " ${jq_asset}" "$sha256_file" | awk '{print $1}')
+	if [[ -z "$expected" ]]; then
+		echo "jq checksum not found in upstream sha256sum.txt for ${jq_asset}" >&2
+		return 1
+	fi
+
+	actual=$(sha256sum "$jq_bin" | awk '{print $1}')
+	if [[ "$expected" != "$actual" ]]; then
+		echo "jq checksum mismatch for ${jq_asset}" >&2
+		rm -f "$jq_bin"
+		return 1
+	fi
+}
+
+ensure_jq() {
+	if command -v jq >/dev/null 2>&1; then
+		return 0
+	fi
+
+	if [[ "$(uname -s)" != "Linux" ]]; then
+		echo "jq not found; install jq locally (automatic bootstrap is Linux-only)" >&2
+		return 1
+	fi
+
+	if ! command -v curl >/dev/null 2>&1; then
+		echo "jq not found and curl is unavailable to download a static binary" >&2
+		return 1
+	fi
+
+	local jq_dir jq_bin jq_asset arch
+	jq_dir="${TMPDIR:-/tmp}/rosa-govulncheck-jq/${jq_version}"
+	jq_bin="${jq_dir}/jq"
+	mkdir -p "$jq_dir"
+
+	case "$(uname -m)" in
+	x86_64 | amd64) arch=amd64 ;;
+	aarch64 | arm64) arch=arm64 ;;
+	s390x) arch=s390x ;;
+	ppc64le) arch=ppc64el ;;
+	*)
+		echo "unsupported architecture for jq bootstrap: $(uname -m)" >&2
+		return 1
+		;;
+	esac
+
+	jq_asset="jq-linux-${arch}"
+
+	if [[ ! -x "$jq_bin" ]]; then
+		echo "jq not found; downloading jq ${jq_version} for ${arch}..."
+		curl -fsSL --retry 5 --retry-delay 2 \
+			-o "$jq_bin" \
+			"https://github.com/jqlang/jq/releases/download/jq-${jq_version}/${jq_asset}"
+		chmod +x "$jq_bin"
+		verify_jq_checksum "$jq_dir" "$jq_asset" "$jq_bin"
+	fi
+
+	export PATH="${jq_dir}:${PATH}"
+}
+
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 cd "$repo_root"
+
+ensure_jq
 
 wrapper="$repo_root/hack/govulncheck-wrapper.sh"
 rosa_binary="$repo_root/rosa"

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
     ":gitSignOff"
   ],
   "enabledManagers": [
+    "custom.regex",
     "gomod",
     "tekton",
     "dockerfile"
@@ -48,7 +49,32 @@
       }
     ]
   },
+  "customManagers": [
+    {
+      "description": "Update jq bootstrap in hack/govulncheck.sh",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^hack/govulncheck\\.sh$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>github-releases) depName=(?<depName>jqlang/jq)(?: extractVersion=(?<extractVersion>[^\\s]+))?\\s+readonly jq_version=\"(?<currentValue>[^\"]+)\""
+      ],
+      "datasourceTemplate": "{{datasource}}",
+      "depNameTemplate": "{{depName}}",
+      "extractVersionTemplate": "{{extractVersion}}"
+    }
+  ],
   "packageRules": [
+    {
+      "description": "govulncheck jq bootstrap",
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDepNames": [
+        "jqlang/jq"
+      ],
+      "groupName": "govulncheck-jq"
+    },
     {
       "description": "Enable automerge Konflux .tekton task updates",
       "matchManagers": [


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
Supported ticket prefixes:
OCM-XXXXX, ROSAENG-XXXX
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For contributor workflow, see: ./CONTRIBUTING.md
For repo-local agent guidance, see: ./AGENTS.md
-->

## PR Summary
Bootstrap `jq` 1.8.2 inside `hack/govulncheck.sh` (with upstream checksum verification) so the govulncheck Prow job succeeds in the OCP builder image, and register the pin with Renovate.

## Detailed Description of the Issue
The optional `govulncheck` presubmit in openshift/release (#81561) failed during `/pj-rehearse` after building `rosa`. The ignore wrapper requires `jq` to parse govulncheck JSON output, but the OCP builder image (`container: from: src`) does not include `jq`. CONTRIBUTING.md incorrectly stated that the builder provides it.

## Related Issues and PRs
- Jira: [ROSAENG-60031](https://issues.redhat.com/browse/ROSAENG-60031)
- Related PR(s): openshift/release#81561 (govulncheck Prow job; blocked until this fix lands on master)
- Related design/docs: Follow-up to openshift/rosa#3330 (govulncheck integration)

## Type of Change
<!-- Check the primary type this PR represents -->
- [ ] feat - adds a new user-facing capability.
- [x] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
`make govulncheck` failed in Prow with `[ERROR] jq not found` when the wrapper ran, even though `rosa` had built successfully.

## Behavior After This Change
On Linux, `hack/govulncheck.sh` downloads a static `jq` **1.8.2** binary to `${TMPDIR:-/tmp}/rosa-govulncheck-jq/${jq_version}/` when `jq` is not on `PATH`, verifies the download against the upstream release `sha256sum.txt`, prepends that directory to `PATH`, then invokes the wrapper. Non-Linux hosts print an install message instead of downloading a Linux binary. Renovate monitors the `jqlang/jq` pin via a regex manager on `hack/govulncheck.sh`. CONTRIBUTING.md documents the bootstrap and checksum behavior.

## How to Test (Step-by-Step)
### Preconditions
- Linux host or container without `jq` on `PATH`
- `curl` and `sha256sum` available (present in OCP builder and UBI images)

### Test Steps
1. Run `make govulncheck` on a host with `jq` installed (baseline).
2. Run `make govulncheck` in a Linux environment without `jq` (e.g. UBI9 container) and confirm the bootstrap downloads jq 1.8.2, verifies checksum, and the scan completes.
3. Run `shellcheck hack/govulncheck.sh`.

### Expected Results
- Source and binary govulncheck scans pass in both cases.
- Bootstrap logs `jq not found; downloading jq 1.8.2 for <arch>...` when jq is missing.
- `shellcheck` reports no issues.

## Proof of the Fix
- Screenshots: N/A
- Videos: N/A
- Logs/CLI output:
  - Local: `make govulncheck` passed (source: 0 unignored, 2 ignored; binary: 0 unignored, 3 ignored).
  - UBI9 container without jq: bootstrap downloaded jq 1.8.2, checksum verified, `jq --version` succeeded.
  - CI builder image pull failed locally (registry auth required); rehearsal on release PR #81561 is the authoritative CI validation after merge.
- Other artifacts: N/A

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [ ] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [ ] `make test` passes.
- [ ] `make lint` passes.
- [x] `make rosa` passes.
- [x] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

**Follow-up:** After merge, re-run `/pj-rehearse pull-ci-openshift-rosa-master-govulncheck` on openshift/release#81561.

[ROSAENG-60031]: https://redhat.atlassian.net/browse/ROSAENG-60031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ