### PR TITLE
ROSAENG-61040 | refactor: remove github.com/pkg/errors

### DIFF
--- a/cmd/upgrade/cluster/cmd.go
+++ b/cmd/upgrade/cluster/cmd.go
@@ -177,21 +177,21 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 	isHypershift := cluster.Hypershift().Enabled()
 
 	if currentUpgradeScheduling.Schedule == "" && currentUpgradeScheduling.AllowMinorVersionUpdates {
-		return fmt.Errorf("The '--allow-minor-version-upgrades' option needs to be used with --schedule")
+		return fmt.Errorf("the '--allow-minor-version-updates' option needs to be used with --schedule")
 	}
 
 	if currentUpgradeScheduling.Schedule != "" && !isHypershift {
-		return fmt.Errorf("The '--schedule' option is only supported for Hosted Control Planes")
+		return fmt.Errorf("the '--schedule' option is only supported for Hosted Control Planes")
 	}
 
 	if (currentUpgradeScheduling.ScheduleDate != "" || currentUpgradeScheduling.ScheduleTime != "") &&
 		currentUpgradeScheduling.Schedule != "" {
-		return fmt.Errorf("The '--schedule-date' and '--schedule-time' options are mutually exclusive with" +
+		return fmt.Errorf("the '--schedule-date' and '--schedule-time' options are mutually exclusive with" +
 			" '--schedule'")
 	}
 
 	if currentUpgradeScheduling.Schedule != "" && args.version != "" {
-		return fmt.Errorf("The '--schedule' option is mutually exclusive with '--version'")
+		return fmt.Errorf("the '--schedule' option is mutually exclusive with '--version'")
 	}
 
 	if args.dryRun {
@@ -200,7 +200,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 
 	// Check cluster preconditions
 	if cluster.State() != cmv1.ClusterStateReady {
-		return fmt.Errorf("Cluster '%s' is not yet ready", clusterKey)
+		return fmt.Errorf("cluster '%s' is not yet ready", clusterKey)
 	}
 	if isHypershift {
 		scheduledUpgrade, err := checkExistingScheduledUpgradeHypershift(r, cluster, clusterKey)
@@ -250,12 +250,12 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 	}
 	_, isSTS := cluster.AWS().STS().GetRoleARN()
 	if !isSTS && mode != "" {
-		return fmt.Errorf("The 'mode' option is only supported for STS clusters")
+		return fmt.Errorf("the 'mode' option is only supported for STS clusters")
 	}
 	if isSTS && mode == "" {
 		mode, err = interactive.GetOptionMode(cmd, mode, "IAM Roles/Policies upgrade mode")
 		if err != nil {
-			r.Reporter.Errorf("Expected a valid role upgrade mode: %v", err)
+			r.Reporter.Errorf("expected a valid role upgrade mode: %v", err)
 			os.Exit(1)
 		}
 	}
@@ -275,7 +275,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 				Required: true,
 			})
 			if err != nil {
-				return fmt.Errorf("Expected an upgrade type: %s", err)
+				return fmt.Errorf("expected an upgrade type: %s", err)
 			}
 
 			if currentUpgradeScheduling.AutomaticUpgrades {
@@ -286,7 +286,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 					Required: false,
 				})
 				if err != nil {
-					return fmt.Errorf("Expected a choice on the versions to target: %s", err)
+					return fmt.Errorf("expected a choice on the versions to target: %s", err)
 				}
 			}
 		}
@@ -319,7 +319,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 		}
 		err = r.OCMClient.CheckUpgradeClusterVersion(availableUpgrades, version, cluster)
 		if err != nil {
-			return fmt.Errorf("%v", err)
+			return fmt.Errorf("%w", err)
 		}
 	}
 
@@ -331,7 +331,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 			// automatic upgrade. Passing "" will still perform the role check.
 			err := checkRolesManagedPolicies(r, cluster, mode, "")
 			if err != nil {
-				return fmt.Errorf("%v", err)
+				return fmt.Errorf("%w", err)
 			}
 		} else {
 			checkSTSRolesCompatibility(r, cluster, mode, version, clusterKey)
@@ -353,7 +353,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 	if !currentUpgradeScheduling.AutomaticUpgrades {
 		version, err = ocm.CheckAndParseVersion(availableUpgrades, version, cluster)
 		if err != nil {
-			return fmt.Errorf("Error parsing version to upgrade to")
+			return fmt.Errorf("error parsing version to upgrade to")
 		}
 
 		if r.Reporter.IsTerminal() && !args.dryRun && !confirm.Confirm("upgrade cluster to version '%s'", version) {
@@ -374,7 +374,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 			currentUpgradeScheduling.ScheduleTime)
 	}
 	if err != nil {
-		return fmt.Errorf("Failed to schedule upgrade for cluster '%s': %v", clusterKey, err)
+		return fmt.Errorf("failed to schedule upgrade for cluster '%s': %w", clusterKey, err)
 	}
 
 	if args.dryRun {
@@ -388,7 +388,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 	// Update cluster with grace period configuration
 	err = r.OCMClient.UpdateCluster(cluster.ID(), r.Creator, clusterSpec)
 	if err != nil {
-		return fmt.Errorf("Failed to update cluster '%s': %v", clusterKey, err)
+		return fmt.Errorf("failed to update cluster '%s': %w", clusterKey, err)
 	}
 
 	r.Reporter.Infof("Upgrade successfully scheduled for cluster '%s'", clusterKey)
@@ -482,7 +482,7 @@ func buildVersion(r *rosa.Runtime, cmd *cobra.Command, cluster *cmv1.Cluster,
 			Required: true,
 		})
 		if err != nil {
-			return availableUpgrades, version, fmt.Errorf("Expected a valid version to upgrade to: %s", err)
+			return availableUpgrades, version, fmt.Errorf("expected a valid version to upgrade to: %s", err)
 		}
 	}
 	return availableUpgrades, version, nil
@@ -492,7 +492,7 @@ func checkExistingScheduledUpgrade(r *rosa.Runtime, cluster *cmv1.Cluster,
 	clusterKey string) (*cmv1.UpgradePolicy, *cmv1.UpgradePolicyState, error) {
 	scheduledUpgrade, upgradeState, err := r.OCMClient.GetScheduledUpgrade(cluster.ID())
 	if err != nil {
-		return nil, nil, fmt.Errorf("Failed to get scheduled upgrades for cluster '%s': %v", clusterKey, err)
+		return nil, nil, fmt.Errorf("failed to get scheduled upgrades for cluster '%s': %v", clusterKey, err)
 	}
 
 	return scheduledUpgrade, upgradeState, nil
@@ -502,7 +502,7 @@ func checkExistingScheduledUpgradeHypershift(r *rosa.Runtime, cluster *cmv1.Clus
 	clusterKey string) (*cmv1.ControlPlaneUpgradePolicy, error) {
 	scheduledUpgrade, err := r.OCMClient.GetControlPlaneScheduledUpgrade(cluster.ID())
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get scheduled control plane upgrades for cluster '%s': %v", clusterKey, err)
+		return nil, fmt.Errorf("failed to get scheduled control plane upgrades for cluster '%s': %v", clusterKey, err)
 	}
 	return scheduledUpgrade, nil
 }
@@ -525,12 +525,12 @@ func checkRolesManagedPolicies(r *rosa.Runtime, cluster *cmv1.Cluster, mode stri
 
 	credRequests, err := ocmClient.GetCredRequests(cluster.Hypershift().Enabled())
 	if err != nil {
-		return fmt.Errorf("Error getting operator credential request from OCM %v", err)
+		return fmt.Errorf("error getting operator credential request from OCM %v", err)
 	}
 
 	unifiedPath, err := aws.GetPathFromAccountRole(cluster, aws.AccountRoles[aws.InstallerAccountRole].Name)
 	if err != nil {
-		return fmt.Errorf("Expected a valid path for '%s': %v", cluster.AWS().STS().RoleARN(), err)
+		return fmt.Errorf("expected a valid path for '%s': %v", cluster.AWS().STS().RoleARN(), err)
 	}
 
 	err = rolesHelper.ValidateAccountAndOperatorRolesManagedPolicies(r, cluster, credRequests, unifiedPath,
@@ -574,7 +574,7 @@ func buildNodeDrainGracePeriod(r *rosa.Runtime, cmd *cobra.Command, cluster *cmv
 			Required: true,
 		})
 		if err != nil {
-			r.Reporter.Errorf("Expected a valid node drain grace period: %s", err)
+			r.Reporter.Errorf("expected a valid node drain grace period: %s", err)
 			os.Exit(1)
 		}
 	}
@@ -586,14 +586,14 @@ func buildNodeDrainGracePeriod(r *rosa.Runtime, cmd *cobra.Command, cluster *cmv
 		}
 	}
 	if !isValidNodeDrainGracePeriod {
-		r.Reporter.Errorf("Expected a valid node drain grace period. Options are [%s]",
+		r.Reporter.Errorf("expected a valid node drain grace period. Options are [%s]",
 			strings.Join(nodeDrainOptions, ", "))
 		os.Exit(1)
 	}
 	nodeDrainParsed := strings.Split(nodeDrainGracePeriod, " ")
 	nodeDrainValue, err := strconv.ParseFloat(nodeDrainParsed[0], commonUtils.MaxByteSize)
 	if err != nil {
-		r.Reporter.Errorf("Expected a valid node drain grace period: %s", err)
+		r.Reporter.Errorf("expected a valid node drain grace period: %s", err)
 		os.Exit(1)
 	}
 	if nodeDrainParsed[1] == "hours" || nodeDrainParsed[1] == "hour" {
@@ -611,7 +611,7 @@ func checkAndAckMissingAgreementsClassic(r *rosa.Runtime, cluster *cmv1.Cluster,
 	gates, err := r.OCMClient.GetMissingGateAgreementsClassic(cluster.ID(), upgradePolicy)
 	if err != nil {
 		return fmt.Errorf("failed to check for missing gate agreements upgrade for "+
-			"cluster '%s': %v", clusterKey, err)
+			"cluster '%s': %w", clusterKey, err)
 	}
 	return checkGates(r, cluster, gates, clusterKey)
 }
@@ -652,7 +652,7 @@ func checkGates(r *rosa.Runtime, cluster *cmv1.Cluster, gates []*cmv1.VersionGat
 				Steps:   []string{str},
 			})
 			if err != nil {
-				return fmt.Errorf("failed to get version gate '%s' for cluster '%s': %v",
+				return fmt.Errorf("failed to get version gate '%s' for cluster '%s': %w",
 					gate.ID(), clusterKey, err)
 			}
 			// for non sts gates we require user agreement
@@ -664,7 +664,7 @@ func checkGates(r *rosa.Runtime, cluster *cmv1.Cluster, gates []*cmv1.VersionGat
 		}
 		err := r.OCMClient.AckVersionGate(cluster.ID(), gate.ID())
 		if err != nil {
-			return fmt.Errorf("failed to acknowledge version gate '%s' for cluster '%s': %v",
+			return fmt.Errorf("failed to acknowledge version gate '%s' for cluster '%s': %w",
 				gate.ID(), clusterKey, err)
 		}
 	}

--- a/cmd/upgrade/cluster/cmd_test.go
+++ b/cmd/upgrade/cluster/cmd_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Upgrade", Ordered, func() {
 		err := runWithRuntime(testRuntime.RosaRuntime, Cmd)
 		Expect(err).ToNot(BeNil())
 		Expect(err.Error()).To(
-			ContainSubstring("The '--schedule' option is only supported for Hosted Control Planes"))
+			ContainSubstring("the '--schedule' option is only supported for Hosted Control Planes"))
 	})
 	It("Fails if we are using minor version flag for manual upgrades", func() {
 		args.schedule = ""
@@ -85,7 +85,7 @@ var _ = Describe("Upgrade", Ordered, func() {
 		testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
 		err := runWithRuntime(testRuntime.RosaRuntime, Cmd)
 		Expect(err).ToNot(BeNil())
-		Expect(err.Error()).To(ContainSubstring("The '--allow-minor-version-upgrades' " +
+		Expect(err.Error()).To(ContainSubstring("the '--allow-minor-version-updates' " +
 			"option needs to be used with --schedule"))
 	})
 	It("Fails if we are mixing scheduling type flags", func() {
@@ -94,7 +94,7 @@ var _ = Describe("Upgrade", Ordered, func() {
 		testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
 		err := runWithRuntime(testRuntime.RosaRuntime, Cmd)
 		Expect(err).ToNot(BeNil())
-		Expect(err.Error()).To(ContainSubstring("The '--schedule-date' and '--schedule-time' " +
+		Expect(err.Error()).To(ContainSubstring("the '--schedule-date' and '--schedule-time' " +
 			"options are mutually exclusive with '--schedule'"))
 	})
 	It("Fails if we are mixing automatic scheduling and version flags", func() {
@@ -104,7 +104,7 @@ var _ = Describe("Upgrade", Ordered, func() {
 		testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
 		err := runWithRuntime(testRuntime.RosaRuntime, Cmd)
 		Expect(err).ToNot(BeNil())
-		Expect(err.Error()).To(ContainSubstring("The '--schedule' " +
+		Expect(err.Error()).To(ContainSubstring("the '--schedule' " +
 			"option is mutually exclusive with '--version'"))
 	})
 	It("Fails if cluster is not ready", func() {
@@ -120,7 +120,7 @@ var _ = Describe("Upgrade", Ordered, func() {
 		)
 		err := runWithRuntime(testRuntime.RosaRuntime, Cmd)
 		Expect(err).ToNot(BeNil())
-		Expect(err.Error()).To(ContainSubstring("Cluster 'cluster1' is not yet ready"))
+		Expect(err.Error()).To(ContainSubstring("cluster 'cluster1' is not yet ready"))
 	})
 	It("Cluster is ready but existing upgrade scheduled", func() {
 		args.schedule = cronSchedule

--- a/cmd/upgrade/machinepool/cmd.go
+++ b/cmd/upgrade/machinepool/cmd.go
@@ -21,7 +21,6 @@ import (
 	"os"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/pkg/input"
@@ -130,34 +129,34 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command, argv []string) error {
 
 	// Check parameters preconditions
 	if currentUpgradeScheduling.Schedule == "" && currentUpgradeScheduling.AllowMinorVersionUpdates {
-		return fmt.Errorf("The '--allow-minor-version-upgrades' option needs to be used with --schedule")
+		return fmt.Errorf("the '--allow-minor-version-updates' option needs to be used with --schedule")
 	}
 
 	if (currentUpgradeScheduling.ScheduleDate != "" || currentUpgradeScheduling.ScheduleTime != "") &&
 		currentUpgradeScheduling.Schedule != "" {
-		return fmt.Errorf("The '--schedule-date' and '--schedule-time' options are mutually exclusive with" +
+		return fmt.Errorf("the '--schedule-date' and '--schedule-time' options are mutually exclusive with" +
 			" '--schedule'")
 	}
 
 	if currentUpgradeScheduling.Schedule != "" && args.version != "" {
-		return fmt.Errorf("The '--schedule' option is mutually exclusive with '--version'")
+		return fmt.Errorf("the '--schedule' option is mutually exclusive with '--version'")
 	}
 
 	// Validate cluster state
 	input.CheckIfHypershiftClusterOrExit(r, cluster)
 	if cluster.State() != cmv1.ClusterStateReady {
-		return fmt.Errorf("Cluster '%s' is not yet ready", clusterKey)
+		return fmt.Errorf("cluster '%s' is not yet ready", clusterKey)
 	}
 
 	if !machinepool.MachinePoolKeyRE.MatchString(machinePoolID) {
-		return fmt.Errorf("Expected a valid identifier for the machine pool")
+		return fmt.Errorf("expected a valid identifier for the machine pool")
 	}
 	_, exists, err := r.OCMClient.GetNodePool(cluster.ID(), machinePoolID)
 	if err != nil {
-		return fmt.Errorf("Failed to get machine pools for hosted cluster '%s': %v", clusterKey, err)
+		return fmt.Errorf("failed to get machine pools for hosted cluster '%s': %w", clusterKey, err)
 	}
 	if !exists {
-		return fmt.Errorf("Machine pool '%s' does not exist for hosted cluster '%s'", machinePoolID, clusterKey)
+		return fmt.Errorf("machine pool '%s' does not exist for hosted cluster '%s'", machinePoolID, clusterKey)
 	}
 
 	// Enable interactive mode if needed
@@ -184,7 +183,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command, argv []string) error {
 			Required: true,
 		})
 		if err != nil {
-			return fmt.Errorf("Expected an upgrade type: %s", err)
+			return fmt.Errorf("expected an upgrade type: %s", err)
 		}
 
 		if currentUpgradeScheduling.AutomaticUpgrades {
@@ -195,7 +194,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command, argv []string) error {
 				Required: false,
 			})
 			if err != nil {
-				return fmt.Errorf("Expected an choice on the versions to target: %s", err)
+				return fmt.Errorf("expected a choice on the versions to target: %s", err)
 			}
 		}
 	}
@@ -230,8 +229,8 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command, argv []string) error {
 	r.Reporter.Debugf("Scheduling the upgrade policy")
 	_, err = r.OCMClient.ScheduleNodePoolUpgrade(cluster.ID(), machinePoolID, upgradePolicy)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to schedule upgrade for machine pool '%s' in cluster '%s'",
-			machinePoolID, clusterKey)
+		return fmt.Errorf("failed to schedule upgrade for machine pool '%s' in cluster '%s': %w",
+			machinePoolID, clusterKey, err)
 	}
 
 	r.Reporter.Infof("Upgrade successfully scheduled for the machine pool '%s' on cluster '%s'", machinePoolID,
@@ -272,8 +271,8 @@ func buildManualUpgradePolicy(r *rosa.Runtime, cmd *cobra.Command, currentUpgrad
 	var upgradePolicy *cmv1.NodePoolUpgradePolicy
 	upgradePolicy, err = r.OCMClient.BuildNodeUpgradePolicy(version, nodePool.ID(), currentUpgradeScheduling)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to build manual schedule upgrade for machine pool '%s' in cluster '%s'",
-			nodePool.ID(), clusterKey)
+		return nil, fmt.Errorf("failed to build manual schedule upgrade for machine pool '%s' in cluster '%s': %w",
+			nodePool.ID(), clusterKey, err)
 	}
 
 	// Ask for confirmation
@@ -301,8 +300,8 @@ func buildAutomaticUpgradePolicy(r *rosa.Runtime, cmd *cobra.Command, currentUpg
 
 	upgradePolicy, err = r.OCMClient.BuildNodeUpgradePolicy("", nodePool.ID(), currentUpgradeScheduling)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to build automatic schedule upgrade for machine pool %s in cluster '%s'",
-			nodePool.ID(), clusterKey)
+		return nil, fmt.Errorf("failed to build automatic schedule upgrade for machine pool %s in cluster '%s': %w",
+			nodePool.ID(), clusterKey, err)
 	}
 
 	// Ask for confirmation
@@ -360,14 +359,14 @@ func ComputeNodePoolVersion(r *rosa.Runtime, cmd *cobra.Command, cluster *cmv1.C
 			Required: true,
 		})
 		if err != nil {
-			return "", fmt.Errorf("Expected a valid machine pool version from interactive prompt: %s", err)
+			return "", fmt.Errorf("expected a valid machine pool version from interactive prompt: %s", err)
 		}
 	}
 	// This is called in HyperShift, but we don't want to exclude version which are HCP disabled for node pools
 	// so we pass the relative parameter as false
 	version, err = r.OCMClient.ValidateVersion(version, filteredVersionList, channelGroup, true, false)
 	if err != nil {
-		return "", fmt.Errorf("Expected a valid machine pool version: %s", err)
+		return "", fmt.Errorf("expected a valid machine pool version: %s", err)
 	}
 	return version, nil
 }

--- a/cmd/upgrade/machinepool/cmd_test.go
+++ b/cmd/upgrade/machinepool/cmd_test.go
@@ -17,7 +17,7 @@ const (
 	invalidScheduleDate = "25h December"
 	validScheduleDate   = "2023-12-25"
 	cronSchedule        = "* * * * *"
-	invalidVersionError = `Expected a valid machine pool version: a valid version number must be specified
+	invalidVersionError = `expected a valid machine pool version: a valid version number must be specified
 Valid versions: 4.12.26 4.12.25`
 )
 
@@ -63,7 +63,7 @@ var _ = Describe("Upgrade machine pool", func() {
 			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
 			err := runWithRuntime(testRuntime.RosaRuntime, Cmd, []string{nodePoolName})
 			Expect(err).ToNot(BeNil())
-			Expect(err.Error()).To(ContainSubstring("The '--allow-minor-version-upgrades' " +
+			Expect(err.Error()).To(ContainSubstring("the '--allow-minor-version-updates' " +
 				"option needs to be used with --schedule"))
 		})
 		It("Fails if we are mixing scheduling type flags", func() {
@@ -73,7 +73,7 @@ var _ = Describe("Upgrade machine pool", func() {
 			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
 			err := runWithRuntime(testRuntime.RosaRuntime, Cmd, []string{nodePoolName})
 			Expect(err).ToNot(BeNil())
-			Expect(err.Error()).To(ContainSubstring("The '--schedule-date' and '--schedule-time' " +
+			Expect(err.Error()).To(ContainSubstring("the '--schedule-date' and '--schedule-time' " +
 				"options are mutually exclusive with '--schedule'"))
 		})
 		It("Fails if we are mixing automatic scheduling and version flags", func() {
@@ -83,7 +83,7 @@ var _ = Describe("Upgrade machine pool", func() {
 			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
 			err := runWithRuntime(testRuntime.RosaRuntime, Cmd, []string{nodePoolName})
 			Expect(err).ToNot(BeNil())
-			Expect(err.Error()).To(ContainSubstring("The '--schedule' " +
+			Expect(err.Error()).To(ContainSubstring("the '--schedule' " +
 				"option is mutually exclusive with '--version'"))
 		})
 		It("Fails if cluster is not ready", func() {
@@ -92,7 +92,7 @@ var _ = Describe("Upgrade machine pool", func() {
 			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterNotReady))
 			err := runWithRuntime(testRuntime.RosaRuntime, Cmd, []string{nodePoolName})
 			Expect(err).ToNot(BeNil())
-			Expect(err.Error()).To(ContainSubstring("Cluster 'cluster1' is not yet ready"))
+			Expect(err.Error()).To(ContainSubstring("cluster 'cluster1' is not yet ready"))
 		})
 		It("Cluster is ready but node pool not found", func() {
 			args.scheduleTime = scheduleTime
@@ -103,7 +103,7 @@ var _ = Describe("Upgrade machine pool", func() {
 			err := runWithRuntime(testRuntime.RosaRuntime, Cmd, []string{nodePoolName})
 			Expect(err).ToNot(BeNil())
 			Expect(err.Error()).To(ContainSubstring(
-				"Machine pool 'nodepool85' does not exist for hosted cluster 'cluster1'"))
+				"machine pool 'nodepool85' does not exist for hosted cluster 'cluster1'"))
 		})
 		It("Cluster is ready and there is a scheduled upgraded", func() {
 			testRuntime.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
@@ -206,7 +206,7 @@ var _ = Describe("Upgrade machine pool", func() {
 			stdout, stderr, err := test.RunWithOutputCaptureAndArgv(runWithRuntime, testRuntime.RosaRuntime,
 				Cmd, &[]string{nodePoolName})
 			Expect(err).ToNot(BeNil())
-			Expect(err.Error()).To(ContainSubstring("Failed to schedule upgrade for machine pool"))
+			Expect(err.Error()).To(ContainSubstring("failed to schedule upgrade for machine pool"))
 			Expect(stderr).To(BeEmpty())
 			Expect(stdout).To(BeEmpty())
 		})

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/openshift-online/ocm-api-model/clientapi v0.0.461
 	github.com/openshift-online/ocm-common v0.0.44
 	github.com/openshift-online/ocm-sdk-go v0.1.505
-	github.com/pkg/errors v0.9.1
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
@@ -57,6 +56,7 @@ require (
 	github.com/lib/pq v1.10.5 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/openshift-online/ocm-api-model/model v0.0.461 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/tests/e2e/hcp_machine_pool_test.go
+++ b/tests/e2e/hcp_machine_pool_test.go
@@ -608,7 +608,7 @@ var _ = Describe("HCP Machine Pool", labels.Feature.Machinepool, func() {
 
 			By("with invalid machinepool id")
 			_, err = machinePoolService.DeleteMachinePool(clusterID, "anything%^")
-			helper.ExpectErrorWithMessage(err, "Expected a valid identifier for the machine pool")
+			helper.ExpectErrorWithMessage(err, "expected a valid identifier for the machine pool")
 
 			By("with unknown flag --interactive")
 			_, err = machinePoolService.DeleteMachinePool(clusterID, "anything", "--interactive")
@@ -734,7 +734,7 @@ var _ = Describe("HCP Machine Pool", labels.Feature.Machinepool, func() {
 					"",
 					"")
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("Cluster '%s' is not yet ready", notReadyClusterID)))
+				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("cluster '%s' is not yet ready", notReadyClusterID)))
 			} else {
 				Logger.Info("No cluster found in state not-ready. Skipping this step")
 			}
@@ -793,7 +793,7 @@ var _ = Describe("HCP Machine Pool", labels.Feature.Machinepool, func() {
 				"",
 				"")
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("Expected a valid machine pool version"))
+			Expect(err.Error()).To(ContainSubstring("expected a valid machine pool version"))
 
 			By("with schedule and version")
 			_, err = machinePoolUpgradeService.CreateAutomaticUpgrade(
@@ -802,7 +802,7 @@ var _ = Describe("HCP Machine Pool", labels.Feature.Machinepool, func() {
 				"2 5 * * *",
 				"--version", clusterConfig.Version.RawID)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("The '--schedule' option is mutually exclusive with '--version'"))
+			Expect(err.Error()).To(ContainSubstring("the '--schedule' option is mutually exclusive with '--version'"))
 
 			By("with schedule and schedule-date")
 			_, err = machinePoolUpgradeService.CreateAutomaticUpgrade(
@@ -813,7 +813,7 @@ var _ = Describe("HCP Machine Pool", labels.Feature.Machinepool, func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(
 				ContainSubstring(
-					"The '--schedule-date' and '--schedule-time' options are mutually exclusive with '--schedule'"))
+					"the '--schedule-date' and '--schedule-time' options are mutually exclusive with '--schedule'"))
 
 			By("with schedule and schedule-time")
 			_, err = machinePoolUpgradeService.CreateAutomaticUpgrade(
@@ -824,7 +824,7 @@ var _ = Describe("HCP Machine Pool", labels.Feature.Machinepool, func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(
 				ContainSubstring(
-					"The '--schedule-date' and '--schedule-time' options are mutually exclusive with '--schedule'"))
+					"the '--schedule-date' and '--schedule-time' options are mutually exclusive with '--schedule'"))
 
 			By("with already existing upgrade")
 			availableUpgradeVersions := helper.ParseCommaSeparatedStrings(upgradableVersion.AvailableUpgrades)

--- a/tests/e2e/test_rosacli_cluster.go
+++ b/tests/e2e/test_rosacli_cluster.go
@@ -814,7 +814,7 @@ var _ = Describe("Edit cluster validation should", labels.Feature.Cluster, func(
 			textData = rosaClient.Parser.TextData.Input(output).Parse().Tip()
 			Expect(textData).
 				To(ContainSubstring(
-					"ERR: The '--schedule-date' and '--schedule-time' options are mutually exclusive with '--schedule'"))
+					"ERR: the '--schedule-date' and '--schedule-time' options are mutually exclusive with '--schedule'"))
 
 			By("Upgrade cluster using --schedule and --version flags at the same time")
 			output, err = upgradeService.Upgrade(
@@ -827,7 +827,7 @@ var _ = Describe("Edit cluster validation should", labels.Feature.Cluster, func(
 			textData = rosaClient.Parser.TextData.Input(output).Parse().Tip()
 			Expect(textData).
 				To(ContainSubstring(
-					"ERR: The '--schedule' option is mutually exclusive with '--version'"))
+					"ERR: the '--schedule' option is mutually exclusive with '--version'"))
 
 			By("Upgrade cluster with value not match the cron epression")
 			output, err = upgradeService.Upgrade(


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
Supported ticket prefixes:
OCM-XXXXX, ROSAENG-XXXX
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For contributor workflow, see: ./CONTRIBUTING.md
For repo-local agent guidance, see: ./AGENTS.md
-->

## PR Summary
Replace 3 `errors.Wrapf` calls with `fmt.Errorf` using the `%w` verb. The` pkg/errors` library is deprecated by its author in favor of standard error wrapping.

## Detailed Description of the Issue
Our ROSA CLI project currently imports several third-party libraries that are only utilized in a single file (e.g., exclusively within a test file or for a single validation function). Relying on entire external dependencies for isolated use cases unnecessarily increases our security attack surface, complicates dependency management, and bloats the project.

This PR is part of that initiative to remove `github.com/pkg/errors`

## Related Issues and PRs
<!-- Link all tracking items and related code changes -->
- Jira: [ROSAENG-61040](https://redhat.atlassian.net/browse/ROSAENG-61040)
- Related design/docs: [https://redhat.atlassian.net/wiki/spaces/ROSACLITF/pages/438405639/Third-Party+Dependency+Audit](https://redhat.atlassian.net/wiki/spaces/ROSACLITF/pages/438405639/Third-Party+Dependency+Audit#github.com%2Fpkg%2Ferrors-(removed))

## Type of Change
<!-- Check the primary type this PR represents -->
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [x] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
<!-- What users or systems experienced before this change -->

## Behavior After This Change
<!-- What changes now, including user-visible and non-user-visible behavior -->

## How to Test (Step-by-Step)
<!-- Provide reproducible validation instructions -->
### Preconditions
<!-- Required setup, environment, credentials, flags, cluster state, etc. -->

### Test Steps
1. run `make test`

### Expected Results
All tests pass

## Proof of the Fix
All tests pass

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
<!-- Required only when breaking changes are introduced -->

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.


[ROSAENG-61040]: https://redhat.atlassian.net/browse/ROSAENG-61040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved and standardized error reporting across upgrade scheduling, validation, and version selection flows.
  * Clarified CLI validation messages for scheduling flags and cluster readiness checks.
  * Updated machine-pool upgrade and node-pool/version prompts to return consistently wrapped, more readable errors.
* **Tests**
  * Adjusted upgrade command tests to match the updated error text and casing.
* **Chores**
  * Updated dependency usage for error-wrapping behavior consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->