### PR TITLE
ROSAENG-61174 | test: complete remaining pkg/aws coverage

### DIFF
--- a/.bingo/mockgen.sum
+++ b/.bingo/mockgen.sum
@@ -1,0 +1,8 @@
+go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=
+go.uber.org/mock v0.4.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=
+golang.org/x/mod v0.11.0 h1:bUO06HqtnRcc/7l71XBe4WcqTZ+3AH1J59zWDDwLKgU=
+golang.org/x/mod v0.11.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/tools v0.2.0 h1:G6AHpWxTMGY1KyEYoAQ5WTtIekUUvDNjan3ugu60JvE=
+golang.org/x/tools v0.2.0/go.mod h1:y4OqIKeOV/fWJetJ8bXPU1sEVniLMIyDAZWeHdV+NTA=

--- a/pkg/aws/api_interface/iam_api_client.go
+++ b/pkg/aws/api_interface/iam_api_client.go
@@ -167,6 +167,10 @@ type IamApiClient interface {
 	UpdateAssumeRolePolicy(ctx context.Context,
 		params *iam.UpdateAssumeRolePolicyInput, optFns ...func(*iam.Options),
 	) (*iam.UpdateAssumeRolePolicyOutput, error)
+
+	SimulatePrincipalPolicy(ctx context.Context,
+		params *iam.SimulatePrincipalPolicyInput, optFns ...func(*iam.Options),
+	) (*iam.SimulatePrincipalPolicyOutput, error)
 }
 
 // interface guard to ensure that all methods defined in the IamApiClient

--- a/pkg/aws/client_test.go
+++ b/pkg/aws/client_test.go
@@ -1136,6 +1136,25 @@ var _ = Describe("Client", func() {
 			Expect(err.Error()).To(ContainSubstring("list objects error"))
 		})
 
+		It("Returns error when DeleteObject fails and does not delete the bucket", func() {
+			mockS3API.EXPECT().HeadBucket(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&s3.HeadBucketOutput{}, nil)
+
+			mockS3API.EXPECT().ListObjects(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&s3.ListObjectsOutput{
+					Contents: []s3types.Object{
+						{Key: awsSdk.String("file1.json")},
+					},
+				}, nil)
+
+			mockS3API.EXPECT().DeleteObject(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, fmt.Errorf("delete object error"))
+
+			err := client.DeleteS3Bucket(bucketName)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("delete object error"))
+		})
+
 		It("Returns error when DeleteBucket fails", func() {
 			mockS3API.EXPECT().HeadBucket(gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(&s3.HeadBucketOutput{}, nil)

--- a/pkg/aws/client_test.go
+++ b/pkg/aws/client_test.go
@@ -1237,6 +1237,22 @@ var _ = Describe("Client", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
+		It("Falls through to DeleteSecret when DescribeSecret fails with a non-not-found error", func() {
+			mockSecretsManagerAPI.EXPECT().DescribeSecret(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, fmt.Errorf("access denied"))
+
+			mockSecretsManagerAPI.EXPECT().DeleteSecret(gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, input *secretsmanager.DeleteSecretInput,
+					_ ...func(*secretsmanager.Options)) (*secretsmanager.DeleteSecretOutput, error) {
+					Expect(*input.SecretId).To(Equal(secretArn))
+					Expect(*input.ForceDeleteWithoutRecovery).To(BeTrue())
+					return &secretsmanager.DeleteSecretOutput{}, nil
+				})
+
+			err := client.DeleteSecretInSecretsManager(secretArn)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
 		It("Returns error when DeleteSecret fails", func() {
 			mockSecretsManagerAPI.EXPECT().DescribeSecret(gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(&secretsmanager.DescribeSecretOutput{

--- a/pkg/aws/client_test.go
+++ b/pkg/aws/client_test.go
@@ -13,6 +13,10 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	secretsmanagertypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/aws/smithy-go"
 	. "github.com/onsi/ginkgo/v2"
@@ -951,6 +955,561 @@ var _ = Describe("Client", func() {
 			// Should succeed but with empty results (role doesn't match cluster)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(roles).To(HaveLen(0))
+		})
+	})
+
+	Context("CreateS3Bucket", func() {
+		bucketName := "test-oidc-bucket"
+
+		It("Returns error when bucket already exists", func() {
+			mockS3API.EXPECT().HeadBucket(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&s3.HeadBucketOutput{}, nil)
+
+			err := client.CreateS3Bucket(bucketName, DefaultRegion)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("already exists"))
+		})
+
+		It("Creates bucket in default region without LocationConstraint", func() {
+			mockS3API.EXPECT().HeadBucket(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, fmt.Errorf("not found"))
+
+			mockS3API.EXPECT().CreateBucket(gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, input *s3.CreateBucketInput,
+					_ ...func(*s3.Options)) (*s3.CreateBucketOutput, error) {
+					Expect(*input.Bucket).To(Equal(bucketName))
+					Expect(input.CreateBucketConfiguration).To(BeNil())
+					return &s3.CreateBucketOutput{}, nil
+				})
+
+			mockS3API.EXPECT().PutPublicAccessBlock(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&s3.PutPublicAccessBlockOutput{}, nil)
+
+			mockS3API.EXPECT().PutBucketPolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&s3.PutBucketPolicyOutput{}, nil)
+
+			mockS3API.EXPECT().PutBucketTagging(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&s3.PutBucketTaggingOutput{}, nil)
+
+			err := client.CreateS3Bucket(bucketName, DefaultRegion)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Creates bucket in non-default region with LocationConstraint", func() {
+			nonDefaultRegion := "eu-west-1"
+
+			mockS3API.EXPECT().HeadBucket(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, fmt.Errorf("not found"))
+
+			mockS3API.EXPECT().CreateBucket(gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, input *s3.CreateBucketInput,
+					_ ...func(*s3.Options)) (*s3.CreateBucketOutput, error) {
+					Expect(*input.Bucket).To(Equal(bucketName))
+					Expect(input.CreateBucketConfiguration).NotTo(BeNil())
+					Expect(input.CreateBucketConfiguration.LocationConstraint).To(
+						Equal(s3types.BucketLocationConstraint(nonDefaultRegion)))
+					return &s3.CreateBucketOutput{}, nil
+				})
+
+			mockS3API.EXPECT().PutPublicAccessBlock(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&s3.PutPublicAccessBlockOutput{}, nil)
+
+			mockS3API.EXPECT().PutBucketPolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&s3.PutBucketPolicyOutput{}, nil)
+
+			mockS3API.EXPECT().PutBucketTagging(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&s3.PutBucketTaggingOutput{}, nil)
+
+			err := client.CreateS3Bucket(bucketName, nonDefaultRegion)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Returns error when CreateBucket fails", func() {
+			mockS3API.EXPECT().HeadBucket(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, fmt.Errorf("not found"))
+
+			mockS3API.EXPECT().CreateBucket(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, fmt.Errorf("bucket creation failed"))
+
+			err := client.CreateS3Bucket(bucketName, DefaultRegion)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("bucket creation failed"))
+		})
+
+		It("Returns error when PutPublicAccessBlock fails", func() {
+			mockS3API.EXPECT().HeadBucket(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, fmt.Errorf("not found"))
+
+			mockS3API.EXPECT().CreateBucket(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&s3.CreateBucketOutput{}, nil)
+
+			mockS3API.EXPECT().PutPublicAccessBlock(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, fmt.Errorf("access block error"))
+
+			err := client.CreateS3Bucket(bucketName, DefaultRegion)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("access block error"))
+		})
+
+		It("Returns error when PutBucketPolicy fails", func() {
+			mockS3API.EXPECT().HeadBucket(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, fmt.Errorf("not found"))
+
+			mockS3API.EXPECT().CreateBucket(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&s3.CreateBucketOutput{}, nil)
+
+			mockS3API.EXPECT().PutPublicAccessBlock(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&s3.PutPublicAccessBlockOutput{}, nil)
+
+			mockS3API.EXPECT().PutBucketPolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, fmt.Errorf("policy error"))
+
+			err := client.CreateS3Bucket(bucketName, DefaultRegion)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("policy error"))
+		})
+
+		It("Returns error when PutBucketTagging fails", func() {
+			mockS3API.EXPECT().HeadBucket(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, fmt.Errorf("not found"))
+
+			mockS3API.EXPECT().CreateBucket(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&s3.CreateBucketOutput{}, nil)
+
+			mockS3API.EXPECT().PutPublicAccessBlock(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&s3.PutPublicAccessBlockOutput{}, nil)
+
+			mockS3API.EXPECT().PutBucketPolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&s3.PutBucketPolicyOutput{}, nil)
+
+			mockS3API.EXPECT().PutBucketTagging(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, fmt.Errorf("tagging error"))
+
+			err := client.CreateS3Bucket(bucketName, DefaultRegion)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("tagging error"))
+		})
+	})
+
+	Context("DeleteS3Bucket", func() {
+		bucketName := "test-oidc-bucket"
+
+		It("Returns nil when bucket is not found", func() {
+			mockS3API.EXPECT().HeadBucket(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, &s3types.NotFound{})
+
+			err := client.DeleteS3Bucket(bucketName)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Empties bucket and deletes it successfully", func() {
+			mockS3API.EXPECT().HeadBucket(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&s3.HeadBucketOutput{}, nil)
+
+			mockS3API.EXPECT().ListObjects(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&s3.ListObjectsOutput{
+					Contents: []s3types.Object{
+						{Key: awsSdk.String("file1.json")},
+						{Key: awsSdk.String("file2.json")},
+					},
+				}, nil)
+
+			mockS3API.EXPECT().DeleteObject(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&s3.DeleteObjectOutput{}, nil).Times(2)
+
+			mockS3API.EXPECT().DeleteBucket(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&s3.DeleteBucketOutput{}, nil)
+
+			err := client.DeleteS3Bucket(bucketName)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Returns error when ListObjects fails", func() {
+			mockS3API.EXPECT().HeadBucket(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&s3.HeadBucketOutput{}, nil)
+
+			mockS3API.EXPECT().ListObjects(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, fmt.Errorf("list objects error"))
+
+			err := client.DeleteS3Bucket(bucketName)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("list objects error"))
+		})
+
+		It("Returns error when DeleteBucket fails", func() {
+			mockS3API.EXPECT().HeadBucket(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&s3.HeadBucketOutput{}, nil)
+
+			mockS3API.EXPECT().ListObjects(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&s3.ListObjectsOutput{Contents: []s3types.Object{}}, nil)
+
+			mockS3API.EXPECT().DeleteBucket(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, fmt.Errorf("delete bucket error"))
+
+			err := client.DeleteS3Bucket(bucketName)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("delete bucket error"))
+		})
+	})
+
+	Context("CreateSecretInSecretsManager", func() {
+		It("Returns ARN on success", func() {
+			expectedArn := "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret-abc123"
+
+			mockSecretsManagerAPI.EXPECT().CreateSecret(gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, input *secretsmanager.CreateSecretInput,
+					_ ...func(*secretsmanager.Options)) (*secretsmanager.CreateSecretOutput, error) {
+					Expect(*input.Name).To(Equal("my-secret"))
+					Expect(*input.SecretString).To(Equal("secret-value"))
+					return &secretsmanager.CreateSecretOutput{
+						ARN: awsSdk.String(expectedArn),
+					}, nil
+				})
+
+			arn, err := client.CreateSecretInSecretsManager("my-secret", "secret-value")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(arn).To(Equal(expectedArn))
+		})
+
+		It("Returns error when CreateSecret fails", func() {
+			mockSecretsManagerAPI.EXPECT().CreateSecret(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, fmt.Errorf("permission denied"))
+
+			arn, err := client.CreateSecretInSecretsManager("my-secret", "secret-value")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("permission denied"))
+			Expect(arn).To(BeEmpty())
+		})
+	})
+
+	Context("DeleteSecretInSecretsManager", func() {
+		secretArn := "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret-abc123"
+
+		It("Returns nil when secret is not found", func() {
+			mockSecretsManagerAPI.EXPECT().DescribeSecret(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, &secretsmanagertypes.ResourceNotFoundException{
+					Message: awsSdk.String("not found"),
+				})
+
+			err := client.DeleteSecretInSecretsManager(secretArn)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Deletes secret successfully when it exists", func() {
+			mockSecretsManagerAPI.EXPECT().DescribeSecret(gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, input *secretsmanager.DescribeSecretInput,
+					_ ...func(*secretsmanager.Options)) (*secretsmanager.DescribeSecretOutput, error) {
+					Expect(*input.SecretId).To(Equal(secretArn))
+					return &secretsmanager.DescribeSecretOutput{
+						ARN:  awsSdk.String(secretArn),
+						Name: awsSdk.String("my-secret"),
+					}, nil
+				})
+
+			mockSecretsManagerAPI.EXPECT().DeleteSecret(gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, input *secretsmanager.DeleteSecretInput,
+					_ ...func(*secretsmanager.Options)) (*secretsmanager.DeleteSecretOutput, error) {
+					Expect(*input.SecretId).To(Equal(secretArn))
+					Expect(*input.ForceDeleteWithoutRecovery).To(BeTrue())
+					return &secretsmanager.DeleteSecretOutput{}, nil
+				})
+
+			err := client.DeleteSecretInSecretsManager(secretArn)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Returns error when DeleteSecret fails", func() {
+			mockSecretsManagerAPI.EXPECT().DescribeSecret(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&secretsmanager.DescribeSecretOutput{
+					ARN: awsSdk.String(secretArn),
+				}, nil)
+
+			mockSecretsManagerAPI.EXPECT().DeleteSecret(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, fmt.Errorf("internal service error"))
+
+			err := client.DeleteSecretInSecretsManager(secretArn)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("internal service error"))
+		})
+	})
+
+	Context("DescribeAvailabilityZones", func() {
+		It("Returns zone names on success", func() {
+			mockEC2API.EXPECT().DescribeAvailabilityZones(gomock.Any(), gomock.Any()).
+				Return(&ec2.DescribeAvailabilityZonesOutput{
+					AvailabilityZones: []ec2types.AvailabilityZone{
+						{ZoneName: awsSdk.String("us-east-1a")},
+						{ZoneName: awsSdk.String("us-east-1b")},
+						{ZoneName: awsSdk.String("us-east-1c")},
+					},
+				}, nil)
+
+			zones, err := client.DescribeAvailabilityZones()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(zones).To(HaveLen(3))
+			Expect(zones).To(ContainElements("us-east-1a", "us-east-1b", "us-east-1c"))
+		})
+
+		It("Propagates API error", func() {
+			mockEC2API.EXPECT().DescribeAvailabilityZones(gomock.Any(), gomock.Any()).
+				Return(nil, fmt.Errorf("ec2 error"))
+
+			zones, err := client.DescribeAvailabilityZones()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("ec2 error"))
+			Expect(zones).To(BeNil())
+		})
+	})
+
+	Context("IsLocalAvailabilityZone", func() {
+		It("Returns true for a local zone", func() {
+			mockEC2API.EXPECT().DescribeAvailabilityZones(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, input *ec2.DescribeAvailabilityZonesInput,
+					_ ...func(*ec2.Options)) (*ec2.DescribeAvailabilityZonesOutput, error) {
+					Expect(input.ZoneNames).To(ContainElement("us-east-1-bos-1a"))
+					return &ec2.DescribeAvailabilityZonesOutput{
+						AvailabilityZones: []ec2types.AvailabilityZone{
+							{ZoneType: awsSdk.String(LocalZone)},
+						},
+					}, nil
+				})
+
+			isLocal, err := client.IsLocalAvailabilityZone("us-east-1-bos-1a")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(isLocal).To(BeTrue())
+		})
+
+		It("Returns false for a non-local zone", func() {
+			mockEC2API.EXPECT().DescribeAvailabilityZones(gomock.Any(), gomock.Any()).
+				Return(&ec2.DescribeAvailabilityZonesOutput{
+					AvailabilityZones: []ec2types.AvailabilityZone{
+						{ZoneType: awsSdk.String("availability-zone")},
+					},
+				}, nil)
+
+			isLocal, err := client.IsLocalAvailabilityZone("us-east-1a")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(isLocal).To(BeFalse())
+		})
+
+		It("Returns error when zone is not found", func() {
+			mockEC2API.EXPECT().DescribeAvailabilityZones(gomock.Any(), gomock.Any()).
+				Return(&ec2.DescribeAvailabilityZonesOutput{
+					AvailabilityZones: []ec2types.AvailabilityZone{},
+				}, nil)
+
+			_, err := client.IsLocalAvailabilityZone("nonexistent-zone")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to find availability zone"))
+		})
+
+		It("Propagates API error", func() {
+			mockEC2API.EXPECT().DescribeAvailabilityZones(gomock.Any(), gomock.Any()).
+				Return(nil, fmt.Errorf("api failure"))
+
+			_, err := client.IsLocalAvailabilityZone("us-east-1a")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("api failure"))
+		})
+	})
+
+	Context("GetSubnetAvailabilityZone", func() {
+		It("Returns availability zone on success", func() {
+			subnetID := "subnet-12345"
+			mockEC2API.EXPECT().DescribeSubnets(gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, input *ec2.DescribeSubnetsInput,
+					_ ...func(*ec2.Options)) (*ec2.DescribeSubnetsOutput, error) {
+					Expect(input.SubnetIds).To(ContainElement(subnetID))
+					return &ec2.DescribeSubnetsOutput{
+						Subnets: []ec2types.Subnet{
+							{
+								SubnetId:         awsSdk.String(subnetID),
+								AvailabilityZone: awsSdk.String("us-east-1a"),
+							},
+						},
+					}, nil
+				})
+
+			az, err := client.GetSubnetAvailabilityZone(subnetID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(az).To(Equal("us-east-1a"))
+		})
+
+		It("Propagates API error", func() {
+			mockEC2API.EXPECT().DescribeSubnets(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, fmt.Errorf("subnet error"))
+
+			_, err := client.GetSubnetAvailabilityZone("subnet-12345")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("subnet error"))
+		})
+	})
+
+	Context("GetVPCSubnets", func() {
+		It("Returns filtered subnets for a VPC", func() {
+			subnetID := "subnet-aaa"
+			vpcID := "vpc-12345"
+			mockEC2API.EXPECT().DescribeSubnets(gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, input *ec2.DescribeSubnetsInput,
+					_ ...func(*ec2.Options)) (*ec2.DescribeSubnetsOutput, error) {
+					for _, f := range input.Filters {
+						if *f.Name == "subnet-id" {
+							return &ec2.DescribeSubnetsOutput{
+								Subnets: []ec2types.Subnet{
+									{
+										SubnetId: awsSdk.String(subnetID),
+										VpcId:    awsSdk.String(vpcID),
+									},
+								},
+							}, nil
+						}
+					}
+					return &ec2.DescribeSubnetsOutput{
+						Subnets: []ec2types.Subnet{
+							{SubnetId: awsSdk.String(subnetID), VpcId: awsSdk.String(vpcID)},
+							{SubnetId: awsSdk.String("subnet-bbb"), VpcId: awsSdk.String(vpcID)},
+							{SubnetId: awsSdk.String("subnet-ccc"), VpcId: awsSdk.String(vpcID)},
+						},
+					}, nil
+				}).Times(2)
+
+			subnets, err := client.GetVPCSubnets(subnetID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(subnets).To(HaveLen(3))
+		})
+
+		It("Propagates error from first DescribeSubnets call", func() {
+			mockEC2API.EXPECT().DescribeSubnets(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, fmt.Errorf("describe subnets error"))
+
+			subnets, err := client.GetVPCSubnets("subnet-aaa")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("describe subnets error"))
+			Expect(subnets).To(BeNil())
+		})
+	})
+
+	Context("CheckRoleExists", func() {
+		When("the role exists", func() {
+			It("returns true and the ARN", func() {
+				mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+					&iam.GetRoleOutput{
+						Role: &iamtypes.Role{
+							RoleName: awsSdk.String("my-role"),
+							Arn:      awsSdk.String("arn:aws:iam::123456789012:role/my-role"),
+						},
+					}, nil)
+
+				exists, roleArn, err := client.CheckRoleExists("my-role")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(exists).To(BeTrue())
+				Expect(roleArn).To(Equal("arn:aws:iam::123456789012:role/my-role"))
+			})
+		})
+
+		When("the role does not exist", func() {
+			It("returns false with empty ARN and nil error", func() {
+				mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+					nil, &iamtypes.NoSuchEntityException{})
+
+				exists, roleArn, err := client.CheckRoleExists("nonexistent-role")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(exists).To(BeFalse())
+				Expect(roleArn).To(BeEmpty())
+			})
+		})
+
+		When("GetRole returns another error", func() {
+			It("propagates the error", func() {
+				mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+					nil, fmt.Errorf("access denied"))
+
+				exists, roleArn, err := client.CheckRoleExists("my-role")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("access denied"))
+				Expect(exists).To(BeFalse())
+				Expect(roleArn).To(BeEmpty())
+			})
+		})
+	})
+
+	Context("GetRoleByARN", func() {
+		When("given a valid role ARN", func() {
+			It("returns the role", func() {
+				testArn := "arn:aws:iam::123456789012:role/my-role"
+				mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+					&iam.GetRoleOutput{
+						Role: &iamtypes.Role{
+							RoleName: awsSdk.String("my-role"),
+							Arn:      awsSdk.String(testArn),
+						},
+					}, nil)
+
+				role, err := client.GetRoleByARN(testArn)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(awsSdk.ToString(role.RoleName)).To(Equal("my-role"))
+				Expect(awsSdk.ToString(role.Arn)).To(Equal(testArn))
+			})
+		})
+
+		When("given an invalid ARN string", func() {
+			It("returns an error", func() {
+				role, err := client.GetRoleByARN("not-a-valid-arn")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("valid IAM role ARN"))
+				Expect(role).To(Equal(iamtypes.Role{}))
+			})
+		})
+
+		When("the ARN is not for a role resource", func() {
+			It("returns an error", func() {
+				role, err := client.GetRoleByARN("arn:aws:iam::123456789012:user/my-user")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("IAM role resource"))
+				Expect(role).To(Equal(iamtypes.Role{}))
+			})
+		})
+
+		When("GetRole fails", func() {
+			It("propagates the error", func() {
+				mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+					nil, fmt.Errorf("iam service error"))
+
+				role, err := client.GetRoleByARN("arn:aws:iam::123456789012:role/missing-role")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("iam service error"))
+				Expect(role).To(Equal(iamtypes.Role{}))
+			})
+		})
+	})
+
+	Context("GetRoleByName", func() {
+		When("the role is found", func() {
+			It("returns the role", func() {
+				mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+					&iam.GetRoleOutput{
+						Role: &iamtypes.Role{
+							RoleName: awsSdk.String("my-role"),
+							Arn:      awsSdk.String("arn:aws:iam::123456789012:role/my-role"),
+						},
+					}, nil)
+
+				role, err := client.GetRoleByName("my-role")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(awsSdk.ToString(role.RoleName)).To(Equal("my-role"))
+			})
+		})
+
+		When("GetRole returns an error", func() {
+			It("propagates the error", func() {
+				mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+					nil, fmt.Errorf("role not found"))
+
+				role, err := client.GetRoleByName("missing-role")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("role not found"))
+				Expect(role).To(Equal(iamtypes.Role{}))
+			})
 		})
 	})
 })

--- a/pkg/aws/cloudformation_test.go
+++ b/pkg/aws/cloudformation_test.go
@@ -302,4 +302,95 @@ var _ = Describe("CloudFormation", func() {
 			))
 		})
 	})
+
+	Context("GetCFStack", func() {
+		stackName := "my-stack"
+
+		It("Returns the stack when DescribeStacks succeeds", func() {
+			expectedStack := cloudformationtypes.Stack{
+				StackName:   awsSdk.String(stackName),
+				StackStatus: cloudformationtypes.StackStatusCreateComplete,
+			}
+			mockCfAPI.EXPECT().DescribeStacks(gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, input *cloudformation.DescribeStacksInput,
+					_ ...func(*cloudformation.Options)) (*cloudformation.DescribeStacksOutput, error) {
+					Expect(*input.StackName).To(Equal(stackName))
+					return &cloudformation.DescribeStacksOutput{
+						Stacks: []cloudformationtypes.Stack{expectedStack},
+					}, nil
+				})
+
+			result, err := client.GetCFStack(context.Background(), stackName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*result.StackName).To(Equal(stackName))
+			Expect(result.StackStatus).To(Equal(cloudformationtypes.StackStatusCreateComplete))
+		})
+
+		It("Propagates DescribeStacks API error", func() {
+			mockCfAPI.EXPECT().DescribeStacks(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, fmt.Errorf("throttling exception"))
+
+			result, err := client.GetCFStack(context.Background(), stackName)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("throttling exception"))
+			Expect(result).To(BeNil())
+		})
+
+		It("Returns error when stack list is empty", func() {
+			mockCfAPI.EXPECT().DescribeStacks(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&cloudformation.DescribeStacksOutput{
+					Stacks: []cloudformationtypes.Stack{},
+				}, nil)
+
+			result, err := client.GetCFStack(context.Background(), stackName)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("No CF stacks with name"))
+			Expect(result).To(BeNil())
+		})
+	})
+
+	Context("DescribeCFStackResources", func() {
+		stackName := "my-stack"
+
+		It("Returns stack resources on success", func() {
+			expectedResources := []cloudformationtypes.StackResource{
+				{
+					LogicalResourceId:  awsSdk.String("MyBucket"),
+					ResourceType:       awsSdk.String("AWS::S3::Bucket"),
+					ResourceStatus:     cloudformationtypes.ResourceStatusCreateComplete,
+					PhysicalResourceId: awsSdk.String("my-bucket-123"),
+				},
+				{
+					LogicalResourceId:  awsSdk.String("MyRole"),
+					ResourceType:       awsSdk.String("AWS::IAM::Role"),
+					ResourceStatus:     cloudformationtypes.ResourceStatusCreateComplete,
+					PhysicalResourceId: awsSdk.String("my-role-456"),
+				},
+			}
+			mockCfAPI.EXPECT().DescribeStackResources(gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, input *cloudformation.DescribeStackResourcesInput,
+					_ ...func(*cloudformation.Options)) (*cloudformation.DescribeStackResourcesOutput, error) {
+					Expect(*input.StackName).To(Equal(stackName))
+					return &cloudformation.DescribeStackResourcesOutput{
+						StackResources: expectedResources,
+					}, nil
+				})
+
+			result, err := client.DescribeCFStackResources(context.Background(), stackName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*result).To(HaveLen(2))
+			Expect(*(*result)[0].LogicalResourceId).To(Equal("MyBucket"))
+			Expect(*(*result)[1].LogicalResourceId).To(Equal("MyRole"))
+		})
+
+		It("Propagates DescribeStackResources API error", func() {
+			mockCfAPI.EXPECT().DescribeStackResources(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, fmt.Errorf("stack not found"))
+
+			result, err := client.DescribeCFStackResources(context.Background(), stackName)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("stack not found"))
+			Expect(result).To(BeNil())
+		})
+	})
 })

--- a/pkg/aws/helpers_test.go
+++ b/pkg/aws/helpers_test.go
@@ -10,6 +10,7 @@ import (
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
 var _ = Describe("UserTagValidator", func() {
@@ -1042,6 +1043,86 @@ var _ = Describe("resolveSTSRole", func() {
 			_, err := resolveSTSRole(malformedARN)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("doesn't appear to have"))
+		})
+	})
+})
+
+var _ = Describe("GetJumpAccount", func() {
+	When("env is production", func() {
+		It("Should return the production jump account", func() {
+			Expect(GetJumpAccount("production")).To(Equal("710019948333"))
+		})
+	})
+
+	When("env is staging", func() {
+		It("Should return the staging jump account", func() {
+			Expect(GetJumpAccount("staging")).To(Equal("644306948063"))
+		})
+	})
+
+	When("env is integration", func() {
+		It("Should return the integration jump account", func() {
+			Expect(GetJumpAccount("integration")).To(Equal("896164604406"))
+		})
+	})
+
+	When("env is local", func() {
+		It("Should return the local jump account", func() {
+			Expect(GetJumpAccount("local")).To(Equal("765374464689"))
+		})
+	})
+
+	When("env is unknown", func() {
+		It("Should return empty string", func() {
+			Expect(GetJumpAccount("unknown-env")).To(BeEmpty())
+		})
+	})
+})
+
+var _ = Describe("ComputeOperatorRoleArn", func() {
+	var operator *cmv1.STSOperator
+
+	BeforeEach(func() {
+		var err error
+		operator, err = cmv1.NewSTSOperator().
+			Namespace("openshift-ingress").
+			Name("cloud-credentials").
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	When("path is empty", func() {
+		It("Should build an ARN without path", func() {
+			creator := &Creator{
+				AccountID: "123456789012",
+				Partition: "aws",
+			}
+			result := ComputeOperatorRoleArn("my-prefix", operator, creator, "")
+			Expect(result).To(Equal(
+				"arn:aws:iam::123456789012:role/my-prefix-openshift-ingress-cloud-credentials"))
+		})
+	})
+
+	When("path is provided", func() {
+		It("Should build an ARN with the path", func() {
+			creator := &Creator{
+				AccountID: "123456789012",
+				Partition: "aws",
+			}
+			result := ComputeOperatorRoleArn("my-prefix", operator, creator, "/my/path/")
+			Expect(result).To(Equal(
+				"arn:aws:iam::123456789012:role/my/path/my-prefix-openshift-ingress-cloud-credentials"))
+		})
+	})
+
+	When("partition is GovCloud", func() {
+		It("Should use the GovCloud partition in the ARN", func() {
+			creator := &Creator{
+				AccountID: "123456789012",
+				Partition: "aws-us-gov",
+			}
+			result := ComputeOperatorRoleArn("prefix", operator, creator, "")
+			Expect(result).To(ContainSubstring("arn:aws-us-gov:iam::"))
 		})
 	})
 })

--- a/pkg/aws/helpers_test.go
+++ b/pkg/aws/helpers_test.go
@@ -11,6 +11,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
+	"github.com/openshift/rosa/pkg/fedramp"
 )
 
 var _ = Describe("UserTagValidator", func() {
@@ -1048,34 +1050,28 @@ var _ = Describe("resolveSTSRole", func() {
 })
 
 var _ = Describe("GetJumpAccount", func() {
-	When("env is production", func() {
-		It("Should return the production jump account", func() {
-			Expect(GetJumpAccount("production")).To(Equal("710019948333"))
-		})
+	BeforeEach(func() {
+		fedramp.Disable()
 	})
 
-	When("env is staging", func() {
-		It("Should return the staging jump account", func() {
-			Expect(GetJumpAccount("staging")).To(Equal("644306948063"))
-		})
+	AfterEach(func() {
+		fedramp.Disable()
 	})
 
-	When("env is integration", func() {
-		It("Should return the integration jump account", func() {
-			Expect(GetJumpAccount("integration")).To(Equal("896164604406"))
-		})
+	It("returns the standard jump account when FedRAMP is disabled", func() {
+		Expect(GetJumpAccount("production")).To(Equal(JumpAccounts["production"]))
+		Expect(GetJumpAccount("local")).To(Equal(JumpAccounts["local"]))
 	})
 
-	When("env is local", func() {
-		It("Should return the local jump account", func() {
-			Expect(GetJumpAccount("local")).To(Equal("765374464689"))
-		})
+	It("returns the FedRAMP jump account when FedRAMP is enabled", func() {
+		fedramp.Enable()
+
+		Expect(GetJumpAccount("production")).To(Equal(fedramp.JumpAccounts["production"]))
+		Expect(GetJumpAccount("integration")).To(Equal(fedramp.JumpAccounts["integration"]))
 	})
 
-	When("env is unknown", func() {
-		It("Should return empty string", func() {
-			Expect(GetJumpAccount("unknown-env")).To(BeEmpty())
-		})
+	It("returns empty string for an unknown environment", func() {
+		Expect(GetJumpAccount("unknown-env")).To(BeEmpty())
 	})
 })
 

--- a/pkg/aws/mocks/iam_api_client_mock.go
+++ b/pkg/aws/mocks/iam_api_client_mock.go
@@ -760,6 +760,26 @@ func (mr *MockIamApiClientMockRecorder) PutRolePolicy(ctx, params any, optFns ..
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutRolePolicy", reflect.TypeOf((*MockIamApiClient)(nil).PutRolePolicy), varargs...)
 }
 
+// SimulatePrincipalPolicy mocks base method.
+func (m *MockIamApiClient) SimulatePrincipalPolicy(ctx context.Context, params *iam.SimulatePrincipalPolicyInput, optFns ...func(*iam.Options)) (*iam.SimulatePrincipalPolicyOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, params}
+	for _, a := range optFns {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "SimulatePrincipalPolicy", varargs...)
+	ret0, _ := ret[0].(*iam.SimulatePrincipalPolicyOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SimulatePrincipalPolicy indicates an expected call of SimulatePrincipalPolicy.
+func (mr *MockIamApiClientMockRecorder) SimulatePrincipalPolicy(ctx, params any, optFns ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, params}, optFns...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SimulatePrincipalPolicy", reflect.TypeOf((*MockIamApiClient)(nil).SimulatePrincipalPolicy), varargs...)
+}
+
 // TagPolicy mocks base method.
 func (m *MockIamApiClient) TagPolicy(ctx context.Context, params *iam.TagPolicyInput, optFns ...func(*iam.Options)) (*iam.TagPolicyOutput, error) {
 	m.ctrl.T.Helper()

--- a/pkg/aws/policies_test.go
+++ b/pkg/aws/policies_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openshift/rosa/pkg/aws/mocks"
 	"github.com/openshift/rosa/pkg/aws/tags"
 	"github.com/openshift/rosa/pkg/logging"
+	"github.com/openshift/rosa/pkg/reporter"
 )
 
 var _ = Describe("ListOperatorRoles", func() {
@@ -1067,6 +1068,727 @@ var _ = Describe("hasCompatibleMajorMinorVersionTags", func() {
 	})
 })
 
+var _ = Describe("FindRoleARNs", func() {
+	var (
+		client     awsClient
+		mockIamAPI *mocks.MockIamApiClient
+		mockCtrl   *gomock.Controller
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockIamAPI = mocks.NewMockIamApiClient(mockCtrl)
+		client = awsClient{iamClient: mockIamAPI}
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	When("A version-compatible installer role exists", func() {
+		It("Should return the role ARN", func() {
+			mockIamAPI.EXPECT().ListRoles(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+				&iam.ListRolesOutput{
+					IsTruncated: false,
+					Roles: []iamtypes.Role{
+						{
+							RoleName: aws.String("my-prefix-Installer-Role"),
+							Arn:      aws.String("arn:aws:iam::123456789012:role/my-prefix-Installer-Role"),
+						},
+					},
+				}, nil)
+			mockIamAPI.EXPECT().ListRoleTags(gomock.Any(), gomock.Any()).Return(
+				&iam.ListRoleTagsOutput{
+					Tags: []iamtypes.Tag{
+						{Key: aws.String("rosa_role_type"), Value: aws.String(InstallerAccountRole)},
+						{Key: aws.String("rosa_openshift_version"), Value: aws.String("4.14")},
+					},
+				}, nil)
+
+			arns, err := client.FindRoleARNs(InstallerAccountRole, "4.14")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(arns).To(HaveLen(1))
+			Expect(arns[0]).To(Equal("arn:aws:iam::123456789012:role/my-prefix-Installer-Role"))
+		})
+	})
+
+	When("A role exists but is version-incompatible", func() {
+		It("Should return empty", func() {
+			mockIamAPI.EXPECT().ListRoles(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+				&iam.ListRolesOutput{
+					IsTruncated: false,
+					Roles: []iamtypes.Role{
+						{
+							RoleName: aws.String("my-prefix-Installer-Role"),
+							Arn:      aws.String("arn:aws:iam::123456789012:role/my-prefix-Installer-Role"),
+						},
+					},
+				}, nil)
+			mockIamAPI.EXPECT().ListRoleTags(gomock.Any(), gomock.Any()).Return(
+				&iam.ListRoleTagsOutput{
+					Tags: []iamtypes.Tag{
+						{Key: aws.String("rosa_role_type"), Value: aws.String(InstallerAccountRole)},
+						{Key: aws.String("rosa_openshift_version"), Value: aws.String("4.12")},
+					},
+				}, nil)
+
+			arns, err := client.FindRoleARNs(InstallerAccountRole, "4.14")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(arns).To(BeEmpty())
+		})
+	})
+
+	When("ListRoles returns an error", func() {
+		It("Should propagate the error", func() {
+			mockIamAPI.EXPECT().ListRoles(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+				nil, fmt.Errorf("access denied"))
+
+			arns, err := client.FindRoleARNs(InstallerAccountRole, "4.14")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("access denied"))
+			Expect(arns).To(BeEmpty())
+		})
+	})
+})
+
+var _ = Describe("FindRoleARNsClassic", func() {
+	var (
+		client     awsClient
+		mockIamAPI *mocks.MockIamApiClient
+		mockCtrl   *gomock.Controller
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockIamAPI = mocks.NewMockIamApiClient(mockCtrl)
+		client = awsClient{iamClient: mockIamAPI}
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	When("A classic-only compatible role exists", func() {
+		It("Should return the role ARN", func() {
+			mockIamAPI.EXPECT().ListRoles(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+				&iam.ListRolesOutput{
+					IsTruncated: false,
+					Roles: []iamtypes.Role{
+						{
+							RoleName: aws.String("prefix-Installer-Role"),
+							Arn:      aws.String("arn:aws:iam::123456789012:role/prefix-Installer-Role"),
+						},
+					},
+				}, nil)
+			mockIamAPI.EXPECT().ListRoleTags(gomock.Any(), gomock.Any()).Return(
+				&iam.ListRoleTagsOutput{
+					Tags: []iamtypes.Tag{
+						{Key: aws.String("rosa_role_type"), Value: aws.String(InstallerAccountRole)},
+						{Key: aws.String("rosa_openshift_version"), Value: aws.String("4.14")},
+					},
+				}, nil)
+
+			arns, err := client.FindRoleARNsClassic(InstallerAccountRole, "4.14")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(arns).To(HaveLen(1))
+		})
+	})
+
+	When("A role has HCP policies tag", func() {
+		It("Should exclude the HCP role", func() {
+			mockIamAPI.EXPECT().ListRoles(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+				&iam.ListRolesOutput{
+					IsTruncated: false,
+					Roles: []iamtypes.Role{
+						{
+							RoleName: aws.String("prefix-Installer-Role"),
+							Arn:      aws.String("arn:aws:iam::123456789012:role/prefix-Installer-Role"),
+						},
+					},
+				}, nil)
+			mockIamAPI.EXPECT().ListRoleTags(gomock.Any(), gomock.Any()).Return(
+				&iam.ListRoleTagsOutput{
+					Tags: []iamtypes.Tag{
+						{Key: aws.String("rosa_role_type"), Value: aws.String(InstallerAccountRole)},
+						{Key: aws.String("rosa_openshift_version"), Value: aws.String("4.14")},
+						{Key: aws.String("rosa_managed_policies"), Value: aws.String(TrueString)},
+						{Key: aws.String("rosa_hcp_policies"), Value: aws.String(TrueString)},
+					},
+				}, nil)
+
+			arns, err := client.FindRoleARNsClassic(InstallerAccountRole, "4.14")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(arns).To(BeEmpty())
+		})
+	})
+})
+
+var _ = Describe("FindRoleARNsHostedCp", func() {
+	var (
+		client     awsClient
+		mockIamAPI *mocks.MockIamApiClient
+		mockCtrl   *gomock.Controller
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockIamAPI = mocks.NewMockIamApiClient(mockCtrl)
+		client = awsClient{iamClient: mockIamAPI}
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	When("A role has HCP policies tag", func() {
+		It("Should return the HCP role ARN", func() {
+			mockIamAPI.EXPECT().ListRoles(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+				&iam.ListRolesOutput{
+					IsTruncated: false,
+					Roles: []iamtypes.Role{
+						{
+							RoleName: aws.String("prefix-Installer-Role"),
+							Arn:      aws.String("arn:aws:iam::123456789012:role/prefix-Installer-Role"),
+						},
+					},
+				}, nil)
+			mockIamAPI.EXPECT().ListRoleTags(gomock.Any(), gomock.Any()).Return(
+				&iam.ListRoleTagsOutput{
+					Tags: []iamtypes.Tag{
+						{Key: aws.String("rosa_role_type"), Value: aws.String(InstallerAccountRole)},
+						{Key: aws.String("rosa_openshift_version"), Value: aws.String("4.14")},
+						{Key: aws.String("rosa_managed_policies"), Value: aws.String(TrueString)},
+						{Key: aws.String("rosa_hcp_policies"), Value: aws.String(TrueString)},
+					},
+				}, nil)
+
+			arns, err := client.FindRoleARNsHostedCp(InstallerAccountRole, "4.14")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(arns).To(HaveLen(1))
+		})
+	})
+
+	When("A role has classic policies only", func() {
+		It("Should exclude the classic role", func() {
+			mockIamAPI.EXPECT().ListRoles(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+				&iam.ListRolesOutput{
+					IsTruncated: false,
+					Roles: []iamtypes.Role{
+						{
+							RoleName: aws.String("prefix-Installer-Role"),
+							Arn:      aws.String("arn:aws:iam::123456789012:role/prefix-Installer-Role"),
+						},
+					},
+				}, nil)
+			mockIamAPI.EXPECT().ListRoleTags(gomock.Any(), gomock.Any()).Return(
+				&iam.ListRoleTagsOutput{
+					Tags: []iamtypes.Tag{
+						{Key: aws.String("rosa_role_type"), Value: aws.String(InstallerAccountRole)},
+						{Key: aws.String("rosa_openshift_version"), Value: aws.String("4.14")},
+						{Key: aws.String("rosa_managed_policies"), Value: aws.String(TrueString)},
+					},
+				}, nil)
+
+			arns, err := client.FindRoleARNsHostedCp(InstallerAccountRole, "4.14")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(arns).To(BeEmpty())
+		})
+	})
+})
+
+var _ = Describe("ValidateAccountRoleVersionCompatibility", func() {
+	var (
+		client     awsClient
+		mockIamAPI *mocks.MockIamApiClient
+		mockCtrl   *gomock.Controller
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockIamAPI = mocks.NewMockIamApiClient(mockCtrl)
+		client = awsClient{iamClient: mockIamAPI}
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	When("Role tags show compatible version", func() {
+		It("Should return true", func() {
+			mockIamAPI.EXPECT().ListRoleTags(gomock.Any(), gomock.Any()).Return(
+				&iam.ListRoleTagsOutput{
+					Tags: []iamtypes.Tag{
+						{Key: aws.String("rosa_role_type"), Value: aws.String(InstallerAccountRole)},
+						{Key: aws.String("rosa_openshift_version"), Value: aws.String("4.14")},
+					},
+				}, nil)
+
+			isValid, err := client.ValidateAccountRoleVersionCompatibility(
+				"my-Installer-Role", InstallerAccountRole, "4.14")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(isValid).To(BeTrue())
+		})
+	})
+
+	When("Role tags show incompatible version", func() {
+		It("Should return false", func() {
+			mockIamAPI.EXPECT().ListRoleTags(gomock.Any(), gomock.Any()).Return(
+				&iam.ListRoleTagsOutput{
+					Tags: []iamtypes.Tag{
+						{Key: aws.String("rosa_role_type"), Value: aws.String(InstallerAccountRole)},
+						{Key: aws.String("rosa_openshift_version"), Value: aws.String("4.12")},
+					},
+				}, nil)
+
+			isValid, err := client.ValidateAccountRoleVersionCompatibility(
+				"my-Installer-Role", InstallerAccountRole, "4.14")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(isValid).To(BeFalse())
+		})
+	})
+
+	When("Role has managed policies", func() {
+		It("Should return compatible regardless of version tag", func() {
+			mockIamAPI.EXPECT().ListRoleTags(gomock.Any(), gomock.Any()).Return(
+				&iam.ListRoleTagsOutput{
+					Tags: []iamtypes.Tag{
+						{Key: aws.String("rosa_role_type"), Value: aws.String(InstallerAccountRole)},
+						{Key: aws.String("rosa_openshift_version"), Value: aws.String("4.12")},
+						{Key: aws.String("rosa_managed_policies"), Value: aws.String(TrueString)},
+					},
+				}, nil)
+
+			isValid, err := client.ValidateAccountRoleVersionCompatibility(
+				"my-Installer-Role", InstallerAccountRole, "4.14")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(isValid).To(BeTrue())
+		})
+	})
+})
+
+var _ = Describe("FindPolicyARN", func() {
+	var (
+		client     awsClient
+		mockIamAPI *mocks.MockIamApiClient
+		mockCtrl   *gomock.Controller
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockIamAPI = mocks.NewMockIamApiClient(mockCtrl)
+		client = awsClient{iamClient: mockIamAPI}
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	When("A matching policy exists", func() {
+		It("Should return the policy ARN", func() {
+			mockIamAPI.EXPECT().ListPolicies(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+				&iam.ListPoliciesOutput{
+					IsTruncated: false,
+					Policies: []iamtypes.Policy{
+						{
+							Arn:        aws.String("arn:aws:iam::123456789012:policy/my-policy"),
+							PolicyName: aws.String("my-policy"),
+						},
+					},
+				}, nil)
+			mockIamAPI.EXPECT().ListPolicyTags(gomock.Any(), gomock.Any()).Return(
+				&iam.ListPolicyTagsOutput{
+					Tags: []iamtypes.Tag{
+						{Key: aws.String("operator_namespace"), Value: aws.String("openshift-ingress")},
+						{Key: aws.String("operator_name"), Value: aws.String("cloud-credentials")},
+						{Key: aws.String("rosa_openshift_version"), Value: aws.String("4.14")},
+					},
+				}, nil)
+
+			policyARN, err := client.FindPolicyARN(
+				Operator{Namespace: "openshift-ingress", Name: "cloud-credentials"}, "4.14")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(policyARN).To(Equal("arn:aws:iam::123456789012:policy/my-policy"))
+		})
+	})
+
+	When("No matching policy exists", func() {
+		It("Should return empty string", func() {
+			mockIamAPI.EXPECT().ListPolicies(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+				&iam.ListPoliciesOutput{
+					IsTruncated: false,
+					Policies: []iamtypes.Policy{
+						{
+							Arn:        aws.String("arn:aws:iam::123456789012:policy/other-policy"),
+							PolicyName: aws.String("other-policy"),
+						},
+					},
+				}, nil)
+			mockIamAPI.EXPECT().ListPolicyTags(gomock.Any(), gomock.Any()).Return(
+				&iam.ListPolicyTagsOutput{
+					Tags: []iamtypes.Tag{
+						{Key: aws.String("operator_namespace"), Value: aws.String("different-ns")},
+						{Key: aws.String("operator_name"), Value: aws.String("cloud-credentials")},
+						{Key: aws.String("rosa_openshift_version"), Value: aws.String("4.14")},
+					},
+				}, nil)
+
+			policyARN, err := client.FindPolicyARN(
+				Operator{Namespace: "openshift-ingress", Name: "cloud-credentials"}, "4.14")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(policyARN).To(BeEmpty())
+		})
+	})
+
+	When("ListPolicies returns an error", func() {
+		It("Should propagate the error", func() {
+			mockIamAPI.EXPECT().ListPolicies(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+				nil, fmt.Errorf("list error"))
+
+			_, err := client.FindPolicyARN(
+				Operator{Namespace: "openshift-ingress", Name: "cloud-credentials"}, "4.14")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("list error"))
+		})
+	})
+})
+
+var _ = Describe("HasHostedCPPolicies", func() {
+	var (
+		client     awsClient
+		mockIamAPI *mocks.MockIamApiClient
+		mockCtrl   *gomock.Controller
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockIamAPI = mocks.NewMockIamApiClient(mockCtrl)
+		client = awsClient{iamClient: mockIamAPI}
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	When("Role has the rosa_hcp_policies tag", func() {
+		It("Should return true", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				&iam.GetRoleOutput{
+					Role: &iamtypes.Role{
+						RoleName: aws.String("test-role"),
+						Arn:      aws.String("arn:aws:iam::123456789012:role/test-role"),
+						Tags: []iamtypes.Tag{
+							{Key: aws.String("rosa_hcp_policies"), Value: aws.String(TrueString)},
+						},
+					},
+				}, nil)
+
+			result, err := client.HasHostedCPPolicies("arn:aws:iam::123456789012:role/test-role")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeTrue())
+		})
+	})
+
+	When("Role does not have the rosa_hcp_policies tag", func() {
+		It("Should return false", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				&iam.GetRoleOutput{
+					Role: &iamtypes.Role{
+						RoleName: aws.String("test-role"),
+						Arn:      aws.String("arn:aws:iam::123456789012:role/test-role"),
+						Tags:     []iamtypes.Tag{},
+					},
+				}, nil)
+
+			result, err := client.HasHostedCPPolicies("arn:aws:iam::123456789012:role/test-role")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeFalse())
+		})
+	})
+
+	When("Role ARN is empty", func() {
+		It("Should return false without calling AWS", func() {
+			result, err := client.HasHostedCPPolicies("")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeFalse())
+		})
+	})
+})
+
+var _ = Describe("HasManagedPolicies", func() {
+	var (
+		client     awsClient
+		mockIamAPI *mocks.MockIamApiClient
+		mockCtrl   *gomock.Controller
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockIamAPI = mocks.NewMockIamApiClient(mockCtrl)
+		client = awsClient{iamClient: mockIamAPI}
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	When("Role has the rosa_managed_policies tag", func() {
+		It("Should return true", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				&iam.GetRoleOutput{
+					Role: &iamtypes.Role{
+						RoleName: aws.String("test-role"),
+						Arn:      aws.String("arn:aws:iam::123456789012:role/test-role"),
+						Tags: []iamtypes.Tag{
+							{Key: aws.String("rosa_managed_policies"), Value: aws.String(TrueString)},
+						},
+					},
+				}, nil)
+
+			result, err := client.HasManagedPolicies("arn:aws:iam::123456789012:role/test-role")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeTrue())
+		})
+	})
+
+	When("Role does not have the rosa_managed_policies tag", func() {
+		It("Should return false", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				&iam.GetRoleOutput{
+					Role: &iamtypes.Role{
+						RoleName: aws.String("test-role"),
+						Arn:      aws.String("arn:aws:iam::123456789012:role/test-role"),
+						Tags:     []iamtypes.Tag{},
+					},
+				}, nil)
+
+			result, err := client.HasManagedPolicies("arn:aws:iam::123456789012:role/test-role")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeFalse())
+		})
+	})
+
+	When("Role ARN is empty", func() {
+		It("Should return false without calling AWS", func() {
+			result, err := client.HasManagedPolicies("")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeFalse())
+		})
+	})
+})
+
+var _ = Describe("UpdateTag", func() {
+	var (
+		client     awsClient
+		mockIamAPI *mocks.MockIamApiClient
+		mockCtrl   *gomock.Controller
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockIamAPI = mocks.NewMockIamApiClient(mockCtrl)
+		client = awsClient{iamClient: mockIamAPI}
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	When("Role exists and tag succeeds", func() {
+		It("Should return nil", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				&iam.GetRoleOutput{
+					Role: &iamtypes.Role{
+						RoleName: aws.String("test-role"),
+					},
+				}, nil)
+			mockIamAPI.EXPECT().TagRole(gomock.Any(), gomock.Any()).Return(
+				&iam.TagRoleOutput{}, nil)
+
+			err := client.UpdateTag("test-role", "4.15")
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	When("GetRole fails", func() {
+		It("Should propagate the error", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				nil, fmt.Errorf("role not found"))
+
+			err := client.UpdateTag("test-role", "4.15")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("role not found"))
+		})
+	})
+})
+
+var _ = Describe("AddRoleTag", func() {
+	var (
+		client     awsClient
+		mockIamAPI *mocks.MockIamApiClient
+		mockCtrl   *gomock.Controller
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockIamAPI = mocks.NewMockIamApiClient(mockCtrl)
+		client = awsClient{iamClient: mockIamAPI}
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	When("Role exists and tagging succeeds", func() {
+		It("Should return nil", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				&iam.GetRoleOutput{
+					Role: &iamtypes.Role{
+						RoleName: aws.String("test-role"),
+					},
+				}, nil)
+			mockIamAPI.EXPECT().TagRole(gomock.Any(), gomock.Any()).Return(
+				&iam.TagRoleOutput{}, nil)
+
+			err := client.AddRoleTag("test-role", "my-key", "my-value")
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	When("TagRole fails", func() {
+		It("Should propagate the error", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				&iam.GetRoleOutput{
+					Role: &iamtypes.Role{
+						RoleName: aws.String("test-role"),
+					},
+				}, nil)
+			mockIamAPI.EXPECT().TagRole(gomock.Any(), gomock.Any()).Return(
+				nil, fmt.Errorf("tagging failed"))
+
+			err := client.AddRoleTag("test-role", "my-key", "my-value")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("tagging failed"))
+		})
+	})
+})
+
+var _ = Describe("GetAccountRoleVersion", func() {
+	var (
+		client     awsClient
+		mockIamAPI *mocks.MockIamApiClient
+		mockCtrl   *gomock.Controller
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockIamAPI = mocks.NewMockIamApiClient(mockCtrl)
+		client = awsClient{iamClient: mockIamAPI}
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	When("Role has the version tag", func() {
+		It("Should return the version", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				&iam.GetRoleOutput{
+					Role: &iamtypes.Role{
+						RoleName: aws.String("test-Installer-Role"),
+						Tags: []iamtypes.Tag{
+							{Key: aws.String("rosa_role_type"), Value: aws.String(InstallerAccountRole)},
+							{Key: aws.String("rosa_openshift_version"), Value: aws.String("4.14")},
+						},
+					},
+				}, nil)
+
+			version, err := client.GetAccountRoleVersion("test-Installer-Role")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(version).To(Equal("4.14"))
+		})
+	})
+
+	When("Role has no version tag", func() {
+		It("Should return empty string", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				&iam.GetRoleOutput{
+					Role: &iamtypes.Role{
+						RoleName: aws.String("test-Installer-Role"),
+						Tags:     []iamtypes.Tag{},
+					},
+				}, nil)
+
+			version, err := client.GetAccountRoleVersion("test-Installer-Role")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(version).To(BeEmpty())
+		})
+	})
+})
+
+var _ = Describe("IsAdminRole", func() {
+	var (
+		client     awsClient
+		mockIamAPI *mocks.MockIamApiClient
+		mockCtrl   *gomock.Controller
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockIamAPI = mocks.NewMockIamApiClient(mockCtrl)
+		client = awsClient{iamClient: mockIamAPI}
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	When("Role has the admin role tag", func() {
+		It("Should return true", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				&iam.GetRoleOutput{
+					Role: &iamtypes.Role{
+						RoleName: aws.String("test-role"),
+						Tags: []iamtypes.Tag{
+							{Key: aws.String(tags.AdminRole), Value: aws.String(TrueString)},
+						},
+					},
+				}, nil)
+
+			isAdmin, err := client.IsAdminRole("test-role")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(isAdmin).To(BeTrue())
+		})
+	})
+
+	When("Role does not have the admin role tag", func() {
+		It("Should return false", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				&iam.GetRoleOutput{
+					Role: &iamtypes.Role{
+						RoleName: aws.String("test-role"),
+						Tags:     []iamtypes.Tag{},
+					},
+				}, nil)
+
+			isAdmin, err := client.IsAdminRole("test-role")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(isAdmin).To(BeFalse())
+		})
+	})
+
+	When("GetRole returns an error", func() {
+		It("Should propagate the error", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				nil, fmt.Errorf("IAM error"))
+
+			isAdmin, err := client.IsAdminRole("test-role")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("IAM error"))
+			Expect(isAdmin).To(BeFalse())
+		})
+	})
+})
+
 var _ = Describe("IsPolicyCompatible", func() {
 	var (
 		client     awsClient
@@ -1136,5 +1858,546 @@ var _ = Describe("IsPolicyCompatible", func() {
 		_, err := client.IsPolicyCompatible("arn:aws:iam::123456789:policy/test", "4.14.0")
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("access denied"))
+	})
+})
+
+var _ = Describe("EnsureRole", func() {
+	var (
+		client     awsClient
+		mockIamAPI *mocks.MockIamApiClient
+		mockCtrl   *gomock.Controller
+		rep        reporter.Logger
+	)
+
+	testPolicy := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+		`"Action":"sts:AssumeRole","Principal":{"Service":["ec2.amazonaws.com"]}}]}`
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockIamAPI = mocks.NewMockIamApiClient(mockCtrl)
+		client = awsClient{iamClient: mockIamAPI}
+		rep = &reporter.Object{}
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	When("the role does not exist", func() {
+		It("creates the role successfully", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				nil, &iamtypes.NoSuchEntityException{})
+			mockIamAPI.EXPECT().CreateRole(gomock.Any(), gomock.Any()).Return(
+				&iam.CreateRoleOutput{
+					Role: &iamtypes.Role{
+						Arn: aws.String("arn:aws:iam::123456789012:role/test-role"),
+					},
+				}, nil)
+
+			roleArn, err := client.EnsureRole(rep, "test-role", testPolicy, "",
+				"", map[string]string{}, "", false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(roleArn).To(Equal("arn:aws:iam::123456789012:role/test-role"))
+		})
+	})
+
+	When("the role exists with matching path", func() {
+		It("reuses the role without updating", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				&iam.GetRoleOutput{
+					Role: &iamtypes.Role{
+						Arn:                      aws.String("arn:aws:iam::123456789012:role/test-role"),
+						RoleName:                 aws.String("test-role"),
+						AssumeRolePolicyDocument: aws.String(testPolicy),
+					},
+				}, nil)
+
+			roleArn, err := client.EnsureRole(rep, "test-role", testPolicy, "",
+				"", map[string]string{}, "", false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(roleArn).To(Equal("arn:aws:iam::123456789012:role/test-role"))
+		})
+	})
+
+	When("the role exists with mismatched path", func() {
+		It("returns an error", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				&iam.GetRoleOutput{
+					Role: &iamtypes.Role{
+						Arn:      aws.String("arn:aws:iam::123456789012:role/custom-path/test-role"),
+						RoleName: aws.String("test-role"),
+					},
+				}, nil)
+
+			_, err := client.EnsureRole(rep, "test-role", testPolicy, "",
+				"", map[string]string{}, "", false)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Role with same name but different path exists"))
+		})
+	})
+
+	When("the role exists with managed policies but role is unmanaged", func() {
+		It("returns an error", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				&iam.GetRoleOutput{
+					Role: &iamtypes.Role{
+						Arn:      aws.String("arn:aws:iam::123456789012:role/test-role"),
+						RoleName: aws.String("test-role"),
+						Tags:     []iamtypes.Tag{},
+					},
+				}, nil)
+
+			_, err := client.EnsureRole(rep, "test-role", testPolicy, "",
+				"", map[string]string{}, "", true)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unmanaged policies already exists"))
+		})
+	})
+
+	When("the role exists with incompatible version", func() {
+		It("updates assume-role policy and tags", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				&iam.GetRoleOutput{
+					Role: &iamtypes.Role{
+						Arn:                      aws.String("arn:aws:iam::123456789012:role/test-role"),
+						RoleName:                 aws.String("test-role"),
+						AssumeRolePolicyDocument: aws.String(testPolicy),
+					},
+				}, nil)
+			mockIamAPI.EXPECT().ListRoleTags(gomock.Any(), gomock.Any()).Return(
+				&iam.ListRoleTagsOutput{
+					Tags: []iamtypes.Tag{
+						{Key: aws.String(common.OpenShiftVersion), Value: aws.String("4.13.0")},
+					},
+				}, nil)
+			mockIamAPI.EXPECT().UpdateAssumeRolePolicy(gomock.Any(), gomock.Any()).Return(
+				&iam.UpdateAssumeRolePolicyOutput{}, nil)
+			mockIamAPI.EXPECT().TagRole(gomock.Any(), gomock.Any()).Return(
+				&iam.TagRoleOutput{}, nil)
+
+			tagList := map[string]string{common.OpenShiftVersion: "4.14.0"}
+			roleArn, err := client.EnsureRole(rep, "test-role", testPolicy, "",
+				"4.14.0", tagList, "", false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(roleArn).To(Equal("arn:aws:iam::123456789012:role/test-role"))
+		})
+	})
+
+	When("permissions boundary should be added", func() {
+		It("calls PutRolePermissionsBoundary", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				&iam.GetRoleOutput{
+					Role: &iamtypes.Role{
+						Arn:                      aws.String("arn:aws:iam::123456789012:role/test-role"),
+						RoleName:                 aws.String("test-role"),
+						AssumeRolePolicyDocument: aws.String(testPolicy),
+					},
+				}, nil)
+			mockIamAPI.EXPECT().PutRolePermissionsBoundary(gomock.Any(), gomock.Any()).Return(
+				&iam.PutRolePermissionsBoundaryOutput{}, nil)
+
+			roleArn, err := client.EnsureRole(rep, "test-role", testPolicy,
+				"arn:aws:iam::123456789012:policy/boundary", "", map[string]string{}, "", false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(roleArn).To(Equal("arn:aws:iam::123456789012:role/test-role"))
+		})
+	})
+
+	When("role has permissions boundary and empty input removes it", func() {
+		It("calls DeleteRolePermissionsBoundary", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				&iam.GetRoleOutput{
+					Role: &iamtypes.Role{
+						Arn:                      aws.String("arn:aws:iam::123456789012:role/test-role"),
+						RoleName:                 aws.String("test-role"),
+						AssumeRolePolicyDocument: aws.String(testPolicy),
+						PermissionsBoundary: &iamtypes.AttachedPermissionsBoundary{
+							PermissionsBoundaryArn: aws.String("arn:aws:iam::123456789012:policy/old-boundary"),
+						},
+					},
+				}, nil)
+			mockIamAPI.EXPECT().DeleteRolePermissionsBoundary(gomock.Any(), gomock.Any()).Return(
+				&iam.DeleteRolePermissionsBoundaryOutput{}, nil)
+
+			roleArn, err := client.EnsureRole(rep, "test-role", testPolicy, "",
+				"", map[string]string{}, "", false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(roleArn).To(Equal("arn:aws:iam::123456789012:role/test-role"))
+		})
+	})
+})
+
+var _ = Describe("EnsurePolicy", func() {
+	var (
+		client     awsClient
+		mockIamAPI *mocks.MockIamApiClient
+		mockCtrl   *gomock.Controller
+	)
+
+	testPolicyArn := "arn:aws:iam::123456789012:policy/test-policy"
+	testDocument := `{"Version":"2012-10-17","Statement":[]}`
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockIamAPI = mocks.NewMockIamApiClient(mockCtrl)
+		client = awsClient{iamClient: mockIamAPI}
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	When("the policy does not exist", func() {
+		It("creates the policy", func() {
+			mockIamAPI.EXPECT().GetPolicy(gomock.Any(), gomock.Any()).Return(
+				nil, &iamtypes.NoSuchEntityException{})
+			mockIamAPI.EXPECT().CreatePolicy(gomock.Any(), gomock.Any()).Return(
+				&iam.CreatePolicyOutput{
+					Policy: &iamtypes.Policy{
+						Arn: aws.String(testPolicyArn),
+					},
+				}, nil)
+
+			resultArn, err := client.EnsurePolicy(testPolicyArn, testDocument,
+				"4.14.0", map[string]string{}, "")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resultArn).To(Equal(testPolicyArn))
+		})
+	})
+
+	When("GetPolicy returns a non-NoSuchEntity error", func() {
+		It("propagates the error", func() {
+			mockIamAPI.EXPECT().GetPolicy(gomock.Any(), gomock.Any()).Return(
+				nil, fmt.Errorf("access denied"))
+
+			_, err := client.EnsurePolicy(testPolicyArn, testDocument,
+				"4.14.0", map[string]string{}, "")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("access denied"))
+		})
+	})
+
+	When("the policy exists and is compatible", func() {
+		It("does not create a new version", func() {
+			mockIamAPI.EXPECT().GetPolicy(gomock.Any(), gomock.Any()).Return(
+				&iam.GetPolicyOutput{
+					Policy: &iamtypes.Policy{Arn: aws.String(testPolicyArn)},
+				}, nil)
+			mockIamAPI.EXPECT().ListPolicyTags(gomock.Any(), gomock.Any()).Return(
+				&iam.ListPolicyTagsOutput{
+					Tags: []iamtypes.Tag{
+						{Key: aws.String(common.OpenShiftVersion), Value: aws.String("4.14.0")},
+					},
+				}, nil)
+
+			resultArn, err := client.EnsurePolicy(testPolicyArn, testDocument,
+				"4.14.0", map[string]string{}, "")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resultArn).To(Equal(testPolicyArn))
+		})
+	})
+
+	When("the policy exists and is incompatible", func() {
+		It("deletes stale versions, creates new default version, and tags", func() {
+			mockIamAPI.EXPECT().GetPolicy(gomock.Any(), gomock.Any()).Return(
+				&iam.GetPolicyOutput{
+					Policy: &iamtypes.Policy{Arn: aws.String(testPolicyArn)},
+				}, nil)
+			mockIamAPI.EXPECT().ListPolicyTags(gomock.Any(), gomock.Any()).Return(
+				&iam.ListPolicyTagsOutput{
+					Tags: []iamtypes.Tag{
+						{Key: aws.String(common.OpenShiftVersion), Value: aws.String("4.13.0")},
+					},
+				}, nil)
+			mockIamAPI.EXPECT().ListPolicyVersions(gomock.Any(), gomock.Any()).Return(
+				&iam.ListPolicyVersionsOutput{
+					Versions: []iamtypes.PolicyVersion{
+						{VersionId: aws.String("v1"), IsDefaultVersion: true},
+						{VersionId: aws.String("v2"), IsDefaultVersion: false},
+					},
+				}, nil)
+			mockIamAPI.EXPECT().DeletePolicyVersion(gomock.Any(), gomock.Any()).Return(
+				&iam.DeletePolicyVersionOutput{}, nil)
+			mockIamAPI.EXPECT().CreatePolicyVersion(gomock.Any(), gomock.Any()).Return(
+				&iam.CreatePolicyVersionOutput{}, nil)
+			mockIamAPI.EXPECT().TagPolicy(gomock.Any(), gomock.Any()).Return(
+				&iam.TagPolicyOutput{}, nil)
+
+			tagList := map[string]string{common.OpenShiftVersion: "4.14.0"}
+			resultArn, err := client.EnsurePolicy(testPolicyArn, testDocument,
+				"4.14.0", tagList, "")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resultArn).To(Equal(testPolicyArn))
+		})
+	})
+
+	When("the HCP shared VPC tag is present", func() {
+		It("short-circuits the version check", func() {
+			mockIamAPI.EXPECT().GetPolicy(gomock.Any(), gomock.Any()).Return(
+				&iam.GetPolicyOutput{
+					Policy: &iamtypes.Policy{Arn: aws.String(testPolicyArn)},
+				}, nil)
+			mockIamAPI.EXPECT().ListPolicyTags(gomock.Any(), gomock.Any()).Return(
+				&iam.ListPolicyTagsOutput{
+					Tags: []iamtypes.Tag{
+						{Key: aws.String(common.OpenShiftVersion), Value: aws.String("4.13.0")},
+					},
+				}, nil)
+
+			tagList := map[string]string{tags.HcpSharedVpc: tags.True}
+			resultArn, err := client.EnsurePolicy(testPolicyArn, testDocument,
+				"4.14.0", tagList, "")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resultArn).To(Equal(testPolicyArn))
+		})
+	})
+})
+
+var _ = Describe("ForceEnsurePolicy", func() {
+	var (
+		client     awsClient
+		mockIamAPI *mocks.MockIamApiClient
+		mockCtrl   *gomock.Controller
+	)
+
+	testPolicyArn := "arn:aws:iam::123456789012:policy/test-policy"
+	testDocument := `{"Version":"2012-10-17","Statement":[]}`
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockIamAPI = mocks.NewMockIamApiClient(mockCtrl)
+		client = awsClient{iamClient: mockIamAPI}
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	When("the policy exists", func() {
+		It("always forces the update path", func() {
+			mockIamAPI.EXPECT().GetPolicy(gomock.Any(), gomock.Any()).Return(
+				&iam.GetPolicyOutput{
+					Policy: &iamtypes.Policy{Arn: aws.String(testPolicyArn)},
+				}, nil)
+			mockIamAPI.EXPECT().ListPolicyVersions(gomock.Any(), gomock.Any()).Return(
+				&iam.ListPolicyVersionsOutput{
+					Versions: []iamtypes.PolicyVersion{
+						{VersionId: aws.String("v1"), IsDefaultVersion: true},
+					},
+				}, nil)
+			mockIamAPI.EXPECT().CreatePolicyVersion(gomock.Any(), gomock.Any()).Return(
+				&iam.CreatePolicyVersionOutput{}, nil)
+			mockIamAPI.EXPECT().TagPolicy(gomock.Any(), gomock.Any()).Return(
+				&iam.TagPolicyOutput{}, nil)
+
+			tagList := map[string]string{common.OpenShiftVersion: "4.14.0"}
+			resultArn, err := client.ForceEnsurePolicy(testPolicyArn, testDocument,
+				"4.14.0", tagList, "")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resultArn).To(Equal(testPolicyArn))
+		})
+	})
+})
+
+var _ = Describe("ValidateRoleNameAvailable", func() {
+	var (
+		client     awsClient
+		mockIamAPI *mocks.MockIamApiClient
+		mockCtrl   *gomock.Controller
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockIamAPI = mocks.NewMockIamApiClient(mockCtrl)
+		client = awsClient{iamClient: mockIamAPI}
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	When("the role does not exist", func() {
+		It("returns nil", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				nil, &iamtypes.NoSuchEntityException{})
+
+			err := client.ValidateRoleNameAvailable("new-role")
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	When("the role exists", func() {
+		It("returns an error", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				&iam.GetRoleOutput{
+					Role: &iamtypes.Role{RoleName: aws.String("existing-role")},
+				}, nil)
+
+			err := client.ValidateRoleNameAvailable("existing-role")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("already exists"))
+		})
+	})
+
+	When("GetRole returns another error", func() {
+		It("returns a wrapped error", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				nil, fmt.Errorf("access denied"))
+
+			err := client.ValidateRoleNameAvailable("some-role")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Error validating role name"))
+			Expect(err.Error()).To(ContainSubstring("access denied"))
+		})
+	})
+})
+
+var _ = Describe("PutRolePolicy", func() {
+	var (
+		client     awsClient
+		mockIamAPI *mocks.MockIamApiClient
+		mockCtrl   *gomock.Controller
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockIamAPI = mocks.NewMockIamApiClient(mockCtrl)
+		client = awsClient{iamClient: mockIamAPI}
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	When("the call succeeds", func() {
+		It("returns nil", func() {
+			mockIamAPI.EXPECT().PutRolePolicy(gomock.Any(), gomock.Any()).Return(
+				&iam.PutRolePolicyOutput{}, nil)
+
+			err := client.PutRolePolicy("my-role", "my-policy", `{"Version":"2012-10-17"}`)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	When("the call fails", func() {
+		It("returns the error", func() {
+			mockIamAPI.EXPECT().PutRolePolicy(gomock.Any(), gomock.Any()).Return(
+				nil, fmt.Errorf("put role policy failed"))
+
+			err := client.PutRolePolicy("my-role", "my-policy", `{"Version":"2012-10-17"}`)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("put role policy failed"))
+		})
+	})
+})
+
+var _ = Describe("AttachRolePolicy", func() {
+	var (
+		client     awsClient
+		mockIamAPI *mocks.MockIamApiClient
+		mockCtrl   *gomock.Controller
+		rep        reporter.Logger
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockIamAPI = mocks.NewMockIamApiClient(mockCtrl)
+		client = awsClient{iamClient: mockIamAPI}
+		rep = &reporter.Object{}
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	When("the call succeeds", func() {
+		It("returns nil", func() {
+			mockIamAPI.EXPECT().AttachRolePolicy(gomock.Any(), gomock.Any()).Return(
+				&iam.AttachRolePolicyOutput{}, nil)
+
+			err := client.AttachRolePolicy(rep, "my-role",
+				"arn:aws:iam::123456789012:policy/my-policy")
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	When("the call fails", func() {
+		It("returns the error", func() {
+			mockIamAPI.EXPECT().AttachRolePolicy(gomock.Any(), gomock.Any()).Return(
+				nil, fmt.Errorf("attach failed"))
+
+			err := client.AttachRolePolicy(rep, "my-role",
+				"arn:aws:iam::123456789012:policy/my-policy")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("attach failed"))
+		})
+	})
+})
+
+var _ = Describe("DeleteInlineRolePolicies", func() {
+	var (
+		client     awsClient
+		mockIamAPI *mocks.MockIamApiClient
+		mockCtrl   *gomock.Controller
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockIamAPI = mocks.NewMockIamApiClient(mockCtrl)
+		client = awsClient{iamClient: mockIamAPI}
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	When("there are no inline policies", func() {
+		It("returns nil without deletions", func() {
+			mockIamAPI.EXPECT().ListRolePolicies(gomock.Any(), gomock.Any()).Return(
+				&iam.ListRolePoliciesOutput{PolicyNames: []string{}}, nil)
+
+			err := client.DeleteInlineRolePolicies("my-role")
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	When("there are multiple inline policies", func() {
+		It("deletes all of them", func() {
+			mockIamAPI.EXPECT().ListRolePolicies(gomock.Any(), gomock.Any()).Return(
+				&iam.ListRolePoliciesOutput{
+					PolicyNames: []string{"policy-a", "policy-b"},
+				}, nil)
+			mockIamAPI.EXPECT().DeleteRolePolicy(gomock.Any(), gomock.Any()).Return(
+				&iam.DeleteRolePolicyOutput{}, nil).Times(2)
+
+			err := client.DeleteInlineRolePolicies("my-role")
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	When("ListRolePolicies returns an error", func() {
+		It("propagates the error", func() {
+			mockIamAPI.EXPECT().ListRolePolicies(gomock.Any(), gomock.Any()).Return(
+				nil, fmt.Errorf("list error"))
+
+			err := client.DeleteInlineRolePolicies("my-role")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("list error"))
+		})
+	})
+
+	When("DeleteRolePolicy returns an error", func() {
+		It("propagates the error", func() {
+			mockIamAPI.EXPECT().ListRolePolicies(gomock.Any(), gomock.Any()).Return(
+				&iam.ListRolePoliciesOutput{
+					PolicyNames: []string{"policy-a"},
+				}, nil)
+			mockIamAPI.EXPECT().DeleteRolePolicy(gomock.Any(), gomock.Any()).Return(
+				nil, fmt.Errorf("delete error"))
+
+			err := client.DeleteInlineRolePolicies("my-role")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("delete error"))
+		})
 	})
 })

--- a/pkg/aws/policies_test.go
+++ b/pkg/aws/policies_test.go
@@ -2116,8 +2116,12 @@ var _ = Describe("EnsurePolicy", func() {
 						{VersionId: aws.String("v2"), IsDefaultVersion: false},
 					},
 				}, nil)
-			mockIamAPI.EXPECT().DeletePolicyVersion(gomock.Any(), gomock.Any()).Return(
-				&iam.DeletePolicyVersionOutput{}, nil)
+			mockIamAPI.EXPECT().DeletePolicyVersion(
+				gomock.Any(),
+				gomock.Cond(func(input *iam.DeletePolicyVersionInput) bool {
+					return aws.ToString(input.VersionId) == "v2"
+				}),
+			).Return(&iam.DeletePolicyVersionOutput{}, nil)
 			mockIamAPI.EXPECT().CreatePolicyVersion(gomock.Any(), gomock.Any()).Return(
 				&iam.CreatePolicyVersionOutput{}, nil)
 			mockIamAPI.EXPECT().TagPolicy(gomock.Any(), gomock.Any()).Return(

--- a/pkg/aws/policy_document.go
+++ b/pkg/aws/policy_document.go
@@ -169,11 +169,9 @@ func (p *PolicyDocument) checkPermissionsUsingQueryClient(queryClient *awsClient
 		})
 	}
 
-	client := iam.NewFromConfig(queryClient.cfg)
-
 	// Collect all failed actions
 	var failedActions []string
-	paginator := iam.NewSimulatePrincipalPolicyPaginator(client, input)
+	paginator := iam.NewSimulatePrincipalPolicyPaginator(queryClient.iamClient, input)
 	for paginator.HasMorePages() {
 		output, err := paginator.NextPage(context.TODO())
 		if err != nil {

--- a/pkg/aws/policy_document_test.go
+++ b/pkg/aws/policy_document_test.go
@@ -2,9 +2,18 @@ package aws
 
 import (
 	"encoding/json"
+	"fmt"
 
+	gomock "go.uber.org/mock/gomock"
+
+	awsSdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+
+	"github.com/openshift/rosa/pkg/aws/mocks"
 )
 
 var _ = Describe("PolicyDocument", func() {
@@ -319,6 +328,161 @@ var _ = Describe("PolicyDocument", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(ContainSubstring("arn:aws-us-gov:iam::"))
 			Expect(result).ToNot(ContainSubstring("arn:aws:"))
+		})
+	})
+
+	Describe("checkPermissionsUsingQueryClient", func() {
+		var (
+			mockCtrl   *gomock.Controller
+			mockIamAPI *mocks.MockIamApiClient
+			client     *awsClient
+		)
+
+		BeforeEach(func() {
+			mockCtrl = gomock.NewController(GinkgoT())
+			mockIamAPI = mocks.NewMockIamApiClient(mockCtrl)
+			client = &awsClient{
+				iamClient: mockIamAPI,
+				logger:    NewLoggerWrapper(logrus.New(), nil),
+			}
+		})
+
+		AfterEach(func() {
+			mockCtrl.Finish()
+		})
+
+		It("returns true when all actions are allowed", func() {
+			doc := &PolicyDocument{
+				Statement: []PolicyStatement{
+					{Effect: "Allow", Action: []interface{}{"s3:GetObject", "s3:PutObject"}},
+				},
+			}
+
+			mockIamAPI.EXPECT().SimulatePrincipalPolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&iam.SimulatePrincipalPolicyOutput{
+					EvaluationResults: []iamtypes.EvaluationResult{
+						{EvalActionName: awsSdk.String("s3:GetObject"), EvalDecision: "allowed"},
+						{EvalActionName: awsSdk.String("s3:PutObject"), EvalDecision: "allowed"},
+					},
+					IsTruncated: false,
+				}, nil)
+
+			result, err := doc.checkPermissionsUsingQueryClient(client,
+				"arn:aws:iam::123456789012:user/TestUser", nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeTrue())
+		})
+
+		It("returns false with failed actions when some are denied", func() {
+			doc := &PolicyDocument{
+				Statement: []PolicyStatement{
+					{Effect: "Allow", Action: []interface{}{"s3:GetObject", "ec2:RunInstances"}},
+				},
+			}
+
+			mockIamAPI.EXPECT().SimulatePrincipalPolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&iam.SimulatePrincipalPolicyOutput{
+					EvaluationResults: []iamtypes.EvaluationResult{
+						{EvalActionName: awsSdk.String("s3:GetObject"), EvalDecision: "allowed"},
+						{EvalActionName: awsSdk.String("ec2:RunInstances"), EvalDecision: "implicitDeny"},
+					},
+					IsTruncated: false,
+				}, nil)
+
+			result, err := doc.checkPermissionsUsingQueryClient(client,
+				"arn:aws:iam::123456789012:user/TestUser", nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("ec2:RunInstances"))
+			Expect(result).To(BeFalse())
+		})
+
+		It("returns error when SimulatePrincipalPolicy fails", func() {
+			doc := &PolicyDocument{
+				Statement: []PolicyStatement{
+					{Effect: "Allow", Action: "s3:GetObject"},
+				},
+			}
+
+			mockIamAPI.EXPECT().SimulatePrincipalPolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, fmt.Errorf("access denied"))
+
+			result, err := doc.checkPermissionsUsingQueryClient(client,
+				"arn:aws:iam::123456789012:user/TestUser", nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("error simulating policy"))
+			Expect(result).To(BeFalse())
+		})
+
+		It("passes region context entry when SimulateParams has a region", func() {
+			doc := &PolicyDocument{
+				Statement: []PolicyStatement{
+					{Effect: "Allow", Action: "s3:GetObject"},
+				},
+			}
+
+			mockIamAPI.EXPECT().SimulatePrincipalPolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ interface{}, input *iam.SimulatePrincipalPolicyInput,
+					_ ...interface{}) (*iam.SimulatePrincipalPolicyOutput, error) {
+					Expect(input.ContextEntries).To(HaveLen(1))
+					Expect(*input.ContextEntries[0].ContextKeyName).To(Equal("aws:RequestedRegion"))
+					Expect(input.ContextEntries[0].ContextKeyValues).To(ConsistOf("us-east-1"))
+					return &iam.SimulatePrincipalPolicyOutput{
+						EvaluationResults: []iamtypes.EvaluationResult{
+							{EvalActionName: awsSdk.String("s3:GetObject"), EvalDecision: "allowed"},
+						},
+						IsTruncated: false,
+					}, nil
+				})
+
+			params := &SimulateParams{Region: "us-east-1"}
+			result, err := doc.checkPermissionsUsingQueryClient(client,
+				"arn:aws:iam::123456789012:user/TestUser", params)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeTrue())
+		})
+
+		It("does not add region context when SimulateParams is nil", func() {
+			doc := &PolicyDocument{
+				Statement: []PolicyStatement{
+					{Effect: "Allow", Action: "s3:GetObject"},
+				},
+			}
+
+			mockIamAPI.EXPECT().SimulatePrincipalPolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ interface{}, input *iam.SimulatePrincipalPolicyInput,
+					_ ...interface{}) (*iam.SimulatePrincipalPolicyOutput, error) {
+					Expect(input.ContextEntries).To(BeEmpty())
+					return &iam.SimulatePrincipalPolicyOutput{
+						EvaluationResults: []iamtypes.EvaluationResult{
+							{EvalActionName: awsSdk.String("s3:GetObject"), EvalDecision: "allowed"},
+						},
+						IsTruncated: false,
+					}, nil
+				})
+
+			result, err := doc.checkPermissionsUsingQueryClient(client,
+				"arn:aws:iam::123456789012:user/TestUser", nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeTrue())
+		})
+
+		It("returns true for a document with no allowed actions", func() {
+			doc := &PolicyDocument{
+				Statement: []PolicyStatement{
+					{Effect: "Deny", Action: "s3:GetObject"},
+				},
+			}
+
+			mockIamAPI.EXPECT().SimulatePrincipalPolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&iam.SimulatePrincipalPolicyOutput{
+					EvaluationResults: []iamtypes.EvaluationResult{},
+					IsTruncated:       false,
+				}, nil)
+
+			result, err := doc.checkPermissionsUsingQueryClient(client,
+				"arn:aws:iam::123456789012:user/TestUser", nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeTrue())
 		})
 	})
 })

--- a/pkg/aws/quota_test.go
+++ b/pkg/aws/quota_test.go
@@ -1,10 +1,19 @@
 package aws
 
 import (
+	"context"
+	"fmt"
+
+	gomock "go.uber.org/mock/gomock"
+
 	awsSdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/servicequotas"
 	servicequotastypes "github.com/aws/aws-sdk-go-v2/service/servicequotas/types"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+
+	"github.com/openshift/rosa/pkg/aws/mocks"
 )
 
 var _ = Describe("Quota", func() {
@@ -71,6 +80,80 @@ var _ = Describe("Quota", func() {
 			Expect(*result.QuotaCode).To(Equal(targetCode))
 			Expect(*result.QuotaName).To(Equal("Target Quota"))
 			Expect(*result.Value).To(Equal(200.0))
+		})
+	})
+
+	Context("GetIAMServiceQuota", func() {
+		var (
+			client          Client
+			mockCtrl        *gomock.Controller
+			mockIamQuotaAPI *mocks.MockServiceQuotasApiClient
+		)
+
+		BeforeEach(func() {
+			mockCtrl = gomock.NewController(GinkgoT())
+			mockIamQuotaAPI = mocks.NewMockServiceQuotasApiClient(mockCtrl)
+			client = New(
+				awsSdk.Config{},
+				NewLoggerWrapper(logrus.New(), nil),
+				mocks.NewMockIamApiClient(mockCtrl),
+				mocks.NewMockEc2ApiClient(mockCtrl),
+				mocks.NewMockOrganizationsApiClient(mockCtrl),
+				mocks.NewMockS3ApiClient(mockCtrl),
+				mocks.NewMockSecretsManagerApiClient(mockCtrl),
+				mocks.NewMockStsApiClient(mockCtrl),
+				mocks.NewMockCloudFormationApiClient(mockCtrl),
+				mocks.NewMockServiceQuotasApiClient(mockCtrl),
+				mockIamQuotaAPI,
+				&AccessKey{},
+				false,
+			)
+		})
+
+		AfterEach(func() {
+			mockCtrl.Finish()
+		})
+
+		It("Returns quota on success", func() {
+			quotaCode := "L-F4A5425F"
+			expectedOutput := &servicequotas.GetServiceQuotaOutput{
+				Quota: &servicequotastypes.ServiceQuota{
+					QuotaCode: awsSdk.String(quotaCode),
+					QuotaName: awsSdk.String("Roles per account"),
+					Value:     awsSdk.Float64(1000.0),
+				},
+			}
+
+			mockIamQuotaAPI.EXPECT().GetServiceQuota(
+				context.Background(),
+				&servicequotas.GetServiceQuotaInput{
+					ServiceCode: awsSdk.String(IAMServiceCode),
+					QuotaCode:   awsSdk.String(quotaCode),
+				},
+			).Return(expectedOutput, nil)
+
+			result, err := client.GetIAMServiceQuota(quotaCode)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(expectedOutput))
+			Expect(*result.Quota.QuotaCode).To(Equal(quotaCode))
+			Expect(*result.Quota.Value).To(Equal(1000.0))
+		})
+
+		It("Propagates API error", func() {
+			quotaCode := "L-F4A5425F"
+
+			mockIamQuotaAPI.EXPECT().GetServiceQuota(
+				context.Background(),
+				&servicequotas.GetServiceQuotaInput{
+					ServiceCode: awsSdk.String(IAMServiceCode),
+					QuotaCode:   awsSdk.String(quotaCode),
+				},
+			).Return(nil, fmt.Errorf("access denied"))
+
+			result, err := client.GetIAMServiceQuota(quotaCode)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("access denied"))
+			Expect(result).To(BeNil())
 		})
 	})
 })

--- a/pkg/aws/sts_test.go
+++ b/pkg/aws/sts_test.go
@@ -324,6 +324,47 @@ var _ = Describe("STS", func() {
 		})
 	})
 
+	Context("HasPermissionsBoundary", func() {
+		It("returns true when role has a permissions boundary", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				&iam.GetRoleOutput{
+					Role: &iamtypes.Role{
+						RoleName: awsSdk.String("test-role"),
+						PermissionsBoundary: &iamtypes.AttachedPermissionsBoundary{
+							PermissionsBoundaryArn: awsSdk.String("arn:aws:iam::123:policy/boundary"),
+						},
+					},
+				}, nil)
+
+			hasBoundary, err := client.HasPermissionsBoundary("test-role")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hasBoundary).To(BeTrue())
+		})
+
+		It("returns false when role has no permissions boundary", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				&iam.GetRoleOutput{
+					Role: &iamtypes.Role{
+						RoleName: awsSdk.String("test-role"),
+					},
+				}, nil)
+
+			hasBoundary, err := client.HasPermissionsBoundary("test-role")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hasBoundary).To(BeFalse())
+		})
+
+		It("returns error when GetRole fails", func() {
+			mockIamAPI.EXPECT().GetRole(gomock.Any(), gomock.Any()).Return(
+				nil, fmt.Errorf("GetRole error"))
+
+			hasBoundary, err := client.HasPermissionsBoundary("test-role")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("GetRole error"))
+			Expect(hasBoundary).To(BeFalse())
+		})
+	})
+
 	Context("DeleteOCMRole", func() {
 		It("detaches but does not delete policies when managedPolicies is true", func() {
 			mockIamAPI.EXPECT().ListAttachedRolePolicies(gomock.Any(), gomock.Any()).Return(


### PR DESCRIPTION
## PR Summary
Add focused unit tests for previously untested ROSA-specific business logic in `pkg/aws`, covering IAM role and policy lifecycle, IAM discovery and upgrade-selection logic, STS validation, CloudFormation stack operations, S3 bucket lifecycle, Secrets Manager helpers, EC2/VPC lookup helpers, service quota validation, and SCP permission simulation.

JIRA: [ROSAENG-61174](https://redhat.atlassian.net/browse/ROSAENG-61174)

## Detailed Description of the Issue
Several ROSA-specific `pkg/aws` behaviors were either untested or only indirectly covered, which made regressions harder to catch in areas such as IAM role creation/update/deletion, policy compatibility checking, role discovery and upgrade-selection, CloudFormation stack lifecycle handling, S3 bucket management, Secrets Manager operations, EC2/VPC subnet and availability zone lookups, service quota validation, and SCP permission simulation. This PR adds targeted automated coverage for those paths so future changes in AWS-facing logic can be validated more reliably.

The SCP simulation path (`checkPermissionsUsingQueryClient`) previously constructed a real IAM client via `iam.NewFromConfig()`, bypassing the injected mockable interface. A small production change adds `SimulatePrincipalPolicy` to the `IamApiClient` interface and uses the injected client instead, making the simulation path testable without widening the production API.

## Related Issues and PRs
- Jira: [ROSAENG-61174](https://redhat.atlassian.net/browse/ROSAENG-61174)
- Fixes: `#`
- Related PR(s): #3299
- Related design/docs: N/A

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [x] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
Key ROSA-specific AWS workflows and helper paths had limited or no direct automated coverage, including:
- IAM role lifecycle (`EnsureRole`, `EnsurePolicy`, `ForceEnsurePolicy`, `ValidateRoleNameAvailable`, `PutRolePolicy`, `AttachRolePolicy`, `DeleteInlineRolePolicies`)
- IAM discovery and upgrade-selection (`FindRoleARNs*`, `ValidateAccountRoleVersionCompatibility`, `FindPolicyARN`, `HasHostedCPPolicies`, `HasManagedPolicies`, `UpdateTag`, `AddRoleTag`, `GetAccountRoleVersion`, `IsAdminRole`)
- STS validation (`HasPermissionsBoundary`)
- Shared client helpers (`CheckRoleExists`, `GetRoleByARN`, `GetRoleByName`)
- CloudFormation wrappers (`GetCFStack`, `DescribeCFStackResources`)
- S3 lifecycle (`CreateS3Bucket`, `DeleteS3Bucket`)
- Secrets Manager (`CreateSecretInSecretsManager`, `DeleteSecretInSecretsManager`)
- EC2/VPC helpers (`DescribeAvailabilityZones`, `IsLocalAvailabilityZone`, `GetSubnetAvailabilityZone`, `GetVPCSubnets`)
- Service quotas (`GetIAMServiceQuota`)
- SCP simulation (`checkPermissionsUsingQueryClient`)

## Behavior After This Change
All listed functions now have focused automated tests covering expected behavior and relevant edge/error cases. The SCP simulation path is now testable via the injected IAM mock. There is no intended user-facing behavior change.

New test coverage summary:
- `policies_test.go`: ~52 new specs (IAM mutators + discovery/upgrade)
- `client_test.go`: ~30 new specs (role lookups, S3, Secrets, EC2/VPC)
- `policy_document_test.go`: 6 new specs (SCP simulation)
- `sts_test.go`: 3 new specs (HasPermissionsBoundary)
- `helpers_test.go`: 4 new specs (GetJumpAccount, ComputeOperatorRoleArn)
- `cloudformation_test.go`: 5 new specs (GetCFStack, DescribeCFStackResources)
- `quota_test.go`: 2 new specs (GetIAMServiceQuota)

## How to Test (Step-by-Step)
### Preconditions
- Go toolchain installed (Go 1.26.3+ or GOTOOLCHAIN=auto)
- Repository cloned with hooks installed

### Test Steps
1. `GOTOOLCHAIN=auto go test ./pkg/aws/... -count=1 -cover`
2. `GOTOOLCHAIN=auto go vet ./pkg/aws/...`
3. `make test`
4. `make lint`

### Expected Results
- All `pkg/aws` tests pass with 40%+ coverage
- `go vet` clean
- `make test` passes (full repo)
- `make lint` passes (0 issues)

## Proof of the Fix
- Pre-push checks passed (format, build, lint, changed-files coverage, unit/integration tests)
- `make fmt`: clean
- `make lint`: 0 issues
- `make test`: all packages pass
- `go test ./pkg/aws/... -count=1 -cover`: 40.0% coverage, 392 specs pass

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [ ] `make rosa` passes.
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

[ROSAENG-61174]: https://redhat.atlassian.net/browse/ROSAENG-61174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROSAENG-61174]: https://redhat.atlassian.net/browse/ROSAENG-61174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IAM permission checks by using the already-configured IAM client when simulating policies, leading to more consistent results and clearer error propagation.
  * Enhanced handling of permission-evaluation edge cases, including implicitly denied actions and optional region context during simulation.

* **Tests**
  * Expanded coverage for S3 bucket and object deletion flows, Secrets Manager create/delete, CloudFormation stack queries, and broader IAM role/policy assurance workflows.
  * Added additional tests for IAM quotas, EC2 availability zone/VPC+subnet helpers, jump account/role ARN generation, and permissions-boundary detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->