### PR TITLE
Add dustman9000 to OWNERS approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,4 +7,5 @@ approvers:
 - gdbranco
 - robpblake
 - davidleerh
+- dustman9000
 - red-hat-konflux[bot]


### PR DESCRIPTION
Add dustman9000 (Dustin Row, ROSA CI/CD team) as an approver for CI job configuration changes that propagate to the release repo (`ci-operator/config/openshift/rosa/` and `ci-operator/jobs/openshift/rosa/`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project approval settings to include an additional approver.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->