### PR TITLE
ROSAENG-61732 | test: move OCP-73162 delete protection off day1 setup

### DIFF
--- a/tests/e2e/test_rosacli_cluster.go
+++ b/tests/e2e/test_rosacli_cluster.go
@@ -1947,7 +1947,7 @@ var _ = Describe("Create cluster delete protection",
 			setupAndTeardown()
 
 			It("can verify delete protection on HCP cluster creation - [id:73162]",
-				labels.High, labels.Runtime.Day1,
+				labels.High, labels.Runtime.Day1Supplemental,
 				verifyDeleteProtection,
 			)
 		})
@@ -1975,7 +1975,7 @@ var _ = Describe("Create cluster delete protection",
 			setupAndTeardown()
 
 			It("can verify delete protection on classic cluster creation - [id:73162]",
-				labels.High, labels.Runtime.Day1,
+				labels.High, labels.Runtime.Day1Supplemental,
 				verifyDeleteProtection,
 			)
 		})


### PR DESCRIPTION
## PR Summary
Relabel OCP-73162 create-time delete protection e2e cases from `day1` to `day1-supplemental` so they no longer run during `rosa-setup` and wipe the shared cluster ID used by readiness.

## Detailed Description of the Issue
After [#3367](https://github.com/openshift/rosa/pull/3367), OCP-73162 was labeled `labels.Runtime.Day1`. The `rosa-setup` step uses `--ginkgo.label-filter "day1"`, so those High delete-protection specs also run during profile cluster preparation.

They use `NewTempClusterHandler` and call `GenerateClusterCreateFlags()`, whose `defer` always writes `cluster-detail.json` / `cluster-id`. Because the temp handler has an empty `ClusterID`, that overwrites the ID from the real profile cluster. The next step, `rosa-setup-readiness-cluster`, then fails immediately with:

```
no Cluster ID defined to wait for
```

Example failures:
- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-rosa-master-e2e-rosa-hcp-advanced-critical-high-f3/2077807746362642432
- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-rosa-master-e2e-rosa-hcp-external-auth-medium-low-f7/2077538129773858816

## Related Issues and PRs
- Jira: [ROSAENG-61732](https://issues.redhat.com/browse/ROSAENG-61732)
- Related PR(s): #3367

## Type of Change
- [x] test - adds or updates tests only.

## Previous Behavior
OCP-73162 ran under the `day1` filter during `rosa-setup`, clobbered the shared cluster identity files, and caused `rosa-setup-readiness-cluster` to fail across rosa-lifecycle jobs once #3367 landed.

## Behavior After This Change
OCP-73162 is labeled `day1-supplemental`, so it runs in the dedicated supplemental job instead of setup. Profile cluster creation + readiness keep a valid shared cluster ID.

## How to Test (Step-by-Step)
### Preconditions
- Local checkout of this branch, or wait for periodics after merge.

### Test Steps
1. Confirm labels in `tests/e2e/test_rosacli_cluster.go` for both OCP-73162 specs are `labels.Runtime.Day1Supplemental`.
2. Optionally: `rosatest --ginkgo.label-filter 'day1' --ginkgo.dry-run` and verify OCP-73162 is not selected; with `day1-supplemental` it is selected.
3. After merge, watch a rosa-lifecycle periodic (e.g. `rosa-hcp-advanced-critical-high-f3`): `rosa-setup` should run 1 day1 spec again, and readiness should no longer fail with `no Cluster ID defined to wait for`.

### Expected Results
- Setup no longer executes OCP-73162.
- Readiness can load the cluster ID written by profile day1 prep.

## Proof of the Fix
- Logs/CLI output: Failure analysis from the prow jobs linked above shows setup ran 3 day1 specs including OCP-73162 immediately before readiness failed.

## Breaking Changes
- [x] No breaking changes

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [ ] `make test` passes.
- [ ] `make lint` passes.
- [x] `make rosa` passes. (pre-push build checks passed)
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

### Follow-up
Optional hardening: gate `clusterHandler.saveToFile()` / the `GenerateClusterCreateFlags` defer so temp handlers cannot rewrite shared cluster identity files even if mislabeled again.

Made with [Cursor](https://cursor.com)

[ROSAENG-61732]: https://redhat.atlassian.net/browse/ROSAENG-61732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test categorization for cluster deletion-protection verification scenarios.
  * Test logic and end-user behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->