### PR TITLE
ROSAENG-60031 | fix(ci): use private mktemp for govulncheck jq bootstrap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ with the GO ID, exact module path, and reason. Remove entries once the fix is ad
 The ignore wrapper requires `jq` to parse govulncheck JSON output. The OCP builder image
 used by ROSA Prow jobs (`container: from: src`) does not include `jq`; `make govulncheck`
 downloads a static `jq` binary (currently pinned in `hack/govulncheck.sh`, monitored by
-Renovate) to a versioned temp directory when it is not already on `PATH`, and verifies the
+Renovate) into a private `mktemp` directory when it is not already on `PATH`, and verifies the
 download against the upstream `sha256sum.txt` for that release. For local runs, install `jq`
 or rely on that bootstrap. `yq` is optional; the wrapper falls back to awk when `yq` is not
 installed.

--- a/hack/govulncheck.sh
+++ b/hack/govulncheck.sh
@@ -51,9 +51,12 @@ ensure_jq() {
 	fi
 
 	local jq_dir jq_bin jq_asset arch
-	jq_dir="${TMPDIR:-/tmp}/rosa-govulncheck-jq/${jq_version}"
+	# Use a private temp dir so a pre-seeded predictable /tmp path cannot
+	# supply an untrusted jq binary that skips checksum verification.
+	jq_dir=$(mktemp -d "${TMPDIR:-/tmp}/rosa-govulncheck-jq.XXXXXX") || return 1
+	# shellcheck disable=SC2064
+	trap 'rm -rf -- "'"$jq_dir"'"' EXIT
 	jq_bin="${jq_dir}/jq"
-	mkdir -p "$jq_dir"
 
 	case "$(uname -m)" in
 	x86_64 | amd64) arch=amd64 ;;
@@ -68,14 +71,12 @@ ensure_jq() {
 
 	jq_asset="jq-linux-${arch}"
 
-	if [[ ! -x "$jq_bin" ]]; then
-		echo "jq not found; downloading jq ${jq_version} for ${arch}..."
-		curl -fsSL --retry 5 --retry-delay 2 \
-			-o "$jq_bin" \
-			"https://github.com/jqlang/jq/releases/download/jq-${jq_version}/${jq_asset}"
-		chmod +x "$jq_bin"
-		verify_jq_checksum "$jq_dir" "$jq_asset" "$jq_bin"
-	fi
+	echo "jq not found; downloading jq ${jq_version} for ${arch}..."
+	curl -fsSL --retry 5 --retry-delay 2 \
+		-o "$jq_bin" \
+		"https://github.com/jqlang/jq/releases/download/jq-${jq_version}/${jq_asset}" || return 1
+	chmod +x "$jq_bin"
+	verify_jq_checksum "$jq_dir" "$jq_asset" "$jq_bin" || return 1
 
 	export PATH="${jq_dir}:${PATH}"
 }


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
Supported ticket prefixes:
OCM-XXXXX, ROSAENG-XXXX
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For contributor workflow, see: ./CONTRIBUTING.md
For repo-local agent guidance, see: ./AGENTS.md
-->

## PR Summary
Use a private `mktemp` directory for the govulncheck `jq` bootstrap so a pre-seeded predictable `/tmp` path cannot supply an untrusted binary that skips checksum verification, and fail closed if download or verification fails.

## Detailed Description of the Issue
`hack/govulncheck.sh` cached `jq` under `${TMPDIR}/rosa-govulncheck-jq/${jq_version}` and skipped checksum verification on cache hits. On a shared `/tmp`, another local user could plant an executable there before the first download. Same hardening already applied in terraform-redhat/terraform-provider-rhcs#1258.

## Related Issues and PRs
- Jira: [ROSAENG-60031](https://issues.redhat.com/browse/ROSAENG-60031)
- Related PR(s): openshift/rosa#3338 (original jq bootstrap); terraform-redhat/terraform-provider-rhcs#1258 (same mktemp fix)
- Related design/docs: N/A

## Type of Change
<!-- Check the primary type this PR represents -->
- [ ] feat - adds a new user-facing capability.
- [x] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
If `${TMPDIR}/rosa-govulncheck-jq/${jq_version}/jq` already existed and was executable, the script trusted it without re-verifying the upstream checksum, then prepended that directory to `PATH`.

## Behavior After This Change
When system `jq` is missing, the script always creates a private `mktemp -d` directory, downloads `jq` into it, verifies against upstream `sha256sum.txt`, exports that path, and removes the directory on exit via `trap`. `mktemp`, `curl`, and checksum verification explicitly return on failure so an unverified binary cannot be added to `PATH`. CONTRIBUTING.md updated to describe the private temp-dir behavior.

## How to Test (Step-by-Step)
### Preconditions
- Linux host or container without `jq` on `PATH`
- `curl`, `sha256sum`, and `mktemp` available

### Test Steps
1. Run `shellcheck hack/govulncheck.sh`.
2. In a Linux environment without `jq`, invoke the bootstrap path (e.g. UBI9 container) and confirm download + checksum succeed under a `/tmp/rosa-govulncheck-jq.XXXXXX` path.
3. Optionally run `make govulncheck`.

### Expected Results
- `shellcheck` reports no issues.
- Bootstrap downloads and verifies jq under a private mktemp path.
- Govulncheck still passes when run.

## Proof of the Fix
- Screenshots: N/A
- Videos: N/A
- Logs/CLI output:
  - `shellcheck hack/govulncheck.sh` passed.
  - UBI9 without jq: `jq not found; downloading jq 1.8.2 for amd64...` then `jq-1.8.2` from `/tmp/rosa-govulncheck-jq.<random>/jq`.
- Other artifacts: N/A

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [ ] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [ ] `make test` passes.
- [ ] `make lint` passes.
- [ ] `make rosa` passes.
- [x] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

[ROSAENG-60031]: https://redhat.atlassian.net/browse/ROSAENG-60031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security and isolation by downloading `jq` into a private temporary directory and ensuring automatic cleanup after checks complete.
  * Ensures `jq` is always downloaded, set executable, and verified via checksum (even when a local `jq` is not already available).
* **Documentation**
  * Updated contributor instructions for how the `jq` bootstrap provisions and verifies the temporary artifact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->