### PR TITLE
ROSAENG-62445 | test: Fixing id:89981,id:42832,id:73731,id:57444,id:75445,id:57094

### DIFF
--- a/tests/e2e/hcp_cluster_test.go
+++ b/tests/e2e/hcp_cluster_test.go
@@ -1,11 +1,13 @@
 package e2e
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -838,11 +840,13 @@ var _ = Describe("HCP cluster testing",
 				Expect(out.String()).To(ContainSubstring("cannot update IAM role ARN when AutoNode is not enabled"))
 
 				By("Edit then describe cluster with autonode configuration")
-				out, err = clusterService.EditCluster(
-					clusterID,
-					"--autonode=enabled",
-					"--autonode-iam-role-arn", autonodeRoleARN,
-				)
+				out, err = config.RetryOnIAMPropagationError(func() (bytes.Buffer, error) {
+					return clusterService.EditCluster(
+						clusterID,
+						"--autonode=enabled",
+						"--autonode-iam-role-arn", autonodeRoleARN,
+					)
+				}, 3, 10*time.Second)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(out.String()).To(ContainSubstring("Updated cluster"))
 
@@ -852,10 +856,12 @@ var _ = Describe("HCP cluster testing",
 				Expect(jsonData.DigString("aws", "auto_node", "role_arn")).To(Equal(autonodeRoleARN))
 
 				By("Update the autonode configuration on cluster")
-				out, err = clusterService.EditCluster(
-					clusterID,
-					"--autonode-iam-role-arn", autonodeRoleARN2,
-				)
+				out, err = config.RetryOnIAMPropagationError(func() (bytes.Buffer, error) {
+					return clusterService.EditCluster(
+						clusterID,
+						"--autonode-iam-role-arn", autonodeRoleARN2,
+					)
+				}, 3, 10*time.Second)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(out.String()).To(ContainSubstring("Updated cluster"))
 

--- a/tests/e2e/test_rosacli_hibernate.go
+++ b/tests/e2e/test_rosacli_hibernate.go
@@ -1,12 +1,15 @@
 package e2e
 
 import (
+	//nolint:staticcheck
 	. "github.com/onsi/ginkgo/v2"
+	//nolint:staticcheck
 	. "github.com/onsi/gomega"
 
 	"github.com/openshift/rosa/tests/ci/labels"
 	"github.com/openshift/rosa/tests/utils/config"
 	"github.com/openshift/rosa/tests/utils/exec/rosacli"
+	"github.com/openshift/rosa/tests/utils/helper"
 )
 
 var _ = Describe("hibernate and resume cluster testing", labels.Feature.Hibernation, func() {
@@ -27,7 +30,6 @@ var _ = Describe("hibernate and resume cluster testing", labels.Feature.Hibernat
 	AfterEach(func() {
 		By("Clean remaining resources")
 		rosaClient.CleanResources(clusterID)
-
 	})
 
 	It("to hibernate and resume then delete cluster via rosacli - [id:42832]",
@@ -39,39 +41,44 @@ var _ = Describe("hibernate and resume cluster testing", labels.Feature.Hibernat
 			if isHostedCP {
 				Skip("Skip this case as it only supports on not-hosted-cp clusters")
 			}
+			isLimitedSupport, err := clusterService.IsLimitedSupport(clusterID)
+			Expect(err).To(BeNil())
+			if isLimitedSupport {
+				Skip("You can't hibernate a cluster in limited support")
+			}
+
+			By("resuming a cluster that's already running should fail")
+			_, err = clusterService.ResumeCluster(clusterID, "-y")
+			rosaClient.Runner.UnsetArgs()
+			helper.ExpectErrorWithMessage(
+				err,
+				"Resuming a cluster from hibernation is only supported for clusters in 'Hibernating' state",
+			)
 
 			By("hibernate cluster")
 			out, err := clusterService.HibernateCluster(clusterID, "-y")
+			rosaClient.Runner.UnsetArgs()
 			Expect(err).To(BeNil())
 			Expect(out.String()).To(ContainSubstring("is hibernating"))
-			rosaClient.Runner.UnsetArgs()
 
 			err = clusterService.WaitClusterStatus(clusterID, "hibernating", 3, 30)
 			Expect(err).To(BeNil(), "It met error or timeout when waiting cluster to hibernating status")
+
+			By("hibernating a cluster that's already hibernating should fail")
+			_, err = clusterService.HibernateCluster(clusterID, "-y")
+			rosaClient.Runner.UnsetArgs()
+			helper.ExpectErrorWithMessage(
+				err,
+				"Hibernating a cluster is only supported for 'Ready' clusters",
+			)
 
 			By("resume cluster")
 			out, err = clusterService.ResumeCluster(clusterID, "-y")
+			rosaClient.Runner.UnsetArgs()
 			Expect(err).To(BeNil())
 			Expect(out.String()).To(ContainSubstring("is resuming"))
-			rosaClient.Runner.UnsetArgs()
 
 			err = clusterService.WaitClusterStatus(clusterID, "ready", 3, 30)
 			Expect(err).To(BeNil(), "It met error or timeout when waiting cluster to ready status")
-
-			By("hibernate the cluster again then delete the cluster in not hibernating status")
-			out, err = clusterService.HibernateCluster(clusterID, "-y")
-			Expect(err).To(BeNil())
-			Expect(out.String()).To(ContainSubstring("is hibernating"))
-			rosaClient.Runner.UnsetArgs()
-
-			err = clusterService.WaitClusterStatus(clusterID, "hibernating", 3, 30)
-			Expect(err).To(BeNil(), "It met error or timeout when waiting cluster to hibernating status")
-
-			_, err = clusterService.DeleteCluster(clusterID, "-y")
-			Expect(err).To(BeNil())
-
-			rosaClient.Runner.UnsetArgs()
-			err = clusterService.WaitClusterDeleted(clusterID, 3, 30)
-			Expect(err).To(BeNil(), "It failed to delete the cluster or met timeout")
 		})
 })

--- a/tests/utils/config/autonode.go
+++ b/tests/utils/config/autonode.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"path"
@@ -148,10 +149,37 @@ func PrepareAutonodeRoleAndPolicy(prefix string, oidcProviderURL string, region 
 		return "", err
 	}
 
-	log.Logger.Info("Waiting 3 seconds for AWS consistency...")
-	time.Sleep(3 * time.Second)
+	log.Logger.Info("Waiting 15 seconds for IAM trust policy propagation...")
+	time.Sleep(15 * time.Second)
 
 	return *role.Arn, nil
+}
+
+// RetryOnIAMPropagationError retries fn when the error indicates that
+// an IAM role's trust policy has not yet propagated ("cannot be assumed").
+// AWS IAM eventual consistency can delay trust-policy visibility for the
+// OCM backend even after the role itself is confirmed to exist.
+func RetryOnIAMPropagationError(
+	fn func() (bytes.Buffer, error),
+	maxRetries int,
+	delay time.Duration,
+) (bytes.Buffer, error) {
+	var out bytes.Buffer
+	var err error
+	for i := 0; i <= maxRetries; i++ {
+		out, err = fn()
+		if err == nil || !strings.Contains(err.Error(), "cannot be assumed") {
+			return out, err
+		}
+		if i < maxRetries {
+			log.Logger.Infof(
+				"IAM trust policy not yet propagated (attempt %d/%d), retrying in %s...",
+				i+1, maxRetries+1, delay,
+			)
+			time.Sleep(delay)
+		}
+	}
+	return out, err
 }
 
 func DeleteAutonodeRoleAndPolicy(prefix string, region string) error {

--- a/tests/utils/exec/rosacli/cluster_service.go
+++ b/tests/utils/exec/rosacli/cluster_service.go
@@ -40,6 +40,7 @@ type ClusterService interface {
 	GetClusterVersion(clusterID string) (config.Version, error)
 	IsBYOVPCCluster(clusterID string) (bool, error)
 	IsExternalAuthenticationEnabled(clusterID string) (bool, error)
+	IsLimitedSupport(clusterID string) (bool, error)
 	DetectProxy(clusterDescription *ClusterDescription) (string, string, string)
 	GetJSONClusterDescription(clusterID string) (*jsonData, error)
 	HibernateCluster(clusterID string, flags ...string) (bytes.Buffer, error)
@@ -235,7 +236,7 @@ func (c *clusterService) ReflectClusterDescription(result bytes.Buffer) (res *Cl
 			newStr = strings.Replace(str, "Failed Inflight Checks:", "Failed Inflight Checks: |", 1)
 			newStr = strings.ReplaceAll(newStr, "\t", "  ")
 			newStr = strings.ReplaceAll(newStr, "not found: Role name", "not found:Role name")
-			//Until https://issues.redhat.com/browse/OCM-11830 fixed
+			// Until https://issues.redhat.com/browse/OCM-11830 fixed
 			newStr = strings.Replace(newStr, "Platform Allowlist:", "Platform Allowlist: \n    - ID:", 1)
 			newStr = strings.Replace(newStr, "[DEPRECATED] User Workload Monitoring:", "User Workload Monitoring:", 1)
 			return
@@ -296,6 +297,7 @@ func (c *clusterService) InstallLog(clusterID string, flags ...string) (bytes.Bu
 		CmdFlags(flags...)
 	return installLog.Run()
 }
+
 func (c *clusterService) UnInstallLog(clusterID string, flags ...string) (bytes.Buffer, error) {
 	UnInstallLog := c.client.Runner.
 		Cmd("logs", "uninstall", "-c", clusterID).
@@ -449,6 +451,16 @@ func (c *clusterService) PrepareClusterForYStreamUpgrade(
 	clusterVersion := strings.TrimSpace(jsonData.DigString("version", "raw_id"))
 	if clusterVersion == "" {
 		return nil, fmt.Errorf("cluster %s returned an empty raw version while preparing y-stream upgrade", clusterID)
+	}
+
+	if strings.TrimSpace(channelGroup) == "" {
+		channelGroup = jsonData.DigString("version", "channel_group")
+		if strings.TrimSpace(channelGroup) == "" {
+			return nil, fmt.Errorf(
+				"cluster %s has no channel group in profile or cluster description",
+				clusterID,
+			)
+		}
 	}
 
 	clusterDescription, err := c.DescribeClusterAndReflect(clusterID)
@@ -776,4 +788,13 @@ func (c *clusterService) WaitForClusterPassWaiting(clusterID string, interval in
 		time.Sleep(time.Duration(interval) * time.Minute)
 	}
 	return fmt.Errorf("timeout for cluster stuck waiting after %d mins", timeoutMin)
+}
+
+func (c *clusterService) IsLimitedSupport(clusterID string) (bool, error) {
+	description, err := c.DescribeClusterAndReflect(clusterID)
+	if err != nil {
+		return false, err
+	}
+	limitedSupport := len(description.LimitedSupport) != 0
+	return limitedSupport, nil
 }


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
Supported ticket prefixes:
OCM-XXXXX, ROSAENG-XXXX
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For contributor workflow, see: ./CONTRIBUTING.md
For repo-local agent guidance, see: ./AGENTS.md
-->

## PR Summary
Fixing a bunch of test cases that I noticed failed in some recent Prow jobs:
- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-rosa-master-e2e-rosa-hcp-arm-f7/2077546928966471680
- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-rosa-master-e2e-rosa-sts-hibernation-f14/2076729338153144320
- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-rosa-master-e2e-rosa-sts-upgrade-y-stream-f3/2079241606715674624

## Detailed Description of the Issue
<!-- Describe the root problem, scope, impact, and user/business context -->

## Related Issues and PRs
<!-- Link all tracking items and related code changes -->
- Jira: https://redhat.atlassian.net/browse/ROSAENG-62445
- Fixes: `#`
- Related PR(s):
- Related design/docs:

## Type of Change
<!-- Check the primary type this PR represents -->
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [x] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
<!-- What users or systems experienced before this change -->

## Behavior After This Change
<!-- What changes now, including user-visible and non-user-visible behavior -->

## How to Test (Step-by-Step)
<!-- Provide reproducible validation instructions -->
### Preconditions
<!-- Required setup, environment, credentials, flags, cluster state, etc. -->

### Test Steps
1.
2.
3.

### Expected Results
<!-- What should happen after running the steps above -->

## Proof of the Fix
<!-- Attach evidence that demonstrates the changed behavior -->
- Screenshots:
- Videos:
- Logs/CLI output:
- Other artifacts:

```
$ TEST_PROFILE="rosa-hcp-advanced" go run github.com/onsi/ginkgo/v2/ginkgo run --timeout 2h --focus "id:84981" tests/e2e/
Running Suite: ROSA CLI e2e tests suite - /home/jkeyne/work/repos/rosa/tests/e2e
================================================================================
Random Seed: 1784751670

Will run 1 of 286 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSStime="2026-07-22 16:21:13" level=info msg="Got file path: /home/jkeyne/.aws/credentials from env variable AWS_SHARED_CREDENTIALS_FILE\n"
time="2026-07-22 16:21:29" level=info msg="Got file path: /home/jkeyne/.aws/credentials from env variable AWS_SHARED_CREDENTIALS_FILE\n"
time="2026-07-22 16:21:52" level=info msg="Got file path: /home/jkeyne/.aws/credentials from env variable AWS_SHARED_CREDENTIALS_FILE\n"
time="2026-07-22 16:21:53" level=info msg="Got file path: /home/jkeyne/.aws/credentials from env variable AWS_SHARED_CREDENTIALS_FILE\n"
•SSS

Ran 1 of 286 Specs in 42.850 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 285 Skipped
PASS

Ginkgo ran 1 suite in 43.923427844s
Test Suite Passed

# This should be representative of the other upgrade tests being fixed
$ TEST_PROFILE="rosa-upgrade-y-stream" go run github.com/onsi/ginkgo/v2/ginkgo run --timeout 2h --focus "id:73731" tests/e2e/
Running Suite: ROSA CLI e2e tests suite - /home/jkeyne/work/repos/rosa/tests/e2e
================================================================================
Random Seed: 1784753235

Will run 1 of 286 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSStime="2026-07-22 16:47:18" level=info msg="Got file path: /home/jkeyne/.aws/credentials from env variable AWS_SHARED_CREDENTIALS_FILE\n"
•SSSSSSSSSSSSSS

Ran 1 of 286 Specs in 233.562 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 285 Skipped
PASS

Ginkgo ran 1 suite in 3m54.675435273s
Test Suite Passed
```
(I forgot to copy the output for the hibernation test case working, but I did run it locally and it works)
## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
<!-- Required only when breaking changes are introduced -->

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [ ] Any risk, limitation, or follow-up work is documented.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when configuring AutoNode by retrying operations affected by IAM propagation delays.
  * Added clearer validation for cluster hibernation and resume operations in unsupported states.
  * Prevented hibernation tests from running against limited-support clusters.

* **Enhancements**
  * Cluster upgrades can now automatically determine the channel group from cluster details when it is not provided.
  * Added validation when no channel group is available for an upgrade.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->