### PR TITLE
ROSAENG-62387 | fix(test): align OCP-45509 proxy assertion and skip on expired AWS creds

### DIFF
--- a/hack/coverage-changed-files.sh
+++ b/hack/coverage-changed-files.sh
@@ -32,7 +32,8 @@ declare -a changed_packages=()
 for file_path in "${candidate_files[@]}"; do
   [ -z "$file_path" ] && continue
   case "$file_path" in
-    vendor/*|.tmp/*|*_test.go)
+    vendor/*|.tmp/*|*_test.go|tests/e2e/*)
+      # e2e sources are not *_test.go and are not runnable as unit coverage locally
       continue
       ;;
   esac
@@ -54,7 +55,7 @@ go test -count=1 -covermode=atomic -coverprofile="$coverage_profile" "${changed_
 GOFLAGS='-mod=mod' go run "${gocovdiff_module}@${gocovdiff_version}" \
   -diff "$diff_file" \
   -cov "$coverage_profile" \
-  -exclude "vendor/,.tmp/" \
+  -exclude "vendor/,.tmp/,tests/e2e/" \
   -target-delta-cov "$required_coverage_percent" \
   -delta-cov-file "$delta_file"
 

--- a/tests/e2e/test_rosacli_cluster.go
+++ b/tests/e2e/test_rosacli_cluster.go
@@ -1272,6 +1272,8 @@ var _ = Describe("Classic cluster creation validation",
 		BeforeEach(func() {
 			var err error
 
+			helper.SkipIfAWSCredentialsInvalid()
+
 			// Init the client
 			rosaClient = rosacli.NewClient()
 			clusterService = rosaClient.Cluster
@@ -1289,7 +1291,9 @@ var _ = Describe("Classic cluster creation validation",
 		})
 
 		AfterEach(func() {
-			clusterHandler.Destroy()
+			if clusterHandler != nil {
+				clusterHandler.Destroy()
+			}
 		})
 
 		It("to check the basic validation for the classic rosa cluster creation by the rosa cli - [id:38770]",
@@ -1992,6 +1996,8 @@ var _ = Describe("Create cluster with invalid options will",
 		)
 
 		BeforeEach(func() {
+			helper.SkipIfAWSCredentialsInvalid()
+
 			// Init the client
 			rosaClient = rosacli.NewClient()
 			clusterService = rosaClient.Cluster
@@ -2218,7 +2224,7 @@ var _ = Describe("Create cluster with invalid options will",
 				)
 				Expect(err).To(HaveOccurred())
 				Expect(output.String()).Should(ContainSubstring(
-					"number of subnets for a 'single AZ' 'cluster' should be '2', instead received: '0'"),
+					"cluster_wide_proxy is only supported if subnetIDs exist"),
 				)
 
 				By("Prepare vpc with subnets")
@@ -2379,6 +2385,7 @@ var _ = Describe("Classic cluster creation negative testing",
 			ocmResourceService       rosacli.OCMResourceService
 		)
 		BeforeEach(func() {
+			helper.SkipIfAWSCredentialsInvalid()
 
 			By("Init the client")
 			rosaClient = rosacli.NewClient()
@@ -2387,14 +2394,17 @@ var _ = Describe("Classic cluster creation negative testing",
 		})
 		AfterEach(func() {
 			By("Delete the resources for testing")
-			if accountRolePrefixToClean != "" {
-				By("Delete the account-roles")
-				rosaClient.Runner.UnsetArgs()
-				_, err := ocmResourceService.DeleteAccountRole("--mode", "auto",
-					"--prefix", accountRolePrefixToClean,
-					"-y")
-				Expect(err).To(BeNil())
+			prefix := accountRolePrefixToClean
+			accountRolePrefixToClean = ""
+			if prefix == "" || rosaClient == nil {
+				return
 			}
+			By("Delete the account-roles")
+			rosaClient.Runner.UnsetArgs()
+			_, err := ocmResourceService.DeleteAccountRole("--mode", "auto",
+				"--prefix", prefix,
+				"-y")
+			Expect(err).To(BeNil())
 		})
 
 		It("to validate to create the sts cluster with the version not compatible with the role version	- [id:45176]",
@@ -2651,6 +2661,8 @@ var _ = Describe("HCP cluster creation negative testing",
 			err            error
 		)
 		BeforeEach(func() {
+			helper.SkipIfAWSCredentialsInvalid()
+
 			By("Init the client")
 			rosaClient = rosacli.NewClient()
 			clusterService = rosaClient.Cluster
@@ -2690,6 +2702,9 @@ var _ = Describe("HCP cluster creation negative testing",
 		})
 
 		AfterEach(func() {
+			if clusterHandler == nil {
+				return
+			}
 			errs := clusterHandler.Destroy()
 			Expect(len(errs)).To(Equal(0))
 		})
@@ -3181,6 +3196,8 @@ var _ = Describe("HCP cluster creation subnets validation",
 			command            string
 		)
 		BeforeEach(func() {
+			helper.SkipIfAWSCredentialsInvalid()
+
 			By("Init the client")
 			rosaClient = rosacli.NewClient()
 			clusterService = rosaClient.Cluster
@@ -3224,9 +3241,14 @@ var _ = Describe("HCP cluster creation subnets validation",
 		AfterEach(func() {
 			defer func() {
 				By("Clean resources")
-				clusterHandler.Destroy()
+				if clusterHandler != nil {
+					clusterHandler.Destroy()
+				}
 			}()
 
+			if rosaClient == nil {
+				return
+			}
 			if clusterID != "" {
 				By("Delete cluster by id")
 				rosaClient.Runner.UnsetArgs()

--- a/tests/utils/helper/aws.go
+++ b/tests/utils/helper/aws.go
@@ -1,0 +1,69 @@
+package helper
+
+import (
+	"fmt"
+	"strings"
+
+	//nolint:staticcheck
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/openshift-online/ocm-common/pkg/aws/aws_client"
+)
+
+// credentialErrorSubstrings match STS/AWS auth failures seen in CI when tokens expire mid-run.
+var credentialErrorSubstrings = []string{
+	"InvalidClientTokenId",
+	"ExpiredToken",
+	"RequestExpired",
+	"security token included in the request is invalid",
+	"security token included in the request is expired",
+	"AWS was not able to validate the provided access credentials",
+	"NoCredentialProviders",
+	"failed to refresh cached credentials",
+}
+
+// createAWSClientForCredCheck is overridable in unit tests.
+var createAWSClientForCredCheck = func() (*aws_client.AWSClient, error) {
+	return aws_client.CreateAWSClient("", "")
+}
+
+// skipForInfra is overridable in unit tests (defaults to Ginkgo Skip).
+var skipForInfra = func(message string, callerSkip ...int) {
+	Skip(message, callerSkip...)
+}
+
+// documentStep is overridable in unit tests (defaults to Ginkgo By).
+var documentStep = By
+
+// AWSCredentialsInvalid reports whether a cheap STS check shows expired/invalid AWS credentials.
+// invalid=false means credentials look usable (or the failure is not a recognized credential error).
+func AWSCredentialsInvalid() (invalid bool, err error) {
+	_, err = createAWSClientForCredCheck()
+	if err == nil {
+		return false, nil
+	}
+	if isAWSCredentialError(err.Error()) {
+		return true, err
+	}
+	return false, err
+}
+
+// SkipIfAWSCredentialsInvalid performs a cheap STS GetCallerIdentity via CreateAWSClient.
+// On expired/invalid credentials it Skips so Ginkgo records infra noise instead of a product failure.
+func SkipIfAWSCredentialsInvalid() {
+	GinkgoHelper()
+	documentStep("Check AWS credentials are valid")
+	invalid, err := AWSCredentialsInvalid()
+	if invalid {
+		skipForInfra(fmt.Sprintf("AWS credentials invalid/expired — infra, not product: %v", err))
+	}
+}
+
+func isAWSCredentialError(errMsg string) bool {
+	lower := strings.ToLower(errMsg)
+	for _, substr := range credentialErrorSubstrings {
+		if strings.Contains(lower, strings.ToLower(substr)) {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/utils/helper/aws_test.go
+++ b/tests/utils/helper/aws_test.go
@@ -1,0 +1,127 @@
+package helper
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openshift-online/ocm-common/pkg/aws/aws_client"
+)
+
+var _ = Describe("isAWSCredentialError", func() {
+	DescribeTable("recognizes credential failures",
+		func(errMsg string, expected bool) {
+			Expect(isAWSCredentialError(errMsg)).To(Equal(expected))
+		},
+		Entry("InvalidClientTokenId",
+			"operation error STS: GetCallerIdentity, https response error StatusCode: 403, "+
+				"RequestID: abc, api error InvalidClientTokenId: The security token included in the request is invalid",
+			true),
+		Entry("ExpiredToken",
+			"ExpiredToken: The security token included in the request is expired",
+			true),
+		Entry("RequestExpired",
+			"RequestExpired: Request has expired",
+			true),
+		Entry("OCM wrapped AWS creds",
+			"AWS was not able to validate the provided access credentials",
+			true),
+		Entry("NoCredentialProviders",
+			"NoCredentialProviders: no valid providers in chain",
+			true),
+		Entry("refresh failure",
+			"failed to refresh cached credentials, expired",
+			true),
+		Entry("unrelated error",
+			"the subnet ID 'subnet-xxx' does not exist",
+			false),
+		Entry("empty",
+			"",
+			false),
+	)
+})
+
+var _ = Describe("AWSCredentialsInvalid", func() {
+	var orig func() (*aws_client.AWSClient, error)
+
+	BeforeEach(func() {
+		orig = createAWSClientForCredCheck
+	})
+
+	AfterEach(func() {
+		createAWSClientForCredCheck = orig
+	})
+
+	It("returns false when credentials are valid", func() {
+		createAWSClientForCredCheck = func() (*aws_client.AWSClient, error) {
+			return &aws_client.AWSClient{}, nil
+		}
+		invalid, err := AWSCredentialsInvalid()
+		Expect(invalid).To(BeFalse())
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("returns true when credentials are invalid", func() {
+		createAWSClientForCredCheck = func() (*aws_client.AWSClient, error) {
+			return nil, fmt.Errorf("api error InvalidClientTokenId: The security token included in the request is invalid")
+		}
+		invalid, err := AWSCredentialsInvalid()
+		Expect(invalid).To(BeTrue())
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("returns false for unrelated create errors", func() {
+		createAWSClientForCredCheck = func() (*aws_client.AWSClient, error) {
+			return nil, fmt.Errorf("dial tcp: lookup sts.amazonaws.com: no such host")
+		}
+		invalid, err := AWSCredentialsInvalid()
+		Expect(invalid).To(BeFalse())
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("SkipIfAWSCredentialsInvalid", func() {
+	var (
+		origClient func() (*aws_client.AWSClient, error)
+		origSkip   func(message string, callerSkip ...int)
+		origDoc    func(text string, callback ...func())
+	)
+
+	BeforeEach(func() {
+		origClient = createAWSClientForCredCheck
+		origSkip = skipForInfra
+		origDoc = documentStep
+		documentStep = func(_ string, _ ...func()) {}
+	})
+
+	AfterEach(func() {
+		createAWSClientForCredCheck = origClient
+		skipForInfra = origSkip
+		documentStep = origDoc
+	})
+
+	It("skips on invalid credentials", func() {
+		createAWSClientForCredCheck = func() (*aws_client.AWSClient, error) {
+			return nil, fmt.Errorf("api error InvalidClientTokenId: The security token included in the request is invalid")
+		}
+		var skippedMsg string
+		skipForInfra = func(message string, _ ...int) {
+			skippedMsg = message
+		}
+		SkipIfAWSCredentialsInvalid()
+		Expect(skippedMsg).ToNot(BeEmpty())
+		Expect(skippedMsg).To(ContainSubstring("infra, not product"))
+	})
+
+	It("does not skip when credentials are valid", func() {
+		createAWSClientForCredCheck = func() (*aws_client.AWSClient, error) {
+			return &aws_client.AWSClient{}, nil
+		}
+		called := false
+		skipForInfra = func(message string, _ ...int) {
+			called = true
+		}
+		SkipIfAWSCredentialsInvalid()
+		Expect(called).To(BeFalse())
+	})
+})

--- a/tests/utils/helper/helper_suite_test.go
+++ b/tests/utils/helper/helper_suite_test.go
@@ -1,0 +1,13 @@
+package helper
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHelper(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Helper Suite")
+}


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
Supported ticket prefixes:
OCM-XXXXX, ROSAENG-XXXX
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For contributor workflow, see: ./CONTRIBUTING.md
For repo-local agent guidance, see: ./AGENTS.md
-->

## PR Summary
Align day1-negative OCP-45509 with current CLI/OCM proxy-without-subnets error, and skip AWS-heavy day1-negative specs when STS credentials are expired so infra noise is not reported as product failures.

## Detailed Description of the Issue
`periodic-ci-openshift-rosa-master-e2e-rosa-day1-negative-f7` has been failing consistently on OCP-45509. The first step calls `rosa create cluster --dry-run` with HTTP/HTTPS proxy flags and no `--subnet-ids`. It still expected the old local message `number of subnets for a 'single AZ' 'cluster' should be '2', instead received: '0'`.

With `--yes` (already set by `CreateDryRun`), the CLI accepts the managed-VPC prompt path and reaches OCM, which rejects the request with `cluster_wide_proxy is only supported if subnetIDs exist`. That is the real validation for proxy without subnet IDs today, not a missing-VPC flake.

Separately, mid-suite STS expiry (`InvalidClientTokenId` / related AWS auth errors) caused rotating product assertion failures on other day1-negative cases.

## Related Issues and PRs
- Jira: [ROSAENG-62387](https://issues.redhat.com/browse/ROSAENG-62387)
- Fixes: N/A
- Related PR(s): N/A
- Related design/docs: N/A

## Type of Change
<!-- Check the primary type this PR represents -->
- [ ] feat - adds a new user-facing capability.
- [x] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
- OCP-45509 failed every run by asserting an obsolete local subnet-count error string.
- Expired AWS/STS credentials mid-job failed subsequent Its as mismatched product error expectations.
- Changing `tests/e2e` sources caused `coverage-changed-files` to attempt running the full e2e suite locally.

## Behavior After This Change
- OCP-45509 first step asserts `cluster_wide_proxy is only supported if subnetIDs exist` (later VPC/proxy steps unchanged).
- AWS-heavy day1-negative `BeforeEach` hooks call `helper.SkipIfAWSCredentialsInvalid()` and Skip with an infra message on known credential failures.
- `hack/coverage-changed-files.sh` excludes `tests/e2e/` from unit coverage collection.

## How to Test (Step-by-Step)
### Preconditions
- Local clone with hooks installed (`make install-hooks`).
- Optional: AWS credentials for a live dry-run of OCP-45509 (not required for unit checks).

### Test Steps
1. `make fmt-check`
2. `make coverage-changed-files` (or `./hack/coverage-changed-files.sh` with staged/committed changes)
3. `make rosa`
4. `make lint`
5. `make test GO_TEST_FLAGS='-count=1'`
6. `go test ./tests/utils/helper/ -count=1 -run 'TestIsAWSCredentialError|TestAWSCredentialsInvalid|TestSkipIfAWSCredentialsInvalid'`
7. Optional: run day1-negative focus for OCP-45509 against stage with valid AWS/OCM creds.

### Expected Results
- Unit/helper tests and repo gates pass.
- OCP-45509 first dry-run failure output contains `cluster_wide_proxy is only supported if subnetIDs exist`.
- With invalid/expired STS tokens, AWS-heavy day1-negative specs Skip instead of failing product assertions.

## Proof of the Fix
- Screenshots: N/A
- Videos: N/A
- Logs/CLI output: Local `make fmt-check`, coverage (88.9% delta on helper), `make rosa`, `make lint`, `make test`, helper package tests, and CodeRabbit (`review --agent --uncommitted`) with 0 findings. Pre-push checks passed on push.
- Other artifacts: Prow investigation for `periodic-ci-openshift-rosa-master-e2e-rosa-day1-negative-f7` builds (OCP-45509 consistent; STS failures rotating).

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

Made with [Cursor](https://cursor.com)

[ROSAENG-62387]: https://redhat.atlassian.net/browse/ROSAENG-62387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end test stability by skipping suites when AWS credentials are invalid.
  * Updated proxy negative-test assertions to match the latest expected error text.
  * Hardened end-to-end cleanup to avoid failing when setup didn’t complete.

* **Tests**
  * Added AWS credential validation helpers and unit tests for detection and conditional skipping.

* **Chores**
  * Excluded end-to-end tests from local and differential coverage computations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->