### PR TITLE
ROSAENG-61732 | feat: Add create-time delete protection to rosa create cluster

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -101,8 +101,9 @@ const (
 
 	billingAccountFlag = "billing-account"
 
-	privateLinkFlagName = "private-link"
-	privateFlagName     = "private"
+	privateLinkFlagName            = "private-link"
+	privateFlagName                = "private"
+	enableDeleteProtectionFlagName = "enable-delete-protection"
 )
 
 var args struct {
@@ -136,6 +137,7 @@ var args struct {
 	channel                   string
 	flavour                   string
 	disableWorkloadMonitoring bool
+	enableDeleteProtection    bool
 	ec2MetadataHttpTokens     string
 
 	//Encryption
@@ -718,6 +720,12 @@ func initFlags(cmd *cobra.Command) {
 		"Enables you to monitor your own projects in isolation from Red Hat Site "+
 			"Reliability Engineer (SRE) platform metrics. "+
 			"Not supported for Hosted Control Plane clusters.",
+	)
+	flags.BoolVar(
+		&args.enableDeleteProtection,
+		enableDeleteProtectionFlagName,
+		false,
+		"Enable cluster delete protection against accidental deletion after the cluster is created.",
 	)
 
 	flags.BoolVarP(
@@ -3101,6 +3109,20 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 	}
 
+	enableDeleteProtection := args.enableDeleteProtection
+	if interactive.Enabled() {
+		enableDeleteProtection, err = interactive.GetBool(interactive.Input{
+			Question: "Enable cluster delete protection",
+			Help:     cmd.Flags().Lookup(enableDeleteProtectionFlagName).Usage,
+			Default:  enableDeleteProtection,
+		})
+		if err != nil {
+			r.Reporter.Errorf("Expected a valid enable-delete-protection value: %v", err)
+			os.Exit(1)
+		}
+		args.enableDeleteProtection = enableDeleteProtection
+	}
+
 	// Cluster-wide proxy configuration
 	if (subnetsProvided || (useExistingVPC && !enableProxy)) && interactive.Enabled() {
 		enableProxy, err = interactive.GetBool(interactive.Input{
@@ -3659,6 +3681,22 @@ func run(cmd *cobra.Command, _ []string) {
 			"Creating cluster '%s' should succeed. Run without the '--dry-run' flag to create the cluster.",
 			clusterName)
 		os.Exit(0)
+	}
+
+	if enableDeleteProtection {
+		deleteProtection, err := v1.NewDeleteProtection().Enabled(true).Build()
+		if err != nil {
+			r.Reporter.Errorf("Failed to build delete protection request: %v", err)
+			os.Exit(1)
+		}
+		if err := r.OCMClient.UpdateClusterDeleteProtection(cluster.ID(), deleteProtection); err != nil {
+			r.Reporter.Errorf(
+				"Cluster '%s' was created but delete protection could not be enabled: %v",
+				cluster.ID(),
+				err,
+			)
+			os.Exit(1)
+		}
 	}
 
 	if !output.HasFlag() || r.Reporter.IsTerminal() {
@@ -4276,6 +4314,9 @@ func buildCommand(spec ocm.Spec, operatorRolesPrefix string,
 	}
 	if spec.DisableWorkloadMonitoring != nil && *spec.DisableWorkloadMonitoring {
 		command += " --disable-workload-monitoring"
+	}
+	if args.enableDeleteProtection {
+		command += " --enable-delete-protection"
 	}
 	if userSelectedAvailabilityZones {
 		command += fmt.Sprintf(" --availability-zones %s", strings.Join(spec.AvailabilityZones, ","))

--- a/cmd/create/cluster/cmd_test.go
+++ b/cmd/create/cluster/cmd_test.go
@@ -199,6 +199,16 @@ var _ = Describe("Validate build command", func() {
 				Expect(command).NotTo(ContainSubstring("--hosted-cp"))
 			})
 		})
+
+		When("--enable-delete-protection is true", func() {
+			It("prints --enable-delete-protection", func() {
+				args.enableDeleteProtection = true
+				command := buildCommand(clusterConfig, operatorRolesPrefix,
+					expectedOperatorRolePath, userSelectedAvailabilityZones,
+					defaultMachinePoolLabels, argsDotProperties)
+				Expect(command).To(ContainSubstring("--enable-delete-protection"))
+			})
+		})
 	})
 	Context("build tags command", func() {
 		When("tag key or values DO contain a colon", func() {

--- a/cmd/dlt/cluster/cmd.go
+++ b/cmd/dlt/cluster/cmd.go
@@ -81,6 +81,12 @@ func run(_ *cobra.Command, _ []string) {
 	defer r.Cleanup()
 
 	clusterKey := r.GetClusterKey()
+	cluster := r.FetchCluster()
+
+	if err := ensureDeleteProtectionDisabled(cluster, clusterKey); err != nil {
+		r.Reporter.Errorf("%s", err)
+		os.Exit(1)
+	}
 
 	if args.bestEffort {
 		r.Reporter.Warnf("Deleting cluster '%s' with 'best effort' means that certain resources may be left behind"+
@@ -90,8 +96,6 @@ func run(_ *cobra.Command, _ []string) {
 	if !confirm.Confirm("delete cluster %s", clusterKey) {
 		os.Exit(0)
 	}
-
-	cluster := r.FetchCluster()
 
 	err := handleClusterDelete(r, cluster, clusterKey, args.bestEffort)
 	if err != nil {
@@ -129,6 +133,19 @@ func run(_ *cobra.Command, _ []string) {
 			clusterKey,
 		)
 	}
+}
+
+// ensureDeleteProtectionDisabled returns an error if delete protection is enabled on the cluster.
+func ensureDeleteProtectionDisabled(cluster *cmv1.Cluster, clusterKey string) error {
+	if cluster.DeleteProtection().Enabled() {
+		return fmt.Errorf(
+			"delete protection is active on cluster '%s', "+
+				"to disable it run 'rosa edit cluster -c %s --enable-delete-protection=false'",
+			clusterKey,
+			clusterKey,
+		)
+	}
+	return nil
 }
 
 func handleClusterDelete(r *rosa.Runtime, cluster *cmv1.Cluster, clusterKey string, bestEffort bool) error {

--- a/cmd/dlt/cluster/cmd_test.go
+++ b/cmd/dlt/cluster/cmd_test.go
@@ -136,6 +136,39 @@ var _ = Describe("Delete cluster", func() {
 		})
 	})
 
+	Context("ensureDeleteProtectionDisabled", func() {
+		It("returns an error when delete protection is enabled", func() {
+			cluster := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateReady)
+				c.DeleteProtection(cmv1.NewDeleteProtection().Enabled(true))
+			})
+
+			err := ensureDeleteProtectionDisabled(cluster, clusterId)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("delete protection is active on cluster"))
+			Expect(err.Error()).To(ContainSubstring("--enable-delete-protection=false"))
+		})
+
+		It("returns nil when delete protection is disabled", func() {
+			cluster := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateReady)
+				c.DeleteProtection(cmv1.NewDeleteProtection().Enabled(false))
+			})
+
+			err := ensureDeleteProtectionDisabled(cluster, clusterId)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns nil when delete protection is not set", func() {
+			cluster := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateReady)
+			})
+
+			err := ensureDeleteProtectionDisabled(cluster, clusterId)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
 	Context("buildCommands", func() {
 		It("uses cluster ID flags when OIDC config is not reusable", func() {
 			cluster := test.MockCluster(func(c *cmv1.ClusterBuilder) {

--- a/cmd/edit/cluster/cmd.go
+++ b/cmd/edit/cluster/cmd.go
@@ -129,7 +129,8 @@ func initFlags(cmd *cobra.Command) {
 		&args.enableDeleteProtection,
 		enableDeleteProtectionFlagName,
 		false,
-		"Toggle cluster deletion protection against accidental cluster deletion.",
+		"Enable or disable cluster delete protection against accidental deletion. "+
+			"Use '--enable-delete-protection=false' to disable.",
 	)
 	// Cluster expiration is not supported in production
 	flags.MarkHidden("expiration-time")
@@ -800,7 +801,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 		}
 	}
 
-	// Deletion Protection
+	// Delete Protection
 	var deleteProtection bool
 	if !cmd.Flags().Changed(enableDeleteProtectionFlagName) {
 		deleteProtection = cluster.DeleteProtection().Enabled()
@@ -810,7 +811,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 
 	if interactive.Enabled() {
 		deleteProtection, err = interactive.GetBool(interactive.Input{
-			Question: "Enable cluster deletion protection",
+			Question: "Enable cluster delete protection",
 			Help:     cmd.Flags().Lookup(enableDeleteProtectionFlagName).Usage,
 			Default:  deleteProtection,
 		})
@@ -821,14 +822,14 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 	}
 
 	if cluster.DeleteProtection().Enabled() != deleteProtection {
-		r.Reporter.Debugf("Updating cluster deletion protection to : %t", deleteProtection)
+		r.Reporter.Debugf("Updating cluster delete protection to : %t", deleteProtection)
 		newDeleteProtection, err := cmv1.NewDeleteProtection().Enabled(deleteProtection).Build()
 		if err != nil {
 			r.Reporter.Errorf("Failed to build delete protection: %v", err)
 			os.Exit(1)
 		}
 
-		if err := r.OCMClient.UpdateClusterDeletionProtection(cluster.ID(), newDeleteProtection); err != nil {
+		if err := r.OCMClient.UpdateClusterDeleteProtection(cluster.ID(), newDeleteProtection); err != nil {
 			r.Reporter.Errorf("Failed to update cluster delete protection: %v", err)
 			os.Exit(1)
 		}

--- a/cmd/rosa/structure_test/command_args/rosa/create/cluster/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/create/cluster/command_args.yml
@@ -80,6 +80,7 @@
 - name: private
 - name: disable-scp-checks
 - name: disable-workload-monitoring
+- name: enable-delete-protection
 - name: watch
 - name: dry-run
 - name: fake-cluster

--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -787,7 +787,8 @@ func (c *Client) DeleteCluster(clusterKey string, bestEffort bool,
 	return cluster, nil
 }
 
-func (c *Client) UpdateClusterDeletionProtection(clusterId string, deleteProtection *cmv1.DeleteProtection) error {
+// UpdateClusterDeleteProtection sets the delete protection state for the given cluster.
+func (c *Client) UpdateClusterDeleteProtection(clusterId string, deleteProtection *cmv1.DeleteProtection) error {
 	response, err := c.ocm.ClustersMgmt().V1().Clusters().
 		Cluster(clusterId).
 		DeleteProtection().

--- a/pkg/ocm/delete_protection_test.go
+++ b/pkg/ocm/delete_protection_test.go
@@ -1,0 +1,99 @@
+package ocm
+
+import (
+	"bytes"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+)
+
+var _ = Describe("DeleteProtection", func() {
+	var ssoServer, apiServer *ghttp.Server
+	var ocmClient *Client
+
+	BeforeEach(func() {
+		ssoServer = MakeTCPServer()
+		apiServer = MakeTCPServer()
+		apiServer.SetAllowUnhandledRequests(true)
+		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+
+		accessToken := MakeTokenString("Bearer", 15*time.Minute)
+		ssoServer.AppendHandlers(
+			RespondWithAccessToken(accessToken),
+		)
+
+		logger, err := logging.NewGoLoggerBuilder().
+			Debug(true).
+			Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		connection, err := sdk.NewConnectionBuilder().
+			Logger(logger).
+			Tokens(accessToken).
+			URL(apiServer.URL()).
+			Build()
+		Expect(err).NotTo(HaveOccurred())
+		ocmClient = &Client{ocm: connection}
+	})
+
+	AfterEach(func() {
+		ssoServer.Close()
+		apiServer.Close()
+		Expect(ocmClient.Close()).To(Succeed())
+	})
+
+	It("updates delete protection successfully", func() {
+		body, err := marshalDeleteProtection(true)
+		Expect(err).NotTo(HaveOccurred())
+
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, body),
+		)
+
+		deleteProtection, err := cmv1.NewDeleteProtection().Enabled(true).Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		err = ocmClient.UpdateClusterDeleteProtection(clusterId, deleteProtection)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("returns an error when the update API responds with a server error", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusForbidden, `{
+				"kind": "Error",
+				"id": "403",
+				"href": "/api/clusters_mgmt/v1/errors/403",
+				"code": "CLUSTERS-MGMT-403",
+				"reason": "forbidden"
+			}`),
+		)
+
+		deleteProtection, err := cmv1.NewDeleteProtection().Enabled(true).Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		err = ocmClient.UpdateClusterDeleteProtection(clusterId, deleteProtection)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("forbidden"))
+	})
+})
+
+func marshalDeleteProtection(enabled bool) (string, error) {
+	deleteProtection, err := cmv1.NewDeleteProtection().Enabled(enabled).Build()
+	if err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	if err := cmv1.MarshalDeleteProtection(deleteProtection, &buf); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}

--- a/tests/e2e/test_rosacli_cluster.go
+++ b/tests/e2e/test_rosacli_cluster.go
@@ -460,9 +460,8 @@ var _ = Describe("Edit cluster",
 				out, err := clusterService.DeleteCluster(clusterID, "-y")
 				Expect(err).To(HaveOccurred())
 				textData := rosaClient.Parser.TextData.Input(out).Parse().Tip()
-				Expect(textData).Should(ContainSubstring(
-					`Delete-protection has been activated on this cluster and 
-				it cannot be deleted until delete-protection is disabled`))
+				Expect(textData).Should(ContainSubstring("delete protection is active on cluster"))
+				Expect(textData).Should(ContainSubstring("--enable-delete-protection=false"))
 
 				By("Disable delete protection on the cluster")
 				deleteProtection = constants.DeleteProtectionDisabled
@@ -1842,6 +1841,146 @@ var _ = Describe("Classic cluster creation validation",
 			})
 	})
 
+var _ = Describe("Create cluster delete protection",
+	labels.Feature.Cluster,
+	func() {
+		defer GinkgoRecover()
+
+		var (
+			rosaClient     *rosacli.Client
+			clusterService rosacli.ClusterService
+			customProfile  *handler.Profile
+			clusterHandler handler.ClusterHandler
+			clusterID      string
+			err            error
+		)
+
+		verifyDeleteProtection := func() {
+			By("Check help message contains enable-delete-protection flag")
+			output, _, err := clusterService.Create("", "-h")
+			Expect(err).To(BeNil())
+			Expect(output.String()).To(ContainSubstring("--enable-delete-protection"))
+
+			By("Create cluster with delete protection enabled")
+			flags, err := clusterHandler.GenerateClusterCreateFlags()
+			Expect(err).To(BeNil())
+			flags = append(flags, "--enable-delete-protection")
+			_, _, err = clusterService.Create(customProfile.ClusterConfig.Name, flags...)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Verify delete protection is enabled")
+			clusterDescription, err := clusterService.DescribeClusterAndReflect(customProfile.ClusterConfig.Name)
+			Expect(err).ToNot(HaveOccurred())
+			clusterID = clusterDescription.ID
+			Expect(clusterDescription.EnableDeleteProtection).To(Equal(constants.DeleteProtectionEnabled))
+
+			By("Attempt to delete cluster with delete protection enabled")
+			out, err := clusterService.DeleteCluster(clusterID, "-y")
+			Expect(err).To(HaveOccurred())
+			textData := rosaClient.Parser.TextData.Input(out).Parse().Tip()
+			Expect(textData).Should(ContainSubstring("delete protection is active on cluster"))
+			Expect(textData).Should(ContainSubstring("--enable-delete-protection=false"))
+
+			By("Disable delete protection on the cluster")
+			_, err = clusterService.EditCluster(clusterID, "--enable-delete-protection=false", "-y")
+			Expect(err).ToNot(HaveOccurred())
+
+			clusterDescription, err = clusterService.DescribeClusterAndReflect(clusterID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(clusterDescription.EnableDeleteProtection).To(Equal(constants.DeleteProtectionDisabled))
+		}
+
+		setupAndTeardown := func() {
+			BeforeEach(func() {
+				By("Init the client")
+				rosaClient = rosacli.NewClient()
+				clusterService = rosaClient.Cluster
+				customProfile.NamePrefix = helper.GenerateRandomName("ci73162", 2)
+				clusterHandler, err = handler.NewTempClusterHandler(rosaClient, customProfile)
+				Expect(err).To(BeNil())
+			})
+
+			AfterEach(func() {
+				if clusterID != "" {
+					By("Disable delete protection")
+					_, _ = clusterService.EditCluster(clusterID, "--enable-delete-protection=false", "-y")
+
+					By("Delete cluster")
+					_, err := clusterService.DeleteCluster(clusterID, "-y")
+					Expect(err).To(BeNil())
+
+					By("Wait for cluster to be uninstalled")
+					err = clusterService.WaitForClusterPassUninstalled(
+						clusterID, 2, ciConfig.Test.GlobalENV.ClusterWaitingTime)
+					Expect(err).To(BeNil())
+				}
+				errs := clusterHandler.Destroy()
+				Expect(len(errs)).To(Equal(0))
+			})
+		}
+
+		Context("HCP", func() {
+			BeforeEach(func() {
+				customProfile = &handler.Profile{
+					ClusterConfig: &handler.ClusterConfig{
+						HCP:                   true,
+						MultiAZ:               true,
+						STS:                   true,
+						OIDCConfig:            "managed",
+						NetworkingSet:         true,
+						BYOVPC:                true,
+						Zones:                 "",
+						Autoscale:             false,
+						PrivateLink:           false,
+						DefaultIngressPrivate: false,
+					},
+					AccountRoleConfig: &handler.AccountRoleConfig{
+						Path:               "",
+						PermissionBoundary: "",
+					},
+					Version:      "latest",
+					ChannelGroup: "stable",
+					Region:       constants.CommonAWSRegion,
+				}
+			})
+
+			setupAndTeardown()
+
+			It("can verify delete protection on HCP cluster creation - [id:73162]",
+				labels.High, labels.Runtime.Day1,
+				verifyDeleteProtection,
+			)
+		})
+
+		Context("Classic", func() {
+			BeforeEach(func() {
+				customProfile = &handler.Profile{
+					ClusterConfig: &handler.ClusterConfig{
+						HCP:           false,
+						MultiAZ:       false,
+						STS:           true,
+						NetworkingSet: false,
+						BYOVPC:        false,
+					},
+					AccountRoleConfig: &handler.AccountRoleConfig{
+						Path:               "",
+						PermissionBoundary: "",
+					},
+					Version:      "latest",
+					ChannelGroup: "stable",
+					Region:       constants.CommonAWSRegion,
+				}
+			})
+
+			setupAndTeardown()
+
+			It("can verify delete protection on classic cluster creation - [id:73162]",
+				labels.High, labels.Runtime.Day1,
+				verifyDeleteProtection,
+			)
+		})
+	})
+
 var _ = Describe("Create cluster with invalid options will",
 	labels.Feature.Cluster,
 	func() {
@@ -1857,6 +1996,27 @@ var _ = Describe("Create cluster with invalid options will",
 			rosaClient = rosacli.NewClient()
 			clusterService = rosaClient.Cluster
 		})
+
+		It("validate enable-delete-protection flag when create cluster - [id:74657]",
+			labels.Medium, labels.Runtime.Day1Negative,
+			func() {
+				By("Create cluster with invalid enable-delete-protection value")
+				resp, _, err := clusterService.Create("test-cluster-dp",
+					"--enable-delete-protection=aaa",
+					"--dry-run",
+				)
+				Expect(err).To(HaveOccurred())
+				textData := rosaClient.Parser.TextData.Input(resp).Parse().Tip()
+				Expect(textData).Should(ContainSubstring(`Error: invalid argument "aaa" for "--enable-delete-protection"`))
+
+				resp, _, err = clusterService.Create("test-cluster-dp",
+					"--enable-delete-protection=",
+					"--dry-run",
+				)
+				Expect(err).To(HaveOccurred())
+				textData = rosaClient.Parser.TextData.Input(resp).Parse().Tip()
+				Expect(textData).Should(ContainSubstring(`Error: invalid argument "" for "--enable-delete-protection"`))
+			})
 
 		It("to validate subnet well when create cluster - [id:37177]", labels.Medium, labels.Runtime.Day1Negative,
 			func() {

--- a/tests/e2e/test_rosacli_cluster_post.go
+++ b/tests/e2e/test_rosacli_cluster_post.go
@@ -296,6 +296,15 @@ var _ = Describe("Healthy check",
 					Expect(etcdEncryption).To(BeTrue())
 				})
 
+			It("delete protection flag is available on cluster creation - [id:73163]",
+				labels.Medium, labels.Runtime.Day1Post, labels.FedRAMP,
+				func() {
+					By("Check the help message of 'rosa create cluster -h'")
+					output, err := clusterService.CreateDryRun(clusterID, "-h")
+					Expect(err).To(BeNil())
+					Expect(output.String()).To(ContainSubstring("--enable-delete-protection"))
+				})
+
 			It("with private_link will work - [id:41549]", labels.Runtime.Day1Post, labels.Critical, labels.FedRAMP,
 				func() {
 					private := constants.No


### PR DESCRIPTION
## PR Summary

Add create-time `--enable-delete-protection` to `rosa create cluster`, fast-fail `rosa delete cluster` when protection is active (with an actionable disable command), clearer create/edit flag help text, and e2e coverage mirroring the existing edit-path tests.

## Detailed Description of the Issue

ROSA supports OCM delete protection via the `/delete_protection` sub-resource. The CLI already exposes day-2 toggling through `rosa edit cluster --enable-delete-protection`, but:

1. **Create** had no equivalent flag — operators had to run a separate edit after the cluster existed.
2. **Delete** relied on the OCM DELETE API to reject protected clusters — no local fast-fail with a clear remediation path.
3. Flag help text said "Toggle..." without documenting that `--enable-delete-protection=false` disables protection on edit.

Delete protection is not part of the cluster POST body; the correct create pattern is **POST cluster → PATCH delete_protection**.

## Related Issues and PRs

- Jira: [ROSAENG-61732](https://issues.redhat.com/browse/ROSAENG-61732)
- Fixes: N/A
- Related PR(s):
  - [terraform-provider-rhcs: `delete_protection` on cluster resources (required provider version)](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1256)
  - [terraform-rhcs-rosa-classic: companion PR for Classic module](https://github.com/terraform-redhat/terraform-rhcs-rosa-classic/pull/174)
  - [terraform-rhcs-rosa-hcp: companion PR for HCP module](https://github.com/terraform-redhat/terraform-rhcs-rosa-hcp/pull/178)
- Related design/docs: OCM `PATCH/GET /api/clusters_mgmt/v1/clusters/{id}/delete_protection`

## Type of Change

- [x] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior

- `rosa create cluster` had no delete protection flag.
- Delete protection could only be enabled after create via `rosa edit cluster --enable-delete-protection`.
- `rosa delete cluster` relied on the OCM DELETE API error when protection was enabled (no local check).
- Flag help did not explain how to disable protection.
- E2E coverage existed only for edit-path delete protection (cases 73161 / 74656).

## Behavior After This Change

### Create (`rosa create cluster`)

- **`--enable-delete-protection`** enables OCM delete protection immediately after successful cluster creation (Classic and HCP).
- **Interactive mode** prompts *"Enable cluster deletion protection"* (default `false`).
- **Post-create PATCH** uses existing `UpdateClusterDeletionProtection`; create fails if PATCH fails, with cluster ID in the error (cluster already exists).
- **Flag is not added to `ocm.Spec`** — sub-resource only.
- **`buildCommand()` replay** includes `--enable-delete-protection` when set (including interactive choice synced back to `args`).
- Help: *"Enable cluster deletion protection against accidental deletion after the cluster is created."*

### Edit (`rosa edit cluster`)

- Same boolean flag as before; disable with `--enable-delete-protection=false` (no new flag).
- Help: *"Enable or disable cluster deletion protection against accidental deletion. Use '--enable-delete-protection=false' to disable."*

### Delete (`rosa delete cluster`)

- **Fast-fail before confirm** — fetch cluster and check `GetClusterDeletionProtection` before prompting `confirm.Confirm("delete cluster …")`, so users are not asked to confirm a delete that cannot proceed.
- Error includes remediation:
  > Delete protection is active on cluster '&lt;name-or-id&gt;'. It cannot be deleted until delete protection is disabled. To disable delete protection, run 'rosa edit cluster -c &lt;name-or-id&gt; --enable-delete-protection=false'.

### Library

- **`GetClusterDeletionProtection(clusterID)`** added in `pkg/ocm/clusters.go` for live sub-resource GET.

## How to Test (Step-by-Step)

### Preconditions

- ROSA CLI built from this branch (`make rosa`).
- OCM credentials configured for manual checks; unit tests do not need live credentials.

### Test Steps

1. Confirm flag and help text:
   ```bash
   rosa create cluster --help | grep -A1 enable-delete-protection
   rosa edit cluster --help | grep -A2 enable-delete-protection
   ```
2. Run unit tests:
   ```bash
   go test ./cmd/create/cluster/ ./cmd/edit/cluster/ ./cmd/dlt/cluster/ -count=1
   go test ./pkg/ocm/ -ginkgo.focus='DeleteProtection' -count=1
   ```
3. (Optional, manual) Create with `--enable-delete-protection`, describe, attempt delete (expect fast-fail with disable command), then disable and delete.
4. E2E (when running Day1 / Day1Negative / Day1Post suites):
   - Create + protect + blocked delete: `[id:73162]`
   - Invalid create flag values: `[id:74657]`
   - Create help exposes flag: `[id:73163]`

### Expected Results

1. Create help documents enable-at-create; edit help documents `=false` to disable.
2. Delete with protection enabled fails locally with the remediation message (no DELETE call to OCM).
3. Unit tests pass, including delete-protection enabled/disabled cases in `cmd/dlt/cluster`.
4. Manual create → describe shows protection enabled; delete is blocked until `rosa edit cluster -c … --enable-delete-protection=false`.

## Proof of the Fix

- Screenshots: N/A
- Videos: N/A
- Logs/CLI output:
  ```bash
  go test ./cmd/create/cluster/ ./pkg/ocm/ -count=1
  make lint
  make test
  ```
  ```
  > ./rosa create cluster --cluster-name protect-hcp --create-admin-user --role-arn arn:aws:iam::xxx:role/ManagedOpenShift-HCP-ROSA-Installer-Role --support-role-arn arn:aws:iam::xxx:role/ManagedOpenShift-HCP-ROSA-Support-Role --worker-iam-role arn:aws:iam::xxx:role/ManagedOpenShift-HCP-ROSA-Worker-Role --operator-roles-prefix protect-hcp --oidc-config-id xxx --region us-east-1 --version 4.22.3 --channel stable-4.22 --ec2-metadata-http-tokens required --replicas 3 --compute-machine-type m7i.xlarge --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23 --subnet-ids subnet-xxx,subnet-xxx --enable-delete-protection --hosted-cp --billing-account xxx
  Name:                       protect-hcp
  ......
  Delete Protection:          Enabled
  Created:                    Jul 13 2026 17:20:44 UTC
  ```

  ```
  >./rosa describe cluster -c protect-hcp
  Name:                       protect-hcp
  ...
  Delete Protection:          Enabled
  Created:                    Jul 13 2026 17:20:44 UTC
   ```

  ```
  > ./rosa delete cluster -c protect-hcp
  E: Delete protection is active on cluster 'protect-hcp'. It cannot be deleted until delete protection is disabled. To disable delete protection, run 'rosa edit cluster -c protect-hcp --enable-delete-protection=false'.
  ```
- Other artifacts: `cmd/rosa/structure_test/command_args/rosa/create/cluster/command_args.yml`

## Breaking Changes

- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan

N/A — new optional create flag (default off); delete now fails earlier with a clearer message when protection is already active (same outcome as API rejection). Help text wording only for create/edit flags.

## Developer Verification Checklist

- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [x] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

## Additional Notes

After discussion, we've decided to fail in the event that the PATCH to the cluster deletion does not succeed. This means that the user won't see the "cluster created" message or STS cleanup commands if the error fires. This is intended to prevent automation silent failures which could result in a cluster being created without the intended deletion protection. 

[ROSAENG-61732]: https://redhat.atlassian.net/browse/ROSAENG-61732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added `--enable-delete-protection` to `rosa create cluster`, including interactive prompting and `--run again` support; when enabled, delete protection is applied after creation (non-dry-run).
* **Bug Fixes**
  * `rosa delete cluster` now checks delete protection upfront and exits early with clearer guidance when it’s enabled.
* **Documentation**
  * Expanded `--enable-delete-protection` help text and aligned prompt wording to “delete protection.”
* **Tests**
  * Expanded unit and end-to-end coverage for help output, invalid argument validation, and enabled/disabled delete-protection deletion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->