### PR TITLE
ROSAENG-60638 | fix: reduce STS pressure and improve retry for transient InvalidClientTokenId

### DIFF
--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -70,6 +70,29 @@ var (
 	throttleErrorCodes []string
 )
 
+// newBackoffWithMinDelay wraps ExponentialJitterBackoff to enforce minimum
+// delays between retries. For throttle-like errors (identified by the
+// allErrorCodes list including InvalidClientTokenId), it uses
+// minThrottleDelay as the floor. For other retryable errors, it uses
+// minDelay. This gives transient STS issues more time to recover.
+func newBackoffWithMinDelay(minDelay, minThrottle, maxDelay time.Duration) retry.BackoffDelayerFunc {
+	base := retry.NewExponentialJitterBackoff(maxDelay)
+	return func(attempt int, err error) (time.Duration, error) {
+		delay, e := base.BackoffDelay(attempt, err)
+		if e != nil {
+			return delay, e
+		}
+		floor := minDelay
+		if err != nil && awserr.IsInvalidTokenException(err) {
+			floor = minThrottle
+		}
+		if delay < floor {
+			return floor, nil
+		}
+		return delay, nil
+	}
+}
+
 // Name of the AWS user that will be used to create all the resources of the cluster:
 const (
 	AdminUserName        = "osdCcsAdmin"
@@ -264,6 +287,7 @@ type awsClient struct {
 	iamQuotaClient      client.ServiceQuotasApiClient
 	awsAccessKeys       *AccessKey
 	useLocalCredentials bool
+	callerIdentity      *sts.GetCallerIdentityOutput
 }
 
 func CreateNewClientOrExit(logger *logrus.Logger, reporter reporter.Logger) Client {
@@ -312,6 +336,7 @@ func New(
 		iamQuotaClient,
 		awsAccessKeys,
 		useLocalCredentials,
+		nil,
 	}
 }
 
@@ -389,8 +414,10 @@ func (b *ClientBuilder) BuildSessionWithOptionsCredentials(value *AccessKey,
 				strings.Join([]string{info.DefaultUserAgent, info.DefaultVersion}, ";")),
 		}),
 		config.WithRetryer(func() aws.Retryer {
-			retryer := retry.AddWithMaxAttempts(retry.NewStandard(), numMaxRetries)
-			retryer = retry.AddWithMaxBackoffDelay(retryer, time.Second)
+			retryer := retry.AddWithMaxAttempts(retry.NewStandard(func(o *retry.StandardOptions) {
+				o.MaxBackoff = maxThrottleDelay
+				o.Backoff = newBackoffWithMinDelay(minRetryDelay, minThrottleDelay, maxThrottleDelay)
+			}), numMaxRetries)
 
 			for _, code := range allErrorCodes {
 				retryer = retry.AddWithErrorCodes(retryer, code)
@@ -417,8 +444,10 @@ func (b *ClientBuilder) BuildSessionWithOptions(logLevel aws.ClientLogMode) (aws
 				strings.Join([]string{info.DefaultUserAgent, info.DefaultVersion}, ";")),
 		}),
 		config.WithRetryer(func() aws.Retryer {
-			retryer := retry.AddWithMaxAttempts(retry.NewStandard(), numMaxRetries)
-			retryer = retry.AddWithMaxBackoffDelay(retryer, time.Second)
+			retryer := retry.AddWithMaxAttempts(retry.NewStandard(func(o *retry.StandardOptions) {
+				o.MaxBackoff = maxThrottleDelay
+				o.Backoff = newBackoffWithMinDelay(minRetryDelay, minThrottleDelay, maxThrottleDelay)
+			}), numMaxRetries)
 
 			for _, code := range allErrorCodes {
 				retryer = retry.AddWithErrorCodes(retryer, code)
@@ -766,20 +795,23 @@ type Creator struct {
 }
 
 func (c *awsClient) GetCallerIdentity() (*sts.GetCallerIdentityOutput, error) {
+	if c.callerIdentity != nil {
+		return c.callerIdentity, nil
+	}
 	getCallerIdentityOutput, err := c.stsClient.GetCallerIdentity(context.Background(), &sts.GetCallerIdentityInput{})
 	if err != nil {
 		return nil, err
 	}
+	c.callerIdentity = getCallerIdentityOutput
 	return getCallerIdentityOutput, nil
 }
 
 func (c *awsClient) GetCreator() (*Creator, error) {
-	getCallerIdentityOutput, err := c.stsClient.GetCallerIdentity(context.Background(), &sts.GetCallerIdentityInput{})
+	identity, err := c.GetCallerIdentity()
 	if err != nil {
 		return nil, err
 	}
-
-	return CreatorForCallerIdentity(getCallerIdentityOutput)
+	return CreatorForCallerIdentity(identity)
 }
 
 // CreatorForCallerIdentity adapts an STS CallerIdentity to the ROSA *Creator
@@ -959,14 +991,14 @@ func (c *awsClient) ValidateAccessKeys(AccessKey *AccessKey) error {
 			if awserr.IsInvalidTokenException(err) {
 				wait := time.Duration((i * 200)) * time.Millisecond
 				waited := time.Since(start)
-				logger.Debug(fmt.Printf("InvalidClientTokenId, waited %.2f\n", waited.Seconds()))
+				logger.Debug(fmt.Sprintf("InvalidClientTokenId, waited %.2f\n", waited.Seconds()))
 				time.Sleep(wait)
 			}
 
 			if awserr.IsAccessDeniedException(err) {
 				wait := time.Duration((i * 200)) * time.Millisecond
 				waited := time.Since(start)
-				logger.Debug(fmt.Printf("AccessDenied, waited %.2f\n", waited.Seconds()))
+				logger.Debug(fmt.Sprintf("AccessDenied, waited %.2f\n", waited.Seconds()))
 				time.Sleep(wait)
 			}
 

--- a/pkg/aws/client_test.go
+++ b/pkg/aws/client_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 	"fmt"
+	"time"
 
 	gomock "go.uber.org/mock/gomock"
 
@@ -952,5 +953,210 @@ var _ = Describe("Client", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(roles).To(HaveLen(0))
 		})
+	})
+})
+
+var _ = Describe("newBackoffWithMinDelay", func() {
+	var backoff func(int, error) (time.Duration, error)
+
+	BeforeEach(func() {
+		backoff = newBackoffWithMinDelay(1*time.Second, 5*time.Second, 5*time.Second)
+	})
+
+	It("enforces minDelay floor for non-throttle errors", func() {
+		genericErr := fmt.Errorf("some transient error")
+		delay, err := backoff(0, genericErr)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(delay).To(BeNumerically(">=", 1*time.Second))
+	})
+
+	It("enforces minThrottle floor for InvalidClientTokenId errors", func() {
+		tokenErr := &smithy.GenericAPIError{Code: "InvalidClientTokenId", Message: "token invalid"}
+		delay, err := backoff(0, tokenErr)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(delay).To(BeNumerically(">=", 5*time.Second))
+	})
+
+	It("does not exceed maxDelay", func() {
+		genericErr := fmt.Errorf("some error")
+		for attempt := 0; attempt < 20; attempt++ {
+			delay, err := backoff(attempt, genericErr)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(delay).To(BeNumerically("<=", 5*time.Second))
+		}
+	})
+
+	It("returns base delay when it exceeds minDelay", func() {
+		genericErr := fmt.Errorf("some error")
+		// At high attempts the base exponential should reach maxDelay (5s) which exceeds minDelay (1s)
+		delay, err := backoff(10, genericErr)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(delay).To(BeNumerically(">=", 1*time.Second))
+		Expect(delay).To(BeNumerically("<=", 5*time.Second))
+	})
+
+	It("uses minDelay floor when error is nil", func() {
+		delay, err := backoff(0, nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(delay).To(BeNumerically(">=", 1*time.Second))
+	})
+})
+
+var _ = Describe("GetCallerIdentity caching", func() {
+	var (
+		mockCtrl   *gomock.Controller
+		mockSTS    *mocks.MockStsApiClient
+		awsClient  Client
+		testOutput *sts.GetCallerIdentityOutput
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockSTS = mocks.NewMockStsApiClient(mockCtrl)
+		testOutput = &sts.GetCallerIdentityOutput{
+			Arn:     awsSdk.String("arn:aws:iam::123456789012:user/TestUser"),
+			UserId:  awsSdk.String("AIDAJQABLZS4A3QDU576Q"),
+			Account: awsSdk.String("123456789012"),
+		}
+		awsClient = New(
+			awsSdk.Config{},
+			NewLoggerWrapper(logrus.New(), nil),
+			mocks.NewMockIamApiClient(mockCtrl),
+			mocks.NewMockEc2ApiClient(mockCtrl),
+			mocks.NewMockOrganizationsApiClient(mockCtrl),
+			mocks.NewMockS3ApiClient(mockCtrl),
+			mocks.NewMockSecretsManagerApiClient(mockCtrl),
+			mockSTS,
+			mocks.NewMockCloudFormationApiClient(mockCtrl),
+			mocks.NewMockServiceQuotasApiClient(mockCtrl),
+			mocks.NewMockServiceQuotasApiClient(mockCtrl),
+			&AccessKey{},
+			false,
+		)
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	It("caches the result after the first successful call", func() {
+		mockSTS.EXPECT().GetCallerIdentity(gomock.Any(), gomock.Any()).
+			Return(testOutput, nil).Times(1)
+
+		out1, err := awsClient.GetCallerIdentity()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out1.Arn).To(Equal(testOutput.Arn))
+
+		out2, err := awsClient.GetCallerIdentity()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out2).To(BeIdenticalTo(out1))
+	})
+
+	It("does not cache errors", func() {
+		gomock.InOrder(
+			mockSTS.EXPECT().GetCallerIdentity(gomock.Any(), gomock.Any()).
+				Return(nil, fmt.Errorf("transient failure")),
+			mockSTS.EXPECT().GetCallerIdentity(gomock.Any(), gomock.Any()).
+				Return(testOutput, nil),
+		)
+
+		_, err := awsClient.GetCallerIdentity()
+		Expect(err).To(HaveOccurred())
+
+		out, err := awsClient.GetCallerIdentity()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out.Arn).To(Equal(testOutput.Arn))
+	})
+
+	It("GetCreator uses the cached identity without additional STS calls", func() {
+		mockSTS.EXPECT().GetCallerIdentity(gomock.Any(), gomock.Any()).
+			Return(testOutput, nil).Times(1)
+
+		_, err := awsClient.GetCallerIdentity()
+		Expect(err).ToNot(HaveOccurred())
+
+		creator, err := awsClient.GetCreator()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(creator.ARN).To(Equal("arn:aws:iam::123456789012:user/TestUser"))
+		Expect(creator.AccountID).To(Equal("123456789012"))
+		Expect(creator.IsSTS).To(BeFalse())
+	})
+
+	It("GetCreator propagates errors from GetCallerIdentity", func() {
+		mockSTS.EXPECT().GetCallerIdentity(gomock.Any(), gomock.Any()).
+			Return(nil, fmt.Errorf("STS unavailable"))
+
+		_, err := awsClient.GetCreator()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("STS unavailable"))
+	})
+})
+
+var _ = Describe("getClientDetails", func() {
+	var (
+		mockCtrl   *gomock.Controller
+		mockSTS    *mocks.MockStsApiClient
+		testClient *awsClient
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockSTS = mocks.NewMockStsApiClient(mockCtrl)
+		testClient = &awsClient{
+			logger:    NewLoggerWrapper(logrus.New(), nil),
+			stsClient: mockSTS,
+		}
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	It("returns caller identity and rootUser=false for IAM user", func() {
+		mockSTS.EXPECT().GetCallerIdentity(gomock.Any(), gomock.Any()).
+			Return(&sts.GetCallerIdentityOutput{
+				Arn:     awsSdk.String("arn:aws:iam::123456789012:user/David"),
+				UserId:  awsSdk.String("AIDAJQABLZS4A3QDU576Q"),
+				Account: awsSdk.String("123456789012"),
+			}, nil)
+
+		user, rootUser, err := getClientDetails(testClient)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(rootUser).To(BeFalse())
+		Expect(*user.Arn).To(Equal("arn:aws:iam::123456789012:user/David"))
+	})
+
+	It("detects root user when AccountID equals UserId", func() {
+		mockSTS.EXPECT().GetCallerIdentity(gomock.Any(), gomock.Any()).
+			Return(&sts.GetCallerIdentityOutput{
+				Arn:     awsSdk.String("arn:aws:iam::123456789012:root"),
+				UserId:  awsSdk.String("123456789012"),
+				Account: awsSdk.String("123456789012"),
+			}, nil)
+
+		_, rootUser, err := getClientDetails(testClient)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(rootUser).To(BeTrue())
+	})
+
+	It("wraps InvalidClientTokenId with credential help text", func() {
+		tokenErr := &smithy.GenericAPIError{Code: "InvalidClientTokenId", Message: "token invalid"}
+		mockSTS.EXPECT().GetCallerIdentity(gomock.Any(), gomock.Any()).
+			Return(nil, tokenErr)
+
+		_, _, err := getClientDetails(testClient)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid AWS Credentials"))
+		Expect(err.Error()).To(ContainSubstring("rosa-config-aws-account"))
+	})
+
+	It("passes through other errors unwrapped", func() {
+		otherErr := fmt.Errorf("network timeout")
+		mockSTS.EXPECT().GetCallerIdentity(gomock.Any(), gomock.Any()).
+			Return(nil, otherErr)
+
+		_, _, err := getClientDetails(testClient)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("network timeout"))
 	})
 })

--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -19,6 +19,7 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	awserr "github.com/openshift-online/ocm-common/pkg/aws/errors"
 	awsCommonUtils "github.com/openshift-online/ocm-common/pkg/aws/utils"
 	awsCommonValidations "github.com/openshift-online/ocm-common/pkg/aws/validations"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -159,13 +160,14 @@ func GetRegion(region string) (string, error) {
 func getClientDetails(awsClient *awsClient) (*sts.GetCallerIdentityOutput, bool, error) {
 	rootUser := false
 
-	_, err := awsClient.ValidateCredentials()
+	user, err := awsClient.GetCallerIdentity()
 	if err != nil {
-		return nil, rootUser, err
-	}
-
-	user, err := awsClient.stsClient.GetCallerIdentity(context.Background(), &sts.GetCallerIdentityInput{})
-	if err != nil {
+		if awserr.IsInvalidTokenException(err) {
+			return nil, rootUser, fmt.Errorf("invalid AWS Credentials: %w.\n For help configuring your credentials, see %s",
+				err,
+				"https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/"+
+					"rosa-config-aws-account.html#rosa-configuring-aws-account_rosa-config-aws-account")
+		}
 		return nil, rootUser, err
 	}
 


### PR DESCRIPTION
## PR Summary

Fixes intermittent `InvalidClientTokenId` failures during AWS client initialization by eliminating redundant STS calls and extending the retry window from ~10 seconds to ~60 seconds.

## Detailed Description of the Issue

ROSA CLI commands and CI e2e tests intermittently fail with `InvalidClientTokenId` when calling STS `GetCallerIdentity`. The credentials are valid — the error is transient and resolves after ~30 seconds. Two root causes were identified:

1. **Redundant STS calls**: A single `WithAWS()` runtime initialization made 3 separate `GetCallerIdentity` calls (`ValidateCredentials` → `GetCallerIdentity`, then `getClientDetails` → `GetCallerIdentity` again, then `GetCreator` → `GetCallerIdentity` a third time), tripling STS pressure and increasing the likelihood of hitting transient failures.

2. **Insufficient retry window**: The SDK retryer was configured with a max backoff of 1 second across 12 attempts (~10s total), but the transient issue needs ~30 seconds to resolve. The constants `minRetryDelay`, `minThrottleDelay`, and `maxThrottleDelay` were defined but never wired into the retryer configuration.

## Related Issues and PRs

- Jira: [ROSAENG-60638](https://issues.redhat.com/browse/ROSAENG-60638)
- Related: [ROSAENG-61036](https://issues.redhat.com/browse/ROSAENG-61036) - Classic cluster creation validation with InvalidClientTokenId
- Parent: [ROSAENG-60115](https://issues.redhat.com/browse/ROSAENG-60115) - Review recent CI failures and fix failing e2e tests

## Type of Change

- [x] fix - resolves an incorrect behavior or bug.

## Previous Behavior

- `getClientDetails()` called `ValidateCredentials()` (which calls `GetCallerIdentity`) and then called `GetCallerIdentity` again directly — result from validation was discarded.
- `GetCreator()` called `GetCallerIdentity` a third time independently.
- The SDK retryer used a max backoff of 1 second with 12 attempts, giving a total retry window of ~10 seconds.
- The constants `minRetryDelay` (1s), `minThrottleDelay` (5s), and `maxThrottleDelay` (5s) were defined but unused.
- `ValidateAccessKeys` had `fmt.Printf` calls where `fmt.Sprintf` was intended (debug logging wrote to stdout instead of the logger).

## Behavior After This Change

- `GetCallerIdentity` result is cached in `awsClient.callerIdentity`. `Build()`, `GetCallerIdentity()`, and `GetCreator()` all share a single STS call.
- `getClientDetails` calls `GetCallerIdentity` once and handles `InvalidClientTokenId` inline.
- The SDK retryer now uses a custom backoff that enforces `minRetryDelay` (1s) as a floor for normal errors, `minThrottleDelay` (5s) as a floor for `InvalidClientTokenId` errors, and `maxThrottleDelay` (5s) as the ceiling. With 12 attempts at 5s floor for token errors, the retry window covers ~60 seconds.
- `ValidateAccessKeys` debug logging now correctly uses `fmt.Sprintf`.

## How to Test (Step-by-Step)

### Preconditions

- Valid AWS credentials configured in the environment.

### Test Steps

1. Build the CLI: `make rosa`
2. Run unit tests: `make test` — verify all pass.
3. Run any ROSA command that initializes an AWS client (e.g. `rosa list clusters`) and confirm it works.

### Expected Results

- All unit tests pass.
- ROSA commands that initialize AWS clients succeed, including under transient STS pressure.

## Proof of the Fix

- All pre-commit and pre-push checks pass (format, build, lint, coverage, unit tests).
- Stress test with 50+ concurrent STS calls succeeds with the new retry configuration.
  - Ran this test script 100 times with no errors: https://privatebin.corp.redhat.com/?d29dc30e7617642b#Eq8tE22RdFWR5wT6ZQiNix5ABLgZvoTUZhxLRhaWh34W
## Breaking Changes

- [x] No breaking changes

## Developer Verification Checklist

- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

Made with [Cursor](https://cursor.com)

[ROSAENG-60638]: https://redhat.atlassian.net/browse/ROSAENG-60638

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AWS credential validation with smarter retry handling for temporary and invalid-token errors.
  * Reduced repeated identity lookups by caching AWS caller identity, which can speed up access checks.
  * Updated error messages for invalid AWS client tokens to provide clearer guidance when configuration issues are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->