### PR TITLE
ROSAENG-61450 | ci: add presubmit client image and go-toolset 1.26.5

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: builder
+  namespace: ocp
+  tag: rhel-9-golang-1.26-openshift-4.23

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,35 @@ Use this file as the starting point for repository context. When this file point
 - `vendor/`
   - Vendored dependencies. Do not edit directly.
 
+## CI Container Images
+
+ROSA uses **OpenShift ci-operator** (config in `openshift/release`) and **Konflux** (`.tekton/`). Each Dockerfile serves a different job type.
+
+| Dockerfile | Built by | Used for |
+|------------|----------|----------|
+| `Dockerfile` | Konflux | Shipping CLI zips (product) |
+| `Dockerfile.clients` | Prow (main config) | Presubmits: lint, build, test, commits, coverage |
+| `images/Dockerfile.e2e` | Prow (e2e/images variants) | E2E runner; promoted as `ci/rosa-aws-cli:latest` |
+| `images/Dockerfile.release` | Prow (images-release) | E2E against latest GitHub release (`ci/rosa-aws-cli:release`) |
+| `images/Dockerfile.konflux` | Konflux | Konflux E2E only |
+
+- Presubmit jobs run inside **`rosa-clients`** (from `Dockerfile.clients`), not `ocp/builder` directly. `Dockerfile.clients` **COPY**s the repo at image build; ci-operator does not re-clone into custom images unless `clone: true`.
+- Prow E2E runs inside **`rosa-aws-cli`** (from `images/Dockerfile.e2e`).
+- **`.ci-operator.yaml`** pins ci-operator `build_root` (`ocp/builder`) for pipeline plumbing (clone and image builds), not presubmit execution.
+
+### Bumping the Go version
+
+Update these together so compile, presubmits, E2E builds, and product images stay aligned:
+
+- `go.mod` (`go` directive)
+- `Dockerfile`, `Dockerfile.clients`, `images/Dockerfile.e2e`, `images/Dockerfile.konflux` — `ubi9/go-toolset` tag
+- `.ci-operator.yaml` — `build_root_image.tag` (match an available `ocp/builder:rhel-9-golang-*` for pipeline plumbing; presubmit compile uses `Dockerfile.clients`)
+- Regenerate `vendor/` when required by `CONTRIBUTING.md`
+
+Not tied to source Go version: `images/Dockerfile.release` (downloads a released CLI binary from GitHub).
+
+Release-side ci-operator configs live under `openshift/release` in `ci-operator/config/openshift/rosa/`. When adding `.ci-operator.yaml`, set `build_root: from_repository: true` in those files instead of duplicating the builder tag.
+
 ## Working Rules
 
 - Keep Cobra-specific logic in `cmd/`; keep non-Cobra logic in `pkg/`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.4-1783442369 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1783931515 AS builder
 COPY --chown=1001:0 . .
 
 ENV GOFLAGS=-buildvcs=false

--- a/Dockerfile.clients
+++ b/Dockerfile.clients
@@ -1,0 +1,17 @@
+# Prow presubmit client image: lint, build, test, commits, coverage.
+# Source is copied at image build (ci-operator builds this image from the PR tree).
+# Custom images with from: rosa-clients do not clone again unless clone: true.
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1783931515
+USER root
+WORKDIR /opt/app-root/src
+RUN dnf install -y --setopt=install_weak_deps=False --nodocs jq && \
+    dnf clean all
+RUN git config --global --add safe.directory /opt/app-root/src
+COPY --chown=1001:0 . .
+# OpenShift Prow: arbitrary UID runs with GID 0; group-writable workdir and Go caches.
+RUN mkdir -p /opt/app-root/src /tmp/gomodcache /tmp/.cache && \
+    chgrp -R 0 /opt/app-root/src /tmp/gomodcache /tmp/.cache && \
+    chmod -R g+rwX /opt/app-root/src /tmp/gomodcache /tmp/.cache
+ENV HOME="/opt/app-root/src" \
+    GOMODCACHE="/tmp/gomodcache" \
+    GOLANGCI_LINT_CACHE="/tmp/.cache"

--- a/images/Dockerfile.e2e
+++ b/images/Dockerfile.e2e
@@ -1,5 +1,5 @@
 # The image is for Prow CI steps to manage the ROSA cluster lifecycle and testing
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.4-1783442369 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1783931515 as builder
 WORKDIR /rosa
 USER root
 ENV GOBIN=/go/bin
@@ -13,13 +13,13 @@ RUN go test -c -o /go/bin/rosatest ./tests/e2e
 RUN rosa verify openshift-client
 RUN rosatest --ginkgo.no-color --ginkgo.label-filter "e2e-commit"
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.4-1783442369 AS rosa-support
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1783931515 AS rosa-support
 WORKDIR /opt/app-root/src/rosa-support
 RUN go install github.com/openshift-online/rosa-support@latest
 
 FROM registry.ci.openshift.org/ci/cli-ocm:latest as ocmcli
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.4-1783442369
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1783931515
 USER root
 COPY --from=builder /go/bin/rosa* /usr/bin
 COPY --from=builder /rosa/tests/ci/data /rosa/tests/ci/data

--- a/images/Dockerfile.konflux
+++ b/images/Dockerfile.konflux
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.4-1783442369 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1783931515 AS builder
 WORKDIR /rosa
 USER root
 COPY . .

--- a/renovate.json
+++ b/renovate.json
@@ -26,6 +26,15 @@
       "at any time"
     ]
   },
+  "dockerfile": {
+    "managerFilePatterns": [
+      "/^Dockerfile$/",
+      "/^Dockerfile\\.clients$/",
+      "/^images/Dockerfile\\.e2e$/",
+      "/^images/Dockerfile\\.release$/",
+      "/^images/Dockerfile\\.konflux$/"
+    ]
+  },
   "gomod": {
     "constraints": {
       "go": "1.26.3"


### PR DESCRIPTION
## PR Summary
Add a Prow presubmit client image (`Dockerfile.clients`), pin ci-operator `build_root` in `.ci-operator.yaml`, document CI images in `AGENTS.md`, align Dockerfiles to `ubi9/go-toolset:1.26.5`, and update Renovate to track all Dockerfiles.

**`go.mod` stays at 1.26.3** so current Prow `from: src` jobs (Go 1.26.3, `GOTOOLCHAIN=local`) keep passing. Bump `go.mod` to 1.26.5 in a follow-up after `openshift/release` switches to `rosa-clients`.

## Detailed Description of the Issue
ROSA presubmits run on `ocp/builder` via `from: src`. We need a repo-owned client image (RHCS-style) on go-toolset. ci-operator does **not** re-clone into custom images from `images:` unless `clone: true`, so `Dockerfile.clients` must **COPY** the PR tree (same lesson as [terraform-provider-rhcs#1257](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1257)). Without COPY, the follow-up release PR would fail with missing `Makefile`.

## Related Issues and PRs
- Jira: [ROSAENG-61450](https://redhat.atlassian.net/browse/ROSAENG-61450)
- Follow-up (openshift/release): https://github.com/openshift/release/pull/81830 — wires `from: rosa-clients` (waits for this PR)
- Related: [terraform-provider-rhcs#1257](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1257) — same COPY vs bind-mount / `from: *-clients` issue
- Follow-up 2: bump `go.mod` to **1.26.5** after the release PR lands

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [x] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
Presubmit jobs use `ocp/builder` (`from: src`). No repo-local presubmit client Dockerfile or `.ci-operator.yaml`.

## Behavior After This Change
- `Dockerfile.clients` on go-toolset **1.26.5** with `jq`, **COPY** of the repo, and Prow-friendly permissions.
- Product/E2E/Konflux Dockerfiles use `ubi9/go-toolset:1.26.5-1783931515`.
- `.ci-operator.yaml` pins `build_root` to `rhel-9-golang-1.26-openshift-4.23`.
- `renovate.json` tracks all ROSA Dockerfiles.
- `AGENTS.md` documents CI images, COPY behavior, and Go bump checklist.
- **`go.mod` remains 1.26.3** until after the release PR.

## How to Test (Step-by-Step)
### Preconditions
- podman or docker

### Test Steps
1. Build: `podman build -f Dockerfile.clients -t rosa-clients:local .`
2. **Prow-shaped** (no bind-mount):
   ```bash
   podman run --rm -w /opt/app-root/src rosa-clients:local \
     bash -c 'export GOTOOLCHAIN=auto && make rosa'
   ```
3. Renovate: `npx --yes --package renovate -- renovate-config-validator`
4. Confirm current Prow `build` / `lint` / `test` still pass (`from: src` until release PR).

### Expected Results
Image contains the repo; `make rosa` works **without** `-v` mounts. Bind-mount testing alone is not enough.

## Proof of the Fix
- `podman build -f Dockerfile.clients` succeeded with COPY.
- Prow-shaped run (no bind-mount): `make rosa` succeeded.
- Bare go-toolset without COPY: `Makefile` missing (confirms the failure mode).

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [ ] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [ ] `make test` passes.
- [ ] `make lint` passes.
- [x] `make rosa` passes.
- [x] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

[ROSAENG-61450]: https://redhat.atlassian.net/browse/ROSAENG-61450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ