### PR TITLE
ROSAENG-61412 | fix: gracefully skip upgrade tests when no version available

### DIFF
--- a/tests/e2e/test_rosacli_upgrade.go
+++ b/tests/e2e/test_rosacli_upgrade.go
@@ -355,8 +355,9 @@ var _ = Describe("Cluster Upgrade testing",
 			Expect(err).To(BeNil())
 			upgradeVersionList, err := upgradeService.ReflectUpgradeVersionList(output)
 			Expect(err).To(BeNil())
-			Expect(len(upgradeVersionList.UpgradeVersions)).To(BeNumerically(">", 0),
-				"Expected at least one upgrade version to be available")
+			if len(upgradeVersionList.UpgradeVersions) == 0 {
+				Skip("Skip this case as no upgrade version available for non-STS cluster")
+			}
 			upgradingVersion := upgradeVersionList.UpgradeVersions[0].Version
 
 			if upgradingVersion == "" {
@@ -825,8 +826,9 @@ var _ = Describe("Describe/List rosa upgrade",
 					Expect(err).To(BeNil())
 					upgradeVersionList, err := upgradeService.ReflectUpgradeVersionList(output)
 					Expect(err).To(BeNil())
-					Expect(len(upgradeVersionList.UpgradeVersions)).To(BeNumerically(">", 0),
-						"Expected at least one upgrade version to be available")
+					if len(upgradeVersionList.UpgradeVersions) == 0 {
+						Skip("Skip this case as no upgrade version available")
+					}
 					upgradingVersion := upgradeVersionList.UpgradeVersions[0].Version
 
 					By("Upgrade cluster")
@@ -1286,8 +1288,9 @@ var _ = Describe("Create cluster upgrade policy validation", labels.Feature.Clus
 			Expect(err).To(BeNil())
 			upgradeVersionList, err := upgradeService.ReflectUpgradeVersionList(output)
 			Expect(err).To(BeNil())
-			Expect(len(upgradeVersionList.UpgradeVersions)).To(BeNumerically(">", 0),
-				"Expected at least one upgrade version to be available")
+			if len(upgradeVersionList.UpgradeVersions) == 0 {
+				Skip("Skip this case as no upgrade version available")
+			}
 			upgradingVersion := upgradeVersionList.UpgradeVersions[0].Version
 
 			if profile.ClusterConfig.STS {


### PR DESCRIPTION
## Summary

Replace hard `Expect` assertions with graceful `Skip` calls in upgrade E2E tests when no upgrade version is available. This prevents the `e2e-rosa-non-sts-upgrade-y-stream` CI job from failing when the cluster version has no available y-stream upgrade target.

## Detailed Description of the Issue

**Jira:** [ROSAENG-61412](https://issues.redhat.com/browse/ROSAENG-61412)

The `e2e-rosa-non-sts-upgrade-y-stream` CI job fails persistently with:

> Expected at least one upgrade version to be available

This occurs because the test uses a hard `Expect` assertion that fails the test immediately when `rosa list upgrade` returns no available versions. In contrast, other upgrade tests in the same file (e.g., HCP and STS Classic paths) already use graceful `Skip()` when no upgrade version is found.

The root cause is environmental: the non-STS cluster version may temporarily have no y-stream upgrade target available in the current OCP release stream. The test should handle this gracefully rather than marking the CI job as failed.

## Type of Change

- fix - resolves an incorrect behavior or bug.

## Previous Behavior

Tests `id:37499`, `id:57094`, and `id:38829` used hard `Expect` assertions that failed the entire test when no upgrade versions were returned by `rosa list upgrade`. This caused the CI job to report a failure for an environmental condition rather than a code regression.

## Behavior After This Change

The tests now use `Skip()` when no upgrade versions are available, matching the pattern already used by the HCP and STS Classic upgrade tests in the same file (lines 485-486, 507-508, 640-641).

## Testing

- `make fmt-check` - passed
- `make lint` - passed (0 issues)
- `make test` - passed
- `make rosa` - passed (binary builds successfully)
- Pre-push checks - all 5/5 passed

[ROSAENG-61412]: https://redhat.atlassian.net/browse/ROSAENG-61412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved an end-to-end upgrade validation test to skip gracefully when no upgrade versions are available, instead of failing the run.  
  * Uses conditional skipping with clearer, case-specific messaging to reduce false failures in environments with temporarily unavailable upgrade options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->