### PR TITLE
ROSAENG-61177 | test: add tests for identity provider commands

### DIFF
--- a/cmd/create/idp/htpasswd_test.go
+++ b/cmd/create/idp/htpasswd_test.go
@@ -101,6 +101,25 @@ var _ = Describe("IDP Tests", func() {
 			Expect(err).To(HaveOccurred())
 		})
 	})
+
+	Describe("validateHtUsernameAndPassword", func() {
+		It("accepts a valid username and password", func() {
+			err := validateHtUsernameAndPassword("testuser", "SecureP@ssword123")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("rejects a username containing a colon", func() {
+			err := validateHtUsernameAndPassword("bad:user", "SecureP@ssword123")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("username must not contain"))
+		})
+
+		It("rejects the reserved cluster-admin username", func() {
+			err := validateHtUsernameAndPassword("cluster-admin", "SecureP@ssword123")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cluster-admin"))
+		})
+	})
 })
 
 func CreateTmpFile(content string) (*os.File, error) {

--- a/cmd/create/idp/validators_test.go
+++ b/cmd/create/idp/validators_test.go
@@ -1,0 +1,107 @@
+package idp
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("IDP Validators", func() {
+	Context("validateGitlabHostURL", func() {
+		It("accepts a valid HTTPS URL", func() {
+			err := validateGitlabHostURL("https://gitlab.example.com")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("rejects a non-HTTPS URL", func() {
+			err := validateGitlabHostURL("http://gitlab.example.com")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("https://"))
+		})
+
+		It("rejects a URL with query parameters", func() {
+			err := validateGitlabHostURL("https://gitlab.example.com?foo=bar")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("query parameters"))
+		})
+
+		It("rejects an invalid URL", func() {
+			err := validateGitlabHostURL("not-a-url")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("valid GitLab provider URL"))
+		})
+
+		It("rejects a URL with a fragment", func() {
+			err := validateGitlabHostURL("https://gitlab.example.com#section")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("valid GitLab provider URL"))
+		})
+	})
+
+	Context("validateGoogleHostedDomain", func() {
+		It("accepts a valid domain", func() {
+			err := validateGoogleHostedDomain("example.com")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("rejects an invalid domain", func() {
+			err := validateGoogleHostedDomain("not a domain")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not valid"))
+		})
+	})
+
+	Context("validateLdapURL", func() {
+		It("accepts an ldap:// URL", func() {
+			err := validateLdapURL("ldap://ldap.example.com/ou=users,dc=example,dc=com?uid")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("accepts an ldaps:// URL", func() {
+			err := validateLdapURL("ldaps://ldap.example.com/ou=users,dc=example,dc=com?uid")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("rejects a non-LDAP scheme", func() {
+			err := validateLdapURL("https://ldap.example.com")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("ldap://"))
+		})
+
+		It("rejects a bare URL with no scheme", func() {
+			err := validateLdapURL("ldap.com")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("expected a valid LDAP URL"))
+		})
+	})
+
+	Context("validateOpenidIssuerURL", func() {
+		It("accepts a valid HTTPS URL", func() {
+			err := validateOpenidIssuerURL("https://accounts.google.com")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("rejects a non-HTTPS URL", func() {
+			err := validateOpenidIssuerURL("http://accounts.google.com")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("https://"))
+		})
+
+		It("rejects a URL with query parameters", func() {
+			err := validateOpenidIssuerURL("https://accounts.google.com?foo=bar")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("query parameters"))
+		})
+
+		It("rejects an invalid URL", func() {
+			err := validateOpenidIssuerURL("not-a-url")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("valid OpenID issuer URL"))
+		})
+
+		It("rejects a URL with a fragment", func() {
+			err := validateOpenidIssuerURL("https://accounts.google.com#section")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("valid OpenID issuer URL"))
+		})
+	})
+})

--- a/cmd/dlt/idp/cmd_test.go
+++ b/cmd/dlt/idp/cmd_test.go
@@ -1,0 +1,27 @@
+package idp
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Delete IDP", func() {
+	Context("Args validator", func() {
+		It("rejects zero arguments", func() {
+			err := Cmd.Args(nil, []string{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Expected exactly one"))
+		})
+
+		It("accepts exactly one argument", func() {
+			err := Cmd.Args(nil, []string{"github-1"})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("rejects two arguments", func() {
+			err := Cmd.Args(nil, []string{"github-1", "extra"})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Expected exactly one"))
+		})
+	})
+})

--- a/cmd/dlt/idp/idp_suite_test.go
+++ b/cmd/dlt/idp/idp_suite_test.go
@@ -1,0 +1,13 @@
+package idp
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDeleteIdp(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Delete IDP Suite")
+}


### PR DESCRIPTION
## PR Summary
Add focused tests for IDP command validators and argument validation, covering the previously untested IDP-type-specific validation logic.

## Detailed Description of the Issue
The IDP commands had partial test coverage (only name generation and htpasswd parsing). The IDP-type validators (GitLab URL, Google hosted domain, LDAP URL, OpenID issuer URL) and the combined username+password validator had no coverage despite being core input validation for cluster identity provider setup.

## Related Issues and PRs
- Jira: [ROSAENG-60112](https://issues.redhat.com/browse/ROSAENG-60112) / [ROSAENG-61177](https://issues.redhat.com/browse/ROSAENG-61177)

## Type of Change
- [x] test

## Previous Behavior
IDP-type validators and delete IDP argument validation had no automated tests.

## Behavior After This Change
16 new test cases across 3 files:

| File | Tests | What's covered |
|------|-------|----------------|
| `cmd/create/idp/validators_test.go` | 10 | GitLab URL (HTTPS, scheme, query, invalid), Google domain, LDAP URL (ldap/ldaps/invalid), OpenID URL (HTTPS, scheme, query, invalid) |
| `cmd/create/idp/htpasswd_test.go` | 3 | validateHtUsernameAndPassword (valid, colon username, reserved cluster-admin) |
| `cmd/dlt/idp/cmd_test.go` | 3 | Args validator (zero, one, two arguments) |

Intentionally skipped: `cmd/list/idp` (all logic in run() with os.Exit, no extracted helpers).

## How to Test
1. `go test ./cmd/create/idp/... ./cmd/dlt/idp/... -count=1`

## Breaking Changes
- [x] No breaking changes

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] Any risk, limitation, or follow-up work is documented.

[ROSAENG-60112]: https://redhat.atlassian.net/browse/ROSAENG-60112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROSAENG-61177]: https://redhat.atlassian.net/browse/ROSAENG-61177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage for identity provider validation, including username/password rules (rejecting invalid characters and reserved usernames).
  * Added comprehensive tests for IDP validator behavior, including URL scheme/format checks and hosted-domain validation across multiple validators.
  * Added a dedicated “Delete IDP” command test suite to verify argument count handling and improve error-message expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->