### PR TITLE
ROSAENG-62289 | test: replace unavailable dl1.24xlarge instance type in id:72174

### DIFF
--- a/tests/e2e/test_rosacli_region.go
+++ b/tests/e2e/test_rosacli_region.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"time"
 
+	//nolint:staticcheck
 	. "github.com/onsi/ginkgo/v2"
+	//nolint:staticcheck
 	. "github.com/onsi/gomega"
 
 	"github.com/openshift/rosa/tests/ci/labels"
@@ -19,7 +21,7 @@ var _ = Describe("Region",
 		var (
 			rosaClient             *rosacli.Client
 			ocmResourceService     rosacli.OCMResourceService
-			permissionsBoundaryArn string = "arn:aws:iam::aws:policy/AdministratorAccess"
+			permissionsBoundaryArn = "arn:aws:iam::aws:policy/AdministratorAccess"
 		)
 
 		BeforeEach(func() {
@@ -97,7 +99,7 @@ var _ = Describe("Region",
 			labels.Low, labels.Runtime.OCMResources,
 			func() {
 				By("List the available instance-types with the region flag")
-				typesList := []string{"dl1.24xlarge", "g4ad.16xlarge", "c5.xlarge"}
+				typesList := []string{"m7i.xlarge", "g4ad.16xlarge", "c5.xlarge"}
 				region := "us-west-2"
 				accountRolePrefix := fmt.Sprintf("QEAuto-accr72174-%s", time.Now().UTC().Format("20060102"))
 				_, err := ocmResourceService.CreateAccountRole("--mode", "auto",


### PR DESCRIPTION
## What this PR does

Replaces the hardcoded `dl1.24xlarge` instance type with `m7i.xlarge` in e2e test `[id:72174]` ("List instance-types with region flag").

## Why

The `dl1.24xlarge` instance type is no longer returned by the ROSA API for `us-west-2`, causing test 72174 to fail consistently in CI (`periodic-ci-openshift-rosa-master-e2e-rosa-ocm-resources-f3`).

`m7i.xlarge` is the current default machine pool instance type (defined in `pkg/options/machinepool/create.go`) and is reliably available in `us-west-2`.

Also fixes pre-existing lint issues in the file (missing `nolint:staticcheck` directives for dot imports, redundant type annotation).

## Jira

https://redhat.atlassian.net/browse/ROSAENG-62289

## Checklist

- [x] Subject and description: includes Jira and explains what/why
- [x] E2E test passes locally (verified 4 consecutive runs post-fix)
- [x] Lint passes (`make lint` returns 0 issues)
- [x] All pre-push checks pass (format, build, lint, coverage, unit tests)

Made with [Cursor](https://cursor.com)