### PR TITLE
[Project Darkstar] ROSAENG-60658: Remediate CVE-2026-27145, CVE-2026-42504 in rosa

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/rosa
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
## Project Darkstar — Automated CVE Remediation

> **This PR was generated by Project Darkstar**, an automated CVE remediation tool.
> For questions or concerns, contact **Kevin Seiter** (ROSA Trust Engineering).

## Summary

- Fixes 2 Important Go stdlib CVEs by bumping `go` directive in `go.mod` from 1.26.3 to 1.26.4
- Builder Dockerfiles already reference `go-toolset:1.26.4`; this update formally enforces the minimum Go toolchain requirement

## CVE Details

### CVE-2026-27145 (Important, CVSS 7.5)
- **Package:** `crypto/x509` (Go stdlib)
- **Description:** `(*x509.Certificate).VerifyHostname` called `strings.Split(host, ".")` repeatedly in a loop over all DNS SAN entries, causing quadratic verification cost with large SAN lists. Exploitable by unauthenticated clients presenting a crafted certificate.
- **Fixed in:** Go 1.26.4
- **Jira:** [ROSAENG-60658](https://redhat.atlassian.net/browse/ROSAENG-60658)

### CVE-2026-42504 (Important, CVSS 7.5)
- **Package:** `mime` (Go stdlib)
- **Description:** `WordDecoder.DecodeHeader` exhibited quadratic complexity when processing maliciously crafted MIME headers, enabling denial-of-service attacks.
- **Fixed in:** Go 1.26.4
- **Jira:** [ROSAENG-60661](https://redhat.atlassian.net/browse/ROSAENG-60661)

## Changes

- `go.mod`: `go 1.26.3` → `go 1.26.4`

## Already Fixed (11 CVEs — no action needed)

The following CVEs discovered in Jira were already resolved by previous automated dependency updates:

| CVE | Component | Current | Fix Version |
|-----|-----------|---------|-------------|
| CVE-2026-39828 | golang.org/x/crypto/ssh | v0.54.0 | v0.52.0 |
| CVE-2026-39829 | golang.org/x/crypto/ssh | v0.54.0 | v0.52.0 |
| CVE-2026-39830 | golang.org/x/crypto/ssh | v0.54.0 | v0.52.0 |
| CVE-2026-39831 | golang.org/x/crypto/ssh | v0.54.0 | v0.52.0 |
| CVE-2026-46595 | golang.org/x/crypto/ssh | v0.54.0 | v0.52.0 |
| CVE-2026-46597 | golang.org/x/crypto/ssh | v0.54.0 | v0.52.0 |
| CVE-2026-39835 | golang.org/x/crypto/ssh | v0.54.0 | v0.53.0 |
| CVE-2026-33811 | Go stdlib net | go1.26.3 | go1.26.3 |
| CVE-2026-39821 | golang.org/x/net/idna | v0.56.0 | v0.55.0 |
| CVE-2026-25681 | golang.org/x/net/html | v0.56.0 | v0.55.0 |
| CVE-2026-27136 | golang.org/x/net/html | v0.56.0 | v0.55.0 |

## Verification

- [x] `go build ./...` passes
- [x] No dependency graph changes (only Go toolchain minimum version bumped)
- [x] Consistent with Dockerfile builder image (`go-toolset:1.26.4`)

## References

- Jira: [ROSAENG-60658](https://redhat.atlassian.net/browse/ROSAENG-60658) (CVE-2026-27145)
- Jira: [ROSAENG-60661](https://redhat.atlassian.net/browse/ROSAENG-60661) (CVE-2026-42504)
- NVD: https://nvd.nist.gov/vuln/detail/CVE-2026-27145
- NVD: https://nvd.nist.gov/vuln/detail/CVE-2026-42504
- Go 1.26.4 release notes: https://go.dev/doc/devel/release#go1.26.4

---
**Project Darkstar** — Automated CVE Remediation | Contact: Kevin Seiter (ROSA Trust Engineering)

[ROSAENG-60658]: https://redhat.atlassian.net/browse/ROSAENG-60658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROSAENG-60661]: https://redhat.atlassian.net/browse/ROSAENG-60661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain version to 1.26.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->