### PR TITLE
ROSAENG-61450 | ci: restore Dockerfile.clients after OpenShift build rewrite

### DIFF
--- a/Dockerfile.clients
+++ b/Dockerfile.clients
@@ -8,6 +8,10 @@ RUN dnf install -y --setopt=install_weak_deps=False --nodocs jq && \
     dnf clean all
 RUN git config --global --add safe.directory /opt/app-root/src
 COPY --chown=1001:0 . .
+# OpenShift Build rewrites this Dockerfile in the build context (BUILD_LOGLEVEL,
+# flattened RUN/ENV, OPENSHIFT_BUILD_*). Restore the committed file so make verify
+# (git diff --exit-code) does not fail on a dirty tree inside the image.
+RUN git checkout -- Dockerfile.clients
 # OpenShift Prow: arbitrary UID runs with GID 0; group-writable workdir and Go caches.
 RUN mkdir -p /opt/app-root/src /tmp/gomodcache /tmp/.cache && \
     chgrp -R 0 /opt/app-root/src /tmp/gomodcache /tmp/.cache && \


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
Supported ticket prefixes:
OCM-XXXXX, ROSAENG-XXXX
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For contributor workflow, see: ./CONTRIBUTING.md
For repo-local agent guidance, see: ./AGENTS.md
-->

## PR Summary
Restore `Dockerfile.clients` after `COPY` so OpenShift Build’s Dockerfile rewrite does not fail `make verify` (`git diff --exit-code`) in the `rosa-clients` image.

## Detailed Description of the Issue
When ci-operator builds `rosa-clients` from `Dockerfile.clients`, OpenShift Build mutates that Dockerfile in the build context (e.g. `BUILD_LOGLEVEL`, flattened `RUN`/`ENV`, `OPENSHIFT_BUILD_*` / `io.openshift.build.*` labels). `COPY . .` bakes the rewritten file into the image worktree. Presubmits that run `make test verify` then fail on `make diff` even though unit tests pass. Seen on release rehearse for openshift/release#81830.

## Related Issues and PRs
- Jira: [ROSAENG-61450](https://issues.redhat.com/browse/ROSAENG-61450)
- Fixes: N/A
- Related PR(s): openshift/rosa#3366 (Dockerfile.clients), openshift/release#81830 (`from: rosa-clients`)
- Related design/docs: N/A

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [x] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
`make verify` inside the `rosa-clients` image failed because `Dockerfile.clients` differed from HEAD after the OpenShift image build.

## Behavior After This Change
Image build restores the committed `Dockerfile.clients` after `COPY`, so `git diff --exit-code` stays clean and `make verify` can pass on the same source tree.

## How to Test (Step-by-Step)
### Preconditions
- Local container engine (`podman`/`docker`) and a checkout of this branch.

### Test Steps
1. `podman build -f Dockerfile.clients -t rosa-clients:local .`
2. `podman run --rm -w /opt/app-root/src rosa-clients:local bash -c 'make verify'`
3. Optionally simulate OpenShift rewrite of `Dockerfile.clients` in a throwaway container, then confirm `git checkout -- Dockerfile.clients` clears `git diff`.
4. After merge, re-rehearse or land openshift/release#81830 and confirm `pull-ci-openshift-rosa-master-test` no longer fails on `Dockerfile.clients` alone.

### Expected Results
- Local `make verify` in the image succeeds when the tree matches HEAD.
- Prow `test` job no longer fails solely due to OpenShift-injected Dockerfile diffs.

## Proof of the Fix
- Screenshots: N/A
- Videos: N/A
- Logs/CLI output: Rehearse failure showed `git diff` only on `Dockerfile.clients` with OpenShift `ENV`/`LABEL` injections; CodeRabbit on this change: 0 findings.
- Other artifacts: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/81830/rehearse-81830-pull-ci-openshift-rosa-master-test/2079584172246044672

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [ ] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [ ] `make test` passes.
- [ ] `make lint` passes.
- [ ] `make rosa` passes.
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

Made with [Cursor](https://cursor.com)

[ROSAENG-61450]: https://redhat.atlassian.net/browse/ROSAENG-61450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container build process to preserve the committed Dockerfile and prevent false change-detection failures during verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->