### PR TITLE
ROSAENG-61040 | refactor: remove github.com/alessio/shellescape

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 require (
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
 	github.com/99designs/keyring v1.2.2 // indirect
-	github.com/alessio/shellescape v1.4.1
+	github.com/alessio/shellescape v1.4.1 // indirect
 	github.com/andybalholm/cascadia v1.3.3 // indirect
 	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14 // indirect

--- a/pkg/clusterregistryconfig/flags.go
+++ b/pkg/clusterregistryconfig/flags.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/alessio/shellescape"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -102,7 +101,7 @@ func GetClusterRegistryConfigOptions(cmd *pflag.FlagSet,
 
 	if !isHostedCP {
 		if IsClusterRegistryConfigSetViaCLI(cmd) {
-			return nil, fmt.Errorf("Setting the registry config is only supported for hosted clusters")
+			return nil, fmt.Errorf("setting the registry config is only supported for hosted clusters")
 		}
 		return nil, nil
 	}
@@ -155,7 +154,7 @@ func GetClusterRegistryConfigOptions(cmd *pflag.FlagSet,
 			Default:  enableRegistriesConfig,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("Expected a valid registries config value: %s", err)
+			return nil, fmt.Errorf("expected a valid registries config value: %s", err)
 		}
 		enableRegistriesConfig = updateRegistriesConfigValue
 	}
@@ -172,7 +171,7 @@ func GetClusterRegistryConfigOptions(cmd *pflag.FlagSet,
 				Default:  strings.Join(defaultAllowedRegistries, ","),
 			})
 			if err != nil {
-				return nil, fmt.Errorf("Expected a comma-separated list of allowed registries: %s", err)
+				return nil, fmt.Errorf("expected a comma-separated list of allowed registries: %s", err)
 			}
 			allowedRegistries = helper.HandleEmptyStringOnSlice(strings.Split(allowedRegistriesInputs, ","))
 
@@ -196,7 +195,7 @@ func GetClusterRegistryConfigOptions(cmd *pflag.FlagSet,
 				Default:  strings.Join(defaultBlockedRegistries, ","),
 			})
 			if err != nil {
-				return nil, fmt.Errorf("Expected a comma-separated list of blocked registries: %s", err)
+				return nil, fmt.Errorf("expected a comma-separated list of blocked registries: %s", err)
 			}
 			result.blockedRegistries = helper.HandleEmptyStringOnSlice(strings.Split(blockedRegistriesInputs, ","))
 			isBlockedRegistryNotSet = result.blockedRegistries == nil || strings.Join(result.blockedRegistries, ",") == ""
@@ -211,7 +210,7 @@ func GetClusterRegistryConfigOptions(cmd *pflag.FlagSet,
 			Default:  strings.Join(defaultInsecureRegistries, ","),
 		})
 		if err != nil {
-			return nil, fmt.Errorf("Expected a comma-separated list of insecure registries: %s", err)
+			return nil, fmt.Errorf("expected a comma-separated list of insecure registries: %s", err)
 		}
 		result.insecureRegistries = helper.HandleEmptyStringOnSlice(strings.Split(insecureRegistriesInputs, ","))
 
@@ -224,7 +223,7 @@ func GetClusterRegistryConfigOptions(cmd *pflag.FlagSet,
 			},
 		})
 		if err != nil {
-			return nil, fmt.Errorf("Expected a comma-separated list of allowed registries for import: %s", err)
+			return nil, fmt.Errorf("expected a comma-separated list of allowed registries for import: %s", err)
 		}
 
 		result.additionalTrustedCa, err = interactive.GetString(interactive.Input{
@@ -233,15 +232,15 @@ func GetClusterRegistryConfigOptions(cmd *pflag.FlagSet,
 			Default:  args.additionalTrustedCa,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("Expected a valid certificate: %s", err)
+			return nil, fmt.Errorf("expected a valid certificate: %s", err)
 		}
 	}
 	if err := ocm.ValidateAllowedRegistriesForImport(result.allowedRegistriesForImport); err != nil {
-		return nil, fmt.Errorf("Expected valid allowed registries for import values: %v", err)
+		return nil, fmt.Errorf("expected valid allowed registries for import values: %v", err)
 	}
 
 	if !isBlockedRegistryNotSet && !isAllowedRegistryNotSet {
-		return nil, fmt.Errorf("Allowed registries and blocked registries are mutually exclusive fields")
+		return nil, fmt.Errorf("allowed registries and blocked registries are mutually exclusive fields")
 	}
 
 	return result, nil
@@ -273,37 +272,37 @@ func BuildRegistryConfigOptions(spec ocm.Spec) string {
 	if len(spec.AllowedRegistries) > 0 {
 		command += fmt.Sprintf(" --%s %s",
 			allowedRegistriesFlag,
-			shellescape.Quote(strings.Join(spec.AllowedRegistries, ",")))
+			helper.ShellQuote(strings.Join(spec.AllowedRegistries, ",")))
 	}
 
 	if len(spec.BlockedRegistries) > 0 {
 		command += fmt.Sprintf(" --%s %s",
 			blockedRegistriesFlag,
-			shellescape.Quote(strings.Join(spec.BlockedRegistries, ",")))
+			helper.ShellQuote(strings.Join(spec.BlockedRegistries, ",")))
 	}
 
 	if len(spec.InsecureRegistries) > 0 {
 		command += fmt.Sprintf(" --%s %s",
 			insecureRegistriesFlag,
-			shellescape.Quote(strings.Join(spec.InsecureRegistries, ",")))
+			helper.ShellQuote(strings.Join(spec.InsecureRegistries, ",")))
 	}
 
 	if spec.AdditionalTrustedCaFile != "" {
 		command += fmt.Sprintf(" --%s %s",
 			additionalTrustedCaPathFlag,
-			shellescape.Quote(spec.AdditionalTrustedCaFile))
+			helper.ShellQuote(spec.AdditionalTrustedCaFile))
 	}
 
 	if spec.PlatformAllowlist != "" {
 		command += fmt.Sprintf(" --%s %s",
 			platformAllowlistFlag,
-			shellescape.Quote(spec.PlatformAllowlist))
+			helper.ShellQuote(spec.PlatformAllowlist))
 	}
 
 	if spec.AllowedRegistriesForImport != "" {
 		command += fmt.Sprintf(" --%s %s",
 			allowedRegistriesForImportFlag,
-			shellescape.Quote(spec.AllowedRegistriesForImport))
+			helper.ShellQuote(spec.AllowedRegistriesForImport))
 	}
 
 	return command
@@ -320,7 +319,7 @@ func BuildAdditionalTrustedCAFromInputFile(specPath string) (map[string]string, 
 		form[k], ok = v.(string)
 		if !ok {
 			return nil, fmt.Errorf("expected a valid value for 'additional_trusted_ca'. " +
-				"Should be in a <registry>:<boolean> format.")
+				"Should be in a <registry>:<boolean> format")
 		}
 	}
 

--- a/pkg/clusterregistryconfig/flags_test.go
+++ b/pkg/clusterregistryconfig/flags_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Cluster Registry Config tests", func() {
 			_, err := BuildAdditionalTrustedCAFromInputFile(caPath)
 			Expect(
 				err,
-			).To(MatchError("expected a valid value for 'additional_trusted_ca'. Should be in a <registry>:<boolean> format."))
+			).To(MatchError("expected a valid value for 'additional_trusted_ca'. Should be in a <registry>:<boolean> format"))
 
 		})
 	})
@@ -106,7 +106,7 @@ var _ = Describe("Cluster Registry Config tests", func() {
 		It("KO: throw error for classic clusters when flag set via cli", func() {
 			flags.Set(allowedRegistriesFlag, "test.com")
 			_, err := GetClusterRegistryConfigOptions(flags, args, false, nil)
-			Expect(err).To(MatchError("Setting the registry config is only supported for hosted clusters"))
+			Expect(err).To(MatchError("setting the registry config is only supported for hosted clusters"))
 		})
 		It("OK: returns the correct output", func() {
 			flags.Set(allowedRegistriesFlag, "test.com")

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"os"
 	"reflect"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -267,4 +268,17 @@ func FilterEmptyStrings(strings []string) []string {
 		}
 	}
 	return filteredResult
+}
+
+var shellUnsafe = regexp.MustCompile(`[^\w@%+=:,./-]`)
+
+// ShellQuote returns s escaped as a single POSIX shell argument.
+func ShellQuote(s string) string {
+	if len(s) == 0 {
+		return "''"
+	}
+	if shellUnsafe.MatchString(s) {
+		return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
+	}
+	return s
 }

--- a/pkg/helper/helpers_test.go
+++ b/pkg/helper/helpers_test.go
@@ -165,5 +165,32 @@ var _ = Describe("Helper", func() {
 				Expect(filteredSubnets).To(Equal([]string{"test1", "test2"}))
 			})
 		})
+
+		var _ = Context("ShellQuote()", func() {
+			It("returns quoted empty string for empty input", func() {
+				Expect(ShellQuote("")).To(Equal("''"))
+			})
+
+			It("returns safe strings unquoted", func() {
+				Expect(ShellQuote("simple")).To(Equal("simple"))
+				Expect(ShellQuote("path/to/file.txt")).To(Equal("path/to/file.txt"))
+				Expect(ShellQuote("key=value,other")).To(Equal("key=value,other"))
+			})
+
+			It("quotes strings with shell metacharacters", func() {
+				Expect(ShellQuote("hello world")).To(Equal("'hello world'"))
+				Expect(ShellQuote("a;b")).To(Equal("'a;b'"))
+				Expect(ShellQuote("$(cmd)")).To(Equal("'$(cmd)'"))
+			})
+
+			It("quotes strings with whitespace", func() {
+				Expect(ShellQuote("has\ttab")).To(Equal("'has\ttab'"))
+				Expect(ShellQuote("has\nnewline")).To(Equal("'has\nnewline'"))
+			})
+
+			It("escapes embedded single quotes", func() {
+				Expect(ShellQuote("it's")).To(Equal("'it'\"'\"'s'"))
+			})
+		})
 	})
 })


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
Supported ticket prefixes:
OCM-XXXXX, ROSAENG-XXXX
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For contributor workflow, see: ./CONTRIBUTING.md
For repo-local agent guidance, see: ./AGENTS.md
-->

## PR Summary
Replace shellescape.Quote with a ~10-line ShellQuote helper in pkg/helper. Exact behavioral match using single-quote wrapping with embedded single-quote escaping.

## Detailed Description of the Issue
Our ROSA CLI project currently imports several third-party libraries that are only utilized in a single file (e.g., exclusively within a test file or for a single validation function). Relying on entire external dependencies for isolated use cases unnecessarily increases our security attack surface, complicates dependency management, and bloats the project.

This PR is part of that initiative to remove `github.com/alessio/shellescape`

## Related Issues and PRs
<!-- Link all tracking items and related code changes -->
- Jira: [ROSAENG-61040](https://redhat.atlassian.net/browse/ROSAENG-61040)
- Related design/docs: [https://redhat.atlassian.net/wiki/spaces/ROSACLITF/pages/438405639/Third-Party+Dependency+Audit](https://redhat.atlassian.net/wiki/spaces/ROSACLITF/pages/438405639/Third-Party+Dependency+Audit#github.com%2Falessio%2Fshellescape-(removed))

## Type of Change
<!-- Check the primary type this PR represents -->
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [x] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
<!-- What users or systems experienced before this change -->
Special characters escaped in shell commands

## Behavior After This Change
<!-- What changes now, including user-visible and non-user-visible behavior -->
No change

## How to Test (Step-by-Step)
<!-- Provide reproducible validation instructions -->
### Preconditions
<!-- Required setup, environment, credentials, flags, cluster state, etc. -->

### Test Steps
1. run `make test`

### Expected Results
<!-- What should happen after running the steps above -->
All tests should pass

## Proof of the Fix
<!-- Attach evidence that demonstrates the changed behavior -->
All tests pass

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.


[ROSAENG-61040]: https://redhat.atlassian.net/browse/ROSAENG-61040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell argument escaping when generating cluster registry commands.
  * Enhanced handling of values containing spaces, special characters, or embedded quotes.
  * Updated validation error messages for improved consistency and clarity.

* **Tests**
  * Added coverage for shell escaping across empty, safe, whitespace-containing, and special-character inputs.
  * Updated validation tests to reflect revised error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->