### PR TITLE
ROSAENG-9174 | feat: enable --component-routes for HCP clusters

### DIFF
--- a/cmd/edit/ingress/cmd.go
+++ b/cmd/edit/ingress/cmd.go
@@ -62,7 +62,7 @@ var Cmd = &cobra.Command{
 	Args: func(_ *cobra.Command, argv []string) error {
 		if len(argv) != 1 {
 			return fmt.Errorf(
-				"Expected exactly one command line parameter containing the id of the ingress",
+				"expected exactly one command line parameter containing the id of the ingress",
 			)
 		}
 		return nil
@@ -369,48 +369,48 @@ func run(cmd *cobra.Command, argv []string) {
 			namespaceOwnershipPolicy = &namespaceOwnershipPolicyArg
 		}
 
-		if cmd.Flags().Changed(componentRoutesFlag) {
-			if ocm.IsHyperShiftCluster(cluster) {
-				r.Reporter.Errorf(
-					"Updating Cluster Component Routes is not supported for Hosted Control Plane clusters",
-				)
-				os.Exit(1)
-			}
-			componentRoutes, err = parseComponentRoutes(args.componentRoutes)
-			if err != nil {
-				r.Reporter.Errorf("An error occurred whilst parsing the supplied component routes: %s", err)
-				os.Exit(1)
-			}
-		} else if isInteractiveEnabledAndNotHcp {
-			componentRoutes = map[string]*cmv1.ComponentRouteBuilder{}
-			if confirm.Prompt(false, "Would you like to edit the component routes?") {
-				for _, componentRoute := range expectedComponentRoutes {
-					componentRouteBuilder := cmv1.NewComponentRoute()
-					for _, parameterName := range expectedParameters {
-						defaultValue := ""
-						// TODO: use reflection, couldn't get it to work
-						if parameterName == hostnameParameter {
-							defaultValue = ingress.ComponentRoutes()[componentRoute].Hostname()
-						} else if parameterName == tlsSecretRefParameter {
-							defaultValue = ingress.ComponentRoutes()[componentRoute].TlsSecretRef()
-						}
-						parameterValue, err := interactive.GetString(interactive.Input{
-							Question: fmt.Sprintf("%s route %s", componentRoute, parameterName),
-							Default:  defaultValue,
-						})
-						if err != nil {
-							r.Reporter.Errorf("Expected a valid component route '%s': %s", parameterName, err)
-							os.Exit(1)
-						}
-						// TODO: use reflection, couldn't get it to work
-						if parameterName == hostnameParameter {
-							componentRouteBuilder.Hostname(parameterValue)
-						} else if parameterName == tlsSecretRefParameter {
-							componentRouteBuilder.TlsSecretRef(parameterValue)
-						}
+	}
+
+	canEditComponentRoutes := !hasLegacyIngressSupport || isHypershift
+	if cmd.Flags().Changed(componentRoutesFlag) {
+		if !canEditComponentRoutes {
+			r.Reporter.Errorf("Updating component routes is not supported for legacy ingress clusters")
+			os.Exit(1)
+		}
+		componentRoutes, err = parseComponentRoutesForAllowed(args.componentRoutes, allowedComponentRoutes(isHypershift))
+		if err != nil {
+			r.Reporter.Errorf("An error occurred whilst parsing the supplied component routes: %s", err)
+			os.Exit(1)
+		}
+	} else if interactive.Enabled() && canEditComponentRoutes {
+		componentRoutes = map[string]*cmv1.ComponentRouteBuilder{}
+		if confirm.Prompt(false, "Would you like to edit the component routes?") {
+			for _, componentRoute := range allowedComponentRoutes(isHypershift) {
+				componentRouteBuilder := cmv1.NewComponentRoute()
+				for _, parameterName := range expectedParameters {
+					defaultValue := ""
+					switch parameterName {
+					case hostnameParameter:
+						defaultValue = ingress.ComponentRoutes()[componentRoute].Hostname()
+					case tlsSecretRefParameter:
+						defaultValue = ingress.ComponentRoutes()[componentRoute].TlsSecretRef()
 					}
-					componentRoutes[componentRoute] = componentRouteBuilder
+					parameterValue, err := interactive.GetString(interactive.Input{
+						Question: fmt.Sprintf("%s route %s", componentRoute, parameterName),
+						Default:  defaultValue,
+					})
+					if err != nil {
+						r.Reporter.Errorf("Expected a valid component route '%s': %s", parameterName, err)
+						os.Exit(1)
+					}
+					switch parameterName {
+					case hostnameParameter:
+						componentRouteBuilder.Hostname(parameterValue)
+					case tlsSecretRefParameter:
+						componentRouteBuilder.TlsSecretRef(parameterValue)
+					}
 				}
+				componentRoutes[componentRoute] = componentRouteBuilder
 			}
 		}
 	}

--- a/cmd/edit/ingress/cmd_test.go
+++ b/cmd/edit/ingress/cmd_test.go
@@ -49,6 +49,63 @@ var _ = Describe("Parse component routes", func() {
 			"oauth: hostname=\"oauth-host\";tlsSecretRef=\"oauth-secret\",downloads: hostname=\"downloads-host\";tlsSecretRef=\"downloads-secret\",console: hostname=\"console-host\";tlsSecretRef=\"console-secret\"",
 		),
 	)
+	DescribeTable(
+		"When parsing HCP component routes it should only allow console and downloads",
+		func(input string) {
+			componentRouteBuilder, err := parseComponentRoutesForAllowed(input, expectedHcpComponentRoutes)
+			Expect(err).To(BeNil())
+			Expect(componentRouteBuilder).To(HaveLen(2))
+			Expect(componentRouteBuilder).To(HaveKey("console"))
+			Expect(componentRouteBuilder).To(HaveKey("downloads"))
+			for key, builder := range componentRouteBuilder {
+				expectedHostname := fmt.Sprintf("%s-host", key)
+				expectedTlsRef := fmt.Sprintf("%s-secret", key)
+				componentRoute, err := builder.Build()
+				Expect(err).To(BeNil())
+				Expect(componentRoute.Hostname()).To(Equal(expectedHostname))
+				Expect(componentRoute.TlsSecretRef()).To(Equal(expectedTlsRef))
+			}
+		},
+		//nolint:lll
+		Entry(
+			"base",
+			"console: hostname=console-host;tlsSecretRef=console-secret,downloads: hostname=downloads-host;tlsSecretRef=downloads-secret",
+		),
+	)
+	Context("When parsing HCP component routes it should reject invalid input", func() {
+		It("When oauth is provided it should be rejected", func() {
+			_, err := parseComponentRoutesForAllowed(
+				//nolint:lll
+				"oauth: hostname=oauth-host;tlsSecretRef=oauth-secret,console: hostname=console-host;tlsSecretRef=console-secret",
+				expectedHcpComponentRoutes,
+			)
+			Expect(err).ToNot(BeNil())
+			Expect(
+				err.Error(),
+			).To(Equal("'oauth' is not a valid component name. Expected include [console, downloads]"))
+		})
+		It("When a duplicate component route is provided it should be rejected", func() {
+			_, err := parseComponentRoutesForAllowed(
+				//nolint:lll
+				"console: hostname=console-host;tlsSecretRef=console-secret,console: hostname=console-host2;tlsSecretRef=console-secret2",
+				expectedHcpComponentRoutes,
+			)
+			Expect(err).ToNot(BeNil())
+			Expect(
+				err.Error(),
+			).To(Equal("component route \"console\" was supplied more than once"))
+		})
+		It("When only one route is provided it should fail with wrong count", func() {
+			_, err := parseComponentRoutesForAllowed(
+				"console: hostname=console-host;tlsSecretRef=console-secret",
+				expectedHcpComponentRoutes,
+			)
+			Expect(err).ToNot(BeNil())
+			Expect(
+				err.Error(),
+			).To(Equal("the expected amount of component routes is 2, but 1 have been supplied"))
+		})
+	})
 	Context("Fails to parse input string for component routes", func() {
 		It("fails due to invalid component route", func() {
 			_, err := parseComponentRoutes(

--- a/cmd/edit/ingress/flags.go
+++ b/cmd/edit/ingress/flags.go
@@ -34,12 +34,24 @@ const (
 )
 
 var exclusivelyIngressV2Flags = []string{excludedNamespacesFlag, wildcardPolicyFlag,
-	namespaceOwnershipPolicyFlag, clusterRoutesHostnameFlag, clusterRoutesTlsSecretRefFlag, componentRoutesFlag}
+	namespaceOwnershipPolicyFlag, clusterRoutesHostnameFlag, clusterRoutesTlsSecretRefFlag}
 
 var expectedComponentRoutes = []string{
 	string(cmv1.ComponentRouteTypeOauth),
 	string(cmv1.ComponentRouteTypeConsole),
 	string(cmv1.ComponentRouteTypeDownloads),
+}
+
+var expectedHcpComponentRoutes = []string{
+	string(cmv1.ComponentRouteTypeConsole),
+	string(cmv1.ComponentRouteTypeDownloads),
+}
+
+func allowedComponentRoutes(isHypershift bool) []string {
+	if isHypershift {
+		return expectedHcpComponentRoutes
+	}
+	return expectedComponentRoutes
 }
 
 var expectedParameters = []string{
@@ -81,19 +93,24 @@ func addIngressV2Flags(flags *pflag.FlagSet) {
 		componentRoutesFlag,
 		"",
 		//nolint:lll
-		"Component routes settings. Available keys [oauth, console, downloads]. For each key a pair of hostname and tlsSecretRef is expected to be supplied. "+
+		"Component routes settings. Available keys [oauth, console, downloads] (HCP clusters support console and downloads only). For each key a pair of hostname and tlsSecretRef is expected to be supplied. "+
 			"Format should be a comma separate list 'oauth: hostname=example-hostname;tlsSecretRef=example-secret-ref,downloads:...",
 	)
 }
 
 func parseComponentRoutes(input string) (map[string]*cmv1.ComponentRouteBuilder, error) {
+	return parseComponentRoutesForAllowed(input, expectedComponentRoutes)
+}
+
+//nolint:lll
+func parseComponentRoutesForAllowed(input string, allowedRoutes []string) (map[string]*cmv1.ComponentRouteBuilder, error) {
 	result := map[string]*cmv1.ComponentRouteBuilder{}
 	input = strings.TrimSpace(input)
 	components := strings.Split(input, ",")
-	if len(components) != len(expectedComponentRoutes) {
+	if len(components) != len(allowedRoutes) {
 		return nil, fmt.Errorf(
 			"the expected amount of component routes is %d, but %d have been supplied",
-			len(expectedComponentRoutes),
+			len(allowedRoutes),
 			len(components),
 		)
 	}
@@ -115,11 +132,15 @@ func parseComponentRoutes(input string) (map[string]*cmv1.ComponentRouteBuilder,
 			)
 		}
 		componentName := strings.TrimSpace(parsedComponent[0])
-		if !helper.Contains(expectedComponentRoutes, componentName) {
+		if _, exists := result[componentName]; exists {
+			return nil, fmt.Errorf(
+				"component route %q was supplied more than once", componentName)
+		}
+		if !helper.Contains(allowedRoutes, componentName) {
 			return nil, fmt.Errorf(
 				"'%s' is not a valid component name. Expected include %s",
 				componentName,
-				helper.SliceToSortedString(expectedComponentRoutes),
+				helper.SliceToSortedString(allowedRoutes),
 			)
 		}
 		parameters := strings.TrimSpace(parsedComponent[1])
@@ -152,7 +173,6 @@ func parseComponentRoutes(input string) (map[string]*cmv1.ComponentRouteBuilder,
 			for _, t := range transformations {
 				parameterValue = t(parameterValue)
 			}
-			// TODO: use reflection, couldn't get it to work
 			switch parameterName {
 			case hostnameParameter:
 				componentRouteBuilder.Hostname(parameterValue)


### PR DESCRIPTION
## PR Summary

Enable `--component-routes` flag and interactive mode for HCP clusters in `rosa edit ingress`, allowing customers to configure custom console and downloads hostnames with TLS certificates.

## Detailed Description of the Issue

ROSA HCP customers cannot use `rosa edit ingress --component-routes` to set custom hostnames for Console and Downloads routes. The CLI blocks all ingress V2 flags for HCP clusters, including `component-routes`. The backend (clusters-service) and HyperShift operator now both support componentRoutes for HCP, but the CLI guard rail prevents customers from using the feature.

## Related Issues and PRs
- Jira: [ROSAENG-9174](https://redhat.atlassian.net/browse/ROSAENG-9174)
- Feature: [ROSA-62](https://issues.redhat.com/browse/ROSA-62)
- HyperShift PR: [openshift/hypershift#8838](https://github.com/openshift/hypershift/pull/8838) (merged)
- HyperShift bug: [OCPBUGS-92791](https://redhat.atlassian.net/browse/OCPBUGS-92791)
- Clusters-service MR: 11393 (merged)
- Terraform PR: [terraform-redhat/terraform-provider-rhcs#1187](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1187) (on hold pending this CLI change)

## Type of Change
- [x] feat - adds a new user-facing capability.

## Previous Behavior

`rosa edit ingress --component-routes` on an HCP cluster returned:
```
ERR: New ingress attributes [component-routes, ...] can't be supplied for Hosted Control Plane clusters
```

## Behavior After This Change

`rosa edit ingress --component-routes` works on HCP clusters for console and downloads routes. OAuth is excluded because it runs on the management cluster and is not configurable via component routes on HCP.

**Flag mode:**
```bash
rosa edit ingress -c mycluster \
  --component-routes 'console: hostname=console.example.com;tlsSecretRef=console-tls, downloads: hostname=downloads.example.com;tlsSecretRef=downloads-tls' \
  <ingress-id>
```

**Interactive mode** (`-i`): prompts for console and downloads only (no oauth).

**Validation:**
- Passing `oauth` as a component name returns: `'oauth' is not a valid component name. Expected include [console, downloads]`
- Passing hostname without tlsSecretRef returns the backend 400 error

## How to Test (Step-by-Step)
### Preconditions
- A running ROSA HCP cluster
- The `hypershift-component-routes` feature toggle enabled
- HyperShift operator >= v0.1.79 deployed
- A TLS secret created in `openshift-config` namespace on the hosted cluster

### Test Steps
1. Set componentRoutes via flag mode: `rosa edit ingress -c <cluster-name> --component-routes 'console: hostname=console.custom.example.com;tlsSecretRef=console-tls-secret, downloads: hostname=downloads.custom.example.com;tlsSecretRef=downloads-tls-secret' <ingress-id>`
2. Verify on the cluster: `oc get ingresses.config.openshift.io cluster -o jsonpath='{.spec.componentRoutes}'`
3. Verify custom routes: `oc get routes -n openshift-console`
4. Test interactive mode: `rosa edit ingress -c <cluster-name> -i <ingress-id>` — should prompt for console and downloads only
5. Test oauth rejection: pass oauth as a component name — should error client-side
6. Test clearing: pass empty hostname and tlsSecretRef values
7. Verify other V2 flags remain blocked: `rosa edit ingress -c <cluster-name> --excluded-namespaces 'test' <ingress-id>`

### Expected Results
- ComponentRoutes set and propagate to hosted cluster ingress config
- Custom routes created (`console-custom`, `downloads-custom`)
- Original routes redirect (301) to custom hostnames
- OAuth rejected client-side with clear error message
- Other V2 flags still blocked for HCP
- Interactive mode only prompts for console and downloads

## Proof of the Fix

**make test:**
```
Ran 13 of 13 Specs in 0.001 seconds
SUCCESS! -- 13 Passed | 0 Failed | 0 Pending | 0 Skipped
```

**Flag mode — set console + downloads:**
```
$ rosa edit ingress -c creed-hcp --component-routes '...' c0p6
INFO: Updated ingress 'c0p6' on cluster '...'
```

**Propagation verified:**
```json
[
  {"hostname":"console.custom.example.com","name":"console","namespace":"openshift-console","servingCertKeyPairSecret":{"name":"console-tls-secret"}},
  {"hostname":"downloads.custom.example.com","name":"downloads","namespace":"openshift-console","servingCertKeyPairSecret":{"name":"downloads-tls-secret"}}
]
```

**Custom routes created:**
```
console-custom     console.custom.example.com        console     https   reencrypt/Redirect
downloads-custom   downloads.custom.example.com      downloads   http    edge/Redirect
```

**OAuth rejection:**
```
ERR: 'oauth' is not a valid component name. Expected include [console, downloads]
```

**Hostname without secret — backend 400:**
```
ERR: Can't update 'console' component route hostname ... without also supplying a new TLS secret reference
```

**Cleanup via empty values:**
```
$ rosa edit ingress -c creed-hcp --component-routes 'console: hostname=;tlsSecretRef=, downloads: hostname=;tlsSecretRef=' c0p6
INFO: Updated ingress 'c0p6' on cluster '...'
```

**Interactive mode — set values (no oauth prompted):**
```
$ rosa edit ingress -c creed-hcp -i c0p6
? Private ingress: No
? Would you like to edit the component routes? Yes
? console route hostname: console.custom.example.com
? console route tlsSecretRef: console-tls-secret
? downloads route hostname: downloads.custom.example.com
? downloads route tlsSecretRef: downloads-tls-secret
W: No need to update ingress as there are no changes
```

**Interactive mode — clear console, keep downloads:**
```
$ rosa edit ingress -c creed-hcp -i c0p6
? Private ingress: No
? Would you like to edit the component routes? Yes
? console route hostname:
? console route tlsSecretRef:
? downloads route hostname: downloads.custom.example.com
? downloads route tlsSecretRef: downloads-tls-secret
I: Updated ingress 'c0p6' on cluster '...'
```

## Breaking Changes
- [x] No breaking changes

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [x] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

[ROSAENG-9174]: https://redhat.atlassian.net/browse/ROSAENG-9174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROSA-62]: https://redhat.atlassian.net/browse/ROSA-62?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OCPBUGS-92791]: https://redhat.atlassian.net/browse/OCPBUGS-92791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enabled component-route editing for Hosted Control Plane clusters.
  - Interactive component-route setup now runs when editing is allowed and prompts for all supported routes for the selected cluster type.
  - Prompts prefill existing ingress values as defaults.

- **Bug Fixes**
  - Component-route parsing and validation are now limited to cluster-type-supported routes.
  - Updated ingress V2 flag exclusivity and improved component-route input validation and error messages (including invalid names and duplicate/wrong counts).

- **Tests**
  - Added Ginkgo coverage for Hosted Control Plane component-route parsing and rejection cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->