### PR TITLE
ROSAENG-61412 | fix: align y-stream upgrade tests with channel flow

### DIFF
--- a/tests/e2e/test_rosacli_upgrade.go
+++ b/tests/e2e/test_rosacli_upgrade.go
@@ -21,6 +21,31 @@ import (
 	"github.com/openshift/rosa/tests/utils/log"
 )
 
+const (
+	yStreamUpgradeWaitInterval = 10 * time.Second
+	yStreamUpgradeWaitTimeout  = 3 * time.Minute
+)
+
+func prepareYStreamUpgradeVersion(
+	clusterID string,
+	channelGroup string,
+	clusterService rosacli.ClusterService,
+	upgradeService rosacli.UpgradeService,
+) (string, error) {
+	preparation, err := clusterService.PrepareClusterForYStreamUpgrade(clusterID, channelGroup)
+	if err != nil {
+		return "", err
+	}
+
+	upgradingVersion, _, err := upgradeService.WaitForAvailableYStreamUpgrade(
+		clusterID,
+		preparation,
+		yStreamUpgradeWaitInterval,
+		yStreamUpgradeWaitTimeout,
+	)
+	return upgradingVersion, err
+}
+
 var _ = Describe("Cluster Upgrade testing",
 	labels.Feature.Policy,
 	func() {
@@ -221,42 +246,14 @@ var _ = Describe("Cluster Upgrade testing",
 				}
 
 			}
-			By("Check and change channel before upgrade")
-			clusterService := rosaClient.Cluster
-			output, err = clusterService.DescribeCluster(clusterID)
-			Expect(err).To(BeNil())
-			CD, err := clusterService.ReflectClusterDescription(output)
-			Expect(err).To(BeNil())
-			currentChannel := CD.Channel
-			if currentChannel != "" {
-				// Before channel feature enabled on Prod, channel field is empty on prod env
-				channelName, _, minorC, _ := helper.ParseChannel(currentChannel)
-				majorV, minorV, _, _ := helper.ParseVersion(clusterVersion)
-
-				if minorC <= minorV {
-					By("Change channel")
-					updatingChannel := fmt.Sprintf("%s-%d.%d", channelName, majorV, minorV+1)
-					output, err := clusterService.EditCluster(clusterID,
-						"--channel", updatingChannel,
-						"-y",
-					)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(output.String()).Should(ContainSubstring("Updated cluster"))
-				}
-			}
-
-			By("Find updating version")
-			versionService := rosaClient.Version
-			clusterVersionList, err := versionService.ListAndReflectVersions("stable", false)
+			By("Prepare cluster for y-stream upgrade target discovery")
+			upgradingVersion, err := prepareYStreamUpgradeVersion(
+				clusterID,
+				profile.ChannelGroup,
+				clusterService,
+				upgradeService,
+			)
 			Expect(err).ToNot(HaveOccurred())
-
-			versions, err := clusterVersionList.FindYStreamUpgradeVersions(clusterVersion)
-			Expect(err).To(BeNil())
-			Expect(len(versions)).
-				To(
-					BeNumerically(">", 0),
-					fmt.Sprintf("No available upgrade version is found for the cluster version %s", clusterVersion))
-			upgradingVersion := versions[0]
 
 			By("Upgrade roles in auto mode")
 			ocmResourceService := rosaClient.OCMResource
@@ -349,24 +346,19 @@ var _ = Describe("Cluster Upgrade testing",
 				Skip("Skip this case as the version defined in profile is not y-1 for non-sts cluster upgrading testing")
 			}
 
-			By("Check the cluster upgrade version to decide if skip this case")
-
-			output, err := upgradeService.ListUpgrades("-c", clusterID)
-			Expect(err).To(BeNil())
-			upgradeVersionList, err := upgradeService.ReflectUpgradeVersionList(output)
-			Expect(err).To(BeNil())
-			Expect(len(upgradeVersionList.UpgradeVersions)).To(BeNumerically(">", 0),
-				"Expected at least one upgrade version to be available")
-			upgradingVersion := upgradeVersionList.UpgradeVersions[0].Version
-
-			if upgradingVersion == "" {
-				Skip("Skip this case as the cluster is being upgraded.")
-			}
+			By("Prepare cluster for y-stream upgrade target discovery")
+			upgradingVersion, err := prepareYStreamUpgradeVersion(
+				clusterID,
+				profile.ChannelGroup,
+				clusterService,
+				upgradeService,
+			)
+			Expect(err).ToNot(HaveOccurred())
 
 			By("Upgrade cluster")
 			scheduledDate := time.Now().Format("2006-01-02")
 			scheduledTime := time.Now().Add(200 * time.Minute).UTC().Format("15:04")
-			output, err = upgradeService.Upgrade(
+			output, err := upgradeService.Upgrade(
 				"-c", clusterID,
 				"--version", upgradingVersion,
 				"--schedule-date", scheduledDate,
@@ -384,21 +376,17 @@ var _ = Describe("Cluster Upgrade testing",
 		It("to upgrade shared VPC cluster across Y stream - [id:67168]", labels.High, labels.Runtime.Upgrade, func() {
 			By("Check the cluster version and whether it is a shared VPC cluster to decide if skip this case")
 			if profile.Version == constants.YStreamPreviousVersion && profile.ClusterConfig.SharedVPC {
-				By("Check the cluster upgrade version to decide if skip this case")
-				output, err := upgradeService.ListUpgrades("-c", clusterID)
-				Expect(err).To(BeNil())
-				upgradeVersionList, err := upgradeService.ReflectUpgradeVersionList(output)
-				Expect(err).To(BeNil())
-				Expect(len(upgradeVersionList.UpgradeVersions)).To(BeNumerically(">", 0),
-					"Expected at least one upgrade version to be available")
-				upgradingVersion := upgradeVersionList.UpgradeVersions[0].Version
-
-				if upgradingVersion == "" {
-					Skip("Skip this case as no available upgrade version.")
-				}
+				By("Prepare cluster for y-stream upgrade target discovery")
+				upgradingVersion, err := prepareYStreamUpgradeVersion(
+					clusterID,
+					profile.ChannelGroup,
+					clusterService,
+					upgradeService,
+				)
+				Expect(err).ToNot(HaveOccurred())
 
 				By("Update cluster with --dry-run")
-				output, err = upgradeService.Upgrade(
+				output, err := upgradeService.Upgrade(
 					"-c", clusterID,
 					"--version", upgradingVersion,
 					"--mode", "auto",
@@ -446,50 +434,22 @@ var _ = Describe("Cluster Upgrade testing",
 				Expect(err).To(BeNil())
 				resourcesHandler := clusterHandler.GetResourcesHandler()
 
-				By("Check and change channel before upgrade")
-				jsonData, err := clusterService.GetJSONClusterDescription(clusterID)
-				Expect(err).To(BeNil())
-				clusterVersion := jsonData.DigString("version", "raw_id")
-				clusterService := rosaClient.Cluster
-				output, err := clusterService.DescribeCluster(clusterID)
-				Expect(err).To(BeNil())
-				CD, err := clusterService.ReflectClusterDescription(output)
-				Expect(err).To(BeNil())
-				currentChannel := CD.Channel
-				if currentChannel != "" {
-					// Before channel feature enabled on Prod, channel field is empty on prod env
-					channelName, _, minorC, _ := helper.ParseChannel(currentChannel)
-					majorV, minorV, _, _ := helper.ParseVersion(clusterVersion)
-
-					if minorC <= minorV {
-						By("Change channel")
-						updatingChannel := fmt.Sprintf("%s-%d.%d", channelName, majorV, minorV+1)
-						output, err := clusterService.EditCluster(clusterID,
-							"--channel", updatingChannel,
-							"-y",
-						)
-						Expect(err).ToNot(HaveOccurred())
-						Expect(output.String()).Should(ContainSubstring("Updated cluster"))
-					}
-				}
+				By("Prepare cluster for y-stream upgrade target discovery")
+				upgradingVersion, err := prepareYStreamUpgradeVersion(
+					clusterID,
+					profile.ChannelGroup,
+					clusterService,
+					upgradeService,
+				)
+				Expect(err).ToNot(HaveOccurred())
 
 				By("Upgrade wide AMI roles in auto mode")
-				clusterVersionList, err := versionService.ListAndReflectVersions(profile.ChannelGroup, false)
-				Expect(err).To(BeNil())
 
 				if profile.ClusterConfig.HCP {
-					By("Find HCP cluster upgrade version")
-					hcpUpgradingVersion, _, err := clusterVersionList.FindUpperYStreamVersion(
-						profile.ChannelGroup, clusterVersion)
-					Expect(err).To(BeNil())
-					if hcpUpgradingVersion == "" {
-						Skip("Skip this case as no version available for upgrade")
-					}
-
 					By("upgrade HCP cluster wide AMI roles in auto mode")
 					output1, err := ocmResourceService.UpgradeRoles(
 						"-c", clusterID,
-						"--cluster-version", hcpUpgradingVersion,
+						"--cluster-version", upgradingVersion,
 						"--mode", "auto",
 						"-y",
 					)
@@ -499,14 +459,7 @@ var _ = Describe("Cluster Upgrade testing",
 					Expect(output1.String()).To(ContainSubstring("Cluster '%s' operator roles have attached managed "+
 						"policies. An upgrade isn't needed", resourcesHandler.GetOperatorRolesPrefix()))
 				} else {
-					By("Find STS Classic cluster upgrade version")
-					classicUpgradingVersion, classicUpgradingMajorVersion, err := clusterVersionList.FindUpperYStreamVersion(
-						profile.ChannelGroup, clusterVersion)
-					Expect(err).To(BeNil())
-
-					if classicUpgradingVersion == "" || classicUpgradingMajorVersion == "" {
-						Skip("Skip this case as no version available for upgrade")
-					}
+					classicUpgradingMajorVersion := helper.SplitMajorVersion(upgradingVersion)
 
 					By("get account roles and operator roles from cluster description")
 					description, err := clusterService.DescribeClusterAndReflect(clusterID)
@@ -540,7 +493,7 @@ var _ = Describe("Cluster Upgrade testing",
 					By("upgrade STS Classic cluster wide AMI roles in auto mode")
 					output, err := ocmResourceService.UpgradeRoles(
 						"-c", clusterID,
-						"--cluster-version", classicUpgradingVersion,
+						"--cluster-version", upgradingVersion,
 						"--mode", "auto",
 						"-y",
 					)
@@ -581,49 +534,21 @@ var _ = Describe("Cluster Upgrade testing",
 				Expect(err).To(BeNil())
 				resourcesHandler := clusterHandler.GetResourcesHandler()
 
-				By("Check and change channel before upgrade")
-				jsonData, err := clusterService.GetJSONClusterDescription(clusterID)
-				Expect(err).To(BeNil())
-				clusterVersion := jsonData.DigString("version", "raw_id")
-				clusterService := rosaClient.Cluster
-				output, err := clusterService.DescribeCluster(clusterID)
-				Expect(err).To(BeNil())
-				CD, err := clusterService.ReflectClusterDescription(output)
-				Expect(err).To(BeNil())
-				currentChannel := CD.Channel
-				if currentChannel != "" {
-					// Before channel feature enabled on Prod, channel field is empty on prod env
-					channelName, _, minorC, _ := helper.ParseChannel(currentChannel)
-					majorV, minorV, _, _ := helper.ParseVersion(clusterVersion)
-
-					if minorC <= minorV {
-						By("Change channel")
-						updatingChannel := fmt.Sprintf("%s-%d.%d", channelName, majorV, minorV+1)
-						output, err := clusterService.EditCluster(clusterID,
-							"--channel", updatingChannel,
-							"-y",
-						)
-						Expect(err).ToNot(HaveOccurred())
-						Expect(output.String()).Should(ContainSubstring("Updated cluster"))
-					}
-				}
+				By("Prepare cluster for y-stream upgrade target discovery")
+				upgradingVersion, err := prepareYStreamUpgradeVersion(
+					clusterID,
+					profile.ChannelGroup,
+					clusterService,
+					upgradeService,
+				)
+				Expect(err).ToNot(HaveOccurred())
 
 				By("Upgrade wide AMI roles in manual mode")
-				clusterVersionList, err := versionService.ListAndReflectVersions(profile.ChannelGroup, false)
-				Expect(err).To(BeNil())
 				if profile.ClusterConfig.HCP {
-					By("Find HCP cluster upgrade version")
-					hcpUpgradingVersion, _, err := clusterVersionList.FindUpperYStreamVersion(profile.ChannelGroup,
-						clusterVersion)
-					Expect(err).To(BeNil())
-					if hcpUpgradingVersion == "" {
-						Skip("Skip this case as no version available for upgrade")
-					}
-
 					By("upgrade HCP cluster wide AMI roles in manual mode")
 					output1, err := ocmResourceService.UpgradeRoles(
 						"-c", clusterID,
-						"--cluster-version", hcpUpgradingVersion,
+						"--cluster-version", upgradingVersion,
 						"--mode", "manual",
 						"-y",
 					)
@@ -633,18 +558,10 @@ var _ = Describe("Cluster Upgrade testing",
 					Expect(output1.String()).To(ContainSubstring("Cluster '%s' operator roles have attached managed "+
 						"policies. An upgrade isn't needed", resourcesHandler.GetOperatorRolesPrefix()))
 				} else {
-					By("Find STS Classic cluster upgrade version")
-					classicUpgradingVersion, _, err := clusterVersionList.FindUpperYStreamVersion(
-						profile.ChannelGroup, clusterVersion)
-					Expect(err).To(BeNil())
-					if classicUpgradingVersion == "" {
-						Skip("Skip this case as no version available for upgrade")
-					}
-
 					By("upgrade STS Classic cluster wide AMI roles in manual mode")
 					output2, err := ocmResourceService.UpgradeRoles(
 						"-c", clusterID,
-						"--cluster-version", classicUpgradingVersion,
+						"--cluster-version", upgradingVersion,
 						"--mode", "manual",
 						"-y",
 					)
@@ -738,6 +655,7 @@ var _ = Describe("Describe/List rosa upgrade",
 		defer GinkgoRecover()
 		var (
 			rosaClient     *rosacli.Client
+			clusterService rosacli.ClusterService
 			upgradeService rosacli.UpgradeService
 			clusterID      string
 			clusterConfig  *config.ClusterConfig
@@ -751,6 +669,7 @@ var _ = Describe("Describe/List rosa upgrade",
 
 			By("Init the client")
 			rosaClient = rosacli.NewClient()
+			clusterService = rosaClient.Cluster
 			upgradeService = rosaClient.Upgrade
 
 			By("Load the profile")
@@ -791,49 +710,24 @@ var _ = Describe("Describe/List rosa upgrade",
 				}
 
 				if clusterConfig.Version.VersionRequirement == constants.YStreamPreviousVersion {
-					By("Check and change channel before upgrade")
-					clusterService := rosaClient.Cluster
-					output, err = clusterService.DescribeCluster(clusterID)
-					Expect(err).To(BeNil())
-					CD, err := clusterService.ReflectClusterDescription(output)
-					Expect(err).To(BeNil())
-					currentChannel := CD.Channel
-					clusterVersion := clusterConfig.Version.RawID
-					if currentChannel != "" {
-						// Before channel feature enabled on Prod, channel field is empty on prod env
-						channelName, _, minorC, _ := helper.ParseChannel(currentChannel)
-						majorV, minorV, _, _ := helper.ParseVersion(clusterVersion)
-
-						if minorC <= minorV {
-							By("Change channel")
-							updatingChannel := fmt.Sprintf("%s-%d.%d", channelName, majorV, minorV+1)
-							output, err := clusterService.EditCluster(clusterID,
-								"--channel", updatingChannel,
-								"-y",
-							)
-							Expect(err).ToNot(HaveOccurred())
-							Expect(output.String()).Should(ContainSubstring("Updated cluster"))
-						}
-					}
+					By("Prepare cluster for y-stream upgrade target discovery")
+					upgradingVersion, err := prepareYStreamUpgradeVersion(
+						clusterID,
+						clusterConfig.Version.ChannelGroup,
+						clusterService,
+						upgradeService,
+					)
+					Expect(err).ToNot(HaveOccurred())
 
 					By("Upgrade cluster and check list/describe upgrade")
 					scheduledDate := time.Now().Format("2006-01-02")
 					scheduledTime := time.Now().Add(20 * time.Minute).UTC().Format("15:04")
 
-					By("Find upper Y stream version")
-					output, err := upgradeService.ListUpgrades("-c", clusterID)
-					Expect(err).To(BeNil())
-					upgradeVersionList, err := upgradeService.ReflectUpgradeVersionList(output)
-					Expect(err).To(BeNil())
-					Expect(len(upgradeVersionList.UpgradeVersions)).To(BeNumerically(">", 0),
-						"Expected at least one upgrade version to be available")
-					upgradingVersion := upgradeVersionList.UpgradeVersions[0].Version
-
 					By("Upgrade cluster")
 					if clusterConfig.Sts {
 
 						By("Update cluster with --dry-run")
-						output, err = upgradeService.Upgrade(
+						output, err := upgradeService.Upgrade(
 							"-c", clusterID,
 							"--version", upgradingVersion,
 							"--mode", "auto",
@@ -893,17 +787,17 @@ var _ = Describe("Describe/List rosa upgrade",
 						"testing")
 				}
 
-				By("Find upper Y stream version")
-				output, err := upgradeService.ListUpgrades("-c", clusterID)
-				Expect(err).To(BeNil())
-				upgradeVersionList, err := upgradeService.ReflectUpgradeVersionList(output)
-				Expect(err).To(BeNil())
-				Expect(len(upgradeVersionList.UpgradeVersions)).To(BeNumerically(">", 0),
-					"Expected at least one upgrade version to be available")
-				upgradingVersion := upgradeVersionList.UpgradeVersions[0].Version
+				By("Prepare cluster for y-stream upgrade target discovery")
+				upgradingVersion, err := prepareYStreamUpgradeVersion(
+					clusterID,
+					clusterConfig.Version.ChannelGroup,
+					clusterService,
+					upgradeService,
+				)
+				Expect(err).ToNot(HaveOccurred())
 
 				By("Check the help message of 'rosa describe upgrade -h'")
-				output, err = upgradeService.ListUpgrades("-c", clusterID, "-h")
+				output, err := upgradeService.ListUpgrades("-c", clusterID, "-h")
 				Expect(err).To(BeNil())
 				Expect(output.String()).To(ContainSubstring("rosa list upgrades [flags]"))
 				Expect(output.String()).To(ContainSubstring("-c, --cluster"))
@@ -1242,6 +1136,7 @@ var _ = Describe("Create cluster upgrade policy validation", labels.Feature.Clus
 	var (
 		clusterID      string
 		rosaClient     *rosacli.Client
+		clusterService rosacli.ClusterService
 		upgradeService rosacli.UpgradeService
 		profile        *handler.Profile
 	)
@@ -1253,6 +1148,7 @@ var _ = Describe("Create cluster upgrade policy validation", labels.Feature.Clus
 
 		By("Init the client")
 		rosaClient = rosacli.NewClient()
+		clusterService = rosaClient.Cluster
 		upgradeService = rosaClient.Upgrade
 
 		By("Load the profile")
@@ -1281,14 +1177,14 @@ var _ = Describe("Create cluster upgrade policy validation", labels.Feature.Clus
 			scheduledDate := time.Now().Format("2006-01-02")
 			scheduledTime := time.Now().Add(50 * time.Minute).UTC().Format("15:04")
 
-			By("Find upper Y stream version")
-			output, err := upgradeService.ListUpgrades("-c", clusterID)
-			Expect(err).To(BeNil())
-			upgradeVersionList, err := upgradeService.ReflectUpgradeVersionList(output)
-			Expect(err).To(BeNil())
-			Expect(len(upgradeVersionList.UpgradeVersions)).To(BeNumerically(">", 0),
-				"Expected at least one upgrade version to be available")
-			upgradingVersion := upgradeVersionList.UpgradeVersions[0].Version
+			By("Prepare cluster for y-stream upgrade target discovery")
+			upgradingVersion, err := prepareYStreamUpgradeVersion(
+				clusterID,
+				profile.ChannelGroup,
+				clusterService,
+				upgradeService,
+			)
+			Expect(err).ToNot(HaveOccurred())
 
 			if profile.ClusterConfig.STS {
 				By("Upgrade cluster with invalid version")

--- a/tests/utils/exec/rosacli/cluster_service.go
+++ b/tests/utils/exec/rosacli/cluster_service.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/openshift/rosa/tests/utils/config"
 	"github.com/openshift/rosa/tests/utils/constants"
+	"github.com/openshift/rosa/tests/utils/helper"
 	"github.com/openshift/rosa/tests/utils/log"
 )
 
@@ -49,10 +50,21 @@ type ClusterService interface {
 	WaitForClusterPassUninstalled(clusterID string, interval int, timeoutMin int) error
 	WaitForClusterPassWaiting(clusterID string, interval int, timeoutMin int) error
 	GetClusterName(clusterID string) (clusterName string, err error)
+	// PrepareClusterForYStreamUpgrade ensures the cluster points at the next-minor
+	// channel and returns the version/channel context needed for y-stream tests.
+	PrepareClusterForYStreamUpgrade(clusterID string, channelGroup string) (*YStreamUpgradePreparation, error)
 }
 
 type clusterService struct {
 	ResourcesService
+}
+
+// YStreamUpgradePreparation captures the cluster version and channel state used
+// to prepare and diagnose y-stream upgrade discovery in tests.
+type YStreamUpgradePreparation struct {
+	ClusterVersion string
+	CurrentChannel string
+	DesiredChannel string
 }
 
 func NewClusterService(client *Client) ClusterService {
@@ -370,6 +382,87 @@ func (c *clusterService) GetClusterName(clusterID string) (clusterName string, e
 	var clusterConfig *config.ClusterConfig
 	clusterConfig, err = config.ParseClusterProfile()
 	return clusterConfig.Name, err
+}
+
+func computeNextMinorChannel(channelGroup string, clusterVersion string) (string, error) {
+	group := strings.TrimSpace(channelGroup)
+	if group == "" {
+		return "", fmt.Errorf("channel group is required to compute the next-minor channel")
+	}
+
+	major, minor, _, err := helper.ParseVersion(clusterVersion)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse cluster version %q: %w", clusterVersion, err)
+	}
+
+	return fmt.Sprintf("%s-%d.%d", group, major, minor+1), nil
+}
+
+func prepareYStreamUpgradeChannel(
+	clusterID string,
+	currentChannel string,
+	clusterVersion string,
+	channelGroup string,
+	editCluster func(clusterID string, flags ...string) (bytes.Buffer, error),
+) (*YStreamUpgradePreparation, error) {
+	preparation := &YStreamUpgradePreparation{
+		ClusterVersion: clusterVersion,
+		CurrentChannel: strings.TrimSpace(currentChannel),
+	}
+
+	desiredChannel, err := computeNextMinorChannel(channelGroup, clusterVersion)
+	if err != nil {
+		return nil, err
+	}
+	preparation.DesiredChannel = desiredChannel
+
+	if preparation.CurrentChannel == desiredChannel {
+		return preparation, nil
+	}
+	if editCluster == nil {
+		return nil, fmt.Errorf("edit cluster function is required to set desired channel %q", desiredChannel)
+	}
+
+	if _, err := editCluster(clusterID, "--channel", desiredChannel, "-y"); err != nil {
+		return nil, fmt.Errorf(
+			"failed to update cluster %s channel from %q to %q: %w",
+			clusterID,
+			preparation.CurrentChannel,
+			desiredChannel,
+			err,
+		)
+	}
+
+	preparation.CurrentChannel = desiredChannel
+	return preparation, nil
+}
+
+func (c *clusterService) PrepareClusterForYStreamUpgrade(
+	clusterID string,
+	channelGroup string,
+) (*YStreamUpgradePreparation, error) {
+	jsonData, err := c.GetJSONClusterDescription(clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	clusterVersion := strings.TrimSpace(jsonData.DigString("version", "raw_id"))
+	if clusterVersion == "" {
+		return nil, fmt.Errorf("cluster %s returned an empty raw version while preparing y-stream upgrade", clusterID)
+	}
+
+	clusterDescription, err := c.DescribeClusterAndReflect(clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	return prepareYStreamUpgradeChannel(
+		clusterID,
+		clusterDescription.Channel,
+		clusterVersion,
+		channelGroup,
+		c.EditCluster,
+	)
 }
 
 func (c *clusterService) GetJSONClusterDescription(clusterID string) (*jsonData, error) {

--- a/tests/utils/exec/rosacli/cluster_service_test.go
+++ b/tests/utils/exec/rosacli/cluster_service_test.go
@@ -1,6 +1,7 @@
 package rosacli
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,8 +14,101 @@ import (
 	"github.com/openshift/rosa/tests/utils/constants"
 )
 
+const testClusterID = "1234abcd"
+
+var _ = Describe("Y-stream channel helpers", func() {
+	It("computes the next-minor channel from the profile channel group", func() {
+		channel, err := computeNextMinorChannel("stable", "4.19.12")
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(channel).To(Equal("stable-4.20"))
+	})
+
+	It("fails when the cluster version cannot be parsed", func() {
+		_, err := computeNextMinorChannel("stable", "y-1")
+
+		Expect(err).To(MatchError(ContainSubstring("failed to parse cluster version")))
+	})
+
+	It("fails when the channel group is empty", func() {
+		_, err := computeNextMinorChannel("", "4.19.12")
+
+		Expect(err).To(MatchError(ContainSubstring("channel group is required")))
+	})
+
+	It("updates the channel when the current channel is empty", func() {
+		var capturedClusterID string
+		var capturedFlags []string
+
+		preparation, err := prepareYStreamUpgradeChannel(
+			testClusterID,
+			"",
+			"4.19.12",
+			"stable",
+			func(clusterID string, flags ...string) (bytes.Buffer, error) {
+				capturedClusterID = clusterID
+				capturedFlags = append([]string{}, flags...)
+				return bytes.Buffer{}, nil
+			},
+		)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(preparation.ClusterVersion).To(Equal("4.19.12"))
+		Expect(preparation.CurrentChannel).To(Equal("stable-4.20"))
+		Expect(preparation.DesiredChannel).To(Equal("stable-4.20"))
+		Expect(capturedClusterID).To(Equal(testClusterID))
+		Expect(capturedFlags).To(Equal([]string{"--channel", "stable-4.20", "-y"}))
+	})
+
+	It("does not update the channel when the desired channel is already set", func() {
+		edited := false
+
+		preparation, err := prepareYStreamUpgradeChannel(
+			testClusterID,
+			"stable-4.20",
+			"4.19.12",
+			"stable",
+			func(clusterID string, flags ...string) (bytes.Buffer, error) {
+				edited = true
+				return bytes.Buffer{}, nil
+			},
+		)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(preparation.DesiredChannel).To(Equal("stable-4.20"))
+		Expect(edited).To(BeFalse())
+	})
+
+	It("fails when it needs to edit but no edit function is provided", func() {
+		_, err := prepareYStreamUpgradeChannel(
+			testClusterID,
+			"",
+			"4.19.12",
+			"stable",
+			nil,
+		)
+
+		Expect(err).To(MatchError(ContainSubstring("edit cluster function is required")))
+	})
+
+	It("wraps the editCluster error when channel update fails", func() {
+		_, err := prepareYStreamUpgradeChannel(
+			testClusterID,
+			"stable-4.19",
+			"4.19.12",
+			"stable",
+			func(clusterID string, flags ...string) (bytes.Buffer, error) {
+				return bytes.Buffer{}, fmt.Errorf("boom")
+			},
+		)
+
+		Expect(err).To(MatchError(ContainSubstring("failed to update cluster 1234abcd channel")))
+		Expect(err).To(MatchError(ContainSubstring("boom")))
+	})
+})
+
 var _ = Describe("Cluster wait helpers", func() {
-	const clusterID = "1234abcd"
+	const clusterID = testClusterID
 
 	It("fails fast when waiting without a cluster ID", func() {
 		service := &clusterService{}

--- a/tests/utils/exec/rosacli/upgrade_service.go
+++ b/tests/utils/exec/rosacli/upgrade_service.go
@@ -2,12 +2,22 @@ package rosacli
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
 
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/openshift/rosa/tests/utils/helper"
 	"github.com/openshift/rosa/tests/utils/log"
+)
+
+const (
+	defaultYStreamPollInterval = time.Second
+	defaultYStreamPollTimeout  = time.Second
 )
 
 type UpgradeService interface {
@@ -21,6 +31,12 @@ type UpgradeService interface {
 	Upgrade(flags ...string) (bytes.Buffer, error)
 
 	WaitForUpgradeToState(clusterID string, state string, timeout int) error
+	WaitForAvailableYStreamUpgrade(
+		clusterID string,
+		preparation *YStreamUpgradePreparation,
+		waitInterval time.Duration,
+		waitTimeout time.Duration,
+	) (string, UpgradeVersionList, error)
 }
 
 type upgradeService struct {
@@ -57,6 +73,39 @@ type UpgradeVersionList struct {
 	UpgradeVersions []UpgradeVersion `json:"UpgradeVersions,omitempty"`
 }
 
+func (u UpgradeVersionList) FindNextMinorUpgrade(clusterVersion string) (string, error) {
+	_, clusterMinor, _, err := helper.ParseVersion(clusterVersion)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse cluster version %q: %w", clusterVersion, err)
+	}
+
+	var fallback string
+	for _, upgradeVersion := range u.UpgradeVersions {
+		version := strings.TrimSpace(upgradeVersion.Version)
+		if version == "" {
+			continue
+		}
+
+		_, upgradeMinor, _, err := helper.ParseVersion(version)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse upgrade version %q: %w", version, err)
+		}
+
+		if upgradeMinor != clusterMinor+1 {
+			continue
+		}
+
+		if strings.Contains(strings.ToLower(upgradeVersion.Notes), "recommended") {
+			return version, nil
+		}
+		if fallback == "" {
+			fallback = version
+		}
+	}
+
+	return fallback, nil
+}
+
 func (u *upgradeService) ListUpgrades(flags ...string) (bytes.Buffer, error) {
 	describe := u.client.Runner.
 		Cmd("list", "upgrade").
@@ -64,7 +113,9 @@ func (u *upgradeService) ListUpgrades(flags ...string) (bytes.Buffer, error) {
 	return describe.Run()
 }
 
-func (u *upgradeService) ReflectUpgradeVersionList(result bytes.Buffer) (upgradeVersionList UpgradeVersionList, err error) {
+func (u *upgradeService) ReflectUpgradeVersionList(
+	result bytes.Buffer,
+) (upgradeVersionList UpgradeVersionList, err error) {
 	upgradeVersionList = UpgradeVersionList{}
 	theMap := u.client.Parser.TableData.Input(result).Parse().Output()
 	for _, upgradeVersionItem := range theMap {
@@ -125,6 +176,114 @@ func (u *upgradeService) Upgrade(flags ...string) (bytes.Buffer, error) {
 		Cmd("upgrade", "cluster").
 		CmdFlags(flags...)
 	return upgrade.Run()
+}
+
+func waitForAvailableYStreamUpgrade(
+	clusterID string,
+	preparation *YStreamUpgradePreparation,
+	waitInterval time.Duration,
+	waitTimeout time.Duration,
+	fetch func() (bytes.Buffer, UpgradeVersionList, error),
+) (string, UpgradeVersionList, error) {
+	if strings.TrimSpace(clusterID) == "" {
+		return "", UpgradeVersionList{}, fmt.Errorf(
+			"cluster ID is required when waiting for y-stream upgrade targets")
+	}
+	if preparation == nil {
+		return "", UpgradeVersionList{}, fmt.Errorf(
+			"y-stream upgrade preparation is required for cluster %s", clusterID)
+	}
+
+	if waitInterval <= 0 {
+		waitInterval = defaultYStreamPollInterval
+	}
+	if waitTimeout <= 0 {
+		waitTimeout = defaultYStreamPollTimeout
+	}
+
+	var lastOutput bytes.Buffer
+	var lastList UpgradeVersionList
+	var lastErr error
+	var result string
+
+	ctx, cancel := context.WithTimeout(context.Background(), waitTimeout)
+	defer cancel()
+
+	pollErr := wait.PollUntilContextCancel(ctx, waitInterval, true,
+		func(ctx context.Context) (bool, error) {
+			output, upgradeVersionList, err := fetch()
+			lastOutput = output
+			lastList = upgradeVersionList
+			if err != nil {
+				lastErr = err
+				return false, nil
+			}
+			upgradingVersion, findErr := upgradeVersionList.FindNextMinorUpgrade(
+				preparation.ClusterVersion)
+			if findErr != nil {
+				lastErr = findErr
+				return false, nil
+			}
+			lastErr = nil
+			result = upgradingVersion
+			return upgradingVersion != "", nil
+		},
+	)
+
+	if pollErr == nil {
+		return result, lastList, nil
+	}
+
+	timeoutErr := fmt.Errorf(
+		"timeout after %s waiting for y-stream upgrade target for cluster %s "+
+			"(version=%s, current channel=%q, desired channel=%q)",
+		waitTimeout,
+		clusterID,
+		preparation.ClusterVersion,
+		preparation.CurrentChannel,
+		preparation.DesiredChannel,
+	)
+	if lastErr != nil {
+		return "", lastList, fmt.Errorf(
+			"%w: last error: %v; last list output:\n%s",
+			timeoutErr,
+			lastErr,
+			lastOutput.String(),
+		)
+	}
+
+	return "", lastList, fmt.Errorf(
+		"%w: no next-minor upgrade target found; last list output:\n%s",
+		timeoutErr,
+		lastOutput.String(),
+	)
+}
+
+func (u *upgradeService) WaitForAvailableYStreamUpgrade(
+	clusterID string,
+	preparation *YStreamUpgradePreparation,
+	waitInterval time.Duration,
+	waitTimeout time.Duration,
+) (string, UpgradeVersionList, error) {
+	return waitForAvailableYStreamUpgrade(
+		clusterID,
+		preparation,
+		waitInterval,
+		waitTimeout,
+		func() (bytes.Buffer, UpgradeVersionList, error) {
+			output, err := u.ListUpgrades("-c", clusterID)
+			if err != nil {
+				return output, UpgradeVersionList{}, err
+			}
+
+			upgradeVersionList, err := u.ReflectUpgradeVersionList(output)
+			if err != nil {
+				return output, UpgradeVersionList{}, err
+			}
+
+			return output, upgradeVersionList, nil
+		},
+	)
 }
 
 func (u *upgradeService) CleanResources(clusterID string) (errors []error) {

--- a/tests/utils/exec/rosacli/upgrade_service_test.go
+++ b/tests/utils/exec/rosacli/upgrade_service_test.go
@@ -1,0 +1,211 @@
+package rosacli
+
+import (
+	"bytes"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Y-stream upgrade discovery helpers", func() {
+	It("selects the first next-minor upgrade from list output", func() {
+		upgradeVersionList := UpgradeVersionList{
+			UpgradeVersions: []UpgradeVersion{
+				{Version: "4.19.14"},
+				{Version: "4.19.17"},
+				{Version: "4.20.0"},
+				{Version: "4.20.3"},
+			},
+		}
+
+		upgradingVersion, err := upgradeVersionList.FindNextMinorUpgrade("4.19.12")
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(upgradingVersion).To(Equal("4.20.0"))
+	})
+
+	It("prefers the recommended entry among same-minor candidates", func() {
+		upgradeVersionList := UpgradeVersionList{
+			UpgradeVersions: []UpgradeVersion{
+				{Version: "4.20.0", Notes: ""},
+				{Version: "4.20.3", Notes: "recommended"},
+				{Version: "4.20.5", Notes: ""},
+			},
+		}
+
+		upgradingVersion, err := upgradeVersionList.FindNextMinorUpgrade("4.19.12")
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(upgradingVersion).To(Equal("4.20.3"))
+	})
+
+	It("falls back to first same-minor candidate when none is recommended", func() {
+		upgradeVersionList := UpgradeVersionList{
+			UpgradeVersions: []UpgradeVersion{
+				{Version: "4.19.14", Notes: ""},
+				{Version: "4.20.0", Notes: ""},
+				{Version: "4.20.3", Notes: ""},
+			},
+		}
+
+		upgradingVersion, err := upgradeVersionList.FindNextMinorUpgrade("4.19.12")
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(upgradingVersion).To(Equal("4.20.0"))
+	})
+
+	It("fails when the cluster version cannot be parsed", func() {
+		upgradeVersionList := UpgradeVersionList{
+			UpgradeVersions: []UpgradeVersion{{Version: "4.20.0"}},
+		}
+
+		_, err := upgradeVersionList.FindNextMinorUpgrade("y-1")
+
+		Expect(err).To(MatchError(ContainSubstring("failed to parse cluster version")))
+	})
+
+	It("fails when an upgrade version cannot be parsed", func() {
+		upgradeVersionList := UpgradeVersionList{
+			UpgradeVersions: []UpgradeVersion{{Version: "not-a-version"}},
+		}
+
+		_, err := upgradeVersionList.FindNextMinorUpgrade("4.19.12")
+
+		Expect(err).To(MatchError(ContainSubstring("failed to parse upgrade version")))
+	})
+
+	It("waits until a next-minor target appears", func() {
+		callCount := 0
+		preparation := &YStreamUpgradePreparation{
+			ClusterVersion: "4.19.12",
+			CurrentChannel: "stable-4.19",
+			DesiredChannel: "stable-4.20",
+		}
+
+		upgradingVersion, _, err := waitForAvailableYStreamUpgrade(
+			testClusterID,
+			preparation,
+			time.Nanosecond,
+			time.Millisecond,
+			func() (bytes.Buffer, UpgradeVersionList, error) {
+				callCount++
+				if callCount == 1 {
+					return *bytes.NewBufferString("VERSION\n4.19.14\n"), UpgradeVersionList{
+						UpgradeVersions: []UpgradeVersion{{Version: "4.19.14"}},
+					}, nil
+				}
+
+				return *bytes.NewBufferString("VERSION\n4.20.0\n"), UpgradeVersionList{
+					UpgradeVersions: []UpgradeVersion{{Version: "4.20.0"}},
+				}, nil
+			},
+		)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(upgradingVersion).To(Equal("4.20.0"))
+		Expect(callCount).To(Equal(2))
+	})
+
+	It("uses default poll values when interval and timeout are non-positive", func() {
+		callCount := 0
+		preparation := &YStreamUpgradePreparation{
+			ClusterVersion: "4.19.12",
+			CurrentChannel: "stable-4.19",
+			DesiredChannel: "stable-4.20",
+		}
+
+		upgradingVersion, _, err := waitForAvailableYStreamUpgrade(
+			testClusterID,
+			preparation,
+			0,
+			0,
+			func() (bytes.Buffer, UpgradeVersionList, error) {
+				callCount++
+				return *bytes.NewBufferString("VERSION\n4.20.0\n"), UpgradeVersionList{
+					UpgradeVersions: []UpgradeVersion{{Version: "4.20.0"}},
+				}, nil
+			},
+		)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(upgradingVersion).To(Equal("4.20.0"))
+		Expect(callCount).To(Equal(1))
+	})
+
+	It("returns a detailed timeout when no next-minor target appears", func() {
+		preparation := &YStreamUpgradePreparation{
+			ClusterVersion: "4.19.12",
+			CurrentChannel: "",
+			DesiredChannel: "stable-4.20",
+		}
+
+		_, _, err := waitForAvailableYStreamUpgrade(
+			testClusterID,
+			preparation,
+			time.Nanosecond,
+			time.Nanosecond,
+			func() (bytes.Buffer, UpgradeVersionList, error) {
+				return *bytes.NewBufferString("VERSION\n4.19.14  recommended\n"), UpgradeVersionList{
+					UpgradeVersions: []UpgradeVersion{{Version: "4.19.14"}},
+				}, nil
+			},
+		)
+
+		Expect(err).To(MatchError(ContainSubstring("timeout after")))
+		Expect(err).To(MatchError(ContainSubstring("cluster 1234abcd")))
+		Expect(err).To(MatchError(ContainSubstring("version=4.19.12")))
+		Expect(err).To(MatchError(ContainSubstring(`desired channel="stable-4.20"`)))
+		Expect(err).To(MatchError(ContainSubstring("context deadline exceeded")))
+		Expect(err).To(MatchError(ContainSubstring("4.19.14")))
+	})
+
+	It("includes the last fetch error in the timeout details", func() {
+		preparation := &YStreamUpgradePreparation{
+			ClusterVersion: "4.19.12",
+			CurrentChannel: "stable-4.19",
+			DesiredChannel: "stable-4.20",
+		}
+
+		_, _, err := waitForAvailableYStreamUpgrade(
+			testClusterID,
+			preparation,
+			time.Nanosecond,
+			time.Nanosecond,
+			func() (bytes.Buffer, UpgradeVersionList, error) {
+				return bytes.Buffer{}, UpgradeVersionList{}, fmt.Errorf("boom")
+			},
+		)
+
+		Expect(err).To(MatchError(ContainSubstring("last error: boom")))
+	})
+
+	It("fails when cluster ID is empty", func() {
+		_, _, err := waitForAvailableYStreamUpgrade(
+			"",
+			&YStreamUpgradePreparation{ClusterVersion: "4.19.12"},
+			time.Millisecond,
+			time.Millisecond,
+			func() (bytes.Buffer, UpgradeVersionList, error) {
+				return bytes.Buffer{}, UpgradeVersionList{}, nil
+			},
+		)
+
+		Expect(err).To(MatchError(ContainSubstring("cluster ID is required")))
+	})
+
+	It("fails when preparation is nil", func() {
+		_, _, err := waitForAvailableYStreamUpgrade(
+			testClusterID,
+			nil,
+			time.Millisecond,
+			time.Millisecond,
+			func() (bytes.Buffer, UpgradeVersionList, error) {
+				return bytes.Buffer{}, UpgradeVersionList{}, nil
+			},
+		)
+
+		Expect(err).To(MatchError(ContainSubstring("y-stream upgrade preparation is required")))
+	})
+})


### PR DESCRIPTION
## Summary

Add shared y-stream upgrade preparation helpers that compute and apply the next-minor channel, then wait for a next-minor upgrade target to appear before the tests proceed.

This aligns the e2e upgrade cases with the documented ROSA upgrade flow, removes duplicated channel setup, and keeps dedicated upgrade lanes red when no real upgrade path can be exercised.

Supersedes #3343.

## Detailed Description of the Issue

**Jira:** [ROSAENG-61412](https://issues.redhat.com/browse/ROSAENG-61412)

The previous change in #3343 addressed the symptom (`rosa list upgrade` returning an empty list) by skipping the dedicated non-STS upgrade lane. Amanda correctly pointed out that this would let the lane go green without actually exercising an upgrade.

The deeper issue is that the y-stream cases were not consistently following the documented ROSA flow for minor upgrades: the cluster needs to move to the next-minor channel before the tests ask for available upgrade targets. Some cases changed the channel first, others did not, and the duplicated logic also skipped the channel update entirely when the cluster reported an empty channel.

This PR introduces a shared preparation flow that:
- computes the desired `y+1` channel from the profile channel group and cluster raw version,
- applies that channel even when the current channel is empty,
- waits for a next-minor target to appear from `rosa list upgrade`, and
- fails with diagnostics if no target appears after bounded waiting.

## Type of Change

- fix - resolves an incorrect behavior or bug.

## Previous Behavior

Y-stream upgrade tests had inconsistent setup:
- some tests queried `rosa list upgrade` directly and assumed targets were already available,
- some tests changed the channel first, but only if `CD.Channel != ""`,
- and the dedicated non-STS lane could be made to skip instead of validating a real upgrade path.

## Behavior After This Change

All affected y-stream upgrade cases now use one shared preparation flow before listing or scheduling upgrades. Dedicated upgrade lanes remain red when they cannot discover a real next-minor target after channel preparation, while shared setup logic is centralized and covered by focused tests.

## Testing

- `make fmt`
- `make fmt-check`
- `make lint`
- `make test`
- `make rosa`
- `GOTOOLCHAIN=auto go test ./tests/e2e/... -run TestDoesNotExist -count=0`
- `GOTOOLCHAIN=auto go test ./tests/utils/exec/rosacli/... -run TestDoesNotExist -count=0`

[ROSAENG-61412]: https://redhat.atlassian.net/browse/ROSAENG-61412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Y-stream upgrade discovery by automatically preparing the cluster’s next minor upgrade channel.
  * Upgrade selection now prioritizes recommended next-minor versions and provides clearer upgrade availability details.
  * Upgrade workflows consistently use the discovered target version for dry runs, scheduling, role upgrades, and validation.

* **Bug Fixes**
  * Added stronger handling for invalid versions, missing channels, unavailable targets, and upgrade discovery timeouts.

* **Tests**
  * Expanded coverage for channel preparation, upgrade selection, polling, retries, and timeout errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->