### PR TITLE
ROSAENG-61172 | test: complete remaining package coverage

### DIFF
--- a/pkg/aws/profile/flag_test.go
+++ b/pkg/aws/profile/flag_test.go
@@ -42,6 +42,15 @@ var _ = Describe("Profile", func() {
 		Expect(flag.DefValue).To(Equal(""))
 	})
 
+	It("reads the parsed profile flag value", func() {
+		flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		AddFlag(flags)
+
+		Expect(flags.Parse([]string{"--profile", "dev-profile"})).To(Succeed())
+
+		Expect(Profile()).To(Equal("dev-profile"))
+	})
+
 	It("prefers the flag value over the environment variable", func() {
 		profile = "flag-profile"
 		Expect(os.Setenv("AWS_PROFILE", "env-profile")).To(Succeed())

--- a/pkg/aws/region/flag_test.go
+++ b/pkg/aws/region/flag_test.go
@@ -42,6 +42,15 @@ var _ = Describe("Region", func() {
 		Expect(flag.DefValue).To(Equal(""))
 	})
 
+	It("reads the parsed region flag value", func() {
+		flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		AddFlag(flags)
+
+		Expect(flags.Parse([]string{"--region", "us-west-2"})).To(Succeed())
+
+		Expect(Region()).To(Equal("us-west-2"))
+	})
+
 	It("prefers the flag value over the environment variable", func() {
 		region = "us-east-1"
 		Expect(os.Setenv("AWS_REGION", "eu-west-1")).To(Succeed())

--- a/pkg/color/flag.go
+++ b/pkg/color/flag.go
@@ -29,6 +29,10 @@ import (
 var color string
 
 var options = []string{"auto", "never", "always"}
+var runtimeGOOS = runtime.GOOS
+var stdoutStat = func() (os.FileInfo, error) {
+	return os.Stdout.Stat()
+}
 
 // AddFlag adds the interactive flag to the given set of command line flags.
 func AddFlag(cmd *cobra.Command) {
@@ -57,10 +61,10 @@ func UseColor() bool {
 	case "auto":
 		fallthrough
 	default:
-		if runtime.GOOS == "windows" {
+		if runtimeGOOS == "windows" {
 			return false
 		}
-		stdout, err := os.Stdout.Stat()
+		stdout, err := stdoutStat()
 		if err != nil {
 			return true
 		}

--- a/pkg/color/flag_test.go
+++ b/pkg/color/flag_test.go
@@ -1,7 +1,10 @@
 package color
 
 import (
+	"errors"
+	"os"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -13,16 +16,33 @@ func TestColor(t *testing.T) {
 	RunSpecs(t, "Color Suite")
 }
 
+type stubFileInfo struct {
+	mode os.FileMode
+}
+
+func (s stubFileInfo) Name() string       { return "stdout" }
+func (s stubFileInfo) Size() int64        { return 0 }
+func (s stubFileInfo) Mode() os.FileMode  { return s.mode }
+func (s stubFileInfo) ModTime() time.Time { return time.Time{} }
+func (s stubFileInfo) IsDir() bool        { return false }
+func (s stubFileInfo) Sys() interface{}   { return nil }
+
 var _ = Describe("Color", func() {
 	var previousColor string
+	var previousGOOS string
+	var previousStdoutStat func() (os.FileInfo, error)
 
 	BeforeEach(func() {
 		previousColor = color
+		previousGOOS = runtimeGOOS
+		previousStdoutStat = stdoutStat
 		color = ""
 	})
 
 	AfterEach(func() {
 		color = previousColor
+		runtimeGOOS = previousGOOS
+		stdoutStat = previousStdoutStat
 	})
 
 	It("registers the color flag with auto as default", func() {
@@ -59,5 +79,45 @@ var _ = Describe("Color", func() {
 		SetColor("unexpected")
 
 		Expect(UseColor()).To(Equal(expected))
+	})
+
+	It("disables color for auto mode on Windows", func() {
+		SetColor("auto")
+		runtimeGOOS = "windows"
+		stdoutStat = func() (os.FileInfo, error) {
+			return stubFileInfo{mode: os.ModeDevice}, nil
+		}
+
+		Expect(UseColor()).To(BeFalse())
+	})
+
+	It("enables color for auto mode when stdout is a terminal", func() {
+		SetColor("auto")
+		runtimeGOOS = "linux"
+		stdoutStat = func() (os.FileInfo, error) {
+			return stubFileInfo{mode: os.ModeDevice}, nil
+		}
+
+		Expect(UseColor()).To(BeTrue())
+	})
+
+	It("disables color for auto mode when stdout is a named pipe", func() {
+		SetColor("auto")
+		runtimeGOOS = "linux"
+		stdoutStat = func() (os.FileInfo, error) {
+			return stubFileInfo{mode: os.ModeNamedPipe}, nil
+		}
+
+		Expect(UseColor()).To(BeFalse())
+	})
+
+	It("enables color for auto mode when stdout stat fails", func() {
+		SetColor("auto")
+		runtimeGOOS = "linux"
+		stdoutStat = func() (os.FileInfo, error) {
+			return nil, errors.New("stat failed")
+		}
+
+		Expect(UseColor()).To(BeTrue())
 	})
 })

--- a/pkg/debug/flag_test.go
+++ b/pkg/debug/flag_test.go
@@ -35,6 +35,15 @@ var _ = Describe("Debug", func() {
 		Expect(flag.DefValue).To(Equal("false"))
 	})
 
+	It("enables debug mode when the parsed debug flag is true", func() {
+		flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		AddFlag(flags)
+
+		Expect(flags.Parse([]string{"--debug"})).To(Succeed())
+
+		Expect(Enabled()).To(BeTrue())
+	})
+
 	It("tracks debug mode through SetEnabled and Enabled", func() {
 		Expect(Enabled()).To(BeFalse())
 

--- a/pkg/fedramp/fedramp_test.go
+++ b/pkg/fedramp/fedramp_test.go
@@ -43,6 +43,7 @@ var _ = Describe("Fedramp", func() {
 
 			Expect(cmd.Flags().Lookup("govcloud")).NotTo(BeNil())
 			Expect(cmd.Flags().Lookup("admin")).NotTo(BeNil())
+			Expect(cmd.Flags().Lookup("admin").Hidden).To(BeTrue())
 			Expect(HasFlag(cmd)).To(BeFalse())
 			Expect(HasAdminFlag(cmd)).To(BeFalse())
 
@@ -51,6 +52,13 @@ var _ = Describe("Fedramp", func() {
 
 			Expect(cmd.Flags().Set("admin", "true")).To(Succeed())
 			Expect(HasAdminFlag(cmd)).To(BeTrue())
+		})
+
+		It("returns false when the command doesn't define the FedRAMP flags", func() {
+			cmd := &cobra.Command{Use: "test"}
+
+			Expect(HasFlag(cmd)).To(BeFalse())
+			Expect(HasAdminFlag(cmd)).To(BeFalse())
 		})
 	})
 
@@ -111,6 +119,15 @@ var _ = Describe("Fedramp", func() {
 		It("returns false when the config file does not exist", func() {
 			tempDir := GinkgoT().TempDir()
 			Expect(os.Setenv("OCM_CONFIG", filepath.Join(tempDir, "missing.json"))).To(Succeed())
+
+			Expect(Enabled()).To(BeFalse())
+		})
+
+		It("returns false when the config file can't be parsed", func() {
+			tempDir := GinkgoT().TempDir()
+			path := filepath.Join(tempDir, "ocm.json")
+			Expect(os.Setenv("OCM_CONFIG", path)).To(Succeed())
+			Expect(os.WriteFile(path, []byte("{not-json"), 0o600)).To(Succeed())
 
 			Expect(Enabled()).To(BeFalse())
 		})
@@ -199,6 +216,35 @@ var _ = Describe("Fedramp", func() {
 		It("rejects unknown environments", func() {
 			Expect(IsValidEnv("dev")).To(BeFalse())
 			Expect(IsValidEnv("")).To(BeFalse())
+		})
+	})
+
+	Describe("FedRAMP endpoint maps", func() {
+		It("exposes the expected URL aliases for each environment", func() {
+			Expect(URLAliases).To(Equal(map[string]string{
+				"production":  "https://api.openshiftusgov.com",
+				"staging":     "https://api.stage.openshiftusgov.com",
+				"staging01":   "https://api01.stage.openshiftusgov.com",
+				"integration": "https://api.int.openshiftusgov.com",
+			}))
+		})
+
+		It("exposes the expected login URLs for each environment", func() {
+			Expect(LoginURLs).To(Equal(map[string]string{
+				"production":  "https://api.openshiftusgov.com/auth",
+				"staging":     "https://api.stage.openshiftusgov.com/auth",
+				"staging01":   "https://api01.stage.openshiftusgov.com/auth",
+				"integration": "https://api.int.openshiftusgov.com/auth",
+			}))
+		})
+
+		It("exposes the expected token URLs for each environment", func() {
+			Expect(TokenURLs).To(Equal(map[string]string{
+				"production":  "https://sso.openshiftusgov.com/realms/redhat-external/protocol/openid-connect/token",
+				"staging":     "https://sso.stage.openshiftusgov.com/realms/redhat-external/protocol/openid-connect/token",
+				"staging01":   "https://sso01.stage.openshiftusgov.com/realms/redhat-external/protocol/openid-connect/token",
+				"integration": "https://sso.int.openshiftusgov.com/realms/redhat-external/protocol/openid-connect/token",
+			}))
 		})
 	})
 })

--- a/pkg/input/input_test.go
+++ b/pkg/input/input_test.go
@@ -10,6 +10,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 
 	"github.com/openshift/rosa/pkg/rosa"
+	"github.com/openshift/rosa/pkg/test"
 )
 
 func TestInput(t *testing.T) {
@@ -76,9 +77,50 @@ var _ = Describe("Input", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(BeNil())
 		})
+
+		It("returns an error when the file can't be read due to permissions", func() {
+			if os.Geteuid() == 0 {
+				Skip("permission checks are not reliable when running as root")
+			}
+
+			tempDir, err := os.MkdirTemp("", "input-perms-*")
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				Expect(os.RemoveAll(tempDir)).To(Succeed())
+			}()
+
+			path := filepath.Join(tempDir, "unreadable.yaml")
+			Expect(os.WriteFile(path, []byte("name: demo\n"), 0o600)).To(Succeed())
+			Expect(os.Chmod(path, 0o000)).To(Succeed())
+
+			_, err = UnmarshalInputFile(path)
+			Expect(err).To(HaveOccurred())
+			Expect(os.IsPermission(err)).To(BeTrue())
+		})
+
+		It("returns an error when the path is a directory", func() {
+			tempDir, err := os.MkdirTemp("", "input-directory-*")
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				Expect(os.RemoveAll(tempDir)).To(Succeed())
+			}()
+
+			_, err = UnmarshalInputFile(tempDir)
+			Expect(err).To(HaveOccurred())
+		})
 	})
 
 	Describe("CheckIfHypershiftClusterOrExit", func() {
+		var previousExitFunc func(int)
+
+		BeforeEach(func() {
+			previousExitFunc = exitFunc
+		})
+
+		AfterEach(func() {
+			exitFunc = previousExitFunc
+		})
+
 		It("returns without exiting for a hypershift cluster", func() {
 			cluster, err := cmv1.NewCluster().
 				Hypershift(cmv1.NewHypershift().Enabled(true)).
@@ -88,6 +130,22 @@ var _ = Describe("Input", func() {
 			Expect(func() {
 				CheckIfHypershiftClusterOrExit(&rosa.Runtime{}, cluster)
 			}).NotTo(Panic())
+		})
+
+		It("exits when the cluster isn't a hypershift cluster", func() {
+			t := test.NewTestRuntime()
+			cluster, err := cmv1.NewCluster().
+				Hypershift(cmv1.NewHypershift().Enabled(false)).
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			exitFunc = func(code int) {
+				panic(code)
+			}
+
+			Expect(func() {
+				CheckIfHypershiftClusterOrExit(t.RosaRuntime, cluster)
+			}).To(PanicWith(1))
 		})
 	})
 })

--- a/pkg/input/input_validation.go
+++ b/pkg/input/input_validation.go
@@ -9,10 +9,12 @@ import (
 	"github.com/openshift/rosa/pkg/rosa"
 )
 
+var exitFunc = os.Exit
+
 // CheckIfHypershiftClusterOrExit will exit if the input cluster is not an Hypershift cluster
 func CheckIfHypershiftClusterOrExit(r *rosa.Runtime, cluster *cmv1.Cluster) {
 	if !ocm.IsHyperShiftCluster(cluster) {
 		r.Reporter.Errorf("This command is only supported for Hosted Control Planes")
-		os.Exit(1)
+		exitFunc(1)
 	}
 }

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -2,6 +2,8 @@ package logging
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -25,10 +27,43 @@ func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) 
 	return f(request)
 }
 
+type stubReadCloser struct {
+	data     []byte
+	readErr  error
+	closeErr error
+}
+
+func (s *stubReadCloser) Read(p []byte) (int, error) {
+	if s.readErr != nil {
+		return 0, s.readErr
+	}
+	if len(s.data) == 0 {
+		return 0, io.EOF
+	}
+	n := copy(p, s.data)
+	s.data = s.data[n:]
+	if len(s.data) == 0 {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+func (s *stubReadCloser) Close() error {
+	return s.closeErr
+}
+
 func newDebugLogger(out *bytes.Buffer) *logrus.Logger {
 	logger := logrus.New()
 	logger.SetOutput(out)
 	logger.SetLevel(logrus.DebugLevel)
+	logger.SetFormatter(&logrus.TextFormatter{DisableColors: true, DisableQuote: true})
+	return logger
+}
+
+func newLoggerWithLevel(out *bytes.Buffer, level logrus.Level) *logrus.Logger {
+	logger := logrus.New()
+	logger.SetOutput(out)
+	logger.SetLevel(level)
 	logger.SetFormatter(&logrus.TextFormatter{DisableColors: true, DisableQuote: true})
 	return logger
 }
@@ -103,6 +138,56 @@ var _ = Describe("Logging", func() {
 			Expect(result.WarnEnabled()).To(BeTrue())
 			Expect(result.ErrorEnabled()).To(BeTrue())
 		})
+
+		It("routes info messages through debug logging", func() {
+			logBuffer := &bytes.Buffer{}
+			result, err := NewOCMLogger().Logger(newLoggerWithLevel(logBuffer, logrus.InfoLevel)).Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			result.Info(context.Background(), "info message %s", "value")
+
+			Expect(logBuffer.String()).To(BeEmpty())
+		})
+
+		It("routes warn messages through debug logging", func() {
+			logBuffer := &bytes.Buffer{}
+			result, err := NewOCMLogger().Logger(newLoggerWithLevel(logBuffer, logrus.WarnLevel)).Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			result.Warn(context.Background(), "warn message %s", "value")
+
+			Expect(logBuffer.String()).To(BeEmpty())
+		})
+
+		It("routes debug messages through debug logging", func() {
+			logBuffer := &bytes.Buffer{}
+			result, err := NewOCMLogger().Logger(newLoggerWithLevel(logBuffer, logrus.DebugLevel)).Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			result.Debug(context.Background(), "debug message %s", "value")
+
+			Expect(logBuffer.String()).To(ContainSubstring("debug message value"))
+		})
+
+		It("routes error messages through error logging", func() {
+			logBuffer := &bytes.Buffer{}
+			result, err := NewOCMLogger().Logger(newLoggerWithLevel(logBuffer, logrus.ErrorLevel)).Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			result.Error(context.Background(), "error message %s", "value")
+
+			Expect(logBuffer.String()).To(ContainSubstring("error message value"))
+		})
+
+		It("routes fatal messages through error logging without exiting", func() {
+			logBuffer := &bytes.Buffer{}
+			result, err := NewOCMLogger().Logger(newLoggerWithLevel(logBuffer, logrus.ErrorLevel)).Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			result.Fatal(context.Background(), "fatal message %s", "value")
+
+			Expect(logBuffer.String()).To(ContainSubstring("fatal message value"))
+		})
 	})
 
 	Describe("RoundTripperBuilder", func() {
@@ -145,6 +230,132 @@ var _ = Describe("Logging", func() {
 	})
 
 	Describe("RoundTripper", func() {
+		It("returns request body read errors without calling the next handler", func() {
+			nextCalled := false
+			roundTripper, err := NewRoundTripper().
+				Logger(newDebugLogger(&bytes.Buffer{})).
+				Next(roundTripFunc(func(request *http.Request) (*http.Response, error) {
+					nextCalled = true
+					return nil, nil
+				})).
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			request, err := http.NewRequest(http.MethodPost, "https://example.com", nil)
+			Expect(err).NotTo(HaveOccurred())
+			request.Body = &stubReadCloser{readErr: errors.New("request read failed")}
+
+			_, err = roundTripper.RoundTrip(request)
+			Expect(err).To(MatchError("request read failed"))
+			Expect(nextCalled).To(BeFalse())
+		})
+
+		It("returns request body close errors without calling the next handler", func() {
+			nextCalled := false
+			roundTripper, err := NewRoundTripper().
+				Logger(newDebugLogger(&bytes.Buffer{})).
+				Next(roundTripFunc(func(request *http.Request) (*http.Response, error) {
+					nextCalled = true
+					return nil, nil
+				})).
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			request, err := http.NewRequest(http.MethodPost, "https://example.com", nil)
+			Expect(err).NotTo(HaveOccurred())
+			request.Body = &stubReadCloser{
+				data:     []byte("request-body"),
+				closeErr: errors.New("request close failed"),
+			}
+
+			_, err = roundTripper.RoundTrip(request)
+			Expect(err).To(MatchError("request close failed"))
+			Expect(nextCalled).To(BeFalse())
+		})
+
+		It("returns errors from the next handler when the request has no body", func() {
+			roundTripper, err := NewRoundTripper().
+				Logger(newDebugLogger(&bytes.Buffer{})).
+				Next(roundTripFunc(func(request *http.Request) (*http.Response, error) {
+					Expect(request.Body).To(BeNil())
+					return nil, errors.New("next failed")
+				})).
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			request, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = roundTripper.RoundTrip(request)
+			Expect(err).To(MatchError("next failed"))
+		})
+
+		It("returns response body read errors", func() {
+			roundTripper, err := NewRoundTripper().
+				Logger(newDebugLogger(&bytes.Buffer{})).
+				Next(roundTripFunc(func(request *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     "200 OK",
+						Header:     http.Header{"Content-Type": []string{"application/json"}},
+						Body:       &stubReadCloser{readErr: errors.New("response read failed")},
+					}, nil
+				})).
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			request, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = roundTripper.RoundTrip(request)
+			Expect(err).To(MatchError("response read failed"))
+		})
+
+		It("returns response body close errors", func() {
+			roundTripper, err := NewRoundTripper().
+				Logger(newDebugLogger(&bytes.Buffer{})).
+				Next(roundTripFunc(func(request *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     "200 OK",
+						Header:     http.Header{"Content-Type": []string{"application/json"}},
+						Body: &stubReadCloser{
+							data:     []byte(`{"visible":"response-value"}`),
+							closeErr: errors.New("response close failed"),
+						},
+					}, nil
+				})).
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			request, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = roundTripper.RoundTrip(request)
+			Expect(err).To(MatchError("response close failed"))
+		})
+
+		It("handles responses without a body", func() {
+			roundTripper, err := NewRoundTripper().
+				Logger(newDebugLogger(&bytes.Buffer{})).
+				Next(roundTripFunc(func(request *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusNoContent,
+						Status:     "204 No Content",
+						Header:     http.Header{},
+					}, nil
+				})).
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			request, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			response, err := roundTripper.RoundTrip(request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(response.Body).To(BeNil())
+		})
+
 		It("preserves request and response bodies through the round trip", func() {
 			var capturedRequestBody string
 			roundTripper, err := NewRoundTripper().
@@ -208,6 +419,63 @@ var _ = Describe("Logging", func() {
 			Expect(logOutput).NotTo(ContainSubstring("response-secret"))
 		})
 
+		It("pretty prints JSON bodies in logs", func() {
+			logBuffer := &bytes.Buffer{}
+			roundTripper, err := NewRoundTripper().
+				Logger(newDebugLogger(logBuffer)).
+				Next(roundTripFunc(func(request *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     "200 OK",
+						Header:     http.Header{"Content-Type": []string{"application/json"}},
+						Body: io.NopCloser(strings.NewReader(
+							`{"visible":"response-value","nested":{"name":"response-child"}}`,
+						)),
+					}, nil
+				})).
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			request, err := http.NewRequest(
+				http.MethodPost,
+				"https://example.com",
+				strings.NewReader(`{"visible":"request-value","nested":{"name":"request-child"}}`),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			request.Header.Set("Content-Type", "application/json")
+
+			_, err = roundTripper.RoundTrip(request)
+			Expect(err).NotTo(HaveOccurred())
+
+			logOutput := logBuffer.String()
+			Expect(logOutput).To(ContainSubstring("{\n  \"visible\": \"request-value\",\n  \"nested\": {\n    \"name\": \"request-child\"\n  }\n}"))
+			Expect(logOutput).To(ContainSubstring("{\n  \"visible\": \"response-value\",\n  \"nested\": {\n    \"name\": \"response-child\"\n  }\n}"))
+		})
+
+		It("falls back to raw bytes for invalid JSON bodies", func() {
+			logBuffer := &bytes.Buffer{}
+			roundTripper, err := NewRoundTripper().
+				Logger(newDebugLogger(logBuffer)).
+				Next(roundTripFunc(func(request *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     "200 OK",
+						Header:     http.Header{},
+						Body:       io.NopCloser(strings.NewReader("ok")),
+					}, nil
+				})).
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			request, err := http.NewRequest(http.MethodPost, "https://example.com", strings.NewReader("{invalid-json"))
+			Expect(err).NotTo(HaveOccurred())
+			request.Header.Set("Content-Type", "application/json")
+
+			_, err = roundTripper.RoundTrip(request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(logBuffer.String()).To(ContainSubstring("{invalid-json"))
+		})
+
 		It("omits the Authorization header from logs", func() {
 			logBuffer := &bytes.Buffer{}
 			roundTripper, err := NewRoundTripper().
@@ -262,6 +530,57 @@ var _ = Describe("Logging", func() {
 			Expect(logOutput).To(ContainSubstring("***"))
 			Expect(logOutput).To(ContainSubstring("name=value"))
 			Expect(logOutput).NotTo(ContainSubstring("secret"))
+		})
+
+		It("omits malformed form bodies instead of logging raw secret values", func() {
+			logBuffer := &bytes.Buffer{}
+			roundTripper, err := NewRoundTripper().
+				Logger(newDebugLogger(logBuffer)).
+				Redact("token").
+				Next(roundTripFunc(func(request *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     "200 OK",
+						Header:     http.Header{},
+						Body:       io.NopCloser(strings.NewReader("ok")),
+					}, nil
+				})).
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			request, err := http.NewRequest(http.MethodPost, "https://example.com", strings.NewReader("token=%zz"))
+			Expect(err).NotTo(HaveOccurred())
+			request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+			_, err = roundTripper.RoundTrip(request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(logBuffer.String()).To(ContainSubstring("Request body omitted due to invalid form encoding"))
+			Expect(logBuffer.String()).NotTo(ContainSubstring("token=%zz"))
+		})
+
+		It("falls back to raw bytes when the content type is malformed", func() {
+			logBuffer := &bytes.Buffer{}
+			roundTripper, err := NewRoundTripper().
+				Logger(newDebugLogger(logBuffer)).
+				Next(roundTripFunc(func(request *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     "200 OK",
+						Header:     http.Header{},
+						Body:       io.NopCloser(strings.NewReader("ok")),
+					}, nil
+				})).
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			request, err := http.NewRequest(http.MethodPost, "https://example.com", strings.NewReader("raw-body"))
+			Expect(err).NotTo(HaveOccurred())
+			request.Header.Set("Content-Type", "invalid;=")
+
+			_, err = roundTripper.RoundTrip(request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(logBuffer.String()).To(ContainSubstring("Failed to parse content type"))
+			Expect(logBuffer.String()).To(ContainSubstring("raw-body"))
 		})
 	})
 })

--- a/pkg/logging/round_tripper.go
+++ b/pkg/logging/round_tripper.go
@@ -241,7 +241,7 @@ func (d *RoundTripper) dumpForm(what string, data []byte) {
 	// Parse the form:
 	form, err := url.ParseQuery(string(data))
 	if err != nil {
-		d.dumpBytes(what, data)
+		d.logger.Debugf("%s body omitted due to invalid form encoding", what)
 		return
 	}
 


### PR DESCRIPTION
## PR Summary

Complete the remaining coverage gaps in shared utility packages and harden malformed form-body logging, on top of the baseline work merged in #3277.

## Detailed Description of the Issue

this PR targets the untested package-level utilities that are reused across many commands. The earlier merged PR [#3277](https://github.com/openshift/rosa/pull/3277) covered the initial scope. This PR is the completion delta: it closes the remaining meaningful gaps that #3277 left open, including FedRAMP endpoint-map smoke tests, input-file edge-case handling, logging round-tripper branch coverage, color auto-detection, and flag-parse wiring for region/profile/debug.

A small production hardening is also included: `pkg/logging/round_tripper.go` now omits malformed form-encoded request bodies from debug logs instead of echoing them verbatim, which could previously leak redacted field values when `url.ParseQuery` failed.

## Related Issues and PRs

- Jira: [ROSAENG-61172](https://redhat.atlassian.net/browse/ROSAENG-61172)
- Fixes: `#`
- Related PR(s): completes the package scope on top of [#3277](https://github.com/openshift/rosa/pull/3277)
- Related design/docs: [ROSAENG-60112](https://redhat.atlassian.net/browse/ROSAENG-60112) 
## Type of Change

- [ ] feat - adds a new user-facing capability.
- [x] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [x] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior

The baseline work left a set of meaningful utility-package gaps untested:
- FedRAMP endpoint-map contents and some config/flag edge paths
- input-file permission-denied and directory-path error handling
- logging JSON pretty-printing, malformed-body handling, and OCM logger routing
- color auto-detection branches (Windows, terminal, pipe, stat failure)
- parse-through flag wiring for region/profile/debug helpers
- malformed form-encoded request bodies were echoed raw to debug logs even when the body contained redacted field values

## Behavior After This Change

This PR completes the remaining package work:
- `pkg/fedramp`: `Enabled()`, `Disable()`, `IsGovRegion()`, `IsValidEnv()`, `HasFlag()` / `HasAdminFlag()`, plus `URLAliases`, `TokenURLs`, and `LoginURLs` smoke tests
- `pkg/input`: valid YAML, valid JSON, missing file, invalid YAML, empty file, permission denied, directory path, and Hosted Control Planes exit-path coverage
- `pkg/logging`: builder validation, request/response body preservation, JSON pretty-printing, form redaction, authorization-header omission, malformed-form omission, invalid-JSON fallback, malformed content-type fallback, body read/close error paths, no-body paths, and OCM logger Debug/Info/Warn/Error/Fatal routing
- `pkg/color`: `never`, `always`, and `auto` paths across Windows, terminal, named-pipe, and stat-failure branches
- `pkg/aws/region`: flag > env > empty precedence plus escaped-empty handling and parse-through wiring
- `pkg/aws/profile`: flag > env > empty precedence and parse-through wiring
- `pkg/debug`: flag parse/state coverage

Small production changes:
- `pkg/color/flag.go`: testability seams for `runtime.GOOS` and `os.Stdout.Stat` (no behavior change)
- `pkg/input/input_validation.go`: testability seam for `os.Exit` in `CheckIfHypershiftClusterOrExit` (no behavior change)
- `pkg/logging/round_tripper.go`: malformed form bodies are now omitted from debug logs instead of being echoed raw

Intentionally skipped per the coverage plan:
- `pkg/info`, `pkg/object`, `pkg/properties`, `pkg/constants` (constants only, no logic)
- `pkg/clients` (pure delegation wrapper; real wrapper methods already have 100% coverage, low raw percentage is from generated mock code)
- `pkg/logging` `dumpJSON()` marshal-fallback branch (practically unreachable, not worth forcing)

## How to Test (Step-by-Step)

### Preconditions

- Go 1.26.3 toolchain available via `GOTOOLCHAIN=auto`
- Repository cloned with hooks installed (`make install-hooks`)

### Test Steps

1. `env GOTOOLCHAIN=auto go test ./pkg/fedramp ./pkg/input ./pkg/logging ./pkg/color ./pkg/aws/region ./pkg/aws/profile ./pkg/debug ./pkg/clients -count=1`
2. `env GOTOOLCHAIN=auto make test`
3. `env GOTOOLCHAIN=auto make lint`
4. `env GOTOOLCHAIN=auto make rosa`

### Expected Results

- All targeted package tests pass
- The repository-wide test suite passes
- Lint passes with 0 issues for the touched packages
- The `rosa` binary builds successfully

## Proof of the Fix

- Logs/CLI output:
  - targeted package tests passed
  - `make test` passed
  - `make lint` passed (targeted packages: 0 issues)
  - `make rosa` passed
  - pre-push checks passed (format, build, lint, changed-files coverage, unit/integration tests)
- Other artifacts:
  - `pkg/fedramp` function coverage: 100%
  - `pkg/input` function coverage: 100%
  - `pkg/color` function coverage: 100%
  - `pkg/aws/region` function coverage: 100%
  - `pkg/aws/profile` function coverage: 100%
  - `pkg/debug` function coverage: 100%
  - `pkg/logging` statement coverage: 99.4% (only the low-value marshal fallback branch in `dumpJSON()` remains uncovered)

## Breaking Changes

- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan

N/A

## Developer Verification Checklist

- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

[ROSAENG-61172]: https://redhat.atlassian.net/browse/ROSAENG-61172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROSAENG-60112]: https://redhat.atlassian.net/browse/ROSAENG-60112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ