### PR TITLE
ROSAENG-00000 | style: fix pre-existing staticcheck issues in files touched by OSDOCS-16406

### DIFF
--- a/cmd/create/oidcconfig/cmd.go
+++ b/cmd/create/oidcconfig/cmd.go
@@ -34,7 +34,7 @@ import (
 	"github.com/openshift/rosa/pkg/aws"
 	awscb "github.com/openshift/rosa/pkg/aws/commandbuilder"
 	"github.com/openshift/rosa/pkg/aws/tags"
-	. "github.com/openshift/rosa/pkg/constants"
+	"github.com/openshift/rosa/pkg/constants"
 	"github.com/openshift/rosa/pkg/helper"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
@@ -101,7 +101,7 @@ func init() {
 	flags.SetNormalizeFunc(arguments.NormalizeFlags)
 	flags.StringVar(
 		&args.installerRoleArn,
-		InstallerRoleArnFlag,
+		constants.InstallerRoleArnFlag,
 		"",
 		"STS Role ARN with get secrets permission.",
 	)
@@ -126,7 +126,7 @@ func checkInteractiveModeNeeded(cmd *cobra.Command) {
 		return
 	}
 	modeIsAuto := cmd.Flag("mode").Value.String() == interactive.ModeAuto
-	installerRoleArnNotSet := (!cmd.Flags().Changed(InstallerRoleArnFlag) || args.installerRoleArn == "") &&
+	installerRoleArnNotSet := (!cmd.Flags().Changed(constants.InstallerRoleArnFlag) || args.installerRoleArn == "") &&
 		!confirm.Yes()
 	if !args.managed && (modeNotChanged || (modeIsAuto && installerRoleArnNotSet)) {
 		interactive.Enable()
@@ -164,7 +164,7 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	if args.rawFiles && args.installerRoleArn != "" {
-		r.Reporter.Warnf("--%s param is not supported alongside --%s param", rawFilesFlag, InstallerRoleArnFlag)
+		r.Reporter.Warnf("--%s param is not supported alongside --%s param", rawFilesFlag, constants.InstallerRoleArnFlag)
 		os.Exit(1)
 	}
 
@@ -198,7 +198,7 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	if args.managed && args.installerRoleArn != "" {
-		r.Reporter.Warnf("--%s param is not supported for managed OIDC config", InstallerRoleArnFlag)
+		r.Reporter.Warnf("--%s param is not supported for managed OIDC config", constants.InstallerRoleArnFlag)
 		os.Exit(1)
 	}
 
@@ -214,7 +214,7 @@ func run(cmd *cobra.Command, _ []string) {
 						r,
 						cmd,
 						args.installerRoleArn,
-						MinorVersionForGetSecret,
+						constants.MinorVersionForGetSecret,
 						r.AWSClient.FindRoleARNs,
 					)
 			}
@@ -255,7 +255,7 @@ func run(cmd *cobra.Command, _ []string) {
 					os.Exit(1)
 				}
 				isValid, err := r.AWSClient.ValidateAccountRoleVersionCompatibility(
-					roleName, aws.InstallerAccountRole, MinorVersionForGetSecret)
+					roleName, aws.InstallerAccountRole, constants.MinorVersionForGetSecret)
 				if err != nil {
 					r.Reporter.Errorf("There was a problem listing role tags: %v", err)
 					os.Exit(1)
@@ -264,7 +264,7 @@ func run(cmd *cobra.Command, _ []string) {
 					r.Reporter.Errorf(
 						"Role '%s' is not of minimum version '%s'",
 						args.installerRoleArn,
-						MinorVersionForGetSecret,
+						constants.MinorVersionForGetSecret,
 					)
 					os.Exit(1)
 				}
@@ -389,21 +389,21 @@ func (s *CreateUnmanagedOidcConfigAutoStrategy) executeNoExit(r *rosa.Runtime) (
 	installerRoleArn := args.installerRoleArn
 	err := r.AWSClient.CreateS3Bucket(bucketName, args.region)
 	if err != nil {
-		return "", fmt.Errorf("There was a problem creating S3 bucket '%s': %s", bucketName, err)
+		return "", fmt.Errorf("there was a problem creating S3 bucket '%s': %s", bucketName, err)
 	}
 	err = r.AWSClient.PutPublicReadObjectInS3Bucket(bucketName, strings.NewReader(discoveryDocument), discoveryDocumentKey)
 	if err != nil {
-		return "", fmt.Errorf("There was a problem populating discovery "+
+		return "", fmt.Errorf("there was a problem populating discovery "+
 			"document to S3 bucket '%s': %s", bucketName, err)
 	}
 	err = r.AWSClient.PutPublicReadObjectInS3Bucket(bucketName, bytes.NewReader(jwks), jwksKey)
 	if err != nil {
-		return "", fmt.Errorf("There was a problem populating JWKS "+
+		return "", fmt.Errorf("there was a problem populating JWKS "+
 			"to S3 bucket '%s': %s", bucketName, err)
 	}
 	secretARN, err := r.AWSClient.CreateSecretInSecretsManager(privateKeySecretName, string(privateKey[:]))
 	if err != nil {
-		return "", fmt.Errorf("There was a problem saving private key to secrets manager: %s", err)
+		return "", fmt.Errorf("there was a problem saving private key to secrets manager: %s", err)
 	}
 	oidcConfig, err := v1.NewOidcConfig().
 		Managed(false).
@@ -415,7 +415,7 @@ func (s *CreateUnmanagedOidcConfigAutoStrategy) executeNoExit(r *rosa.Runtime) (
 		oidcConfig, err = r.OCMClient.CreateOidcConfig(oidcConfig)
 	}
 	if err != nil {
-		return "", fmt.Errorf("There was a problem building your unmanaged OIDC Configuration: %v.\n"+
+		return "", fmt.Errorf("there was a problem building your unmanaged OIDC Configuration: %v.\n"+
 			"Please refer to documentation and try again through:\n"+
 			"\trosa register oidc-config --issuer-url %s --secret-arn %s --role-arn %s",
 			err, bucketUrl, secretARN, installerRoleArn)
@@ -496,7 +496,7 @@ func (s *CreateUnmanagedOidcConfigAutoStrategy) execute(r *rosa.Runtime) string 
 		if spin != nil {
 			spin.Stop()
 		}
-		output := fmt.Sprintf(InformOperatorRolesOutput, oidcConfig.ID())
+		output := fmt.Sprintf(constants.InformOperatorRolesOutput, oidcConfig.ID())
 		r.Reporter.Infof(output)
 	}
 	return oidcConfig.ID()
@@ -651,7 +651,7 @@ func (s *CreateManagedOidcConfigAutoStrategy) execute(r *rosa.Runtime) string {
 		if spin != nil {
 			spin.Stop()
 		}
-		output := fmt.Sprintf(InformOperatorRolesOutput, oidcConfig.ID())
+		output := fmt.Sprintf(constants.InformOperatorRolesOutput, oidcConfig.ID())
 		r.Reporter.Infof(output)
 	}
 	return oidcConfig.ID()
@@ -660,11 +660,11 @@ func (s *CreateManagedOidcConfigAutoStrategy) execute(r *rosa.Runtime) string {
 func (s *CreateManagedOidcConfigAutoStrategy) executeNoExit(r *rosa.Runtime) (string, error) {
 	oidcConfig, err := v1.NewOidcConfig().Managed(true).Build()
 	if err != nil {
-		return "", fmt.Errorf("There was a problem building the managed OIDC Configuration: %v", err)
+		return "", fmt.Errorf("there was a problem building the managed OIDC Configuration: %v", err)
 	}
 	oidcConfig, err = r.OCMClient.CreateOidcConfig(oidcConfig)
 	if err != nil {
-		return "", fmt.Errorf("There was a problem building the managed OIDC Configuration: %v", err)
+		return "", fmt.Errorf("there was a problem building the managed OIDC Configuration: %v", err)
 	}
 	s.oidcConfigInput.IssuerUrl = oidcConfig.IssuerUrl()
 	return oidcConfig.ID(), nil

--- a/cmd/dlt/accountroles/cmd.go
+++ b/cmd/dlt/accountroles/cmd.go
@@ -235,7 +235,7 @@ func deleteAccountRoles(r *rosa.Runtime, cmd *cobra.Command, env string, prefix 
 		r.OCMClient.LogEvent("ROSADeleteAccountRoleModeManual", nil)
 		policyMap, arbitraryPolicyMap, err := r.AWSClient.GetAccountRolePolicies(finalRoleList, prefix)
 		if err != nil {
-			return fmt.Errorf("There was an error getting the policy: %v", err)
+			return fmt.Errorf("there was an error getting the policy: %v", err)
 		}
 
 		// Get HCP shared vpc policy details if the user is deleting roles related to HCP shared vpc
@@ -269,7 +269,7 @@ func getRoleListForDeletion(r *rosa.Runtime, env string, prefix string, clusters
 	finalRoleList := []string{}
 	roles, err := r.AWSClient.GetAccountRoleForCurrentEnvWithPrefix(env, prefix, accountRolesMap)
 	if err != nil {
-		return finalRoleList, false, fmt.Errorf("Error getting role: %s", err)
+		return finalRoleList, false, fmt.Errorf("error getting role: %s", err)
 	}
 	if len(roles) == 0 {
 		return finalRoleList, false, nil
@@ -281,7 +281,7 @@ func getRoleListForDeletion(r *rosa.Runtime, env string, prefix string, clusters
 		}
 		clusterID := checkIfRoleAssociated(clusters, role)
 		if clusterID != "" {
-			return finalRoleList, false, fmt.Errorf("Role %s is associated with the cluster %s", role.RoleName, clusterID)
+			return finalRoleList, false, fmt.Errorf("role %s is associated with the cluster %s", role.RoleName, clusterID)
 		}
 		finalRoleList = append(finalRoleList, role.RoleName)
 	}
@@ -292,18 +292,18 @@ func getRoleListForDeletion(r *rosa.Runtime, env string, prefix string, clusters
 	for _, role := range finalRoleList {
 		instanceProfiles, err := r.AWSClient.GetInstanceProfilesForRole(role)
 		if err != nil {
-			return finalRoleList, false, fmt.Errorf("Error checking for instance roles: %s", err)
+			return finalRoleList, false, fmt.Errorf("error checking for instance roles: %s", err)
 		}
 		if len(instanceProfiles) > 0 {
 			return finalRoleList, false, fmt.Errorf(
-				"Instance Profiles are attached to the role. Please make sure it is deleted: %s",
+				"instance profiles are attached to the role. Please make sure it is deleted: %s",
 				strings.Join(instanceProfiles, ","))
 		}
 	}
 
 	managedPolicies, err := r.AWSClient.HasManagedPolicies(roles[0].RoleARN)
 	if err != nil {
-		return finalRoleList, false, fmt.Errorf("Failed to determine if cluster has managed policies: %v", err)
+		return finalRoleList, false, fmt.Errorf("failed to determine if cluster has managed policies: %v", err)
 	}
 
 	return finalRoleList, managedPolicies, nil
@@ -377,9 +377,10 @@ func buildCommand(roleNames []string, policyMap map[string][]aws.PolicyDetail,
 			hasRhManagedTag := false
 			hasHcpSharedVpcTag := false
 			for _, tag := range hcpSharedVpcPolicy.Policy.Tags {
-				if *tag.Key == tags.RedHatManaged {
+				switch *tag.Key {
+				case tags.RedHatManaged:
 					hasRhManagedTag = true
-				} else if *tag.Key == tags.HcpSharedVpc {
+				case tags.HcpSharedVpc:
 					hasHcpSharedVpcTag = true
 				}
 			}

--- a/cmd/dlt/idp/cmd.go
+++ b/cmd/dlt/idp/cmd.go
@@ -40,7 +40,7 @@ var Cmd = &cobra.Command{
 	Args: func(_ *cobra.Command, argv []string) error {
 		if len(argv) != 1 {
 			return fmt.Errorf(
-				"Expected exactly one command line parameter containing the name of the identity provider",
+				"expected exactly one command line parameter containing the name of the identity provider",
 			)
 		}
 		return nil

--- a/cmd/dlt/idp/cmd_test.go
+++ b/cmd/dlt/idp/cmd_test.go
@@ -10,7 +10,7 @@ var _ = Describe("Delete IDP", func() {
 		It("rejects zero arguments", func() {
 			err := Cmd.Args(nil, []string{})
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("Expected exactly one"))
+			Expect(err.Error()).To(ContainSubstring("expected exactly one"))
 		})
 
 		It("accepts exactly one argument", func() {
@@ -21,7 +21,7 @@ var _ = Describe("Delete IDP", func() {
 		It("rejects two arguments", func() {
 			err := Cmd.Args(nil, []string{"github-1", "extra"})
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("Expected exactly one"))
+			Expect(err.Error()).To(ContainSubstring("expected exactly one"))
 		})
 	})
 })

--- a/cmd/dlt/operatorrole/cmd.go
+++ b/cmd/dlt/operatorrole/cmd.go
@@ -377,9 +377,10 @@ func buildCommand(r *rosa.Runtime, roleNames []string, policyMap map[string][]st
 			hasRhManagedTag := false
 			hasHcpSharedVpcTag := false
 			for _, tag := range hcpSharedVpcPolicy.Policy.Tags {
-				if *tag.Key == tags.RedHatManaged {
+				switch *tag.Key {
+				case tags.RedHatManaged:
 					hasRhManagedTag = true
-				} else if *tag.Key == tags.HcpSharedVpc {
+				case tags.HcpSharedVpc:
 					hasHcpSharedVpcTag = true
 				}
 			}

--- a/cmd/verify/network/cmd.go
+++ b/cmd/verify/network/cmd.go
@@ -161,12 +161,12 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 		if cluster != nil {
 			if !helper.IsBYOVPC(cluster) {
 				return fmt.Errorf(
-					"Running the network verifier is only supported for BYO VPC clusters")
+					"running the network verifier is only supported for BYO VPC clusters")
 			}
 
 			args.subnetIDs = cluster.AWS().SubnetIDs()
 		} else {
-			return fmt.Errorf("At least one subnet IDs is required")
+			return fmt.Errorf("at least one subnet IDs is required")
 		}
 	}
 
@@ -177,7 +177,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 	if cmd.Flags().Changed(roleArnFlag) {
 		err := aws.ARNValidator(args.roleArn)
 		if err != nil {
-			return fmt.Errorf("Expected a valid ARN: %s", err)
+			return fmt.Errorf("expected a valid ARN: %s", err)
 		}
 	} else if !cmd.Flags().Changed(statusOnlyFlag) {
 		if cmd.Flags().Changed(clusterFlag) {
@@ -223,7 +223,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 			}
 			_, err := r.OCMClient.VerifyNetworkSubnetsByCluster(cluster.ID(), tagsList)
 			if err != nil {
-				return fmt.Errorf("Error verifying subnets by cluster: %s", err)
+				return fmt.Errorf("error verifying subnets by cluster: %s", err)
 			}
 		} else {
 			// Default platform type set to 'aws-classic'
@@ -233,7 +233,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 			}
 			_, err := r.OCMClient.VerifyNetworkSubnets(args.roleArn, args.region, args.subnetIDs, tagsList, platform)
 			if err != nil {
-				return fmt.Errorf("Error verifying subnets: %s", err)
+				return fmt.Errorf("error verifying subnets: %s", err)
 			}
 		}
 	}
@@ -271,7 +271,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 			spin.Stop()
 		}
 	} else {
-		var pending bool = false
+		pending := false
 		for i := 0; i < len(args.subnetIDs); i++ {
 			subnet := args.subnetIDs[i]
 			status, err := r.OCMClient.GetVerifyNetworkSubnet(subnet)
@@ -331,7 +331,7 @@ func getRegion(cmd *cobra.Command, cluster *cmv1.Cluster) (region string, err er
 	if cmd.Flags().Changed("region") {
 		region, err = aws.GetRegion(arguments.GetRegion())
 		if err != nil {
-			return "", fmt.Errorf("Error getting region: %v", err)
+			return "", fmt.Errorf("error getting region: %v", err)
 		}
 		return region, nil
 	}
@@ -339,5 +339,5 @@ func getRegion(cmd *cobra.Command, cluster *cmv1.Cluster) (region string, err er
 		return cluster.Region().ID(), nil
 	}
 
-	return "", fmt.Errorf("Region is required")
+	return "", fmt.Errorf("region is required")
 }

--- a/cmd/verify/network/cmd_test.go
+++ b/cmd/verify/network/cmd_test.go
@@ -178,14 +178,14 @@ INFO: subnet-0f87f640e56934cbc, platform: aws, tags: {"t1":"v1"}: passed
 		err := runWithRuntime(r, cmd)
 		Expect(err).ToNot(BeNil())
 		Expect(err.Error()).To(
-			ContainSubstring("At least one subnet IDs is required"))
+			ContainSubstring("at least one subnet IDs is required"))
 	})
 	It("Fails if no --region without --cluster", func() {
 		cmd.Flags().Set(subnetIDsFlag, "abc,def")
 		err := runWithRuntime(r, cmd)
 		Expect(err).ToNot(BeNil())
 		Expect(err.Error()).To(
-			ContainSubstring("Region is required"))
+			ContainSubstring("region is required"))
 	})
 	It("Fails if no --role-arn without --cluster", func() {
 		cmd.Flags().Set(subnetIDsFlag, "abc,def")
@@ -427,6 +427,6 @@ INFO: subnet-0f87f640e56934cbc, platform: aws, tags: {"t1":"v1"}: passed
 		Expect(err).ToNot(BeNil())
 		Expect(err.Error()).To(
 			ContainSubstring(
-				"Running the network verifier is only supported for BYO VPC clusters"))
+				"running the network verifier is only supported for BYO VPC clusters"))
 	})
 })


### PR DESCRIPTION
## Detailed Description of the Issue
This PR fixes 25 pre-existing staticcheck lint issues that were surfaced by PR #3345 ([OSDOCS-16406](https://redhat.atlassian.net/browse/OSDOCS-16406)) due to the `whole-files: true` setting in `.golangci.yml`. These issues existed before #3345 but were only reported because that PR touched the affected files.

## Type of Change
- [X] style - formatting or naming changes with no logic impact.

## Changes
- **ST1001**: Replaced dot import of `pkg/constants` with a named import in `cmd/create/oidcconfig/cmd.go`
- **ST1005**: Lowercased first letter of error strings across 5 files (Go convention: error strings should not be capitalized)
- **QF1003**: Refactored `if/else if` chains on `*tag.Key` into tagged switch statements in `cmd/dlt/accountroles/cmd.go` and `cmd/dlt/operatorrole/cmd.go`
- **ST1023**: Replaced `var pending bool = false` with `pending := false` in `cmd/verify/network/cmd.go`
- Updated test assertions to match the new lowercase error strings

## Developer Verification Checklist
- [X] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [X] PR description clearly explains both **what** changed and **why**.
- [X] Relevant Jira/GitHub issues and related PRs are linked.
- [X] `make install-hooks` has been run in this clone.
- [X] Tests were added/updated where appropriate.
- [X] I manually tested the change.
- [X] `make test` passes.
- [X] `make lint` passes.
- [X] `make rosa` passes.
- [X] Documentation or repo-local agent guidance was added/updated where appropriate.
- [X] Any risk, limitation, or follow-up work is documented.

Related: https://github.com/openshift/rosa/pull/3345

[OSDOCS-16406]: https://redhat.atlassian.net/browse/OSDOCS-16406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency and clarity of error messages across OIDC configuration, account role, identity provider, and network verification commands.
  * Updated validation feedback for invalid arguments, missing regions or subnets, role validation failures, and provisioning errors.
  * Refined operator guidance messages during OIDC configuration workflows.

* **Tests**
  * Updated command validation tests to match the revised error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->