### PR TITLE
ROSAENG-5957 - Don't display user-provided admin password on cluster creation

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -822,7 +822,8 @@ func initFlags(cmd *cobra.Command) {
 		"",
 		`The password must
 		- Be at least 14 characters (ASCII-standard) without whitespaces
-		- Include uppercase letters, lowercase letters, and numbers or symbols (ASCII-standard characters only)`,
+		- Include uppercase letters, lowercase letters, and numbers or symbols (ASCII-standard characters only)
+		For security reasons, password will not be displayed`,
 	)
 	flags.MarkHidden("cluster-admin-user")
 
@@ -1231,7 +1232,9 @@ func run(cmd *cobra.Command, _ []string) {
 			}
 		}
 	}
-	outputClusterAdminDetails(r, isClusterAdmin, clusterAdminUser, clusterAdminPassword)
+
+	outputClusterAdminDetails(r, isClusterAdmin, clusterAdminUser, clusterAdminPassword,
+		strings.Trim(args.clusterAdminPassword, " \t") != "")
 
 	if isHostedCP && cmd.Flags().Changed(arguments.NewDefaultMPLabelsFlag) {
 		r.Reporter.Errorf("Setting the worker machine pool labels is not supported for hosted clusters")
@@ -4138,6 +4141,7 @@ func parseRFC3339(s string) (time.Time, error) {
 }
 
 const hostedCPFlag = "--hosted-cp"
+const clusterAdminPasswordPlaceholder = "<redacted>"
 
 func buildCommand(spec ocm.Spec, operatorRolesPrefix string,
 	operatorRolePath string, userSelectedAvailabilityZones bool, labels string,
@@ -4161,7 +4165,7 @@ func buildCommand(spec ocm.Spec, operatorRolesPrefix string,
 		argAdded := false
 		// Checks if admin password is from user (both flag and interactive)
 		if args.clusterAdminPassword != "" && spec.ClusterAdminPassword != "" {
-			command += fmt.Sprintf(" --cluster-admin-password %s", spec.ClusterAdminPassword)
+			command += fmt.Sprintf(" --cluster-admin-password %q", clusterAdminPasswordPlaceholder)
 			argAdded = true
 		}
 		if spec.ClusterAdminUser != admin.ClusterAdminUsername {
@@ -4507,10 +4511,14 @@ func getInitialValidSubnets(awsClient aws.Client, ids []string, r reporter.Logge
 	return initialValidSubnets, nil
 }
 
-func outputClusterAdminDetails(r *rosa.Runtime, isClusterAdmin bool, createAdminUser, createAdminPassword string) {
+func outputClusterAdminDetails(r *rosa.Runtime, isClusterAdmin bool, createAdminUser, createAdminPassword string,
+	customAdminPassword bool) {
 	if isClusterAdmin {
 		r.Reporter.Infof("cluster admin user is %s", createAdminUser)
-		r.Reporter.Infof("cluster admin password is %s", createAdminPassword)
+		if !customAdminPassword {
+			// If the admin password was generated, it needs to be displayed so the user can save it
+			r.Reporter.Infof("cluster admin password is %s", createAdminPassword)
+		}
 	}
 }
 

--- a/cmd/create/cluster/cmd_test.go
+++ b/cmd/create/cluster/cmd_test.go
@@ -17,6 +17,7 @@ import (
 	v1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/rosa/cmd/create/admin"
 	mock "github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/aws/tags"
 	"github.com/openshift/rosa/pkg/logging"
@@ -42,6 +43,7 @@ var _ = Describe("Validate build command", func() {
 		userSelectedAvailabilityZones = false
 		defaultMachinePoolLabels = "machine-pool-label"
 	})
+
 	Context("build command", func() {
 		When("domain prefix is present", func() {
 			It("prints --domain-prefix", func() {
@@ -209,7 +211,52 @@ var _ = Describe("Validate build command", func() {
 				Expect(command).To(ContainSubstring("--enable-delete-protection"))
 			})
 		})
+
+		When("--cluster-admin-password is provided by the user", func() {
+			It("prints --cluster-admin-password with a redacted placeholder", func() {
+				clusterConfig.ClusterAdminUser = admin.ClusterAdminUsername
+				clusterConfig.ClusterAdminPassword = "MySecretPass123!"
+				args.clusterAdminPassword = "MySecretPass123!"
+				defer func() { args.clusterAdminPassword = "" }()
+				command := buildCommand(clusterConfig, operatorRolesPrefix,
+					expectedOperatorRolePath, userSelectedAvailabilityZones,
+					defaultMachinePoolLabels, argsDotProperties)
+				Expect(command).To(ContainSubstring(
+					"--cluster-admin-password \"<redacted>\""))
+				Expect(command).NotTo(ContainSubstring("MySecretPass123!"))
+			})
+		})
+
+		When("cluster admin is created without a user-provided password", func() {
+			It("prints --create-admin-user", func() {
+				clusterConfig.ClusterAdminUser = admin.ClusterAdminUsername
+				clusterConfig.ClusterAdminPassword = "GeneratedPass456!"
+				command := buildCommand(clusterConfig, operatorRolesPrefix,
+					expectedOperatorRolePath, userSelectedAvailabilityZones,
+					defaultMachinePoolLabels, argsDotProperties)
+				Expect(command).To(ContainSubstring("--create-admin-user"))
+				Expect(command).NotTo(ContainSubstring("--cluster-admin-password"))
+				Expect(command).NotTo(ContainSubstring("GeneratedPass456!"))
+			})
+		})
+
+		When("custom admin user and password are provided", func() {
+			It("prints both --cluster-admin-password redacted and --cluster-admin-user", func() {
+				clusterConfig.ClusterAdminUser = "my-admin"
+				clusterConfig.ClusterAdminPassword = "CustomPass789!"
+				args.clusterAdminPassword = "CustomPass789!"
+				defer func() { args.clusterAdminPassword = "" }()
+				command := buildCommand(clusterConfig, operatorRolesPrefix,
+					expectedOperatorRolePath, userSelectedAvailabilityZones,
+					defaultMachinePoolLabels, argsDotProperties)
+				Expect(command).To(ContainSubstring(
+					"--cluster-admin-password \"<redacted>\""))
+				Expect(command).To(ContainSubstring("--cluster-admin-user my-admin"))
+				Expect(command).NotTo(ContainSubstring("CustomPass789!"))
+			})
+		})
 	})
+
 	Context("build tags command", func() {
 		When("tag key or values DO contain a colon", func() {
 			It("should build tags command with a space as a delimiter", func() {

--- a/cmd/create/idp/htpasswd.go
+++ b/cmd/create/idp/htpasswd.go
@@ -223,7 +223,7 @@ func GetIdpUserNameFromPrompt(cmd *cobra.Command, r *rosa.Runtime,
 func GetIdpPasswordFromPrompt(cmd *cobra.Command, r *rosa.Runtime,
 	passwordKey, defaultPassword string) string {
 	password, err := interactive.GetPassword(interactive.Input{
-		Question: "Password",
+		Question: "Password (will not be shown after entry)",
 		Help:     cmd.Flags().Lookup(passwordKey).Usage,
 		Default:  defaultPassword,
 		Required: true,


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
Supported ticket prefixes:
OCM-XXXXX, ROSAENG-XXXX
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For contributor workflow, see: ./CONTRIBUTING.md
For repo-local agent guidance, see: ./AGENTS.md
-->

## PR Summary
Hides entered admin password when creating a cluster. When creating an admin account with a generated password, the password is still displayed as it needs to be recorded by the user.

## Detailed Description of the Issue
<!-- Describe the root problem, scope, impact, and user/business context -->
When creating a cluster in interactive mode, user is asked if they want to create a `cluster admin user`, and if so, if they want to `Create a custom password for cluster admin`. If creating a custom password for the admin cluster, currently the password is displayed back to the user. We should not output the provided password for security purposes. Instead, indicate when entering the password that it will not be provided after it is entered for security purposes.

In cases when a cluster admin is created, but a custom password is not provided, the password will still need to be displayed so the user can record it.

## Related Issues and PRs
<!-- Link all tracking items and related code changes -->
- Jira: [OCM-XXXXX](https://issues.redhat.com/browse/OCM-XXXXX) or [ROSAENG-5957](https://redhat.atlassian.net/browse/ROSAENG-5957)
- Fixes: `#5957`
- Related PR(s):
- Related design/docs:

## Type of Change
<!-- Check the primary type this PR represents -->
- [ ] feat - adds a new user-facing capability.
- [x] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
<!-- What users or systems experienced before this change -->
When entering a custom password for the cluster admin, password is displayed back to the user:

```
? Create cluster admin user: Yes
? Create custom password for cluster admin: Yes
I: cluster admin user is cluster-admin
I: cluster admin password is ttn4K-DxxeA-jFvLZ-tym8z
```

## Behavior After This Change
<!-- What changes now, including user-visible and non-user-visible behavior -->
When entering a custom password for the cluster admin, password is hidden form the user:

```
? Create cluster admin user: Yes
? Create custom password for cluster admin: Yes
? Password <hidden for security>: [? for help] *****************
I: cluster admin user is cluster-admin
I: cluster admin password is <hidden for security>
```

## How to Test (Step-by-Step)
<!-- Provide reproducible validation instructions -->
### Preconditions
<!-- Required setup, environment, credentials, flags, cluster state, etc. -->
None

### Test Steps
1. Create cluster with `rosa create cluster --hosted-cp -i`
2. Select Hosted Control Plane cluster
3. When asked to create admin user, select Y
4. When asked to create a custom password for cluster admin, select Y
5. When asked to provide a custom password, provide a valid password

### Expected Results
<!-- What should happen after running the steps above -->
 Ensure that cluster admin name is provided, but password is not

## Proof of the Fix
<!-- Attach evidence that demonstrates the changed behavior -->
<img width="641" height="211" alt="image" src="https://github.com/user-attachments/assets/496e89e6-53a9-4747-849b-091fe58da38a" />

## Breaking Changes
- [ ] No breaking changes
- [x] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
<!-- Required only when breaking changes are introduced -->
Workflows that depend on passwords being displayed will have to be modified:
* Password will no longer be displayed immediately when a custom cluster admin password is entered
* Password will no longer be displayed when the built command is displayed after using interactive mode, and is instead replaced with `<redacted>`.

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [ ] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [ ] `make test` passes.
- [ ] `make lint` passes.
- [ ] `make rosa` passes.
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [ ] Any risk, limitation, or follow-up work is documented.


[ROSAENG-5957]: https://redhat.atlassian.net/browse/ROSAENG-5957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Security Enhancements**
  * Updated the cluster admin password flag help text to note the password won’t be displayed.
  * Cluster admin password output is suppressed when a custom password is provided.
  * “Re-run this command” now redacts custom admin passwords with a placeholder.
  * Identity provider password prompts now explicitly indicate the input won’t be shown after entry.
* **Tests**
  * Added coverage to verify redaction and correct command generation for admin password scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->