### PR TITLE
ROSAENG-61173 | test: complete delete cluster command coverage

### DIFF
--- a/cmd/dlt/cluster/cmd.go
+++ b/cmd/dlt/cluster/cmd.go
@@ -80,6 +80,20 @@ func run(_ *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
 
+	err := runWithRuntime(r, confirm.Confirm, func(clusterKey string) {
+		uninstallLogs.Cmd.Run(uninstallLogs.Cmd, []string{clusterKey})
+	})
+	if err != nil {
+		r.Reporter.Errorf("%s", err)
+		os.Exit(1)
+	}
+}
+
+func runWithRuntime(
+	r *rosa.Runtime,
+	confirmFn func(string, ...interface{}) bool,
+	uninstallLogsFn func(string),
+) error {
 	clusterKey := r.GetClusterKey()
 
 	if args.bestEffort {
@@ -87,16 +101,15 @@ func run(_ *cobra.Command, _ []string) {
 			" in AWS account '%s'. These resources will need to be deleted manually.", clusterKey, r.Creator.AccountID)
 	}
 
-	if !confirm.Confirm("delete cluster %s", clusterKey) {
-		os.Exit(0)
+	if !confirmFn("delete cluster %s", clusterKey) {
+		return nil
 	}
 
 	cluster := r.FetchCluster()
 
 	err := handleClusterDelete(r, cluster, clusterKey, args.bestEffort)
 	if err != nil {
-		r.Reporter.Errorf("%s", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to delete cluster '%s': %w", clusterKey, err)
 	}
 
 	if cluster.AWS().STS().RoleARN() != "" {
@@ -122,13 +135,15 @@ func run(_ *cobra.Command, _ []string) {
 	}
 	if args.watch {
 		arguments.DisableRegionDeprecationWarning = true // disable region deprecation warning
-		uninstallLogs.Cmd.Run(uninstallLogs.Cmd, []string{clusterKey})
+		uninstallLogsFn(clusterKey)
 		arguments.DisableRegionDeprecationWarning = false // enable region deprecation again
 	} else {
 		r.Reporter.Infof("To watch your cluster uninstallation logs, run 'rosa logs uninstall -c %s --watch'",
 			clusterKey,
 		)
 	}
+
+	return nil
 }
 
 func handleClusterDelete(r *rosa.Runtime, cluster *cmv1.Cluster, clusterKey string, bestEffort bool) error {

--- a/cmd/dlt/cluster/cmd_test.go
+++ b/cmd/dlt/cluster/cmd_test.go
@@ -2,15 +2,42 @@ package cluster
 
 import (
 	"fmt"
+	"io"
 	"net/http"
+	"os"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	. "github.com/openshift-online/ocm-sdk-go/testing"
 
+	"github.com/openshift/rosa/pkg/arguments"
+	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/test"
 )
+
+func captureRun(fn func() error) (string, string, error) {
+	rout, wout, _ := os.Pipe()
+	rerr, werr, _ := os.Pipe()
+	origOut := os.Stdout
+	origErr := os.Stderr
+	defer func() {
+		os.Stdout = origOut
+		os.Stderr = origErr
+	}()
+	os.Stdout = wout
+	os.Stderr = werr
+
+	var err error
+	go func() {
+		err = fn()
+		wout.Close()
+		werr.Close()
+	}()
+	stdout, _ := io.ReadAll(rout)
+	stderr, _ := io.ReadAll(rerr)
+	return string(stdout), string(stderr), err
+}
 
 var _ = Describe("Delete cluster", func() {
 	var (
@@ -21,6 +48,276 @@ var _ = Describe("Delete cluster", func() {
 	BeforeEach(func() {
 		t = test.NewTestRuntime()
 		clusterId = test.MockClusterID
+		args.bestEffort = false
+		args.watch = false
+		interactive.SetEnabled(false)
+		arguments.DisableRegionDeprecationWarning = false
+	})
+
+	Context("runWithRuntime", func() {
+		stubConfirm := func(string, ...interface{}) bool { return true }
+		stubNoConfirm := func(string, ...interface{}) bool { return false }
+		stubLogs := func(string) {}
+
+		BeforeEach(func() {
+			args.bestEffort = false
+			args.watch = false
+			interactive.SetEnabled(false)
+			arguments.DisableRegionDeprecationWarning = false
+		})
+
+		It("runs the non-STS happy path and prints the uninstall log hint", func() {
+			clusterReady := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateReady)
+				c.AWS(cmv1.NewAWS().STS(cmv1.NewSTS()))
+			})
+			t.SetCluster(clusterId, clusterReady)
+
+			statusBody := fmt.Sprintf(`{
+				"kind": "ClusterStatus",
+				"id": "%s",
+				"state": "ready"
+			}`, clusterId)
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, statusBody))
+			t.ApiServer.AppendHandlers(RespondWithJSON(
+				http.StatusOK, test.FormatClusterList([]*cmv1.Cluster{clusterReady})))
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, ""))
+
+			stdout, stderr, err := captureRun(func() error {
+				return runWithRuntime(t.RosaRuntime, stubConfirm, stubLogs)
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stderr).To(BeEmpty())
+			Expect(stdout).To(ContainSubstring("will start uninstalling"))
+			Expect(stdout).To(ContainSubstring("rosa logs uninstall -c"))
+			Expect(stdout).To(ContainSubstring("--watch"))
+		})
+
+		It("returns cleanly when deletion is not confirmed", func() {
+			clusterReady := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateReady)
+				c.AWS(cmv1.NewAWS().STS(cmv1.NewSTS()))
+			})
+			t.SetCluster(clusterId, clusterReady)
+
+			stdout, stderr, err := captureRun(func() error {
+				return runWithRuntime(t.RosaRuntime, stubNoConfirm, stubLogs)
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stderr).To(BeEmpty())
+			Expect(stdout).To(BeEmpty())
+		})
+
+		It("prints the best-effort warning and passes the flag through", func() {
+			clusterReady := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateReady)
+				c.AWS(cmv1.NewAWS().STS(cmv1.NewSTS()))
+			})
+			t.SetCluster(clusterId, clusterReady)
+			args.bestEffort = true
+
+			statusBody := fmt.Sprintf(`{
+				"kind": "ClusterStatus",
+				"id": "%s",
+				"state": "ready"
+			}`, clusterId)
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, statusBody))
+			t.ApiServer.AppendHandlers(RespondWithJSON(
+				http.StatusOK, test.FormatClusterList([]*cmv1.Cluster{clusterReady})))
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, ""))
+
+			stdout, stderr, err := captureRun(func() error {
+				return runWithRuntime(t.RosaRuntime, stubConfirm, stubLogs)
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stderr).To(ContainSubstring("best effort"))
+			Expect(stderr).To(ContainSubstring("certain resources may be left behind"))
+			Expect(stdout).To(ContainSubstring("will start uninstalling"))
+		})
+
+		It("prints STS cleanup guidance for clusters with operator roles", func() {
+			clusterReady := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateReady)
+				c.AWS(cmv1.NewAWS().STS(
+					cmv1.NewSTS().
+						RoleARN("arn:aws:iam::123456789012:role/Installer").
+						OIDCEndpointURL("https://oidc.example.com").
+						OperatorRolePrefix("my-prefix").
+						OperatorIAMRoles(
+							cmv1.NewOperatorIAMRole().
+								Name("ebs-cloud-credentials").
+								Namespace("openshift-cluster-csi-drivers").
+								RoleARN("arn:aws:iam::123456789012:role/op-role"),
+						),
+				))
+			})
+			t.SetCluster(clusterId, clusterReady)
+
+			statusBody := fmt.Sprintf(`{
+				"kind": "ClusterStatus",
+				"id": "%s",
+				"state": "ready"
+			}`, clusterId)
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, statusBody))
+			t.ApiServer.AppendHandlers(RespondWithJSON(
+				http.StatusOK, test.FormatClusterList([]*cmv1.Cluster{clusterReady})))
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, ""))
+
+			stdout, stderr, err := captureRun(func() error {
+				return runWithRuntime(t.RosaRuntime, stubConfirm, stubLogs)
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stderr).To(BeEmpty())
+			Expect(stdout).To(ContainSubstring("Operator IAM Roles:"))
+			Expect(stdout).To(ContainSubstring("arn:aws:iam::123456789012:role/op-role"))
+			Expect(stdout).To(ContainSubstring("OIDC Provider : https://oidc.example.com"))
+			Expect(stdout).To(ContainSubstring("rosa delete operator-roles -c"))
+			Expect(stdout).To(ContainSubstring("rosa delete oidc-provider -c"))
+		})
+
+		It("prints STS cleanup guidance without operator role output when none remain", func() {
+			clusterReady := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateReady)
+				c.AWS(cmv1.NewAWS().STS(
+					cmv1.NewSTS().
+						RoleARN("arn:aws:iam::123456789012:role/Installer").
+						OIDCEndpointURL("https://oidc-no-roles.example.com"),
+				))
+			})
+			t.SetCluster(clusterId, clusterReady)
+
+			statusBody := fmt.Sprintf(`{
+				"kind": "ClusterStatus",
+				"id": "%s",
+				"state": "ready"
+			}`, clusterId)
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, statusBody))
+			t.ApiServer.AppendHandlers(RespondWithJSON(
+				http.StatusOK, test.FormatClusterList([]*cmv1.Cluster{clusterReady})))
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, ""))
+
+			stdout, stderr, err := captureRun(func() error {
+				return runWithRuntime(t.RosaRuntime, stubConfirm, stubLogs)
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stderr).To(BeEmpty())
+			Expect(stdout).NotTo(ContainSubstring("Operator IAM Roles:"))
+			Expect(stdout).To(ContainSubstring("OIDC Provider : https://oidc-no-roles.example.com"))
+			Expect(stdout).To(ContainSubstring("rosa delete operator-roles -c"))
+			Expect(stdout).To(ContainSubstring("rosa delete oidc-provider -c"))
+		})
+
+		It("runs uninstall logs when watch is enabled and restores the deprecation warning flag", func() {
+			clusterReady := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateReady)
+				c.AWS(cmv1.NewAWS().STS(cmv1.NewSTS()))
+			})
+			t.SetCluster(clusterId, clusterReady)
+			args.watch = true
+
+			statusBody := fmt.Sprintf(`{
+				"kind": "ClusterStatus",
+				"id": "%s",
+				"state": "ready"
+			}`, clusterId)
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, statusBody))
+			t.ApiServer.AppendHandlers(RespondWithJSON(
+				http.StatusOK, test.FormatClusterList([]*cmv1.Cluster{clusterReady})))
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, ""))
+
+			var watchedClusterKey string
+			var sawDisabledWarning bool
+			watchStub := func(clusterKey string) {
+				watchedClusterKey = clusterKey
+				sawDisabledWarning = arguments.DisableRegionDeprecationWarning
+			}
+
+			stdout, stderr, err := captureRun(func() error {
+				return runWithRuntime(t.RosaRuntime, stubConfirm, watchStub)
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stderr).To(BeEmpty())
+			Expect(stdout).To(ContainSubstring("will start uninstalling"))
+			Expect(watchedClusterKey).To(Equal(clusterId))
+			Expect(sawDisabledWarning).To(BeTrue())
+			Expect(arguments.DisableRegionDeprecationWarning).To(BeFalse())
+			Expect(stdout).NotTo(ContainSubstring("rosa logs uninstall -c"))
+		})
+
+		It("returns the already-uninstalling path through the command wrapper", func() {
+			clusterReady := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateReady)
+				c.AWS(cmv1.NewAWS().STS(cmv1.NewSTS()))
+			})
+			t.SetCluster(clusterId, clusterReady)
+
+			statusBody := fmt.Sprintf(`{
+				"kind": "ClusterStatus",
+				"id": "%s",
+				"state": "uninstalling"
+			}`, clusterId)
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, statusBody))
+
+			stdout, stderr, err := captureRun(func() error {
+				return runWithRuntime(t.RosaRuntime, stubConfirm, stubLogs)
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stderr).To(BeEmpty())
+			Expect(stdout).To(ContainSubstring("already uninstalling"))
+			Expect(stdout).To(ContainSubstring("rosa logs uninstall -c"))
+		})
+
+		It("returns an error from GetClusterState through the command wrapper", func() {
+			clusterReady := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateReady)
+				c.AWS(cmv1.NewAWS().STS(cmv1.NewSTS()))
+			})
+			t.SetCluster(clusterId, clusterReady)
+
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusInternalServerError, ""))
+
+			stdout, stderr, err := captureRun(func() error {
+				return runWithRuntime(t.RosaRuntime, stubConfirm, stubLogs)
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(stderr).To(BeEmpty())
+			Expect(stdout).To(BeEmpty())
+			Expect(err.Error()).To(ContainSubstring("failed to delete cluster"))
+			Expect(err.Error()).To(ContainSubstring("expected response content type"))
+		})
+
+		It("returns a delete error through the command wrapper", func() {
+			clusterReady := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateReady)
+				c.AWS(cmv1.NewAWS().STS(cmv1.NewSTS()))
+			})
+			t.SetCluster(clusterId, clusterReady)
+
+			statusBody := fmt.Sprintf(`{
+				"kind": "ClusterStatus",
+				"id": "%s",
+				"state": "ready"
+			}`, clusterId)
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, statusBody))
+			t.ApiServer.AppendHandlers(RespondWithJSON(
+				http.StatusOK, test.FormatClusterList([]*cmv1.Cluster{clusterReady})))
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusForbidden, `{
+				"kind": "Error",
+				"id": "403",
+				"href": "/api/clusters_mgmt/v1/errors/403",
+				"code": "CLUSTERS-MGMT-403",
+				"reason": "forbidden"
+			}`))
+
+			stdout, stderr, err := captureRun(func() error {
+				return runWithRuntime(t.RosaRuntime, stubConfirm, stubLogs)
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(stderr).To(BeEmpty())
+			Expect(stdout).To(BeEmpty())
+			Expect(err.Error()).To(ContainSubstring("failed to delete cluster"))
+			Expect(err.Error()).To(ContainSubstring("forbidden"))
+		})
 	})
 
 	Context("handleClusterDelete", func() {


### PR DESCRIPTION
## PR Summary
Complete the remaining coverage for `rosa delete cluster` by adding command-level tests for the legacy delete flow and a small refactor that makes the command body testable without changing CLI behavior.

## Detailed Description of the Issue
PR #3298 added helper coverage for `handleClusterDelete()` and `buildCommands()`, but the actual `rosa delete cluster` command flow was still untested. Phase 2B still required coverage for confirmation handling, best-effort output, STS cleanup messaging, uninstall log watching, and wrapper-level error propagation.

This change extracts a testable `runWithRuntime(...)` helper in `cmd/dlt/cluster/cmd.go` and adds focused Ginkgo coverage for the remaining command behaviors while preserving the existing `Run: run` entrypoint, flags, and user-facing flow.

## Related Issues and PRs
- Jira: [ROSAENG-61173](https://issues.redhat.com/browse/ROSAENG-61173)
- Fixes: N/A
- Related PR(s): #3298
- Related design/docs: coverage planning tracked under [ROSAENG-60112](https://redhat.atlassian.net/browse/ROSAENG-60112)

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [x] refactor - code restructuring with no behavior change.
- [x] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
`cmd/dlt/cluster` had helper-level coverage, but the full command flow remained untested. Important behaviors like confirmation decline, `--best-effort`, STS cleanup output, `--watch`, and wrapper-level error handling were still gaps in Phase 2B.

## Behavior After This Change
The delete-cluster command now has focused command-level coverage for:
- non-STS happy path with uninstall-log suggestion output
- STS happy path with operator role output, OIDC provider output, and cleanup commands
- STS clusters with no operator roles
- `--best-effort` warning and passthrough behavior
- confirmation decline
- already-uninstalling clusters
- `GetClusterState` and `DeleteCluster` errors
- `--watch` invoking uninstall logs while restoring the region deprecation warning flag

The command shape, flags, and user-facing behavior remain unchanged.

## How to Test (Step-by-Step)
### Preconditions
- Go toolchain compatible with the version required by `go.mod`
- If your shell exports `GOTOOLCHAIN=local`, use `GOTOOLCHAIN=auto` for the commands below

### Test Steps
1. `GOTOOLCHAIN=auto make fmt`
2. `GOTOOLCHAIN=auto go test ./cmd/dlt/cluster/... -count=1`
3. `GOTOOLCHAIN=auto make lint`
4. `GOTOOLCHAIN=auto make rosa`
5. `GOTOOLCHAIN=auto make test`

### Expected Results
- The `cmd/dlt/cluster` package tests pass
- Lint passes with no issues
- The `rosa` binary builds successfully
- The full repo test suite passes

## Proof of the Fix
- Logs/CLI output:
  - `go test ./cmd/dlt/cluster/... -count=1` passed
  - `make lint` passed (0 issues)
  - `make rosa` passed
  - `make test` passed
  - `git push` pre-push checks: 5/5 passed (format, build, lint, changed-files coverage, unit/integration tests)

## Breaking Changes
- [x] No breaking changes

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

[ROSAENG-61173]: https://redhat.atlassian.net/browse/ROSAENG-61173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROSAENG-60112]: https://redhat.atlassian.net/browse/ROSAENG-60112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `rosa delete cluster` control flow, error propagation, and output when confirmation is declined.
  * Clearer guidance for clusters already uninstalling and for failures during cluster state checks or delete operations (including forbidden errors).

* **User Experience**
  * Enhanced `--watch` behavior to run uninstall logs automatically and adjust messaging/hints accordingly.
  * Better handling of best-effort warnings and STS operator-role cleanup guidance.

* **Tests**
  * Expanded coverage for runtime, watch mode, warning behavior, messaging, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->