### PR TITLE
ROSAENG-60614 | feat: allow partial component route updates

### DIFF
--- a/cmd/edit/ingress/cmd.go
+++ b/cmd/edit/ingress/cmd.go
@@ -489,8 +489,7 @@ func run(cmd *cobra.Command, argv []string) {
 	sameNamespaceOwnershipPolicy := (namespaceOwnershipPolicy == nil) ||
 		(curNamespaceOwnershipPolicy == ingress.RouteNamespaceOwnershipPolicy())
 
-	sameComponentRoutes := (componentRoutes == nil) ||
-		(reflect.DeepEqual(curComponentRoutes, ingress.ComponentRoutes()))
+	sameComponentRoutes := componentRoutes == nil || sparseComponentRoutesEqual(curComponentRoutes, componentRoutes)
 
 	if sameListeningMethod && sameRouteSelectors && sameLbType &&
 		sameExcludedNamespaces && sameWildcardPolicy && sameNamespaceOwnershipPolicy &&
@@ -507,4 +506,27 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 	r.Reporter.Infof("Updated ingress '%s' on cluster '%s'", ingress.ID(), clusterKey)
+}
+
+func sparseComponentRoutesEqual(
+	current map[string]*cmv1.ComponentRoute,
+	patch map[string]*cmv1.ComponentRouteBuilder,
+) bool {
+	for key, builder := range patch {
+		route, err := builder.Build()
+		if err != nil {
+			return false
+		}
+		cur, exists := current[key]
+		if !exists {
+			if route.Hostname() != "" || route.TlsSecretRef() != "" {
+				return false
+			}
+			continue
+		}
+		if cur.Hostname() != route.Hostname() || cur.TlsSecretRef() != route.TlsSecretRef() {
+			return false
+		}
+	}
+	return true
 }

--- a/cmd/edit/ingress/cmd_test.go
+++ b/cmd/edit/ingress/cmd_test.go
@@ -17,10 +17,13 @@ limitations under the License.
 package ingress
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
 var _ = Describe("Parse component routes", func() {
@@ -95,15 +98,61 @@ var _ = Describe("Parse component routes", func() {
 				err.Error(),
 			).To(Equal("component route \"console\" was supplied more than once"))
 		})
-		It("When only one route is provided it should fail with wrong count", func() {
-			_, err := parseComponentRoutesForAllowed(
+		It("When only one route is provided it should succeed", func() {
+			result, err := parseComponentRoutesForAllowed(
 				"console: hostname=console-host;tlsSecretRef=console-secret",
 				expectedHcpComponentRoutes,
 			)
-			Expect(err).ToNot(BeNil())
-			Expect(
-				err.Error(),
-			).To(Equal("the expected amount of component routes is 2, but 1 have been supplied"))
+			Expect(err).To(BeNil())
+			Expect(result).To(HaveLen(1))
+			Expect(result).To(HaveKey("console"))
+		})
+		It("When a partial update is provided it should only include the specified route in the serialized payload", func() {
+			result, err := parseComponentRoutesForAllowed(
+				"console: hostname=console-host;tlsSecretRef=console-secret",
+				expectedHcpComponentRoutes,
+			)
+			Expect(err).To(BeNil())
+			ingress, err := cmv1.NewIngress().ComponentRoutes(result).Build()
+			Expect(err).To(BeNil())
+
+			var buf bytes.Buffer
+			err = cmv1.MarshalIngress(ingress, &buf)
+			Expect(err).To(BeNil())
+			var body map[string]interface{}
+			err = json.Unmarshal(buf.Bytes(), &body)
+			Expect(err).To(BeNil())
+
+			cr := body["component_routes"].(map[string]interface{})
+			Expect(cr).To(HaveLen(1))
+			Expect(cr).To(HaveKey("console"))
+			Expect(cr).ToNot(HaveKey("downloads"))
+			console := cr["console"].(map[string]interface{})
+			Expect(console["hostname"]).To(Equal("console-host"))
+			Expect(console["tls_secret_ref"]).To(Equal("console-secret"))
+		})
+		It("When empty values are provided it should serialize as a clear", func() {
+			result, err := parseComponentRoutesForAllowed(
+				"downloads: hostname=;tlsSecretRef=",
+				expectedHcpComponentRoutes,
+			)
+			Expect(err).To(BeNil())
+			ingress, err := cmv1.NewIngress().ComponentRoutes(result).Build()
+			Expect(err).To(BeNil())
+
+			var buf bytes.Buffer
+			err = cmv1.MarshalIngress(ingress, &buf)
+			Expect(err).To(BeNil())
+			var body map[string]interface{}
+			err = json.Unmarshal(buf.Bytes(), &body)
+			Expect(err).To(BeNil())
+
+			cr := body["component_routes"].(map[string]interface{})
+			Expect(cr).To(HaveLen(1))
+			Expect(cr).To(HaveKey("downloads"))
+			downloads := cr["downloads"].(map[string]interface{})
+			Expect(downloads["hostname"]).To(Equal(""))
+			Expect(downloads["tls_secret_ref"]).To(Equal(""))
 		})
 	})
 	Context("Fails to parse input string for component routes", func() {
@@ -117,15 +166,15 @@ var _ = Describe("Parse component routes", func() {
 				err.Error(),
 			).To(Equal("'unknown' is not a valid component name. Expected include [oauth, console, downloads]"))
 		})
-		It("fails due to wrong amount of component routes", func() {
-			_, err := parseComponentRoutes(
+		It("When partial classic routes are provided it should succeed", func() {
+			result, err := parseComponentRoutes(
 				//nolint:lll
 				"oauth: hostname=oauth-host;tlsSecretRef=oauth-secret,downloads: hostname=downloads-host;tlsSecretRef=downloads-secret",
 			)
-			Expect(err).ToNot(BeNil())
-			Expect(
-				err.Error(),
-			).To(Equal("the expected amount of component routes is 3, but 2 have been supplied"))
+			Expect(err).To(BeNil())
+			Expect(result).To(HaveLen(2))
+			Expect(result).To(HaveKey("oauth"))
+			Expect(result).To(HaveKey("downloads"))
 		})
 		It("fails if it can split ':' in more than one key separation", func() {
 			_, err := parseComponentRoutes(

--- a/cmd/edit/ingress/flags.go
+++ b/cmd/edit/ingress/flags.go
@@ -93,8 +93,10 @@ func addIngressV2Flags(flags *pflag.FlagSet) {
 		componentRoutesFlag,
 		"",
 		//nolint:lll
-		"Component routes settings. Available keys [oauth, console, downloads] (HCP clusters support console and downloads only). For each key a pair of hostname and tlsSecretRef is expected to be supplied. "+
-			"Format should be a comma separate list 'oauth: hostname=example-hostname;tlsSecretRef=example-secret-ref,downloads:...",
+		"Component route settings. Specify one or more routes to update; routes not specified remain unchanged. "+
+			"Available keys are [oauth, console, downloads] (HCP clusters support console and downloads only). "+
+			"Each route requires a hostname and tlsSecretRef. To clear a route, set both to empty values. "+
+			"Format: 'console: hostname=example-hostname;tlsSecretRef=example-secret-ref,downloads:...'",
 	)
 }
 
@@ -107,13 +109,6 @@ func parseComponentRoutesForAllowed(input string, allowedRoutes []string) (map[s
 	result := map[string]*cmv1.ComponentRouteBuilder{}
 	input = strings.TrimSpace(input)
 	components := strings.Split(input, ",")
-	if len(components) != len(allowedRoutes) {
-		return nil, fmt.Errorf(
-			"the expected amount of component routes is %d, but %d have been supplied",
-			len(allowedRoutes),
-			len(components),
-		)
-	}
 	transformations := []stringTransformation{
 		func(source string) string {
 			return strings.TrimSpace(source)


### PR DESCRIPTION
## PR Summary

Allow partial component route updates via `rosa edit ingress --component-routes` — users can now set a single route (e.g. only console) without providing all routes.

## Detailed Description of the Issue

The previous change (openshift/rosa#3376) followed the Classic CLI framework which required all routes to be set together (classic: oauth+console+downloads, HCP: console+downloads). The OCM API supports partial updates — setting only console leaves downloads unchanged — but the CLI rejected partial input with "the expected amount of component routes is N, but M have been supplied". After review feedback, the decision is to allow partial updates to match the API flexibility.

## Related Issues and PRs
- Jira: [ROSAENG-60614](https://redhat.atlassian.net/browse/ROSAENG-60614)
- Related PR: [openshift/rosa#3376](https://github.com/openshift/rosa/pull/3376) (merged — enabled componentRoutes for HCP)
- Related PR: [terraform-redhat/terraform-provider-rhcs#1187](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1187) (TF provider — also aligning to partial updates)

## Type of Change
- [x] feat - adds a new user-facing capability.

## Previous Behavior

`rosa edit ingress --component-routes` required all routes for the platform — classic required oauth+console+downloads (3), HCP required console+downloads (2). Passing fewer routes returned:
```
ERR: the expected amount of component routes is 2, but 1 have been supplied
```

## Behavior After This Change

Users can pass any subset of valid routes. Name validation and duplicate detection are preserved.

```bash
# Set only console (HCP)
rosa edit ingress -c mycluster --component-routes 'console: hostname=console.example.com;tlsSecretRef=console-tls' <ingress-id>

# Set only downloads (HCP)
rosa edit ingress -c mycluster --component-routes 'downloads: hostname=downloads.example.com;tlsSecretRef=downloads-tls' <ingress-id>

# Set both (still works)
rosa edit ingress -c mycluster --component-routes 'console: hostname=console.example.com;tlsSecretRef=console-tls, downloads: hostname=downloads.example.com;tlsSecretRef=downloads-tls' <ingress-id>
```

Invalid names and duplicates are still rejected:
```
ERR: 'oauth' is not a valid component name. Expected include [console, downloads]
ERR: component route "console" was supplied more than once
```

## How to Test (Step-by-Step)
### Preconditions
- A running ROSA HCP cluster with `hypershift-component-routes` feature toggle enabled
- HyperShift operator >= v0.1.79
- TLS secret in `openshift-config` on the hosted cluster

### Test Steps
1. Set only console: `rosa edit ingress -c <cluster> --component-routes 'console: hostname=console.example.com;tlsSecretRef=console-tls' <ingress-id>`
2. Verify console route updated, downloads unchanged
3. Set only downloads: `rosa edit ingress -c <cluster> --component-routes 'downloads: hostname=downloads.example.com;tlsSecretRef=downloads-tls' <ingress-id>`
4. Verify downloads route updated, console unchanged
5. Verify invalid name still rejected: `rosa edit ingress -c <cluster> --component-routes 'oauth: hostname=x;tlsSecretRef=y' <ingress-id>`
6. Verify duplicate still rejected: `rosa edit ingress -c <cluster> --component-routes 'console: hostname=a;tlsSecretRef=b, console: hostname=c;tlsSecretRef=d' <ingress-id>`

### Expected Results
- Partial updates succeed
- Invalid names and duplicates still rejected
- Existing routes not included in the update remain unchanged on the cluster

## Proof of the Fix

```
$ go test ./cmd/edit/ingress/... -v
Ran 14 of 14 Specs in 0.002 seconds
SUCCESS! -- 14 Passed | 0 Failed | 0 Pending | 0 Skipped
```

### Live cluster — partial updates and clearing

**1. Set console only:**
```
$ rosa edit ingress -c creed-hcp --component-routes 'console: hostname=console.custom.example.com;tlsSecretRef=console-tls-secret' o5n4
INFO: Updated ingress 'o5n4'
```
API state: `{"console": {"hostname": "console.custom.example.com", "tls_secret_ref": "console-tls-secret"}}`

**2. Add downloads (console unchanged):**
```
$ rosa edit ingress -c creed-hcp --component-routes 'downloads: hostname=downloads.custom.example.com;tlsSecretRef=downloads-tls-secret' o5n4
INFO: Updated ingress 'o5n4'
```
API state: `{"console": {...}, "downloads": {"hostname": "downloads.custom.example.com", "tls_secret_ref": "downloads-tls-secret"}}`

**3. Clear downloads only (console unchanged):**
```
$ rosa edit ingress -c creed-hcp --component-routes 'downloads: hostname=;tlsSecretRef=' o5n4
INFO: Updated ingress 'o5n4'
```
API state: `{"console": {"hostname": "console.custom.example.com", "tls_secret_ref": "console-tls-secret"}}`

## Breaking Changes
- [x] No breaking changes

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [x] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

[ROSAENG-60614]: https://redhat.atlassian.net/browse/ROSAENG-60614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the `component-routes` CLI flag help text to clarify HCP-supported components and the required `hostname` + `tlsSecretRef` pair per route.
* **Bug Fixes**
  * Improved HCP component-route validation to avoid failing solely due to a component count mismatch, while still accepting valid partial configurations.
* **Tests**
  * Expanded ingress component-route parsing tests to confirm correct output when only selected routes are provided and that empty parameter values are serialized as empty strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
