### PR TITLE
fix: add channel_group to y-stream upgrade profiles

### DIFF
--- a/tests/ci/data/profiles/rosa-classic.yaml
+++ b/tests/ci/data/profiles/rosa-classic.yaml
@@ -165,6 +165,7 @@ profiles:
       permission_boundary: ""
   - as: rosa-upgrade-y-stream
     version: "y-1"
+    channel_group: stable
     region: "us-east-1"
     cluster:
       multi_az: false

--- a/tests/ci/data/profiles/rosa-hcp.yaml
+++ b/tests/ci/data/profiles/rosa-hcp.yaml
@@ -99,6 +99,7 @@ profiles:
       permission_boundary: ""
   - as: rosa-hcp-upgrade-y-stream
     version: "y-1"
+    channel_group: stable
     region: "us-west-2"
     cluster:
       multi_az: true


### PR DESCRIPTION
## Summary
Add `channel_group: stable` to `rosa-upgrade-y-stream` and `rosa-hcp-upgrade-y-stream` CI profiles.

## Problem
PR #3353 (merged July 13) added `computeNextMinorChannel()` which requires `channel_group` in CI profiles. The z-stream and non-STS y-stream profiles have it, but the STS/HCP y-stream profiles were missed. All y-stream upgrade tests fail with:

```
channel group is required to compute the next-minor channel
```

Affected jobs (all 4x persistent failures):
- `periodic-ci-openshift-rosa-master-e2e-rosa-sts-upgrade-y-stream-f3`
- `periodic-ci-openshift-rosa-master-e2e-rosa-hcp-upgrade-y-stream-f3`
- `periodic-ci-openshift-rosa-master-e2e-rosa-sts-upgrade-y-stream-prod-f3`

## Fix
One-line addition per profile file, matching existing working profiles (`rosa-upgrade-z-stream`, `rosa-non-sts-upgrade-y-stream`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated upgrade test configurations to use the stable channel group for ROSA Classic and ROSA HCP scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->