### PR TITLE
ROSAENG-61178 | test: add auth and utility command coverage

### DIFF
--- a/cmd/download/oc/cmd.go
+++ b/cmd/download/oc/cmd.go
@@ -23,10 +23,13 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/openshift/rosa/cmd/verify/oc"
+	verifyOC "github.com/openshift/rosa/cmd/verify/oc"
 	helper "github.com/openshift/rosa/pkg/helper/download"
 	rprtr "github.com/openshift/rosa/pkg/reporter"
 )
+
+var downloadFn = helper.Download
+var verifyOCRun = verifyOC.Cmd.Run
 
 var Cmd = &cobra.Command{
 	Use:     "openshift-client",
@@ -41,31 +44,50 @@ var Cmd = &cobra.Command{
 
 func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporter()
+	err := runDownloadOC(reporter, verifyOCRun, downloadFn, runtime.GOOS, cmd, argv)
+	if err != nil {
+		os.Exit(1)
+	}
+}
 
-	// Verify whether `oc` is installed
-	oc.Cmd.Run(cmd, argv)
+func runDownloadOC(
+	reporter rprtr.Logger,
+	verify func(*cobra.Command, []string),
+	download func(string, string) error,
+	goos string,
+	cmd *cobra.Command,
+	argv []string,
+) error {
+	verify(cmd, argv)
 
-	platform := getPlatform()
-	extension := helper.GetExtension()
+	platform := platformForGOOS(goos)
+	extension := extensionForGOOS(goos)
 
 	filename := fmt.Sprintf("openshift-client-%s.%s", platform, extension)
 	downloadURL := fmt.Sprintf("https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/%s", filename)
 
 	reporter.Infof("Downloading %s", downloadURL)
 
-	err := helper.Download(downloadURL, filename)
+	err := download(downloadURL, filename)
 	if err != nil {
 		reporter.Errorf("%s", err)
-		os.Exit(1)
+		return err
 	}
 
 	reporter.Infof("Successfully downloaded %s", filename)
+	return nil
 }
 
-// Get the platform name used on the oc tarball filename
-func getPlatform() string {
-	if runtime.GOOS == "darwin" {
+func platformForGOOS(goos string) string {
+	if goos == "darwin" {
 		return "mac"
 	}
-	return runtime.GOOS
+	return goos
+}
+
+func extensionForGOOS(goos string) string {
+	if goos == "windows" {
+		return "zip"
+	}
+	return "tar.gz"
 }

--- a/cmd/download/oc/cmd_test.go
+++ b/cmd/download/oc/cmd_test.go
@@ -1,0 +1,109 @@
+package oc
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+)
+
+type mockReporter struct {
+	infos []string
+	errs  []string
+}
+
+func (m *mockReporter) Debugf(_ string, _ ...any) {}
+func (m *mockReporter) Infof(f string, a ...any)  { m.infos = append(m.infos, fmt.Sprintf(f, a...)) }
+func (m *mockReporter) Warnf(_ string, _ ...any)  {}
+func (m *mockReporter) Errorf(f string, a ...any) error {
+	m.errs = append(m.errs, fmt.Sprintf(f, a...))
+	return nil
+}
+func (m *mockReporter) IsTerminal() bool { return true }
+
+var _ = Describe("download oc", func() {
+	It("Calls verify preflight before downloading", func() {
+		verifyCalled := false
+		verify := func(_ *cobra.Command, _ []string) {
+			verifyCalled = true
+		}
+		download := func(_, _ string) error { return nil }
+		reporter := &mockReporter{}
+		cmd := &cobra.Command{}
+
+		err := runDownloadOC(reporter, verify, download, "linux", cmd, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(verifyCalled).To(BeTrue())
+	})
+
+	It("Downloads successfully with correct URL for linux", func() {
+		var capturedURL, capturedFile string
+		verify := func(_ *cobra.Command, _ []string) {}
+		download := func(url, file string) error {
+			capturedURL = url
+			capturedFile = file
+			return nil
+		}
+		reporter := &mockReporter{}
+		cmd := &cobra.Command{}
+
+		err := runDownloadOC(reporter, verify, download, "linux", cmd, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(capturedURL).To(ContainSubstring("openshift-client-linux.tar.gz"))
+		Expect(capturedFile).To(Equal("openshift-client-linux.tar.gz"))
+		Expect(reporter.infos).To(HaveLen(2))
+		Expect(reporter.infos[1]).To(ContainSubstring("Successfully downloaded"))
+	})
+
+	It("Builds a windows zip target independent of host OS", func() {
+		var capturedURL, capturedFile string
+		verify := func(_ *cobra.Command, _ []string) {}
+		download := func(url, file string) error {
+			capturedURL = url
+			capturedFile = file
+			return nil
+		}
+		reporter := &mockReporter{}
+		cmd := &cobra.Command{}
+
+		err := runDownloadOC(reporter, verify, download, "windows", cmd, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(capturedURL).To(ContainSubstring("openshift-client-windows.zip"))
+		Expect(capturedFile).To(Equal("openshift-client-windows.zip"))
+	})
+
+	It("Returns error when download fails", func() {
+		verify := func(_ *cobra.Command, _ []string) {}
+		download := func(_, _ string) error { return fmt.Errorf("network timeout") }
+		reporter := &mockReporter{}
+		cmd := &cobra.Command{}
+
+		err := runDownloadOC(reporter, verify, download, "linux", cmd, nil)
+		Expect(err).To(HaveOccurred())
+		Expect(reporter.errs).To(HaveLen(1))
+		Expect(reporter.errs[0]).To(ContainSubstring("network timeout"))
+	})
+
+	It("Maps darwin to mac for platform detection", func() {
+		Expect(platformForGOOS("darwin")).To(Equal("mac"))
+		Expect(platformForGOOS("linux")).To(Equal("linux"))
+		Expect(platformForGOOS("windows")).To(Equal("windows"))
+	})
+
+	It("Maps windows to zip extension", func() {
+		Expect(extensionForGOOS("windows")).To(Equal("zip"))
+		Expect(extensionForGOOS("linux")).To(Equal("tar.gz"))
+	})
+
+	It("Rejects extra arguments via cobra.NoArgs", func() {
+		Expect(Cmd.Args).NotTo(BeNil())
+		err := Cmd.Args(Cmd, []string{"unexpected"})
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("Has expected command aliases", func() {
+		Expect(Cmd.Aliases).To(ContainElement("oc"))
+		Expect(Cmd.Aliases).To(ContainElement("openshift"))
+	})
+})

--- a/cmd/download/oc/oc_suite_test.go
+++ b/cmd/download/oc/oc_suite_test.go
@@ -1,0 +1,13 @@
+package oc
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDownloadOC(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Download OC Suite")
+}

--- a/cmd/download/rosa/cmd.go
+++ b/cmd/download/rosa/cmd.go
@@ -28,6 +28,8 @@ import (
 	"github.com/openshift/rosa/pkg/version"
 )
 
+var downloadFn = helper.Download
+
 var Cmd = &cobra.Command{
 	Use:     "rosa-client",
 	Aliases: []string{"rosa"},
@@ -41,29 +43,41 @@ var Cmd = &cobra.Command{
 
 func run(_ *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporter()
+	err := runDownloadRosa(reporter, downloadFn, runtime.GOOS)
+	if err != nil {
+		os.Exit(1)
+	}
+}
 
-	platform := getPlatform()
-	extension := helper.GetExtension()
+func runDownloadRosa(reporter rprtr.Logger, download func(string, string) error, goos string) error {
+	platform := platformForGOOS(goos)
+	extension := extensionForGOOS(goos)
 
 	filename := fmt.Sprintf("rosa-%s.%s", platform, extension)
-
 	downloadURL := fmt.Sprintf("%s%s", version.DownloadLatestMirrorFolder, filename)
 
 	reporter.Infof("Downloading %s to your current directory", downloadURL)
 
-	err := helper.Download(downloadURL, filename)
+	err := download(downloadURL, filename)
 	if err != nil {
 		reporter.Errorf("%s", err)
-		os.Exit(1)
+		return err
 	}
 
 	reporter.Infof("Successfully downloaded %s", filename)
+	return nil
 }
 
-// Get the platform name used on the oc tarball filename
-func getPlatform() string {
-	if runtime.GOOS == "darwin" {
+func platformForGOOS(goos string) string {
+	if goos == "darwin" {
 		return "macosx"
 	}
-	return runtime.GOOS
+	return goos
+}
+
+func extensionForGOOS(goos string) string {
+	if goos == "windows" {
+		return "zip"
+	}
+	return "tar.gz"
 }

--- a/cmd/download/rosa/cmd_test.go
+++ b/cmd/download/rosa/cmd_test.go
@@ -1,0 +1,91 @@
+package rosa
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/rosa/pkg/version"
+)
+
+type mockReporter struct {
+	infos []string
+	errs  []string
+}
+
+func (m *mockReporter) Debugf(_ string, _ ...any) {}
+func (m *mockReporter) Infof(f string, a ...any)  { m.infos = append(m.infos, fmt.Sprintf(f, a...)) }
+func (m *mockReporter) Warnf(_ string, _ ...any)  {}
+func (m *mockReporter) Errorf(f string, a ...any) error {
+	m.errs = append(m.errs, fmt.Sprintf(f, a...))
+	return nil
+}
+func (m *mockReporter) IsTerminal() bool { return true }
+
+var _ = Describe("download rosa", func() {
+	It("Downloads successfully with correct URL using DownloadLatestMirrorFolder", func() {
+		var capturedURL, capturedFile string
+		download := func(url, file string) error {
+			capturedURL = url
+			capturedFile = file
+			return nil
+		}
+		reporter := &mockReporter{}
+
+		err := runDownloadRosa(reporter, download, "linux")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(capturedURL).To(HavePrefix(version.DownloadLatestMirrorFolder))
+		Expect(capturedURL).To(ContainSubstring("rosa-linux.tar.gz"))
+		Expect(capturedFile).To(Equal("rosa-linux.tar.gz"))
+		Expect(reporter.infos).To(HaveLen(2))
+		Expect(reporter.infos[1]).To(ContainSubstring("Successfully downloaded"))
+	})
+
+	It("Builds a windows zip target independent of host OS", func() {
+		var capturedURL, capturedFile string
+		download := func(url, file string) error {
+			capturedURL = url
+			capturedFile = file
+			return nil
+		}
+		reporter := &mockReporter{}
+
+		err := runDownloadRosa(reporter, download, "windows")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(capturedURL).To(HavePrefix(version.DownloadLatestMirrorFolder))
+		Expect(capturedURL).To(ContainSubstring("rosa-windows.zip"))
+		Expect(capturedFile).To(Equal("rosa-windows.zip"))
+	})
+
+	It("Returns error when download fails", func() {
+		download := func(_, _ string) error { return fmt.Errorf("connection refused") }
+		reporter := &mockReporter{}
+
+		err := runDownloadRosa(reporter, download, "linux")
+		Expect(err).To(HaveOccurred())
+		Expect(reporter.errs).To(HaveLen(1))
+		Expect(reporter.errs[0]).To(ContainSubstring("connection refused"))
+	})
+
+	It("Maps darwin to macosx for platform detection", func() {
+		Expect(platformForGOOS("darwin")).To(Equal("macosx"))
+		Expect(platformForGOOS("linux")).To(Equal("linux"))
+		Expect(platformForGOOS("windows")).To(Equal("windows"))
+	})
+
+	It("Maps windows to zip extension", func() {
+		Expect(extensionForGOOS("windows")).To(Equal("zip"))
+		Expect(extensionForGOOS("linux")).To(Equal("tar.gz"))
+	})
+
+	It("Rejects extra arguments via cobra.NoArgs", func() {
+		Expect(Cmd.Args).NotTo(BeNil())
+		err := Cmd.Args(Cmd, []string{"unexpected"})
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("Has expected command aliases", func() {
+		Expect(Cmd.Aliases).To(ContainElement("rosa"))
+	})
+})

--- a/cmd/download/rosa/rosa_suite_test.go
+++ b/cmd/download/rosa/rosa_suite_test.go
@@ -1,0 +1,13 @@
+package rosa
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDownloadRosa(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Download Rosa Suite")
+}

--- a/cmd/initialize/cmd.go
+++ b/cmd/initialize/cmd.go
@@ -17,10 +17,12 @@ limitations under the License.
 package initialize
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/cmd/login"
@@ -33,6 +35,7 @@ import (
 	"github.com/openshift/rosa/pkg/helper"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/reporter"
 	"github.com/openshift/rosa/pkg/rosa"
 )
 
@@ -57,6 +60,36 @@ var Cmd = &cobra.Command{
   rosa init --token=$OFFLINE_ACCESS_TOKEN`,
 	Run:  run,
 	Args: cobra.NoArgs,
+}
+
+var errInitExitZero = errors.New("initialize exit zero")
+
+type initDeps struct {
+	loginCall      func(*cobra.Command, []string, reporter.Logger) error
+	buildAWSClient func(*logrus.Logger, string, bool) (aws.Client, error)
+	buildCFClient  func(reporter.Logger, *logrus.Logger, []string, bool) aws.Client
+	confirmPrompt  func(string, ...interface{}) bool
+	runPermissions func(*cobra.Command, []string)
+	runQuota       func(*cobra.Command, []string)
+	runVerifyOC    func(*cobra.Command, []string)
+}
+
+func defaultInitDeps() initDeps {
+	return initDeps{
+		loginCall: login.Call,
+		buildAWSClient: func(logger *logrus.Logger, region string, useLocalCredentials bool) (aws.Client, error) {
+			return aws.NewClient().
+				Logger(logger).
+				Region(region).
+				UseLocalCredentials(useLocalCredentials).
+				Build()
+		},
+		buildCFClient:  aws.GetAWSClientForUserRegion,
+		confirmPrompt:  confirm.Confirm,
+		runPermissions: permissions.Cmd.Run,
+		runQuota:       quota.Cmd.Run,
+		runVerifyOC:    oc.Cmd.Run,
+	}
 }
 
 func init() {
@@ -103,46 +136,51 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) {
 	r := rosa.NewRuntime().WithOCM()
-	defer r.Cleanup()
+	err := runWithRuntime(r, cmd, argv, defaultInitDeps())
+	r.Cleanup()
+	if err != nil {
+		if errors.Is(err, errInitExitZero) {
+			os.Exit(0)
+		}
+		os.Exit(1)
+	}
+}
 
+func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command, argv []string, deps initDeps) error {
 	// If necessary, call `login` as part of `init`. We do this before
 	// other validations to get the prompt out of the way before performing
 	// longer checks.
-	err := login.Call(cmd, argv, r.Reporter)
+	err := deps.loginCall(cmd, argv, r.Reporter)
 	if err != nil {
 		r.Reporter.Errorf("Failed to login to OCM: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to login to OCM: %w", err)
 	}
 
 	// Get AWS region
 	awsRegion, err := aws.GetRegion(arguments.GetRegion())
 	if err != nil {
 		r.Reporter.Errorf("Error getting region: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("error getting region: %w", err)
 	}
 	supportedRegions, err := r.OCMClient.GetDatabaseRegionList()
 	if err != nil {
 		r.Reporter.Errorf("Unable to retrieve supported regions: %v", err)
+		return fmt.Errorf("retrieving supported regions: %w", err)
 	}
 	if !helper.Contains(supportedRegions, awsRegion) {
 		r.Reporter.Errorf("Unsupported region '%s', available regions: %s",
 			awsRegion, helper.SliceToSortedString(supportedRegions))
-		os.Exit(1)
+		return fmt.Errorf("unsupported region '%s'", awsRegion)
 	}
 	// Create the AWS client:
-	client, err := aws.NewClient().
-		Logger(r.Logger).
-		Region(awsRegion).
-		UseLocalCredentials(args.useLocalCredentials).
-		Build()
-
+	client, err := deps.buildAWSClient(r.Logger, awsRegion, args.useLocalCredentials)
 	if err != nil {
 		// FIXME Hack to capture errors due to using STS accounts
 		if strings.Contains(fmt.Sprintf("%s", err), "STS") {
 			r.OCMClient.LogEvent("ROSAInitCredentialsSTS", nil)
 		}
 		r.Reporter.Errorf("Error creating AWS client: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("creating AWS client: %w", err)
 	}
 
 	// Validate AWS credentials for current user
@@ -151,48 +189,44 @@ func run(cmd *cobra.Command, argv []string) {
 	if err != nil {
 		r.OCMClient.LogEvent("ROSAInitCredentialsFailed", nil)
 		r.Reporter.Errorf("Error validating AWS credentials: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("validating AWS credentials: %w", err)
 	}
 	if !ok {
 		r.OCMClient.LogEvent("ROSAInitCredentialsInvalid", nil)
 		r.Reporter.Errorf("AWS credentials are invalid")
-		os.Exit(1)
+		return fmt.Errorf("AWS credentials are invalid")
 	}
 	r.Reporter.Infof("AWS credentials are valid!")
 
-	cfClient := aws.GetAWSClientForUserRegion(r.Reporter, r.Logger, supportedRegions, args.useLocalCredentials)
+	cfClient := deps.buildCFClient(r.Reporter, r.Logger, supportedRegions, args.useLocalCredentials)
 
 	// Delete CloudFormation stack and exit
 	if args.dlt {
-		if !confirm.Confirm("delete cluster administrator user '%s'", aws.AdminUserName) {
-			os.Exit(0)
+		if !deps.confirmPrompt("delete cluster administrator user '%s'", aws.AdminUserName) {
+			return errInitExitZero
 		}
 		r.Reporter.Infof("Deleting cluster administrator user '%s'...", aws.AdminUserName)
 		err = deleteStack(cfClient, r.OCMClient)
 		if err != nil {
 			r.Reporter.Errorf("%v", err)
-			os.Exit(1)
+			return fmt.Errorf("deleting cluster administrator user: %w", err)
 		}
 
 		r.Reporter.Infof("Admin user '%s' deleted successfully!", aws.AdminUserName)
-		os.Exit(0)
+		return errInitExitZero
 	}
 
 	// Validate AWS SCP/IAM Permissions
 	// Call `verify permissions` as part of init
 	// Skip this check if --disable-scp-checks is true
-	// If SCP policies conditions restrict an AWS accounts permissions by region
-	// AWS will fail all policy simulation checks
-	// Validate AWS credentials for current user
 	if !args.disableSCPChecks {
-		permissions.Cmd.Run(cmd, argv)
+		deps.runPermissions(cmd, argv)
 	} else {
 		r.Reporter.Infof("Skipping AWS SCP policies check")
 	}
 
 	// Validate AWS quota
-	// Call `verify quota` as part of init
-	quota.Cmd.Run(cmd, argv)
+	deps.runQuota(cmd, argv)
 
 	// Ensure that there is an AWS user to create all the resources needed by the cluster:
 	r.Reporter.Infof("Ensuring cluster administrator user '%s'...", aws.AdminUserName)
@@ -200,7 +234,7 @@ func run(cmd *cobra.Command, argv []string) {
 	if err != nil {
 		r.OCMClient.LogEvent("ROSAInitCreateStackFailed", nil)
 		r.Reporter.Errorf("Failed to create user '%s': %v", aws.AdminUserName, err)
-		os.Exit(1)
+		return fmt.Errorf("creating cluster administrator user '%s': %w", aws.AdminUserName, err)
 	}
 	if created {
 		r.Reporter.Infof("Admin user '%s' created successfully!", aws.AdminUserName)
@@ -209,7 +243,6 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// Check if osdCcsAdmin has right permissions
-	// Skip this check if --disable-scp-checks is true
 	if !args.disableSCPChecks {
 		r.Reporter.Infof("Validating SCP policies for '%s'...", aws.AdminUserName)
 		target := aws.AdminUserName
@@ -217,13 +250,18 @@ func run(cmd *cobra.Command, argv []string) {
 		policies, err := r.OCMClient.GetPolicies("OSDSCPPolicy")
 		if err != nil {
 			r.Reporter.Errorf("Failed to get 'osdscppolicy' for '%s': %v", aws.AdminUserName, err)
-			os.Exit(1)
+			return fmt.Errorf("getting SCP policies for '%s': %w", aws.AdminUserName, err)
 		}
 		isValid, err := client.ValidateSCP(&target, policies)
-		if !isValid {
+		if err != nil {
 			r.OCMClient.LogEvent("ROSAInitSCPPoliciesFailed", nil)
 			r.Reporter.Errorf("Failed to verify permissions for user '%s': %v", target, err)
-			os.Exit(1)
+			return fmt.Errorf("failed to verify permissions for user '%s': %w", target, err)
+		}
+		if !isValid {
+			r.OCMClient.LogEvent("ROSAInitSCPPoliciesFailed", nil)
+			r.Reporter.Errorf("Failed to verify permissions for user '%s'", target)
+			return fmt.Errorf("failed to verify permissions for user '%s'", target)
 		}
 		r.Reporter.Infof("AWS SCP policies ok")
 	} else {
@@ -242,7 +280,8 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	// Verify version of `oc`
-	oc.Cmd.Run(cmd, argv)
+	deps.runVerifyOC(cmd, argv)
+	return nil
 }
 
 func deleteStack(awsClient aws.Client, ocmClient *ocm.Client) error {
@@ -250,24 +289,24 @@ func deleteStack(awsClient aws.Client, ocmClient *ocm.Client) error {
 	awsCreator, err := awsClient.GetCreator()
 	if err != nil {
 		ocmClient.LogEvent("ROSAInitGetCreatorFailed", nil)
-		return fmt.Errorf("Failed to get AWS creator: %v", err)
+		return fmt.Errorf("failed to get AWS creator: %w", err)
 	}
 
 	// Check whether the account has clusters:
 	hasClusters, err := ocmClient.HasClusters(awsCreator)
 	if err != nil {
-		return fmt.Errorf("Failed to check for clusters: %v", err)
+		return fmt.Errorf("failed to check for clusters: %w", err)
 	}
 
 	if hasClusters {
-		return fmt.Errorf("Failed to delete '%s': User still has clusters", aws.AdminUserName)
+		return fmt.Errorf("failed to delete '%s': user still has clusters", aws.AdminUserName)
 	}
 
 	// Delete the CloudFormation stack
 	err = awsClient.DeleteOsdCcsAdminUser(aws.OsdCcsAdminStackName)
 	if err != nil {
 		ocmClient.LogEvent("ROSAInitDeleteStackFailed", nil)
-		return fmt.Errorf("Failed to delete user '%s': %v", aws.AdminUserName, err)
+		return fmt.Errorf("failed to delete user '%s': %w", aws.AdminUserName, err)
 	}
 
 	return nil
@@ -282,13 +321,13 @@ func simulateCluster(awsClient aws.Client, ocmClient *ocm.Client, region string)
 	awsCreator, err := awsClient.GetCreator()
 	if err != nil {
 		ocmClient.LogEvent("ROSAInitGetCreatorFailed", nil)
-		return fmt.Errorf("Failed to get AWS creator: %v", err)
+		return fmt.Errorf("failed to get AWS creator: %w", err)
 	}
 
 	awsAccessKey, err := awsClient.GetLocalAWSAccessKeys()
 	if err != nil {
 		ocmClient.LogEvent("ROSAInitGetLocalAWSAccessKeysFailed", nil)
-		return fmt.Errorf("Failed to get AWS Access Key: %v", err)
+		return fmt.Errorf("failed to get AWS access key: %w", err)
 	}
 	spec := ocm.Spec{
 		Name:           "rosa-init",

--- a/cmd/initialize/cmd_test.go
+++ b/cmd/initialize/cmd_test.go
@@ -1,0 +1,568 @@
+package initialize
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+
+	"go.uber.org/mock/gomock"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/reporter"
+	"github.com/openshift/rosa/pkg/rosa"
+	"github.com/openshift/rosa/pkg/test"
+)
+
+const (
+	supportedRegionsResponse   = `{"kind":"CloudRegionList","page":1,"size":1,"total":1,"items":[{"id":"us-east-1"}]}`
+	unsupportedRegionsResponse = `{"kind":"CloudRegionList","page":1,"size":1,"total":1,"items":[{"id":"us-west-2"}]}`
+	stsPoliciesResponse        = `{"kind":"AWSSTSPolicyList","page":1,"size":0,"total":0,"items":[]}`
+)
+
+var _ = Describe("initialize command", func() {
+	Context("Command structure", func() {
+		It("Rejects extra arguments via cobra.NoArgs", func() {
+			Expect(Cmd.Args).NotTo(BeNil())
+			err := Cmd.Args(Cmd, []string{"unexpected"})
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("Has expected flags", func() {
+			Expect(Cmd.Flags().Lookup("delete")).NotTo(BeNil())
+			Expect(Cmd.Flags().Lookup("disable-scp-checks")).NotTo(BeNil())
+			Expect(Cmd.Flags().Lookup("use-local-credentials")).NotTo(BeNil())
+			Expect(Cmd.Flags().Lookup("token")).NotTo(BeNil())
+		})
+	})
+
+	Context("runWithRuntime", func() {
+		var (
+			ctrl           *gomock.Controller
+			mockAWS        *aws.MockClient
+			mockCF         *aws.MockClient
+			t              *test.TestingRuntime
+			permissionsRan int
+			quotaRan       int
+			verifyOCRan    int
+		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+			mockAWS = aws.NewMockClient(ctrl)
+			mockCF = aws.NewMockClient(ctrl)
+			t = test.NewTestRuntime()
+			Expect(os.Setenv("AWS_REGION", "us-east-1")).To(Succeed())
+			DeferCleanup(os.Unsetenv, "AWS_REGION")
+
+			args.dlt = false
+			args.disableSCPChecks = false
+			args.sts = false
+			args.region = ""
+			args.useLocalCredentials = false
+
+			permissionsRan = 0
+			quotaRan = 0
+			verifyOCRan = 0
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
+		})
+
+		newDeps := func(loginErr error, confirmResult bool) initDeps {
+			return initDeps{
+				loginCall: func(_ *cobra.Command, _ []string, _ reporter.Logger) error {
+					return loginErr
+				},
+				buildAWSClient: func(_ *logrus.Logger, _ string, _ bool) (aws.Client, error) {
+					return mockAWS, nil
+				},
+				buildCFClient: func(_ reporter.Logger, _ *logrus.Logger, _ []string, _ bool) aws.Client {
+					return mockCF
+				},
+				confirmPrompt: func(_ string, _ ...interface{}) bool {
+					return confirmResult
+				},
+				runPermissions: func(_ *cobra.Command, _ []string) {
+					permissionsRan++
+				},
+				runQuota: func(_ *cobra.Command, _ []string) {
+					quotaRan++
+				},
+				runVerifyOC: func(_ *cobra.Command, _ []string) {
+					verifyOCRan++
+				},
+			}
+		}
+
+		It("Returns an error when login fails", func() {
+			deps := newDeps(fmt.Errorf("login failed"), true)
+
+			err := runWithRuntime(t.RosaRuntime, Cmd, []string{}, deps)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("login failed"))
+		})
+
+		It("Returns an error for an unsupported region", func() {
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusOK, unsupportedRegionsResponse),
+			)
+			deps := newDeps(nil, true)
+
+			err := runWithRuntime(t.RosaRuntime, Cmd, []string{}, deps)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unsupported region"))
+		})
+
+		It("Returns the supported-region retrieval error immediately", func() {
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusInternalServerError, "{}"),
+			)
+			deps := newDeps(nil, true)
+
+			err := runWithRuntime(t.RosaRuntime, Cmd, []string{}, deps)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("retrieving supported regions"))
+		})
+
+		It("Returns an error when ValidateCredentials fails", func() {
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusOK, supportedRegionsResponse),
+			)
+			deps := newDeps(nil, true)
+			deps.buildAWSClient = func(_ *logrus.Logger, _ string, _ bool) (aws.Client, error) {
+				mockAWS.EXPECT().ValidateCredentials().Return(false, fmt.Errorf("credentials invalid"))
+				return mockAWS, nil
+			}
+
+			err := runWithRuntime(t.RosaRuntime, Cmd, []string{}, deps)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("credentials invalid"))
+		})
+
+		It("Returns an error when ValidateCredentials returns false", func() {
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusOK, supportedRegionsResponse),
+			)
+			deps := newDeps(nil, true)
+			deps.buildAWSClient = func(_ *logrus.Logger, _ string, _ bool) (aws.Client, error) {
+				mockAWS.EXPECT().ValidateCredentials().Return(false, nil)
+				return mockAWS, nil
+			}
+
+			err := runWithRuntime(t.RosaRuntime, Cmd, []string{}, deps)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("AWS credentials are invalid"))
+		})
+
+		It("Returns exit-zero sentinel when delete confirmation is declined", func() {
+			args.dlt = true
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusOK, supportedRegionsResponse),
+			)
+			deps := newDeps(nil, false)
+			deps.buildAWSClient = func(_ *logrus.Logger, _ string, _ bool) (aws.Client, error) {
+				mockAWS.EXPECT().ValidateCredentials().Return(true, nil)
+				return mockAWS, nil
+			}
+
+			err := runWithRuntime(t.RosaRuntime, Cmd, []string{}, deps)
+			Expect(errors.Is(err, errInitExitZero)).To(BeTrue())
+		})
+
+		It("Returns an error when delete mode fails in deleteStack", func() {
+			args.dlt = true
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusOK, supportedRegionsResponse),
+				RespondWithJSON(http.StatusOK, `{"kind":"ClusterList","page":1,"size":0,"total":0,"items":[]}`),
+			)
+			deps := newDeps(nil, true)
+			deps.buildAWSClient = func(_ *logrus.Logger, _ string, _ bool) (aws.Client, error) {
+				mockAWS.EXPECT().ValidateCredentials().Return(true, nil)
+				return mockAWS, nil
+			}
+			deps.buildCFClient = func(_ reporter.Logger, _ *logrus.Logger, _ []string, _ bool) aws.Client {
+				mockCF.EXPECT().GetCreator().Return(&aws.Creator{ARN: "arn:aws:iam::123:user/test", AccountID: "123"}, nil)
+				mockCF.EXPECT().DeleteOsdCcsAdminUser(aws.OsdCcsAdminStackName).Return(fmt.Errorf("delete failed"))
+				return mockCF
+			}
+
+			err := runWithRuntime(t.RosaRuntime, Cmd, []string{}, deps)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("delete failed"))
+		})
+
+		It("Returns exit-zero sentinel when delete mode succeeds", func() {
+			args.dlt = true
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusOK, supportedRegionsResponse),
+				RespondWithJSON(http.StatusOK, `{"kind":"ClusterList","page":1,"size":0,"total":0,"items":[]}`),
+			)
+			deps := newDeps(nil, true)
+			deps.buildAWSClient = func(_ *logrus.Logger, _ string, _ bool) (aws.Client, error) {
+				mockAWS.EXPECT().ValidateCredentials().Return(true, nil)
+				return mockAWS, nil
+			}
+			deps.buildCFClient = func(_ reporter.Logger, _ *logrus.Logger, _ []string, _ bool) aws.Client {
+				mockCF.EXPECT().GetCreator().Return(&aws.Creator{ARN: "arn:aws:iam::123:user/test", AccountID: "123"}, nil)
+				mockCF.EXPECT().DeleteOsdCcsAdminUser(aws.OsdCcsAdminStackName).Return(nil)
+				return mockCF
+			}
+
+			err := runWithRuntime(t.RosaRuntime, Cmd, []string{}, deps)
+			Expect(errors.Is(err, errInitExitZero)).To(BeTrue())
+		})
+
+		It("Skips permissions when disable-scp-checks is set", func() {
+			args.disableSCPChecks = true
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusOK, supportedRegionsResponse),
+				RespondWithJSON(http.StatusCreated, `{"kind":"Cluster","id":"dry-run-id","name":"rosa-init"}`),
+			)
+			deps := newDeps(nil, true)
+			deps.buildAWSClient = func(_ *logrus.Logger, _ string, _ bool) (aws.Client, error) {
+				mockAWS.EXPECT().ValidateCredentials().Return(true, nil)
+				return mockAWS, nil
+			}
+			deps.buildCFClient = func(_ reporter.Logger, _ *logrus.Logger, _ []string, _ bool) aws.Client {
+				mockCF.EXPECT().EnsureOsdCcsAdminUser(aws.OsdCcsAdminStackName, aws.AdminUserName, "us-east-1").Return(true, nil)
+				mockCF.EXPECT().GetCreator().Return(&aws.Creator{ARN: "arn:aws:iam::123:user/test", AccountID: "123"}, nil)
+				mockCF.EXPECT().GetLocalAWSAccessKeys().Return(&aws.AccessKey{AccessKeyID: "AKIA123", SecretAccessKey: "secret"}, nil)
+				return mockCF
+			}
+
+			err := runWithRuntime(t.RosaRuntime, Cmd, []string{}, deps)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(permissionsRan).To(Equal(0))
+			Expect(quotaRan).To(Equal(1))
+			Expect(verifyOCRan).To(Equal(1))
+		})
+
+		It("Runs permissions, quota, and verify oc on the normal path", func() {
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusOK, supportedRegionsResponse),
+				RespondWithJSON(http.StatusOK, stsPoliciesResponse),
+				RespondWithJSON(http.StatusCreated, `{"kind":"Cluster","id":"dry-run-id","name":"rosa-init"}`),
+			)
+			deps := newDeps(nil, true)
+			deps.buildAWSClient = func(_ *logrus.Logger, _ string, _ bool) (aws.Client, error) {
+				mockAWS.EXPECT().ValidateCredentials().Return(true, nil)
+				mockAWS.EXPECT().ValidateSCP(gomock.Any(), gomock.Any()).Return(true, nil)
+				return mockAWS, nil
+			}
+			deps.buildCFClient = func(_ reporter.Logger, _ *logrus.Logger, _ []string, _ bool) aws.Client {
+				mockCF.EXPECT().EnsureOsdCcsAdminUser(aws.OsdCcsAdminStackName, aws.AdminUserName, "us-east-1").Return(true, nil)
+				mockCF.EXPECT().GetCreator().Return(&aws.Creator{ARN: "arn:aws:iam::123:user/test", AccountID: "123"}, nil)
+				mockCF.EXPECT().GetLocalAWSAccessKeys().Return(&aws.AccessKey{AccessKeyID: "AKIA123", SecretAccessKey: "secret"}, nil)
+				return mockCF
+			}
+
+			err := runWithRuntime(t.RosaRuntime, Cmd, []string{}, deps)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(permissionsRan).To(Equal(1))
+			Expect(quotaRan).To(Equal(1))
+			Expect(verifyOCRan).To(Equal(1))
+		})
+
+		It("Returns an error when EnsureOsdCcsAdminUser fails", func() {
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusOK, supportedRegionsResponse),
+			)
+			deps := newDeps(nil, true)
+			deps.buildAWSClient = func(_ *logrus.Logger, _ string, _ bool) (aws.Client, error) {
+				mockAWS.EXPECT().ValidateCredentials().Return(true, nil)
+				return mockAWS, nil
+			}
+			deps.buildCFClient = func(_ reporter.Logger, _ *logrus.Logger, _ []string, _ bool) aws.Client {
+				mockCF.EXPECT().EnsureOsdCcsAdminUser(aws.OsdCcsAdminStackName, aws.AdminUserName, "us-east-1").Return(false, fmt.Errorf("ensure failed"))
+				return mockCF
+			}
+
+			err := runWithRuntime(t.RosaRuntime, Cmd, []string{}, deps)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("ensure failed"))
+		})
+
+		It("Returns an error when admin SCP validation fails", func() {
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusOK, supportedRegionsResponse),
+				RespondWithJSON(http.StatusOK, stsPoliciesResponse),
+			)
+			deps := newDeps(nil, true)
+			deps.buildAWSClient = func(_ *logrus.Logger, _ string, _ bool) (aws.Client, error) {
+				mockAWS.EXPECT().ValidateCredentials().Return(true, nil)
+				mockAWS.EXPECT().ValidateSCP(gomock.Any(), gomock.Any()).Return(false, fmt.Errorf("scp blocked"))
+				return mockAWS, nil
+			}
+			deps.buildCFClient = func(_ reporter.Logger, _ *logrus.Logger, _ []string, _ bool) aws.Client {
+				mockCF.EXPECT().EnsureOsdCcsAdminUser(aws.OsdCcsAdminStackName, aws.AdminUserName, "us-east-1").Return(true, nil)
+				return mockCF
+			}
+
+			err := runWithRuntime(t.RosaRuntime, Cmd, []string{}, deps)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("scp blocked"))
+		})
+
+		It("Returns an error when ValidateSCP returns true with an error", func() {
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusOK, supportedRegionsResponse),
+				RespondWithJSON(http.StatusOK, stsPoliciesResponse),
+			)
+			deps := newDeps(nil, true)
+			deps.buildAWSClient = func(_ *logrus.Logger, _ string, _ bool) (aws.Client, error) {
+				mockAWS.EXPECT().ValidateCredentials().Return(true, nil)
+				mockAWS.EXPECT().ValidateSCP(gomock.Any(), gomock.Any()).Return(true, fmt.Errorf("scp API error"))
+				return mockAWS, nil
+			}
+			deps.buildCFClient = func(_ reporter.Logger, _ *logrus.Logger, _ []string, _ bool) aws.Client {
+				mockCF.EXPECT().EnsureOsdCcsAdminUser(aws.OsdCcsAdminStackName, aws.AdminUserName, "us-east-1").Return(true, nil)
+				return mockCF
+			}
+
+			err := runWithRuntime(t.RosaRuntime, Cmd, []string{}, deps)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("scp API error"))
+		})
+
+		It("Continues with a warning when simulateCluster fails", func() {
+			stdoutCapture := func(deps initDeps) (string, string, error) {
+				return test.RunWithOutputCapture(func(r *rosa.Runtime, _ *cobra.Command) error {
+					return runWithRuntime(r, Cmd, []string{}, deps)
+				}, t.RosaRuntime, Cmd)
+			}
+
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusOK, supportedRegionsResponse),
+				RespondWithJSON(http.StatusOK, stsPoliciesResponse),
+				RespondWithJSON(http.StatusBadRequest, `{"kind":"Error","id":"400","code":"CLUSTERS-MGMT-400","reason":"dry run failed"}`),
+			)
+			deps := newDeps(nil, true)
+			deps.buildAWSClient = func(_ *logrus.Logger, _ string, _ bool) (aws.Client, error) {
+				mockAWS.EXPECT().ValidateCredentials().Return(true, nil)
+				mockAWS.EXPECT().ValidateSCP(gomock.Any(), gomock.Any()).Return(true, nil)
+				return mockAWS, nil
+			}
+			deps.buildCFClient = func(_ reporter.Logger, _ *logrus.Logger, _ []string, _ bool) aws.Client {
+				mockCF.EXPECT().EnsureOsdCcsAdminUser(aws.OsdCcsAdminStackName, aws.AdminUserName, "us-east-1").Return(false, nil)
+				mockCF.EXPECT().GetCreator().Return(&aws.Creator{ARN: "arn:aws:iam::123:user/test", AccountID: "123"}, nil)
+				mockCF.EXPECT().GetLocalAWSAccessKeys().Return(&aws.AccessKey{AccessKeyID: "AKIA123", SecretAccessKey: "secret"}, nil)
+				return mockCF
+			}
+
+			stdout, stderr, err := stdoutCapture(deps)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stderr).To(ContainSubstring("Cluster creation failed"))
+			Expect(stdout).To(ContainSubstring("Ensuring cluster administrator user"))
+			Expect(verifyOCRan).To(Equal(1))
+		})
+	})
+
+	Context("deleteStack", func() {
+		var (
+			ctrl      *gomock.Controller
+			mockAWS   *aws.MockClient
+			t         *test.TestingRuntime
+			ocmClient *ocm.Client
+		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+			mockAWS = aws.NewMockClient(ctrl)
+			t = test.NewTestRuntime()
+			ocmClient = t.RosaRuntime.OCMClient
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
+		})
+
+		It("Returns error when GetCreator fails", func() {
+			mockAWS.EXPECT().GetCreator().Return(nil, fmt.Errorf("STS error"))
+
+			err := deleteStack(mockAWS, ocmClient)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to get AWS creator"))
+		})
+
+		It("Returns error when HasClusters fails", func() {
+			mockAWS.EXPECT().GetCreator().Return(&aws.Creator{
+				ARN:       "arn:aws:iam::123:user/test",
+				AccountID: "123",
+			}, nil)
+
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusInternalServerError, "{}"),
+			)
+
+			err := deleteStack(mockAWS, ocmClient)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to check for clusters"))
+		})
+
+		It("Returns error when user still has clusters", func() {
+			mockAWS.EXPECT().GetCreator().Return(&aws.Creator{
+				ARN:       "arn:aws:iam::123:user/test",
+				AccountID: "123",
+			}, nil)
+
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusOK, `{"kind":"ClusterList","page":1,"size":1,"total":1,"items":[{"id":"abc","name":"mycluster"}]}`),
+			)
+
+			err := deleteStack(mockAWS, ocmClient)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("user still has clusters"))
+		})
+
+		It("Returns error when DeleteOsdCcsAdminUser fails", func() {
+			mockAWS.EXPECT().GetCreator().Return(&aws.Creator{
+				ARN:       "arn:aws:iam::123:user/test",
+				AccountID: "123",
+			}, nil)
+
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusOK, `{"kind":"ClusterList","page":1,"size":0,"total":0,"items":[]}`),
+			)
+
+			mockAWS.EXPECT().DeleteOsdCcsAdminUser(aws.OsdCcsAdminStackName).
+				Return(fmt.Errorf("stack delete failed"))
+
+			err := deleteStack(mockAWS, ocmClient)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to delete user"))
+		})
+
+		It("Succeeds when no clusters exist and delete works", func() {
+			mockAWS.EXPECT().GetCreator().Return(&aws.Creator{
+				ARN:       "arn:aws:iam::123:user/test",
+				AccountID: "123",
+			}, nil)
+
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusOK, `{"kind":"ClusterList","page":1,"size":0,"total":0,"items":[]}`),
+			)
+
+			mockAWS.EXPECT().DeleteOsdCcsAdminUser(aws.OsdCcsAdminStackName).Return(nil)
+
+			err := deleteStack(mockAWS, ocmClient)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("simulateCluster", func() {
+		var (
+			ctrl      *gomock.Controller
+			mockAWS   *aws.MockClient
+			t         *test.TestingRuntime
+			ocmClient *ocm.Client
+		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+			mockAWS = aws.NewMockClient(ctrl)
+			t = test.NewTestRuntime()
+			ocmClient = t.RosaRuntime.OCMClient
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
+		})
+
+		It("Returns error when GetCreator fails", func() {
+			mockAWS.EXPECT().GetCreator().Return(nil, fmt.Errorf("caller identity error"))
+
+			err := simulateCluster(mockAWS, ocmClient, "us-east-1")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to get AWS creator"))
+		})
+
+		It("Returns error when GetLocalAWSAccessKeys fails", func() {
+			mockAWS.EXPECT().GetCreator().Return(&aws.Creator{
+				ARN:       "arn:aws:iam::123:user/test",
+				AccountID: "123",
+			}, nil)
+			mockAWS.EXPECT().GetLocalAWSAccessKeys().Return(nil, fmt.Errorf("no keys"))
+
+			err := simulateCluster(mockAWS, ocmClient, "us-east-1")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to get AWS access key"))
+		})
+
+		It("Returns error when CreateCluster dry run fails", func() {
+			mockAWS.EXPECT().GetCreator().Return(&aws.Creator{
+				ARN:       "arn:aws:iam::123:user/test",
+				AccountID: "123",
+			}, nil)
+			mockAWS.EXPECT().GetLocalAWSAccessKeys().Return(&aws.AccessKey{
+				AccessKeyID:     "AKIA123",
+				SecretAccessKey: "secret",
+			}, nil)
+
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusBadRequest, `{"kind":"Error","id":"400","code":"CLUSTERS-MGMT-400","reason":"dry run failed"}`),
+			)
+
+			err := simulateCluster(mockAWS, ocmClient, "us-east-1")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("Succeeds with a valid dry run", func() {
+			mockAWS.EXPECT().GetCreator().Return(&aws.Creator{
+				ARN:       "arn:aws:iam::123:user/test",
+				AccountID: "123",
+			}, nil)
+			mockAWS.EXPECT().GetLocalAWSAccessKeys().Return(&aws.AccessKey{
+				AccessKeyID:     "AKIA123",
+				SecretAccessKey: "secret",
+			}, nil)
+
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusCreated, `{"kind":"Cluster","id":"dry-run-id","name":"rosa-init"}`),
+			)
+
+			err := simulateCluster(mockAWS, ocmClient, "us-east-1")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Defaults to us-east-1 when region is empty", func() {
+			mockAWS.EXPECT().GetCreator().Return(&aws.Creator{
+				ARN:       "arn:aws:iam::123:user/test",
+				AccountID: "123",
+			}, nil)
+			mockAWS.EXPECT().GetLocalAWSAccessKeys().Return(&aws.AccessKey{
+				AccessKeyID:     "AKIA123",
+				SecretAccessKey: "secret",
+			}, nil)
+
+			t.ApiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("POST", "/api/clusters_mgmt/v1/clusters"),
+					func(w http.ResponseWriter, req *http.Request) {
+						var body map[string]interface{}
+						Expect(json.NewDecoder(req.Body).Decode(&body)).To(Succeed())
+						regionBody, ok := body["region"].(map[string]interface{})
+						Expect(ok).To(BeTrue())
+						Expect(regionBody["id"]).To(Equal("us-east-1"))
+						w.WriteHeader(http.StatusCreated)
+						_, err := w.Write([]byte(`{"kind":"Cluster","id":"dry-run-id","name":"rosa-init"}`))
+						Expect(err).NotTo(HaveOccurred())
+					},
+				),
+			)
+
+			err := simulateCluster(mockAWS, ocmClient, "")
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/cmd/initialize/init_suite_test.go
+++ b/cmd/initialize/init_suite_test.go
@@ -1,0 +1,13 @@
+package initialize
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestInitialize(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Initialize Suite")
+}

--- a/cmd/logout/cmd.go
+++ b/cmd/logout/cmd.go
@@ -35,10 +35,13 @@ var Cmd = &cobra.Command{
 
 func run(_ *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporter()
-	// Remove the configuration file:
-	err := config.Remove()
+	err := runLogout()
 	if err != nil {
 		reporter.Errorf("Failed to remove config file: %v", err)
 		os.Exit(1)
 	}
+}
+
+func runLogout() error {
+	return config.Remove()
 }

--- a/cmd/logout/cmd_test.go
+++ b/cmd/logout/cmd_test.go
@@ -1,0 +1,87 @@
+package logout
+
+import (
+	"fmt"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/rosa/pkg/config"
+	"github.com/openshift/rosa/pkg/properties"
+)
+
+var _ = Describe("logout command", func() {
+	var tmpdir string
+
+	BeforeEach(func() {
+		var err error
+		tmpdir, err = os.MkdirTemp("", ".ocm-logout-test-*")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.Setenv("OCM_CONFIG", tmpdir+"/ocm_config.json")).To(Succeed())
+		DeferCleanup(os.RemoveAll, tmpdir)
+		DeferCleanup(os.Unsetenv, "OCM_CONFIG")
+	})
+
+	It("Removes config file successfully when it exists", func() {
+		cfg := &config.Config{
+			AccessToken: "test-token",
+			URL:         "https://api.example.com",
+		}
+		err := config.Save(cfg)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = runLogout()
+		Expect(err).NotTo(HaveOccurred())
+
+		_, statErr := os.Stat(tmpdir + "/ocm_config.json")
+		Expect(os.IsNotExist(statErr)).To(BeTrue())
+	})
+
+	It("Returns nil when config file does not exist", func() {
+		err := runLogout()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Removes keyring-managed config successfully", func() {
+		Expect(os.Setenv(properties.KeyringEnvKey, "test-keyring")).To(Succeed())
+		DeferCleanup(os.Unsetenv, properties.KeyringEnvKey)
+
+		called := false
+		originalRemoveConfigFromKeyring := config.RemoveConfigFromKeyring
+		DeferCleanup(func() {
+			config.RemoveConfigFromKeyring = originalRemoveConfigFromKeyring
+		})
+		config.RemoveConfigFromKeyring = func(_ string) error {
+			called = true
+			return nil
+		}
+
+		err := runLogout()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(called).To(BeTrue())
+	})
+
+	It("Returns an error when keyring removal fails", func() {
+		Expect(os.Setenv(properties.KeyringEnvKey, "test-keyring")).To(Succeed())
+		DeferCleanup(os.Unsetenv, properties.KeyringEnvKey)
+
+		originalRemoveConfigFromKeyring := config.RemoveConfigFromKeyring
+		DeferCleanup(func() {
+			config.RemoveConfigFromKeyring = originalRemoveConfigFromKeyring
+		})
+		config.RemoveConfigFromKeyring = func(_ string) error {
+			return fmt.Errorf("keyring locked")
+		}
+
+		err := runLogout()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("keyring"))
+	})
+
+	It("Rejects extra arguments via cobra.NoArgs", func() {
+		Expect(Cmd.Args).NotTo(BeNil())
+		err := Cmd.Args(Cmd, []string{"unexpected"})
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/cmd/logout/logout_suite_test.go
+++ b/cmd/logout/logout_suite_test.go
@@ -1,0 +1,13 @@
+package logout
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestLogout(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Logout Suite")
+}

--- a/cmd/verify/oc/cmd.go
+++ b/cmd/verify/oc/cmd.go
@@ -17,6 +17,7 @@ limitations under the License.
 package oc
 
 import (
+	"context"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -25,6 +26,10 @@ import (
 
 	rprtr "github.com/openshift/rosa/pkg/reporter"
 )
+
+var ocVersionOutput = func(ctx context.Context) ([]byte, error) {
+	return exec.CommandContext(ctx, "oc", "version", "--client").Output()
+}
 
 var Cmd = &cobra.Command{
 	Use:     "openshift-client",
@@ -37,22 +42,31 @@ var Cmd = &cobra.Command{
 	Args: cobra.NoArgs,
 }
 
-func run(_ *cobra.Command, _ []string) {
+func run(cmd *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporter()
+	ctx := context.Background()
+	if cmd != nil {
+		ctx = cmd.Context()
+	}
+	runVerifyOC(ctx, reporter, ocVersionOutput)
+}
 
-	// Verify whether `oc` is installed
+func runVerifyOC(ctx context.Context, reporter rprtr.Logger, getVersion func(context.Context) ([]byte, error)) {
 	if reporter.IsTerminal() {
 		reporter.Infof("Verifying whether OpenShift command-line tool is available...")
 	}
 
-	output, err := exec.Command("oc", "version", "--client").Output()
+	output, err := getVersion(ctx)
 	if output == nil && err != nil {
 		reporter.Warnf("OpenShift command-line tool is not installed.\n" +
 			"Run 'rosa download oc' to download the latest version, then add it to your PATH.")
 		return
 	}
+	if err != nil {
+		reporter.Errorf("Failed to verify OpenShift command-line tool: %v", err)
+		return
+	}
 
-	// Parse the version for the OpenShift Client
 	version := strings.Replace(strings.Split(string(output), "\n")[0], "\n", "", 1)
 	isCorrectVersion, err := regexp.Match(`\W4.\d*`, output)
 	if err != nil {

--- a/cmd/verify/oc/cmd_test.go
+++ b/cmd/verify/oc/cmd_test.go
@@ -1,0 +1,95 @@
+package oc
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type mockReporter struct {
+	infos    []string
+	warns    []string
+	errs     []string
+	terminal bool
+}
+
+func (m *mockReporter) Debugf(_ string, _ ...any) {}
+func (m *mockReporter) Infof(f string, a ...any)  { m.infos = append(m.infos, fmt.Sprintf(f, a...)) }
+func (m *mockReporter) Warnf(f string, a ...any)  { m.warns = append(m.warns, fmt.Sprintf(f, a...)) }
+func (m *mockReporter) Errorf(f string, a ...any) error {
+	m.errs = append(m.errs, fmt.Sprintf(f, a...))
+	return nil
+}
+func (m *mockReporter) IsTerminal() bool { return m.terminal }
+
+var _ = Describe("verify oc", func() {
+	It("Warns when oc is not installed", func() {
+		reporter := &mockReporter{terminal: true}
+		getVersion := func(context.Context) ([]byte, error) {
+			return nil, fmt.Errorf("exec: \"oc\": executable file not found in $PATH")
+		}
+
+		runVerifyOC(context.Background(), reporter, getVersion)
+
+		Expect(reporter.warns).To(HaveLen(1), "expected one warning for missing oc binary")
+		Expect(reporter.warns[0]).To(ContainSubstring("not installed"), "expected missing-binary warning text")
+	})
+
+	It("Reports correct version when 4.x is installed", func() {
+		reporter := &mockReporter{terminal: true}
+		getVersion := func(context.Context) ([]byte, error) {
+			return []byte("Client Version: 4.14.0\n"), nil
+		}
+
+		runVerifyOC(context.Background(), reporter, getVersion)
+
+		Expect(reporter.warns).To(BeEmpty(), "expected no warnings for supported 4.x version")
+		Expect(reporter.errs).To(BeEmpty(), "expected no errors for supported 4.x version")
+		Expect(reporter.infos).To(HaveLen(2), "expected start and success info messages in terminal mode")
+		Expect(reporter.infos[1]).To(ContainSubstring("4.14.0"), "expected success info to mention the detected version")
+	})
+
+	It("Warns when oc version is not 4.x", func() {
+		reporter := &mockReporter{terminal: true}
+		getVersion := func(context.Context) ([]byte, error) {
+			return []byte("Client Version: 3.11.0\n"), nil
+		}
+
+		runVerifyOC(context.Background(), reporter, getVersion)
+
+		Expect(reporter.warns).To(HaveLen(2), "expected version and unsupported warnings for non-4.x oc")
+		Expect(reporter.warns[0]).To(ContainSubstring("3.11.0"), "expected first warning to include the detected version")
+		Expect(reporter.warns[1]).To(ContainSubstring("not supported"), "expected unsupported-version warning text")
+	})
+
+	It("Reports an error when oc returns output and an execution error", func() {
+		reporter := &mockReporter{terminal: true}
+		getVersion := func(context.Context) ([]byte, error) {
+			return []byte("Client Version: 4.14.0\n"), fmt.Errorf("permission denied")
+		}
+
+		runVerifyOC(context.Background(), reporter, getVersion)
+
+		Expect(reporter.errs).To(HaveLen(1), "expected one error when oc returns a non-not-found execution failure")
+		Expect(reporter.errs[0]).To(ContainSubstring("permission denied"), "expected the execution error to be surfaced")
+	})
+
+	It("Does not print verifying message when not in terminal mode", func() {
+		reporter := &mockReporter{terminal: false}
+		getVersion := func(context.Context) ([]byte, error) {
+			return []byte("Client Version: 4.14.0\n"), nil
+		}
+
+		runVerifyOC(context.Background(), reporter, getVersion)
+
+		Expect(reporter.infos).To(BeEmpty(), "expected no informational output in non-terminal mode")
+	})
+
+	It("Rejects extra arguments via cobra.NoArgs", func() {
+		Expect(Cmd.Args).NotTo(BeNil(), "expected cobra.NoArgs validation to be configured")
+		err := Cmd.Args(Cmd, []string{"unexpected"})
+		Expect(err).To(HaveOccurred(), "expected extra arguments to be rejected")
+	})
+})

--- a/cmd/verify/oc/oc_suite_test.go
+++ b/cmd/verify/oc/oc_suite_test.go
@@ -1,0 +1,13 @@
+package oc
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestVerifyOC(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Verify OC Suite")
+}

--- a/cmd/verify/permissions/cmd.go
+++ b/cmd/verify/permissions/cmd.go
@@ -52,26 +52,32 @@ func init() {
 func run(_ *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithOCM()
 	defer r.Cleanup()
+	err := runWithRuntime(r)
+	if err != nil {
+		os.Exit(1)
+	}
+}
 
-	// Get AWS region
+func runWithRuntime(r *rosa.Runtime) error {
 	region, err := aws.GetRegion(arguments.GetRegion())
 	if err != nil {
 		r.Reporter.Errorf("Error getting region: %v", err)
-		os.Exit(1)
+		return err
 	}
 
-	// Create the AWS client:
-	r.AWSClient, err = aws.NewClient().
-		Logger(r.Logger).
-		Region(region).
-		Build()
-	if err != nil {
-		// FIXME Hack to capture errors due to using STS accounts
-		if strings.Contains(fmt.Sprintf("%s", err), "STS") {
-			r.OCMClient.LogEvent("ROSAInitCredentialsSTS", nil)
+	if r.AWSClient == nil {
+		r.AWSClient, err = aws.NewClient().
+			Logger(r.Logger).
+			Region(region).
+			Build()
+		if err != nil {
+			// FIXME Hack to capture errors due to using STS accounts
+			if strings.Contains(fmt.Sprintf("%s", err), "STS") {
+				r.OCMClient.LogEvent("ROSAInitCredentialsSTS", nil)
+			}
+			r.Reporter.Errorf("Error creating AWS client: %v", err)
+			return err
 		}
-		r.Reporter.Errorf("Error creating AWS client: %v", err)
-		os.Exit(1)
 	}
 
 	r.Reporter.Infof("Verifying permissions for non-STS clusters")
@@ -79,7 +85,7 @@ func run(_ *cobra.Command, _ []string) {
 	policies, err := r.OCMClient.GetPolicies("OSDSCPPolicy")
 	if err != nil {
 		r.Reporter.Errorf("Failed to get 'osdscppolicy' for '%s': %v", aws.AdminUserName, err)
-		os.Exit(1)
+		return err
 	}
 	ok, err := r.AWSClient.ValidateSCP(nil, policies)
 	if err != nil {
@@ -88,14 +94,15 @@ func run(_ *cobra.Command, _ []string) {
 			"SCP is not preventing this account from performing the required checks")
 		if strings.Contains(err.Error(), "Throttling: Rate exceeded") {
 			r.Reporter.Errorf("Throttling: Rate exceeded. Please wait 3-5 minutes before retrying.")
-			os.Exit(1)
+			return err
 		}
 		r.Reporter.Errorf("%v", err)
-		os.Exit(1)
+		return err
 	}
 	if !ok {
 		r.OCMClient.LogEvent("ROSAVerifyPermissionsSCPInvalid", nil)
 		r.Reporter.Warnf("Failed to validate SCP policies. Will try to continue anyway...")
 	}
 	r.Reporter.Infof("AWS SCP policies ok")
+	return nil
 }

--- a/cmd/verify/permissions/cmd_test.go
+++ b/cmd/verify/permissions/cmd_test.go
@@ -1,0 +1,124 @@
+package permissions
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/rosa"
+	"github.com/openshift/rosa/pkg/test"
+)
+
+const stsPoliciesResponse = `{
+	"kind": "AWSSTSPolicyList",
+	"page": 1,
+	"size": 0,
+	"total": 0,
+	"items": []
+}`
+
+var _ = Describe("verify permissions", func() {
+	var t *test.TestingRuntime
+
+	BeforeEach(func() {
+		t = test.NewTestRuntime()
+		os.Setenv("AWS_REGION", "us-east-1")
+		DeferCleanup(os.Unsetenv, "AWS_REGION")
+	})
+
+	It("Succeeds when SCP validation passes", func() {
+		t.ApiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, stsPoliciesResponse),
+		)
+		mockClient := t.RosaRuntime.AWSClient.(*aws.MockClient)
+		mockClient.EXPECT().ValidateSCP(nil, map[string]*cmv1.AWSSTSPolicy{}).Return(true, nil)
+
+		stdout, stderr, err := test.RunWithOutputCapture(
+			func(r *rosa.Runtime, _ *cobra.Command) error {
+				return runWithRuntime(r)
+			}, t.RosaRuntime, Cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stderr).To(BeEmpty())
+		Expect(stdout).To(ContainSubstring("AWS SCP policies ok"))
+	})
+
+	It("Returns error when GetPolicies API fails", func() {
+		t.ApiServer.AppendHandlers(
+			RespondWithJSON(http.StatusInternalServerError, "{}"),
+		)
+
+		_, stderr, err := test.RunWithOutputCapture(
+			func(r *rosa.Runtime, _ *cobra.Command) error {
+				return runWithRuntime(r)
+			}, t.RosaRuntime, Cmd)
+		Expect(err).To(HaveOccurred())
+		Expect(stderr).To(ContainSubstring("Failed to get 'osdscppolicy'"))
+	})
+
+	It("Returns error with throttling message when rate exceeded", func() {
+		t.ApiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, stsPoliciesResponse),
+		)
+		mockClient := t.RosaRuntime.AWSClient.(*aws.MockClient)
+		mockClient.EXPECT().ValidateSCP(nil, map[string]*cmv1.AWSSTSPolicy{}).
+			Return(false, fmt.Errorf("Throttling: Rate exceeded"))
+
+		_, stderr, err := test.RunWithOutputCapture(
+			func(r *rosa.Runtime, _ *cobra.Command) error {
+				return runWithRuntime(r)
+			}, t.RosaRuntime, Cmd)
+		Expect(err).To(HaveOccurred())
+		Expect(stderr).To(ContainSubstring("Unable to validate SCP policies"))
+		Expect(stderr).To(ContainSubstring("Throttling: Rate exceeded. Please wait 3-5 minutes"))
+	})
+
+	It("Returns error with details when ValidateSCP fails without throttling", func() {
+		t.ApiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, stsPoliciesResponse),
+		)
+		mockClient := t.RosaRuntime.AWSClient.(*aws.MockClient)
+		mockClient.EXPECT().ValidateSCP(nil, map[string]*cmv1.AWSSTSPolicy{}).
+			Return(false, fmt.Errorf("access denied for policy simulation"))
+
+		_, stderr, err := test.RunWithOutputCapture(
+			func(r *rosa.Runtime, _ *cobra.Command) error {
+				return runWithRuntime(r)
+			}, t.RosaRuntime, Cmd)
+		Expect(err).To(HaveOccurred())
+		Expect(stderr).To(ContainSubstring("Unable to validate SCP policies"))
+		Expect(stderr).To(ContainSubstring("access denied for policy simulation"))
+	})
+
+	It("Continues with warning when ValidateSCP returns ok=false without error", func() {
+		t.ApiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, stsPoliciesResponse),
+		)
+		mockClient := t.RosaRuntime.AWSClient.(*aws.MockClient)
+		mockClient.EXPECT().ValidateSCP(nil, map[string]*cmv1.AWSSTSPolicy{}).Return(false, nil)
+
+		stdout, stderr, err := test.RunWithOutputCapture(
+			func(r *rosa.Runtime, _ *cobra.Command) error {
+				return runWithRuntime(r)
+			}, t.RosaRuntime, Cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stderr).To(ContainSubstring("Failed to validate SCP policies. Will try to continue anyway"))
+		Expect(stdout).To(ContainSubstring("AWS SCP policies ok"))
+	})
+
+	It("Rejects extra arguments via cobra.NoArgs", func() {
+		Expect(Cmd.Args).NotTo(BeNil())
+		err := Cmd.Args(Cmd, []string{"unexpected"})
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("Has scp as a command alias", func() {
+		Expect(Cmd.Aliases).To(ContainElement("scp"))
+	})
+})

--- a/cmd/verify/permissions/permissions_suite_test.go
+++ b/cmd/verify/permissions/permissions_suite_test.go
@@ -1,0 +1,13 @@
+package permissions
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPermissions(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Verify Permissions Suite")
+}

--- a/cmd/verify/quota/cmd.go
+++ b/cmd/verify/quota/cmd.go
@@ -50,42 +50,54 @@ func init() {
 
 func run(_ *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithOCM()
-	defer r.Cleanup()
+	err := runWithRuntime(r)
+	r.Cleanup()
+	if err != nil {
+		os.Exit(1)
+	}
+}
 
-	// Get AWS region
+func runWithRuntime(r *rosa.Runtime) error {
 	region, err := aws.GetRegion(arguments.GetRegion())
 	if err != nil {
 		r.Reporter.Errorf("Error getting region: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("getting AWS region for quota verification: %w", err)
 	}
 
-	// Create the AWS client:
-	r.AWSClient, err = aws.NewClient().
-		Logger(r.Logger).
-		Region(region).
-		Build()
-	if err != nil {
-		// FIXME Hack to capture errors due to using STS accounts
-		if strings.Contains(fmt.Sprintf("%s", err), "STS") {
-			r.OCMClient.LogEvent("ROSAInitCredentialsSTS", nil)
+	if r.AWSClient == nil {
+		r.AWSClient, err = aws.NewClient().
+			Logger(r.Logger).
+			Region(region).
+			Build()
+		if err != nil {
+			// FIXME Hack to capture errors due to using STS accounts
+			if strings.Contains(fmt.Sprintf("%s", err), "STS") {
+				r.OCMClient.LogEvent("ROSAInitCredentialsSTS", nil)
+			}
+			r.Reporter.Errorf("Error creating AWS client: %v", err)
+			return fmt.Errorf("building AWS client for quota verification: %w", err)
 		}
-		r.Reporter.Errorf("Error creating AWS client: %v", err)
-		os.Exit(1)
 	}
 
 	if r.Reporter.IsTerminal() {
 		r.Reporter.Infof("Validating AWS quota...")
 	}
-	_, err = r.AWSClient.ValidateQuota()
+	ok, err := r.AWSClient.ValidateQuota()
 	if err != nil {
 		r.OCMClient.LogEvent("ROSAVerifyQuotaInsufficient", nil)
 		r.Reporter.Errorf("Insufficient AWS quotas")
 		r.Reporter.Errorf("%v", err)
-		os.Exit(1)
+		return fmt.Errorf("validating AWS quotas: %w", err)
+	}
+	if !ok {
+		r.OCMClient.LogEvent("ROSAVerifyQuotaInsufficient", nil)
+		r.Reporter.Errorf("Insufficient AWS quotas")
+		return fmt.Errorf("validating AWS quotas: insufficient AWS quotas")
 	}
 	if r.Reporter.IsTerminal() {
 		r.Reporter.Infof("AWS quota ok. " +
 			"If cluster installation fails, validate actual AWS resource usage against " +
 			"https://docs.openshift.com/rosa/rosa_getting_started/rosa-required-aws-service-quotas.html")
 	}
+	return nil
 }

--- a/cmd/verify/quota/cmd_test.go
+++ b/cmd/verify/quota/cmd_test.go
@@ -1,0 +1,78 @@
+package quota
+
+import (
+	"fmt"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/rosa"
+	"github.com/openshift/rosa/pkg/test"
+)
+
+var _ = Describe("verify quota", func() {
+	var t *test.TestingRuntime
+
+	BeforeEach(func() {
+		t = test.NewTestRuntime()
+		Expect(os.Setenv("AWS_REGION", "us-east-1")).To(Succeed())
+		DeferCleanup(os.Unsetenv, "AWS_REGION")
+	})
+
+	It("Succeeds when quota validation passes", func() {
+		mockClient := t.RosaRuntime.AWSClient.(*aws.MockClient)
+		mockClient.EXPECT().ValidateQuota().Return(true, nil)
+
+		err := runWithRuntime(t.RosaRuntime)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Prints no info messages when not running in a terminal", func() {
+		mockClient := t.RosaRuntime.AWSClient.(*aws.MockClient)
+		mockClient.EXPECT().ValidateQuota().Return(true, nil)
+
+		stdout, stderr, err := test.RunWithOutputCapture(
+			func(r *rosa.Runtime, _ *cobra.Command) error {
+				return runWithRuntime(r)
+			}, t.RosaRuntime, Cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stderr).To(BeEmpty())
+		Expect(stdout).To(BeEmpty())
+	})
+
+	It("Returns error and prints failure details when ValidateQuota fails with error", func() {
+		mockClient := t.RosaRuntime.AWSClient.(*aws.MockClient)
+		mockClient.EXPECT().ValidateQuota().Return(false, fmt.Errorf("not enough vCPU"))
+
+		stdout, stderr, err := test.RunWithOutputCapture(
+			func(r *rosa.Runtime, _ *cobra.Command) error {
+				return runWithRuntime(r)
+			}, t.RosaRuntime, Cmd)
+		Expect(err).To(HaveOccurred())
+		Expect(stderr).To(ContainSubstring("Insufficient AWS quotas"))
+		Expect(stderr).To(ContainSubstring("not enough vCPU"))
+		Expect(stdout).To(BeEmpty())
+	})
+
+	It("Returns error when ValidateQuota returns false without error", func() {
+		mockClient := t.RosaRuntime.AWSClient.(*aws.MockClient)
+		mockClient.EXPECT().ValidateQuota().Return(false, nil)
+
+		stdout, stderr, err := test.RunWithOutputCapture(
+			func(r *rosa.Runtime, _ *cobra.Command) error {
+				return runWithRuntime(r)
+			}, t.RosaRuntime, Cmd)
+		Expect(err).To(HaveOccurred())
+		Expect(stderr).To(ContainSubstring("Insufficient AWS quotas"))
+		Expect(stdout).To(BeEmpty())
+	})
+
+	It("Rejects extra arguments via cobra.NoArgs", func() {
+		Expect(Cmd.Args).NotTo(BeNil())
+		err := Cmd.Args(Cmd, []string{"unexpected"})
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/cmd/verify/quota/quota_suite_test.go
+++ b/cmd/verify/quota/quota_suite_test.go
@@ -1,0 +1,13 @@
+package quota
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestQuota(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Verify Quota Suite")
+}

--- a/cmd/whoami/cmd.go
+++ b/cmd/whoami/cmd.go
@@ -17,6 +17,7 @@ limitations under the License.
 package whoami
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -43,6 +44,8 @@ var Cmd = &cobra.Command{
 	Args: cobra.NoArgs,
 }
 
+var errNotLoggedIn = errors.New("user is not logged in to OCM")
+
 func init() {
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)
@@ -52,59 +55,71 @@ func init() {
 
 func run(_ *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithAWS()
+	err := runWithRuntime(r)
+	r.Cleanup()
+	if err != nil {
+		if errors.Is(err, errNotLoggedIn) {
+			os.Exit(0)
+		}
+		os.Exit(1)
+	}
+}
 
-	// Get default AWS region:
+func runWithRuntime(r *rosa.Runtime) error {
 	awsRegion, err := aws.GetRegion("")
 	if err != nil {
 		r.Reporter.Errorf("Error getting AWS region: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("error getting AWS region: %w", err)
 	}
 
-	// Load the configuration file:
 	cfg, err := config.Load()
 	if err != nil {
 		r.Reporter.Errorf("Failed to load config file: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("loading config file: %w", err)
 	}
 	if cfg == nil || config.IsNotValid(cfg) {
 		r.Reporter.Errorf("User is not logged in to OCM")
-		os.Exit(0)
+		return errNotLoggedIn
 	}
 
-	// Verify configuration file:
 	loggedIn, err := cfg.Armed()
 	if err != nil {
 		r.Reporter.Errorf("Failed to verify configuration: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("verifying configuration: %w", err)
 	}
 	if !loggedIn {
 		r.Reporter.Errorf("User is not logged in to OCM")
-		os.Exit(0)
+		return errNotLoggedIn
 	}
 
-	// Create a connection to OCM:
+	if r.OCMClient != nil {
+		err = r.OCMClient.Close()
+		if err != nil {
+			r.Reporter.Errorf("Failed to close existing OCM connection: %v", err)
+			return fmt.Errorf("closing existing OCM connection: %w", err)
+		}
+	}
+
 	r.OCMClient, err = ocm.NewClient().
 		Config(cfg).
 		Logger(r.Logger).
 		Build()
 	if err != nil {
 		r.Reporter.Errorf("Failed to create OCM connection: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("creating OCM connection: %w", err)
 	}
-	defer r.Cleanup()
 
-	// Get current OCM account:
 	account, err := r.OCMClient.GetCurrentAccount()
 	if err != nil {
 		r.Reporter.Errorf("Failed to get current account: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("getting current account: %w", err)
 	}
 
 	if account == nil {
 		account, err = getAccountDataFromToken(cfg)
 		if err != nil {
 			r.Reporter.Errorf("Failed to get account data from token: %v", err)
-			os.Exit(1)
+			return fmt.Errorf("getting account data from token: %w", err)
 		}
 	}
 	outputObject := object.Object{
@@ -127,9 +142,9 @@ func run(_ *cobra.Command, _ []string) {
 		err = output.Print(outputObject)
 		if err != nil {
 			r.Reporter.Errorf("%s", err)
-			os.Exit(1)
+			return fmt.Errorf("printing whoami output: %w", err)
 		}
-		return
+		return nil
 	}
 	keys := make([]string, 0, len(outputObject))
 	for key := range outputObject {
@@ -140,6 +155,7 @@ func run(_ *cobra.Command, _ []string) {
 		fmt.Printf("%-30s%v\n", key+":", outputObject[key])
 	}
 	fmt.Println()
+	return nil
 }
 
 func getAccountDataFromToken(cfg *config.Config) (*amsv1.Account, error) {

--- a/cmd/whoami/cmd_test.go
+++ b/cmd/whoami/cmd_test.go
@@ -1,0 +1,330 @@
+package whoami
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/config"
+	"github.com/openshift/rosa/pkg/output"
+	"github.com/openshift/rosa/pkg/rosa"
+	"github.com/openshift/rosa/pkg/test"
+)
+
+var _ = Describe("whoami command", func() {
+	var t *test.TestingRuntime
+	var tmpdir string
+
+	BeforeEach(func() {
+		t = test.NewTestRuntime()
+		Expect(os.Setenv("AWS_REGION", "us-east-1")).To(Succeed())
+		DeferCleanup(os.Unsetenv, "AWS_REGION")
+
+		var err error
+		tmpdir, err = os.MkdirTemp("", ".ocm-whoami-test-*")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(os.RemoveAll, tmpdir)
+
+		output.SetOutput("")
+		DeferCleanup(output.SetOutput, "")
+	})
+
+	saveConfig := func(cfg *config.Config) {
+		Expect(os.Setenv("OCM_CONFIG", tmpdir+"/ocm_config.json")).To(Succeed())
+		DeferCleanup(os.Unsetenv, "OCM_CONFIG")
+		Expect(config.Save(cfg)).To(Succeed())
+	}
+
+	validConfig := func() *config.Config {
+		accessToken := MakeTokenString("Bearer", 15*time.Minute)
+		return &config.Config{
+			AccessToken: accessToken,
+			ClientID:    "test-client",
+			URL:         t.ApiServer.URL(),
+			TokenURL:    t.SsoServer.URL(),
+		}
+	}
+
+	accountResponse := func(extID string) string {
+		resp := map[string]interface{}{
+			"kind":       "Account",
+			"id":         "acct-123",
+			"first_name": "Test",
+			"last_name":  "User",
+			"username":   "testuser",
+			"email":      "test@example.com",
+			"organization": map[string]interface{}{
+				"id":          "org-456",
+				"name":        "Test Org",
+				"external_id": extID,
+			},
+		}
+		data, _ := json.Marshal(resp)
+		return string(data)
+	}
+
+	It("Displays account information from OCM in text mode", func() {
+		cfg := validConfig()
+		saveConfig(cfg)
+
+		t.ApiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, accountResponse("ext-789")),
+		)
+
+		stdout, stderr, err := test.RunWithOutputCapture(
+			func(r *rosa.Runtime, _ *cobra.Command) error {
+				return runWithRuntime(r)
+			}, t.RosaRuntime, Cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stderr).To(BeEmpty())
+		Expect(stdout).To(ContainSubstring("AWS Account ID:"))
+		Expect(stdout).To(ContainSubstring("OCM Account Username:"))
+		Expect(stdout).To(ContainSubstring("testuser"))
+	})
+
+	It("Displays account information in JSON mode", func() {
+		cfg := validConfig()
+		saveConfig(cfg)
+		output.SetOutput(output.JSON)
+
+		t.ApiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, accountResponse("ext-789")),
+		)
+
+		stdout, _, err := test.RunWithOutputCapture(
+			func(r *rosa.Runtime, _ *cobra.Command) error {
+				return runWithRuntime(r)
+			}, t.RosaRuntime, Cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stdout).To(ContainSubstring("OCM Account Username"))
+	})
+
+	It("Falls back to token data when GetCurrentAccount returns nil", func() {
+		claims := MakeClaims()
+		claims["first_name"] = "Token"
+		claims["last_name"] = "Fallback"
+		claims["username"] = "tokenuser"
+		claims["email"] = "token@example.com"
+		claims["org_id"] = "org-from-token"
+		tokenObj := MakeTokenObject(claims)
+
+		cfg := &config.Config{
+			AccessToken: tokenObj.Raw,
+			ClientID:    "test-client",
+			URL:         t.ApiServer.URL(),
+			TokenURL:    t.SsoServer.URL(),
+		}
+		saveConfig(cfg)
+
+		t.ApiServer.AppendHandlers(
+			RespondWithJSON(http.StatusNotFound, "{}"),
+		)
+
+		stdout, stderr, err := test.RunWithOutputCapture(
+			func(r *rosa.Runtime, _ *cobra.Command) error {
+				return runWithRuntime(r)
+			}, t.RosaRuntime, Cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stderr).To(BeEmpty())
+		Expect(stdout).To(ContainSubstring("tokenuser"))
+	})
+
+	It("Includes org external ID when present", func() {
+		cfg := validConfig()
+		saveConfig(cfg)
+
+		t.ApiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, accountResponse("ext-789")),
+		)
+
+		stdout, _, err := test.RunWithOutputCapture(
+			func(r *rosa.Runtime, _ *cobra.Command) error {
+				return runWithRuntime(r)
+			}, t.RosaRuntime, Cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stdout).To(ContainSubstring("OCM Organization External ID:"))
+		Expect(stdout).To(ContainSubstring("ext-789"))
+	})
+
+	It("Omits org external ID when empty", func() {
+		cfg := validConfig()
+		saveConfig(cfg)
+
+		t.ApiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, accountResponse("")),
+		)
+
+		stdout, _, err := test.RunWithOutputCapture(
+			func(r *rosa.Runtime, _ *cobra.Command) error {
+				return runWithRuntime(r)
+			}, t.RosaRuntime, Cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stdout).NotTo(ContainSubstring("OCM Organization External ID"))
+	})
+
+	It("Returns error when config file cannot be loaded", func() {
+		Expect(os.Setenv("OCM_CONFIG", tmpdir)).To(Succeed())
+		DeferCleanup(os.Unsetenv, "OCM_CONFIG")
+
+		_, stderr, err := test.RunWithOutputCapture(
+			func(r *rosa.Runtime, _ *cobra.Command) error {
+				return runWithRuntime(r)
+			}, t.RosaRuntime, Cmd)
+		Expect(err).To(HaveOccurred())
+		Expect(stderr).To(ContainSubstring("Failed to load config file"))
+	})
+
+	It("Returns error when config is nil", func() {
+		Expect(os.Setenv("OCM_CONFIG", tmpdir+"/empty_config.json")).To(Succeed())
+		DeferCleanup(os.Unsetenv, "OCM_CONFIG")
+
+		_, stderr, err := test.RunWithOutputCapture(
+			func(r *rosa.Runtime, _ *cobra.Command) error {
+				return runWithRuntime(r)
+			}, t.RosaRuntime, Cmd)
+		Expect(err).To(HaveOccurred())
+		Expect(stderr).To(ContainSubstring("not logged in"))
+	})
+
+	It("Returns error when config is invalid", func() {
+		invalidCfg := &config.Config{
+			AccessToken: "",
+			ClientID:    "",
+			URL:         "",
+			TokenURL:    "",
+		}
+		saveConfig(invalidCfg)
+
+		_, stderr, err := test.RunWithOutputCapture(
+			func(r *rosa.Runtime, _ *cobra.Command) error {
+				return runWithRuntime(r)
+			}, t.RosaRuntime, Cmd)
+		Expect(err).To(HaveOccurred())
+		Expect(stderr).To(ContainSubstring("not logged in"))
+	})
+
+	It("Returns error when Armed() fails", func() {
+		cfg := &config.Config{
+			AccessToken: "invalid-jwt-token",
+			ClientID:    "test-client",
+			URL:         t.ApiServer.URL(),
+			TokenURL:    t.SsoServer.URL(),
+		}
+		saveConfig(cfg)
+
+		_, stderr, err := test.RunWithOutputCapture(
+			func(r *rosa.Runtime, _ *cobra.Command) error {
+				return runWithRuntime(r)
+			}, t.RosaRuntime, Cmd)
+		Expect(err).To(HaveOccurred())
+		Expect(stderr).To(ContainSubstring("Failed to verify configuration"))
+	})
+
+	It("Returns error when GetCurrentAccount API fails", func() {
+		cfg := validConfig()
+		saveConfig(cfg)
+
+		t.ApiServer.AppendHandlers(
+			RespondWithJSON(http.StatusInternalServerError, `{"kind":"Error","id":"500","href":"/api/accounts_mgmt/v1/errors/500","code":"ACCOUNTS-MGMT-500","reason":"internal error"}`),
+		)
+
+		_, stderr, err := test.RunWithOutputCapture(
+			func(r *rosa.Runtime, _ *cobra.Command) error {
+				return runWithRuntime(r)
+			}, t.RosaRuntime, Cmd)
+		Expect(err).To(HaveOccurred())
+		Expect(stderr).To(ContainSubstring("Failed to get current account"))
+	})
+
+	It("Returns error when token fallback fails due to bad token data", func() {
+		cfg := &config.Config{
+			AccessToken: MakeTokenString("Bearer", 15*time.Minute),
+			ClientID:    "test-client",
+			URL:         t.ApiServer.URL(),
+			TokenURL:    t.SsoServer.URL(),
+		}
+		saveConfig(cfg)
+
+		t.ApiServer.AppendHandlers(
+			RespondWithJSON(http.StatusNotFound, "{}"),
+		)
+
+		_, stderr, err := test.RunWithOutputCapture(
+			func(r *rosa.Runtime, _ *cobra.Command) error {
+				return runWithRuntime(r)
+			}, t.RosaRuntime, Cmd)
+		Expect(err).To(HaveOccurred())
+		Expect(stderr).To(ContainSubstring("Failed to get account data from token"))
+	})
+
+	It("Returns error when structured output format is invalid", func() {
+		cfg := validConfig()
+		saveConfig(cfg)
+		output.SetOutput("bogus-format")
+
+		t.ApiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, accountResponse("")),
+		)
+
+		_, stderr, err := test.RunWithOutputCapture(
+			func(r *rosa.Runtime, _ *cobra.Command) error {
+				return runWithRuntime(r)
+			}, t.RosaRuntime, Cmd)
+		Expect(err).To(HaveOccurred())
+		Expect(stderr).To(ContainSubstring("unknown format"))
+	})
+
+	It("Sets AWS fields from the pre-set Creator", func() {
+		cfg := validConfig()
+		saveConfig(cfg)
+
+		t.RosaRuntime.Creator = &aws.Creator{
+			ARN:       "arn:aws:iam::123456789:user/testuser",
+			AccountID: "123456789",
+			IsSTS:     false,
+		}
+
+		t.ApiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, accountResponse("")),
+		)
+
+		stdout, _, err := test.RunWithOutputCapture(
+			func(r *rosa.Runtime, _ *cobra.Command) error {
+				return runWithRuntime(r)
+			}, t.RosaRuntime, Cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stdout).To(ContainSubstring("123456789"))
+		Expect(stdout).To(ContainSubstring("arn:aws:iam::123456789:user/testuser"))
+	})
+
+	It("Builds an OCM client when the runtime does not already have one", func() {
+		cfg := validConfig()
+		saveConfig(cfg)
+		t.RosaRuntime.OCMClient = nil
+
+		t.ApiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, accountResponse("")),
+		)
+
+		stdout, stderr, err := test.RunWithOutputCapture(
+			func(r *rosa.Runtime, _ *cobra.Command) error {
+				return runWithRuntime(r)
+			}, t.RosaRuntime, Cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stderr).To(BeEmpty())
+		Expect(stdout).To(ContainSubstring("OCM Account Username:"))
+	})
+
+	It("Rejects extra arguments via cobra.NoArgs", func() {
+		Expect(Cmd.Args).NotTo(BeNil())
+		err := Cmd.Args(Cmd, []string{"unexpected"})
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/cmd/whoami/whoami_suite_test.go
+++ b/cmd/whoami/whoami_suite_test.go
@@ -1,0 +1,13 @@
+package whoami
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestWhoami(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Whoami Suite")
+}


### PR DESCRIPTION
## PR Summary

Adds unit tests for ROSA auth and utility command behavior in `logout`, `verify/quota`, `verify/permissions`, `whoami`, `verify/oc`, `download/oc`, and `download/rosa`, plus direct runner and helper coverage for `initialize`.

## Detailed Description of the Issue

These command areas had little or no unit-test coverage because their `run()` paths relied on direct `os.Exit(...)`, external processes, global output state, or tightly-coupled AWS/OCM helpers. The changes extract testable seams where safe, add regression coverage for real command behavior, and preserve the existing user-facing output contract.

## Related Issues and PRs

- Jira: [ROSAENG-61178](https://issues.redhat.com/browse/ROSAENG-61178)
- Related design/docs: Phase 8 of the ROSA CLI test coverage plan

## Type of Change

- [x] test - adds or updates tests only.
- [x] refactor - code restructuring with no behavior change.
- [x] fix - resolves an incorrect behavior or bug.

## Previous Behavior

- `logout`, `verify/quota`, and `verify/permissions` had 0% command-level unit coverage
- `whoami`, `verify/oc`, and both download commands were untested
- `cmd/initialize` only had helper-level coverage in this branch before the latest follow-up
- `cmd/verify/quota` incorrectly ignored the boolean return from `ValidateQuota()`
- `whoami` temporarily regressed the "not logged in" path to exit with status 1 instead of preserving the historical informational exit path

## Behavior After This Change

- `logout`, `verify/quota`, and `verify/permissions` now use testable helpers while preserving output and exit behavior
- `verify/quota` now treats `ValidateQuota() == false` as a failure even when `err == nil`
- `whoami` uses a testable helper, preserves the historical not-logged-in exit behavior, and rebuilds its OCM client from loaded config inside the helper path
- `verify/oc`, `download/oc`, and `download/rosa` now have injectable seams for deterministic tests
- `initialize` now has both helper coverage (`deleteStack`, `simulateCluster`) and direct runner-level orchestration coverage through injected dependencies for login, AWS builders, confirmation, nested verify commands, and `oc`

## How to Test (Step-by-Step)

### Preconditions

- Go 1.26.3+ installed
- Repository cloned with `make install-hooks` run

### Test Steps

1. `go test ./cmd/logout/... ./cmd/verify/quota/... ./cmd/verify/permissions/... ./cmd/whoami/... ./cmd/initialize/... ./cmd/verify/oc/... ./cmd/download/oc/... ./cmd/download/rosa/...`
2. `make test`
3. `make lint`
4. `make rosa`

### Expected Results

All targeted suites pass, the full suite passes, lint reports no issues, and the `rosa` binary builds successfully.

## Proof of the Fix

- All local pre-push checks passed on the latest branch head: format, build, lint, changed-file coverage, and unit/integration tests.

## Breaking Changes

- [x] No breaking changes

## Developer Verification Checklist

- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [x] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

[ROSAENG-61178]: https://redhat.atlassian.net/browse/ROSAENG-61178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and exit behavior across `logout`, `verify permissions`, `verify quota`, `verify oc`, `whoami`, OC/ROSA download, and `initialize`, with more reliable failure propagation and consistent messaging.
  * `logout` now removes configuration cleanly, including keyring-managed entries when applicable.
  * SCP/quota validation now treats “invalid but no error” outcomes as failures, while preserving the designed “warn and continue” behavior for invalid SCP.

* **Tests**
  * Added/expanded Ginkgo/Gomega coverage for `logout`, `initialize`, `whoami`, `verify oc`, `verify permissions`, `verify quota`, and OC/ROSA downloads (success/failure, output, aliases, and argument validation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->