### PR TITLE
ROSAENG-61414 | ci: enforce Exclude label in CI label filter

### DIFF
--- a/tests/prow_ci.sh
+++ b/tests/prow_ci.sh
@@ -151,7 +151,11 @@ generate_label_filter_switch () {
     label_filter="$label_filter&&$2" 
     echo "[CI] Got IMPORTANCE specified to $2"
   fi
-  LABEL_FILTER_SWITCH="--ginkgo.label-filter '${label_filter}'"
+  if [ -z "$label_filter" ]; then
+    LABEL_FILTER_SWITCH="--ginkgo.label-filter '!Exclude'"
+  else
+    LABEL_FILTER_SWITCH="--ginkgo.label-filter '${label_filter}&&!Exclude'"
+  fi
 }
 
 # generate_junit is used to generate junit file path


### PR DESCRIPTION
## PR Summary

Fix the CI label filter to respect the `Exclude` Ginkgo label so that excluded tests (like `id:57408` -- classic managed policies) are never selected by CI jobs.

## Detailed Description of the Issue

The `generate_label_filter_switch` function in `tests/prow_ci.sh` builds the `--ginkgo.label-filter` expression from the job's `TEST_LABEL_FILTER` and `IMPORTANCE` parameters. However, it never appended `&&!Exclude` to the expression. This meant any test carrying `labels.Exclude` was still matched by the CI filter as long as the test's other labels (like `Critical` and `Runtime.OCMResources`) satisfied the expression.

Test `id:57408` ("create/delete classic account roles with managed policies") has been marked with `labels.Exclude` because classic managed policies were never fully implemented and are planned for removal. Despite the label, CI continued to select and run this test, which failed because the feature it tests is non-functional in production.

## Related Issues and PRs

- Jira: [ROSAENG-61414](https://issues.redhat.com/browse/ROSAENG-61414)
- Also fixes failures for 3 other tests carrying `labels.Exclude`:
  - `id:68172` (additional security groups, excluded until day1 refactor)
  - `id:64040` (windows certificates expiration)
  - `id:73161` / `id:74656` (delete protection, excluded until bug resolved)

## Type of Change

- [x] ci - changes CI pipelines, jobs, or automation workflows.

## Previous Behavior

`generate_label_filter_switch` produced a filter like `--ginkgo.label-filter 'OCMResources&&(Critical||High)'`. A test with labels `[Critical, OCMResources, Exclude]` still matched because `Exclude` was never negated.

## Behavior After This Change

The function now appends `&&!Exclude` to every generated filter expression: `--ginkgo.label-filter 'OCMResources&&(Critical||High)&&!Exclude'`. When no filter is provided, it defaults to `--ginkgo.label-filter '!Exclude'`. Any test with the `Exclude` label is now skipped regardless of the CI job's own filter parameters.

## How to Test (Step-by-Step)

### Preconditions
- A CI job that runs the `rosa-ocm-resources` profile (or any profile that would pick up `id:57408`)

### Test Steps
1. Run the CI job with this change
2. Check the Ginkgo output for test `id:57408`

### Expected Results
- Test `id:57408` should appear as "SKIPPED" (filtered out by label), not "FAILED"

## Breaking Changes

- [x] No breaking changes

## Developer Verification Checklist

- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [x] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

[ROSAENG-61414]: https://redhat.atlassian.net/browse/ROSAENG-61414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test filtering so empty filters now correctly exclude blocked tests, and existing filters automatically include the exclusion rule.
  * Prevented invalid or less-accurate test selection when no label filter is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->