### PR TITLE
OCM-00000 | docs: add communication channels and feature process to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,13 @@
 # Contributing to ROSA
 Welcome, and thank you for considering to contribute to ROSA.
-Before you begin, or have more questions reach out to us on [Slack @rosa-cli](https://redhat.enterprise.slack.com/archives/CB53T9ZHQ)
+
+## Communication
+
+For internal Red Hat contributors: post your PR link and Jira story in `#forum-rosa-service-engineering` and ping `@rosa-cli-tf-devs` on Red Hat Slack.
+
+## Design source of truth
+
+The ROSA CLI is the design source of truth for all downstream projects (terraform-provider-rhcs, terraform-rhcs-rosa-classic, terraform-rhcs-rosa-hcp). New features and API changes should land here first.
 
 ## AI-Assisted Contributions
 


### PR DESCRIPTION
## Summary

- Adds a **Communication** section directing internal contributors to `#forum-rosa-service-engineering` and `@rosa-cli-tf-devs`
- Adds a **Design source of truth** note clarifying the CLI is the upstream source for all downstream projects (provider + terraform modules)

## Test plan

- [x] Docs-only change, no code impact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidance with a structured Communication section.
  * Added a “Design source of truth” note clarifying that the ROSA CLI is the primary place for downstream design alignment, and that new features/API changes should land there first.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->