### PR TITLE
ROSAENG-00000 | test: Fixing id:77149,id:75603,id:45745

### DIFF
--- a/tests/e2e/test_rosacli_cluster.go
+++ b/tests/e2e/test_rosacli_cluster.go
@@ -194,7 +194,7 @@ var _ = Describe("Edit cluster",
 				}
 
 				if jsonData.DigBool("hypershift", "enabled") {
-					//todo
+					// todo
 				} else {
 					if jsonData.DigBool("multi_az") {
 						Expect(CD.MultiAZ).To(Equal(jsonData.DigBool("multi_az")))
@@ -499,7 +499,7 @@ var _ = Describe("Edit cluster",
 				clusterConfig, err := config.ParseClusterProfile()
 				Expect(err).ToNot(HaveOccurred())
 
-				var verifyProxy = func(httpProxy string, httpsProxy string, noProxy string, caFile string) {
+				verifyProxy := func(httpProxy string, httpsProxy string, noProxy string, caFile string) {
 					clusterDescription, err := clusterService.DescribeClusterAndReflect(clusterID)
 					Expect(err).ToNot(HaveOccurred())
 
@@ -522,8 +522,7 @@ var _ = Describe("Edit cluster",
 				if clusterConfig.Proxy.Enabled {
 					originalHttpProxy,
 						originalHTTPSProxy,
-						originalNoProxy, originalCAFile =
-						clusterConfig.Proxy.Http,
+						originalNoProxy, originalCAFile = clusterConfig.Proxy.Http,
 						clusterConfig.Proxy.Https,
 						clusterConfig.Proxy.NoProxy,
 						clusterConfig.Proxy.TrustBundleFile
@@ -883,8 +882,7 @@ var _ = Describe("Edit cluster validation should", labels.Feature.Cluster, func(
 			if clusterConfig.Proxy != nil && clusterConfig.Proxy.Enabled {
 				originalHttpProxy,
 					originalHTTPSProxy,
-					originalNoProxy, originalCAFile =
-					clusterConfig.Proxy.Http,
+					originalNoProxy, originalCAFile = clusterConfig.Proxy.Http,
 					clusterConfig.Proxy.Https,
 					clusterConfig.Proxy.NoProxy,
 					clusterConfig.Proxy.TrustBundleFile
@@ -974,7 +972,6 @@ var _ = Describe("Edit cluster validation should", labels.Feature.Cluster, func(
 			Expect(err).To(HaveOccurred())
 			Expect(output.String()).Should(
 				ContainSubstring("ERR: Expected at least one of the following: http-proxy, https-proxy"))
-
 		})
 
 	It("can validate cluster registry config patching well - [id:77149]", labels.Medium, labels.Runtime.Day2,
@@ -983,29 +980,22 @@ var _ = Describe("Edit cluster validation should", labels.Feature.Cluster, func(
 			hostedCluster, err := clusterService.IsHostedCPCluster(clusterID)
 			Expect(err).ToNot(HaveOccurred())
 			if !hostedCluster {
-				output, err := clusterService.EditCluster(clusterID,
+				_, err = clusterService.EditCluster(clusterID,
 					"--registry-config-blocked-registries", "test.blocked.com")
-				Expect(err).To(HaveOccurred())
-				Expect(output.String()).Should(
-					ContainSubstring("ERR: Setting the registry config is only supported for hosted clusters"))
+				helper.ExpectErrorWithMessage(err, "Setting the registry config is only supported for hosted clusters")
 				return
 			}
 
 			By("patch hcp with --registry-config-blocked-registries and --registry-config-allowed-registries at same time")
-			output, err := clusterService.EditCluster(clusterID,
+			_, err = clusterService.EditCluster(clusterID,
 				"--registry-config-blocked-registries", "test.blocked.com",
 				"--registry-config-allowed-registries", "test.com")
-			Expect(err).To(HaveOccurred())
-			Expect(output.String()).Should(
-				ContainSubstring("ERR: Allowed registries and blocked registries are mutually exclusive fields"))
+			helper.ExpectErrorWithMessage(err, "allowed registries and blocked registries are mutually exclusive fields")
 
 			By("patch hcp with invalid value for --registry-config-allowed-registries-for-import flag")
-			output, err = clusterService.EditCluster(clusterID,
+			_, err = clusterService.EditCluster(clusterID,
 				"--registry-config-allowed-registries-for-import", "test.com:stringType")
-			Expect(err).To(HaveOccurred())
-			Expect(output.String()).Should(
-				ContainSubstring("ERR: Expected valid allowed registries for import values"))
-
+			helper.ExpectErrorWithMessage(err, "Expected valid allowed registries for import values")
 		})
 	It("can validate autonode edit - [id:84982]", labels.Medium, labels.Runtime.Day2,
 		labels.FedRAMP, func() {
@@ -1045,7 +1035,8 @@ var _ = Describe("Edit cluster validation should", labels.Feature.Cluster, func(
 			var subCommandArgs []string
 			if jsonData.DigString("auto_node", "mode") == "enabled" {
 				subCommandArgs = []string{
-					"--autonode-iam-role-arn", "invalide-arn"}
+					"--autonode-iam-role-arn", "invalide-arn",
+				}
 				By("Validate invalide autonde-iam-role-arn when autonode is enabled")
 				output, err = clusterService.EditCluster(clusterID,
 					subCommandArgs...)
@@ -1072,6 +1063,7 @@ var _ = Describe("Edit cluster validation should", labels.Feature.Cluster, func(
 			}
 		})
 })
+
 var _ = Describe("Additional security groups validation",
 	labels.Feature.Cluster,
 	func() {
@@ -1151,7 +1143,7 @@ var _ = Describe("Additional security groups validation",
 				subnetMap, err := resourcesHandler.PrepareSubnets([]string{}, false)
 				Expect(err).ToNot(HaveOccurred())
 
-				//Check all subnets are created successfully and are in available state. If not, wait for them to be available
+				// Check all subnets are created successfully and are in available state. If not, wait for them to be available
 				subnetIDs := append(subnetMap["private"], subnetMap["public"]...)
 
 				awsClient, err := aws_client.CreateAWSClient("", resourcesHandler.GetVPC().Region)
@@ -1555,14 +1547,12 @@ var _ = Describe("Classic cluster creation validation",
 				Expect(out.String()).
 					To(ContainSubstring(
 						"invalid tag format for tag '[name gender age]'. Expected tag format: 'key value'"))
-
 			})
 
 		It("Create cluster with invalid volume size [id:66372]",
 			labels.Medium,
 			labels.Runtime.Day1Negative,
 			func() {
-
 				minSize := constants.MinClassicDiskSize
 				maxSize := constants.MaxDiskSize
 				clusterName := helper.GenerateRandomName("ocp-66372", 2)
@@ -2064,7 +2054,8 @@ var _ = Describe("Create cluster with invalid options will",
 						"--subnet-ids", strings.Join(
 							[]string{
 								subnetMap["private"].ID,
-								subnetMap2["private"].ID},
+								subnetMap2["private"].ID,
+							},
 							","),
 						"--region", testingTegion,
 					)
@@ -2203,7 +2194,6 @@ var _ = Describe("Create cluster with invalid options will",
 				Expect(err).To(HaveOccurred())
 				Expect(output.String()).Should(
 					ContainSubstring(`invalid argument "invalid" for "--host-prefix" flag`))
-
 			})
 
 		It("to validate the invalid proxy when create cluster - [id:45509]", labels.Medium, labels.Runtime.Day1Negative,
@@ -2335,9 +2325,7 @@ var _ = Describe("Classic cluster deletion validation",
 	func() {
 		defer GinkgoRecover()
 
-		var (
-			rosaClient *rosacli.Client
-		)
+		var rosaClient *rosacli.Client
 
 		BeforeEach(func() {
 			// Init the client
@@ -2379,7 +2367,6 @@ var _ = Describe("Classic cluster creation negative testing",
 			ocmResourceService       rosacli.OCMResourceService
 		)
 		BeforeEach(func() {
-
 			By("Init the client")
 			rosaClient = rosacli.NewClient()
 			clusterService = rosaClient.Cluster
@@ -2536,7 +2523,6 @@ var _ = Describe("Classic cluster creation negative testing",
 				)
 				Expect(err).NotTo(BeNil())
 				Expect(out.String()).To(ContainSubstring("The subnet ID 'subnet-xxx' does not exist"))
-
 			})
 		It("to validate to create sts cluster with dulicated role arns- [id:74620]",
 			labels.Low, labels.Runtime.Day1Negative,
@@ -2593,32 +2579,45 @@ var _ = Describe("Classic cluster creation negative testing",
 						"time: invalid duration \"e\"": {"--autoscaler-scale-down-delay-after-add", "e"},
 
 					"Error validating delay-after-delete: " +
-						"time: missing unit in duration \"3.3\"": {"--autoscaler-scale-down-delay-after-delete",
-						"3.3"},
+						"time: missing unit in duration \"3.3\"": {
+						"--autoscaler-scale-down-delay-after-delete",
+						"3.3",
+					},
 					"Error validating min-cores: Number " +
-						"must be greater or equal to zero": {"--autoscaler-min-cores", "-5",
-						"--autoscaler-max-cores", "0"},
+						"must be greater or equal to zero": {
+						"--autoscaler-min-cores", "-5",
+						"--autoscaler-max-cores", "0",
+					},
 
 					"Error validating max-cores: Number" +
-						" must be greater or equal to zero": {"--autoscaler-min-cores", "0",
-						"--autoscaler-max-cores", "-5"},
+						" must be greater or equal to zero": {
+						"--autoscaler-min-cores", "0",
+						"--autoscaler-max-cores", "-5",
+					},
 
 					"Error validating cores range: max" +
-						" value must be greater or equal than min value 100": {"--autoscaler-min-cores", "100",
-						"--autoscaler-max-cores", "5"},
+						" value must be greater or equal than min value 100": {
+						"--autoscaler-min-cores", "100",
+						"--autoscaler-max-cores", "5",
+					},
 
 					"Error validating max-cores: Should" +
-						" provide an integer number between 0 to 2147483647": {"--autoscaler-min-cores", "5",
-						"--autoscaler-max-cores", "1152000000000"},
+						" provide an integer number between 0 to 2147483647": {
+						"--autoscaler-min-cores", "5",
+						"--autoscaler-max-cores", "1152000000000",
+					},
 
 					"Error validating memory range: max value" +
-						" must be greater or equal than min value 1000": {"--autoscaler-min-memory", "1000",
-						"--autoscaler-max-memory", "100"},
+						" must be greater or equal than min value 1000": {
+						"--autoscaler-min-memory", "1000",
+						"--autoscaler-max-memory", "100",
+					},
 
 					"Error validating GPU range: max value " +
 						"must be greater or equal than min value 15": {
 						"--autoscaler-gpu-limit", "nvidia.com/gpu,0,10",
-						"--autoscaler-gpu-limit", "amd.com/gpu,15,5"},
+						"--autoscaler-gpu-limit", "amd.com/gpu,15,5",
+					},
 				}
 
 				for errMsg, flag := range errAndFlagMap {
@@ -3075,7 +3074,7 @@ var _ = Describe("HCP cluster creation negative testing",
 					"--support-role-arn": ar.SupportRole,
 					"--worker-iam-role":  ar.WorkerRole,
 				}
-				var accountRoles = make(map[string]string)
+				accountRoles := make(map[string]string)
 				arnPrefix := "arn:aws:iam::aws:policy/service-role"
 				for _, r := range arl.AccountRoles(accountRolePrefix) {
 					switch r.RoleType {
@@ -3162,6 +3161,7 @@ var _ = Describe("HCP cluster creation negative testing",
 					"ERR: Allowed registries and blocked registries are mutually exclusive fields"))
 			})
 	})
+
 var _ = Describe("HCP cluster creation subnets validation",
 	labels.Feature.Cluster,
 	func() {
@@ -3417,7 +3417,6 @@ var _ = Describe("Create cluster with availability zones testing",
 		AfterEach(func() {
 			By("Clean remaining resources")
 			rosaClient.CleanResources(clusterID)
-
 		})
 
 		It("User can set availability zones - [id:52691]",
@@ -3458,6 +3457,7 @@ var _ = Describe("Create cluster with availability zones testing",
 				Expect(helper.ReplaceCommaSpaceWithComma(mp.AvalaiblityZones)).To(Equal(availabilityZones))
 			})
 	})
+
 var _ = Describe("Create sts and hcp cluster with the IAM roles with path setting", labels.Feature.Cluster, func() {
 	defer GinkgoRecover()
 	var (
@@ -3484,7 +3484,6 @@ var _ = Describe("Create sts and hcp cluster with the IAM roles with path settin
 	AfterEach(func() {
 		By("Clean remaining resources")
 		rosaClient.CleanResources(clusterID)
-
 	})
 
 	It("to check the IAM roles can be used to create clsuters - [id:53570]",
@@ -3597,7 +3596,6 @@ var _ = Describe("Create cluster with existing operator-roles prefix which roles
 					"-y")
 				Expect(err).To(BeNil())
 			}
-
 		})
 
 		It("to validate to create cluster with existing operator roles prefix - [id:45742]",
@@ -3826,6 +3824,7 @@ var _ = Describe("create/delete operator-roles and oidc-provider to cluster",
 				}
 			})
 	})
+
 var _ = Describe("Reusing opeartor prefix and oidc config to create clsuter", labels.Feature.Cluster, func() {
 	defer GinkgoRecover()
 	var (
@@ -3883,7 +3882,6 @@ var _ = Describe("Reusing opeartor prefix and oidc config to create clsuter", la
 			textData := rosaClient.Parser.TextData.Input(output).Parse().Tip()
 			Expect(textData).To(ContainSubstring("Successfully deleted the OIDC provider"))
 		}
-
 	})
 
 	It("to reuse operator-roles prefix and oidc config - [id:60688]",
@@ -3988,6 +3986,7 @@ var _ = Describe("Reusing opeartor prefix and oidc config to create clsuter", la
 			}
 		})
 })
+
 var _ = Describe("Sts cluster creation with external id",
 	labels.Feature.Cluster,
 	func() {
@@ -4080,71 +4079,85 @@ var _ = Describe("Sts cluster creation with external id",
 				rosalCommand.AddFlags("--mode", "auto")
 
 				By("Update installer role")
-				ExternalId := "223B9588-36A5-ECA4-BE8D-7C673B77CEC1"
+				ExternalID := "223B9588-36A5-ECA4-BE8D-7C673B77CEC1"
 				installRoleArn := rosalCommand.GetFlagValue("--role-arn", true)
-				_, roleName, err := helper.ParseRoleARN(installRoleArn)
+				_, installerRoleName, err := helper.ParseRoleARN(installRoleArn)
 				Expect(err).To(BeNil())
+				supportRoleArn := rosalCommand.GetFlagValue("--support-role-arn", true)
+				_, supportRoleName, err := helper.ParseRoleARN(supportRoleArn)
+				Expect(err).To(BeNil())
+
+				accountRoleNames := []string{
+					installerRoleName,
+					supportRoleName,
+				}
 
 				awsClient, err := aws_client.CreateAWSClient("", "")
 				Expect(err).To(BeNil())
-				opRole, err := awsClient.IamClient.GetRole(
-					context.TODO(),
-					&iam.GetRoleInput{
-						RoleName: &roleName,
-					})
-				Expect(err).To(BeNil())
 
-				decodedPolicyDocument, err := url.QueryUnescape(*opRole.Role.AssumeRolePolicyDocument)
-				Expect(err).To(BeNil())
-
-				By("update the trust relationship")
-				var policyDocument map[string]interface{}
-
-				err = json.Unmarshal([]byte(decodedPolicyDocument), &policyDocument)
-				Expect(err).To(BeNil())
-
-				newCondition := map[string]interface{}{
-					"StringEquals": map[string]interface{}{
-						"sts:ExternalId": ExternalId,
-					},
-				}
-
-				statements := policyDocument["Statement"].([]interface{})
-				for _, statement := range statements {
-					stmt := statement.(map[string]interface{})
-					stmt["Condition"] = newCondition
-				}
-				updatedPolicyDocument, err := json.Marshal(policyDocument)
-				Expect(err).To(BeNil())
-
-				_, err = awsClient.IamClient.UpdateAssumeRolePolicy(context.TODO(), &iam.UpdateAssumeRolePolicyInput{
-					RoleName:       aws.String(roleName),
-					PolicyDocument: aws.String(string(updatedPolicyDocument)),
-				})
-				Expect(err).To(BeNil())
-
-				By("Wait for the trust relationship to be updated")
-				err = wait.PollUntilContextTimeout(
-					context.Background(),
-					20*time.Second,
-					300*time.Second,
-					false,
-					func(context.Context) (bool, error) {
-						result, err := awsClient.IamClient.GetRole(context.TODO(), &iam.GetRoleInput{
-							RoleName: aws.String(roleName),
+				for _, roleName := range accountRoleNames {
+					opRole, err := awsClient.IamClient.GetRole(
+						context.TODO(),
+						&iam.GetRoleInput{
+							RoleName: &roleName,
 						})
+					Expect(err).To(BeNil())
 
-						if strings.Contains(*result.Role.AssumeRolePolicyDocument, ExternalId) {
-							return true, nil
-						}
+					decodedPolicyDocument, err := url.QueryUnescape(*opRole.Role.AssumeRolePolicyDocument)
+					Expect(err).To(BeNil())
 
-						return false, err
+					By("update the trust relationship")
+					var policyDocument map[string]any
+
+					err = json.Unmarshal([]byte(decodedPolicyDocument), &policyDocument)
+					Expect(err).To(BeNil())
+
+					newCondition := map[string]any{
+						"StringEquals": map[string]any{
+							"sts:ExternalId": ExternalID,
+						},
+					}
+
+					statements := policyDocument["Statement"].([]any)
+					for _, statement := range statements {
+						stmt := statement.(map[string]any)
+						stmt["Condition"] = newCondition
+					}
+					updatedPolicyDocument, err := json.Marshal(policyDocument)
+					Expect(err).To(BeNil())
+
+					_, err = awsClient.IamClient.UpdateAssumeRolePolicy(context.TODO(), &iam.UpdateAssumeRolePolicyInput{
+						RoleName:       aws.String(roleName),
+						PolicyDocument: aws.String(string(updatedPolicyDocument)),
 					})
-				Expect(err).To(BeNil())
+					Expect(err).To(BeNil())
+
+					By("Wait for the trust relationship to be updated")
+					err = wait.PollUntilContextTimeout(
+						context.Background(),
+						20*time.Second,
+						300*time.Second,
+						false,
+						func(context.Context) (bool, error) {
+							result, err := awsClient.IamClient.GetRole(context.TODO(), &iam.GetRoleInput{
+								RoleName: aws.String(roleName),
+							})
+
+							if err != nil || result == nil {
+								return false, nil
+							}
+							if strings.Contains(*result.Role.AssumeRolePolicyDocument, ExternalID) {
+								return true, nil
+							}
+
+							return false, err
+						})
+					Expect(err).To(BeNil())
+				}
 
 				By("Create cluster with external id not same with the role setting one")
-				notMatchExternalId := "333B9588-36A5-ECA4-BE8D-7C673B77CDCD"
-				rosalCommand.AddFlags("--external-id", notMatchExternalId)
+				notMatchExternalID := "333B9588-36A5-ECA4-BE8D-7C673B77CDCD"
+				rosalCommand.AddFlags("--external-id", notMatchExternalID)
 				stdout, err := rosaClient.Runner.RunCMD(strings.Split(rosalCommand.GetFullCommand(), " "))
 				Expect(err).ToNot(BeNil())
 				Expect(stdout.String()).To(ContainSubstring(
@@ -4152,7 +4165,7 @@ var _ = Describe("Sts cluster creation with external id",
 
 				By("Create cluster with external id")
 				rosalCommand.ReplaceFlagValue(map[string]string{
-					"--external-id": ExternalId,
+					"--external-id": ExternalID,
 				})
 				stdout, err = rosaClient.Runner.RunCMD(strings.Split(rosalCommand.GetFullCommand(), " "))
 				Expect(err).To(BeNil())
@@ -4167,6 +4180,7 @@ var _ = Describe("Sts cluster creation with external id",
 				Expect(err).To(BeNil())
 			})
 	})
+
 var _ = Describe("HCP cluster creation supplemental testing",
 	labels.Feature.Cluster,
 	func() {
@@ -4429,6 +4443,7 @@ var _ = Describe("HCP cluster creation supplemental testing",
 				Expect(err).To(BeNil(), "It met error or timeout when waiting cluster to ready status")
 			})
 	})
+
 var _ = Describe("Sts cluster creation supplemental testing",
 	labels.Feature.Cluster,
 	func() {
@@ -4775,6 +4790,7 @@ var _ = Describe("Sts cluster with BYO oidc flow creation supplemental testing",
 				Expect(err).To(BeNil(), "It met error or timeout when waiting cluster to installing status")
 			})
 	})
+
 var _ = Describe("Non-STS cluster with local credentials",
 	labels.Feature.Cluster,
 	func() {

--- a/tests/e2e/test_rosacli_operator_roles.go
+++ b/tests/e2e/test_rosacli_operator_roles.go
@@ -356,7 +356,6 @@ var _ = Describe("Edit operator roles", labels.Feature.OperatorRoles, func() {
 				Expect(err).To(BeNil())
 				textData := rosaClient.Parser.TextData.Input(output).Parse().Tip()
 				Expect(textData).To(ContainSubstring("Successfully deleted the operator roles"))
-
 			}()
 
 			roles, err := listOperatorRoles(classicSTSOperatorRolesPrefix)
@@ -464,7 +463,6 @@ var _ = Describe("Edit operator roles", labels.Feature.OperatorRoles, func() {
 				Should(ContainSubstring(
 					"Either a cluster key for STS cluster or an operator roles prefix must be specified"))
 		})
-
 })
 
 var _ = Describe("create operator-roles forcely testing",
@@ -591,6 +589,7 @@ var _ = Describe("create operator-roles forcely testing",
 				}
 			})
 	})
+
 var _ = Describe("create IAM roles forcely testing",
 	func() {
 		defer GinkgoRecover()
@@ -804,6 +803,7 @@ var _ = Describe("create IAM roles forcely testing",
 				}
 			})
 	})
+
 var _ = Describe("Detele operator roles with byo oidc", labels.Feature.OperatorRoles, func() {
 	defer GinkgoRecover()
 	var (
@@ -832,10 +832,8 @@ var _ = Describe("Detele operator roles with byo oidc", labels.Feature.OperatorR
 
 		By("Get the default dir")
 		defaultDir = rosaClient.Runner.GetDir()
-
 	})
 	AfterEach(func() {
-
 		By("Delete testing operator-roles")
 		_, err = ocmResourceService.DeleteOperatorRoles(
 			"--prefix", operatorRolePrefixC,
@@ -949,7 +947,6 @@ var _ = Describe("Detele operator roles with byo oidc", labels.Feature.OperatorR
 				Expect(err).To(BeNil())
 			}
 		})
-
 })
 
 var _ = Describe("Create cluster with oprator roles which are attaching managed policies in manual mode",
@@ -1178,21 +1175,28 @@ var _ = Describe("Upgrade operator roles in auto mode",
 				err = clusterService.WaitClusterStatus(clusterID, constants.Ready, 3, 60)
 				Expect(err).To(BeNil())
 
+				By("Edit cluster channel")
+				preparation, err := clusterService.PrepareClusterForYStreamUpgrade(clusterID, customProfile.ChannelGroup)
+				Expect(err).ToNot(HaveOccurred())
+
 				By("Get cluster upgrade version")
-				output, err := upgradeService.ListUpgrades("-c", clusterID)
-				Expect(err).To(BeNil())
-				upgradeVersionList, err := upgradeService.ReflectUpgradeVersionList(output)
-				Expect(err).To(BeNil())
-				Expect(len(upgradeVersionList.UpgradeVersions)).To(BeNumerically(">", 0),
-					"Expected at least one upgrade version to be available")
-				upgradingVersion := upgradeVersionList.UpgradeVersions[0].Version
+				upgradingVersion, _, err := upgradeService.WaitForAvailableYStreamUpgrade(
+					clusterID,
+					preparation,
+					yStreamUpgradeWaitInterval,
+					yStreamUpgradeWaitTimeout,
+				)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(upgradingVersion).ToNot(BeEmpty(), "Failed to find an upgrade target")
+
 				_, _, roleUpgradeVersion, err := helper.GetMajorMinorFromVersion(upgradingVersion)
 				Expect(err).To(BeNil())
 
 				By("Upgrade cluster to verify if there are any prompts to upgrade account roles firstly")
-				scheduledDate := time.Now().Format("2006-01-02")
-				scheduledTime := time.Now().Add(10 * time.Minute).UTC().Format("15:04")
-				output, err = upgradeService.Upgrade(
+				scheduledAt := time.Now().UTC().Add(10 * time.Minute)
+				scheduledDate := scheduledAt.Format("2006-01-02")
+				scheduledTime := scheduledAt.Format("15:04")
+				output, err := upgradeService.Upgrade(
 					"-c", clusterID,
 					"--version", upgradingVersion,
 					"--schedule-date", scheduledDate,
@@ -1271,7 +1275,6 @@ var _ = Describe("Create/Delete operator roles for hosted-cp shared vpc", labels
 		By("Init the client")
 		rosaClient = rosacli.NewClient()
 		ocmResourceService = rosaClient.OCMResource
-
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
Supported ticket prefixes:
OCM-XXXXX, ROSAENG-XXXX
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For contributor workflow, see: ./CONTRIBUTING.md
For repo-local agent guidance, see: ./AGENTS.md
-->

## PR Summary
Fixing a few test cases from recent CI failures:
- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-rosa-master-e2e-rosa-day1-supplemental-f3/2080794141960179712
- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-rosa-master-e2e-rosa-hcp-shared-vpc-f3/2080805857615941632

## Detailed Description of the Issue
<!-- Describe the root problem, scope, impact, and user/business context -->

## Related Issues and PRs
<!-- Link all tracking items and related code changes -->
- Jira: [OCM-XXXXX](https://issues.redhat.com/browse/OCM-XXXXX) or [ROSAENG-XXXX](https://issues.redhat.com/browse/ROSAENG-XXXX)
- Fixes: `#`
- Related PR(s):
- Related design/docs:

## Type of Change
<!-- Check the primary type this PR represents -->
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [x] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
<!-- What users or systems experienced before this change -->

## Behavior After This Change
<!-- What changes now, including user-visible and non-user-visible behavior -->

## How to Test (Step-by-Step)
<!-- Provide reproducible validation instructions -->
### Preconditions
<!-- Required setup, environment, credentials, flags, cluster state, etc. -->

### Test Steps
1.
2.
3.

### Expected Results
<!-- What should happen after running the steps above -->

## Proof of the Fix
<!-- Attach evidence that demonstrates the changed behavior -->
- Screenshots:
- Videos:
- Logs/CLI output:
- Other artifacts:

### `id:45745`
```
...
  INFO: Ensuring account role policies compatibility for upgrade
  INFO: Starting to upgrade the policies
  INFO: Attached policy 'arn:aws:iam::*************:policy/rosacli-ci-1qin-Installer-Role-Policy' to role 'rosacli-ci-1qin-Installer-Role(https://console.aws.amazon.com/iam/home?#/roles/rosacli-ci-1qin-Installer-Role)'

  INFO: Upgraded policy with ARN 'arn:aws:iam::*************:policy/rosacli-ci-1qin-Installer-Role-Policy' to version '4.22'
  INFO: Attached policy 'arn:aws:iam::*************:policy/rosacli-ci-1qin-ControlPlane-Role-Policy' to role 'rosacli-ci-1qin-ControlPlane-Role(https://console.aws.amazon.com/iam/home?#/roles/rosacli-ci-1qin-ControlPlane-Role)'

  INFO: Upgraded policy with ARN 'arn:aws:iam::*************:policy/rosacli-ci-1qin-ControlPlane-Role-Policy' to version '4.22'
  INFO: Attached policy 'arn:aws:iam::*************:policy/rosacli-ci-1qin-Worker-Role-Policy' to role 'rosacli-ci-1qin-Worker-Role(https://console.aws.amazon.com/iam/home?#/roles/rosacli-ci-1qin-Worker-Role)'

  INFO: Upgraded policy with ARN 'arn:aws:iam::*************:policy/rosacli-ci-1qin-Worker-Role-Policy' to version '4.22'
  INFO: Attached policy 'arn:aws:iam::*************:policy/rosacli-ci-1qin-Support-Role-Policy' to role 'rosacli-ci-1qin-Support-Role(https://console.aws.amazon.com/iam/home?#/roles/rosacli-ci-1qin-Support-Role)'

  INFO: Upgraded policy with ARN 'arn:aws:iam::*************:policy/rosacli-ci-1qin-Support-Role-Policy' to version '4.22'

  STEP: Upgrade operator roles in auto mode @ 07/27/26 14:55:42.346
  time=2026-07-27T14:55:42-04:00 level=info msg=Running command: rosa upgrade operator-roles --cluster 2rqkv6rv6jqp2aisvu515344mtphv721 --version 4.22.2 --mode auto -y
  time=2026-07-27T14:55:47-04:00 level=info msg=Get Combining Stdout and Stderr is :
  INFO: Starting to upgrade the operator IAM roles and policies
  INFO: Upgraded policy with ARN 'arn:aws:iam::*************:policy/rosacli-ci-1qin-openshift-cloud-credential-operator-cloud-creden' to version '4.22'
  INFO: Upgraded policy with ARN 'arn:aws:iam::*************:policy/rosacli-ci-1qin-openshift-image-registry-installer-cloud-credent' to version '4.22'
  INFO: Upgraded policy with ARN 'arn:aws:iam::*************:policy/rosacli-ci-1qin-openshift-ingress-operator-cloud-credentials' to version '4.22'
  INFO: Upgraded policy with ARN 'arn:aws:iam::*************:policy/rosacli-ci-1qin-openshift-cluster-csi-drivers-ebs-cloud-credenti' to version '4.22'
  INFO: Upgraded policy with ARN 'arn:aws:iam::*************:policy/rosacli-ci-1qin-openshift-cloud-network-config-controller-cloud-' to version '4.22'
  INFO: Upgraded policy with ARN 'arn:aws:iam::*************:policy/rosacli-ci-1qin-openshift-machine-api-aws-cloud-credentials' to version '4.22'

  STEP: Update cluster with --dry-run @ 07/27/26 14:55:47.449
  time=2026-07-27T14:55:47-04:00 level=info msg=Running command: rosa upgrade cluster -c 2rqkv6rv6jqp2aisvu515344mtphv721 --version 4.22.2 --mode auto -y
  time=2026-07-27T14:56:00-04:00 level=info msg=Get Combining Stdout and Stderr is :
  INFO: Ensuring account and operator role policies for cluster '2rqkv6rv6jqp2aisvu515344mtphv721' are compatible with upgrade.
  INFO: Account roles/policies for cluster '2rqkv6rv6jqp2aisvu515344mtphv721' are already up-to-date.
  INFO: Operator roles/policies associated with the cluster '2rqkv6rv6jqp2aisvu515344mtphv721' are already up-to-date.
  WARN: To check and acknowledge gates prior to scheduling an upgrade, run this command with '--dry-run', particularly if you encounter an upgrade failure related to acknowledged agreements.
  INFO: Upgrade successfully scheduled for cluster '2rqkv6rv6jqp2aisvu515344mtphv721'

  STEP: Delete cluster @ 07/27/26 14:56:00.251
  time=2026-07-27T14:56:00-04:00 level=info msg=Running command: rosa delete cluster -c 2rqkv6rv6jqp2aisvu515344mtphv721 -y
  time=2026-07-27T14:56:01-04:00 level=info msg=Get Combining Stdout and Stderr is :
  INFO: Cluster '2rqkv6rv6jqp2aisvu515344mtphv721' will start uninstalling now
  INFO: Your cluster '2rqkv6rv6jqp2aisvu515344mtphv721' will be deleted but the following objects may remain
  INFO: Operator IAM Roles: - arn:aws:iam::*************:role/rosacli-ci-1qin-openshift-image-registry-installer-cloud-credent
   - arn:aws:iam::*************:role/rosacli-ci-1qin-openshift-ingress-operator-cloud-credentials
   - arn:aws:iam::*************:role/rosacli-ci-1qin-openshift-cluster-csi-drivers-ebs-cloud-credenti
   - arn:aws:iam::*************:role/rosacli-ci-1qin-openshift-cloud-network-config-controller-cloud-
   - arn:aws:iam::*************:role/rosacli-ci-1qin-openshift-machine-api-aws-cloud-credentials
   - arn:aws:iam::*************:role/rosacli-ci-1qin-openshift-cloud-credential-operator-cloud-creden

  INFO: OIDC Provider : https://oidc.os1.devshift.org/2rqkv6rv6jqp2aisvu515344mtphv721

  INFO: Once the cluster is uninstalled use the following commands to remove the above aws resources.

        rosa delete operator-roles -c 2rqkv6rv6jqp2aisvu515344mtphv721
        rosa delete oidc-provider -c 2rqkv6rv6jqp2aisvu515344mtphv721
  INFO: To watch your cluster uninstallation logs, run 'rosa logs uninstall -c 2rqkv6rv6jqp2aisvu515344mtphv721 --watch'

  time=2026-07-27T14:59:01-04:00 level=info msg=Running command: rosa list cluster
  time=2026-07-27T14:59:01-04:00 level=info msg=Get Combining Stdout and Stderr is :
  ID                                NAME                                                    STATE         TOPOLOGY
  2rqhk5o7evefn0qk8fslon6j43svsn5t  jkeyne-ozqh4hli                                         ready         Hosted CP
  2rqims6s26e99jenfa3tqjfva10jsrhb  ci-rhcs-hcp-pl-jus-pr                                   ready         Hosted CP
  2rqioaiugmtvm6eat41mh4ba5t86cj94  ci-rhcs-sts-ad-z5t-pr                                   ready         Classic (STS)
  2rqiorcv2qjcafo88s20fih0iq46bhna  ci-rhcs-hcp-ad-qam-pr                                   ready         Hosted CP
  2rqj1rq4ls96t578hm5vd1bsslafmb2d  ci-rhcs-sts-ad-abs-pr                                   ready         Classic (STS)
  2rqkv6rv6jqp2aisvu515344mtphv721  c45745-ka                                               uninstalling  Classic (STS)
  2rql28u1b07dnim5rckm20eql2ijjtvg  pr-rosacli-ueimobbnl1fygayh8mdsarqgnilpjmglan6r5prerbx  installing    Classic (STS)
  2rql3smrn0pfu0i2ijpf0hkaud9vjl97  pr-rosacli-ge8x                                         uninstalling  Hosted CP
  2rqlg65l1nevcqkgq9ee8ff81s234elp  rosa-upgz-f3-2d                                         installing    Classic (STS)
  2rqlk996keq8d227psovv9244be9bc84  ci-rhcs-hcp-pl-xq9-pr                                   ready         Hosted CP
  2rqlle1l1uh6ao3898o601lge9of5tth  ci-rhcs-hcp-ad-cia-pr                                   installing    Hosted CP
  2rqlnjmviqu4odgvrkua0gnu71ljhm6f  ci-rhcs-sts-pl-bhu-pr                                   validating    Classic (STS)

  time=2026-07-27T15:02:01-04:00 level=info msg=Running command: rosa list cluster
  time=2026-07-27T15:02:01-04:00 level=info msg=Get Combining Stdout and Stderr is :
  ID                                NAME                                                    STATE         TOPOLOGY
  2rqhk5o7evefn0qk8fslon6j43svsn5t  jkeyne-ozqh4hli                                         ready         Hosted CP
  2rqims6s26e99jenfa3tqjfva10jsrhb  ci-rhcs-hcp-pl-jus-pr                                   ready         Hosted CP
  2rqioaiugmtvm6eat41mh4ba5t86cj94  ci-rhcs-sts-ad-z5t-pr                                   ready         Classic (STS)
  2rqiorcv2qjcafo88s20fih0iq46bhna  ci-rhcs-hcp-ad-qam-pr                                   ready         Hosted CP
  2rqj1rq4ls96t578hm5vd1bsslafmb2d  ci-rhcs-sts-ad-abs-pr                                   ready         Classic (STS)
  2rqkv6rv6jqp2aisvu515344mtphv721  c45745-ka                                               uninstalling  Classic (STS)
  2rql28u1b07dnim5rckm20eql2ijjtvg  pr-rosacli-ueimobbnl1fygayh8mdsarqgnilpjmglan6r5prerbx  installing    Classic (STS)
  2rqlg65l1nevcqkgq9ee8ff81s234elp  rosa-upgz-f3-2d                                         installing    Classic (STS)
  2rqlk996keq8d227psovv9244be9bc84  ci-rhcs-hcp-pl-xq9-pr                                   ready         Hosted CP
  2rqlle1l1uh6ao3898o601lge9of5tth  ci-rhcs-hcp-ad-cia-pr                                   ready         Hosted CP
  2rqlnjmviqu4odgvrkua0gnu71ljhm6f  ci-rhcs-sts-pl-bhu-pr                                   installing    Classic (STS)
  2rqlp5sdta7km38udbm4dgupji88iu7o  ci-rhcs-sts-ad-rw7-pr                                   validating    Classic (STS)

  time=2026-07-27T15:05:01-04:00 level=info msg=Running command: rosa list cluster
  time=2026-07-27T15:05:01-04:00 level=info msg=Get Combining Stdout and Stderr is :
  ID                                NAME                                                    STATE       TOPOLOGY
  2rqhk5o7evefn0qk8fslon6j43svsn5t  jkeyne-ozqh4hli                                         ready       Hosted CP
  2rqims6s26e99jenfa3tqjfva10jsrhb  ci-rhcs-hcp-pl-jus-pr                                   ready       Hosted CP
  2rqioaiugmtvm6eat41mh4ba5t86cj94  ci-rhcs-sts-ad-z5t-pr                                   ready       Classic (STS)
  2rqiorcv2qjcafo88s20fih0iq46bhna  ci-rhcs-hcp-ad-qam-pr                                   ready       Hosted CP
  2rqj1rq4ls96t578hm5vd1bsslafmb2d  ci-rhcs-sts-ad-abs-pr                                   ready       Classic (STS)
  2rql28u1b07dnim5rckm20eql2ijjtvg  pr-rosacli-ueimobbnl1fygayh8mdsarqgnilpjmglan6r5prerbx  ready       Classic (STS)
  2rqlg65l1nevcqkgq9ee8ff81s234elp  rosa-upgz-f3-2d                                         installing  Classic (STS)
  2rqlk996keq8d227psovv9244be9bc84  ci-rhcs-hcp-pl-xq9-pr                                   ready       Hosted CP
  2rqlle1l1uh6ao3898o601lge9of5tth  ci-rhcs-hcp-ad-cia-pr                                   ready       Hosted CP
  2rqlnjmviqu4odgvrkua0gnu71ljhm6f  ci-rhcs-sts-pl-bhu-pr                                   installing  Classic (STS)
  2rqlp5sdta7km38udbm4dgupji88iu7o  ci-rhcs-sts-ad-rw7-pr                                   installing  Classic (STS)

  STEP: Clean resources @ 07/27/26 15:05:01.69
  time=2026-07-27T15:05:01-04:00 level=info msg=Find prepared account roles with prefix: rosacli-ci-1qin
  time=2026-07-27T15:05:01-04:00 level=info msg=Running command: rosa delete account-roles --mode auto --prefix rosacli-ci-1qin -y
  time=2026-07-27T15:05:07-04:00 level=info msg=Get Combining Stdout and Stderr is :
  INFO: Deleting classic account roles
  INFO: Deleting account role 'rosacli-ci-1qin-Installer-Role'
  INFO: Deleting account role 'rosacli-ci-1qin-ControlPlane-Role'
  INFO: Deleting account role 'rosacli-ci-1qin-Worker-Role'
  INFO: Deleting account role 'rosacli-ci-1qin-Support-Role'
  INFO: Successfully deleted the classic account roles
  WARN: There are no hosted CP account roles to be deleted

  time=2026-07-27T15:05:07-04:00 level=info msg=Delete account roles successfully
  time=2026-07-27T15:05:07-04:00 level=info msg=Rewrite User data file
• [3720.909 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 286 Specs in 3720.918 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 285 Skipped
PASS

Ginkgo ran 1 suite in 1h2m4.217923791s
Test Suite Passed
```

### `id:75603`
```
...
time="2026-07-27 13:53:21" level=info msg="Got file path: /home/jkeyne/.aws/credentials from env variable AWS_SHARED_CREDENTIALS_FILE\n"
  STEP: update the trust relationship @ 07/27/26 13:53:21.264
  STEP: Wait for the trust relationship to be updated @ 07/27/26 13:53:21.349
  STEP: update the trust relationship @ 07/27/26 13:53:41.677
  STEP: Wait for the trust relationship to be updated @ 07/27/26 13:53:41.779
  STEP: Create cluster with external id not same with the role setting one @ 07/27/26 13:54:01.856
  time=2026-07-27T13:54:01-04:00 level=info msg=rosa command is running
  STEP: Create cluster with external id @ 07/27/26 13:54:04.849
  time=2026-07-27T13:54:04-04:00 level=info msg=rosa command is running
  time=2026-07-27T13:54:27-04:00 level=info msg=Running command: rosa list cluster
  time=2026-07-27T13:54:28-04:00 level=info msg=Get Combining Stdout and Stderr is :
  ID                                NAME                   STATE       TOPOLOGY
  2rqhk5o7evefn0qk8fslon6j43svsn5t  jkeyne-ozqh4hli        ready       Hosted CP
  2rqims6s26e99jenfa3tqjfva10jsrhb  ci-rhcs-hcp-pl-jus-pr  ready       Hosted CP
  2rqioaiugmtvm6eat41mh4ba5t86cj94  ci-rhcs-sts-ad-z5t-pr  ready       Classic (STS)
  2rqiorcv2qjcafo88s20fih0iq46bhna  ci-rhcs-hcp-ad-qam-pr  ready       Hosted CP
  2rqj1rq4ls96t578hm5vd1bsslafmb2d  ci-rhcs-sts-ad-abs-pr  ready       Classic (STS)
  2rqk3knio407qbua91aktnbku4c9m06l  ci-rhcs-sts-pl-lfv-pr  ready       Classic (STS)
  2rqk45c02u7itv92kegl1hs7244voaah  ci-rhcs-sts-ad-nd4-pr  installing  Classic (STS)
  2rqk6macldchotvbnq7p3c9eu2r9022a  ci-rhcs-sts-pl-ifb-pr  installing  Classic (STS)
  2rqkl6dk8ch1f82pi9prrlfuaf5h36kg  ci-rhcs-hcp-pl-g3h-pr  ready       Hosted CP
  2rqkl7vonih08pfvpepleajk26nch7l5  ci-rhcs-sts-pl-ovl-pr  installing  Classic (STS)
  2rqklu7l5ri4vs9rfhcftpqvam78erak  ci-rhcs-hcp-ad-hxf-pr  ready       Hosted CP
  2rqkmhon9ru7fvu35ajodmngdkeo9k87  ci-rhcs-sts-ad-757-pr  installing  Classic (STS)
  2rqkqhgt4vvju7brgnd6dpdsee3bhm07  c75603-zt              waiting     Classic (STS)

  time=2026-07-27T13:57:28-04:00 level=info msg=Running command: rosa list cluster
  time=2026-07-27T13:57:29-04:00 level=info msg=Get Combining Stdout and Stderr is :
  ID                                NAME                   STATE       TOPOLOGY
  2rqhk5o7evefn0qk8fslon6j43svsn5t  jkeyne-ozqh4hli        ready       Hosted CP
  2rqims6s26e99jenfa3tqjfva10jsrhb  ci-rhcs-hcp-pl-jus-pr  ready       Hosted CP
  2rqioaiugmtvm6eat41mh4ba5t86cj94  ci-rhcs-sts-ad-z5t-pr  ready       Classic (STS)
  2rqiorcv2qjcafo88s20fih0iq46bhna  ci-rhcs-hcp-ad-qam-pr  ready       Hosted CP
  2rqj1rq4ls96t578hm5vd1bsslafmb2d  ci-rhcs-sts-ad-abs-pr  ready       Classic (STS)
  2rqk3knio407qbua91aktnbku4c9m06l  ci-rhcs-sts-pl-lfv-pr  ready       Classic (STS)
  2rqk45c02u7itv92kegl1hs7244voaah  ci-rhcs-sts-ad-nd4-pr  ready       Classic (STS)
  2rqk6macldchotvbnq7p3c9eu2r9022a  ci-rhcs-sts-pl-ifb-pr  installing  Classic (STS)
  2rqkl6dk8ch1f82pi9prrlfuaf5h36kg  ci-rhcs-hcp-pl-g3h-pr  ready       Hosted CP
  2rqkl7vonih08pfvpepleajk26nch7l5  ci-rhcs-sts-pl-ovl-pr  installing  Classic (STS)
  2rqklu7l5ri4vs9rfhcftpqvam78erak  ci-rhcs-hcp-ad-hxf-pr  ready       Hosted CP
  2rqkmhon9ru7fvu35ajodmngdkeo9k87  ci-rhcs-sts-ad-757-pr  installing  Classic (STS)
  2rqkqhgt4vvju7brgnd6dpdsee3bhm07  c75603-zt              installing  Classic (STS)

  STEP: Delete cluster @ 07/27/26 13:57:29.144
  time=2026-07-27T13:57:29-04:00 level=info msg=Running command: rosa delete cluster -c 2rqkqhgt4vvju7brgnd6dpdsee3bhm07 -y
  time=2026-07-27T13:57:30-04:00 level=info msg=Get Combining Stdout and Stderr is :
  INFO: Cluster '2rqkqhgt4vvju7brgnd6dpdsee3bhm07' will start uninstalling now
  INFO: Your cluster '2rqkqhgt4vvju7brgnd6dpdsee3bhm07' will be deleted but the following objects may remain
  INFO: Operator IAM Roles: - arn:aws:iam::*************:role/aa/bb/opp75603-ov-openshift-ingress-operator-cloud-credentials
   - arn:aws:iam::*************:role/aa/bb/opp75603-ov-openshift-cluster-csi-drivers-ebs-cloud-credentials
   - arn:aws:iam::*************:role/aa/bb/opp75603-ov-openshift-cloud-network-config-controller-cloud-cred
   - arn:aws:iam::*************:role/aa/bb/opp75603-ov-openshift-machine-api-aws-cloud-credentials
   - arn:aws:iam::*************:role/aa/bb/opp75603-ov-openshift-cloud-credential-operator-cloud-credential
   - arn:aws:iam::*************:role/aa/bb/opp75603-ov-openshift-image-registry-installer-cloud-credentials

  INFO: OIDC Provider : https://oidc.os1.devshift.org/2rqkqhgt4vvju7brgnd6dpdsee3bhm07

  INFO: Once the cluster is uninstalled use the following commands to remove the above aws resources.

        rosa delete operator-roles -c 2rqkqhgt4vvju7brgnd6dpdsee3bhm07
        rosa delete oidc-provider -c 2rqkqhgt4vvju7brgnd6dpdsee3bhm07
  INFO: To watch your cluster uninstallation logs, run 'rosa logs uninstall -c 2rqkqhgt4vvju7brgnd6dpdsee3bhm07 --watch'

  time=2026-07-27T14:00:30-04:00 level=info msg=Running command: rosa list cluster
  time=2026-07-27T14:00:30-04:00 level=info msg=Get Combining Stdout and Stderr is :
  ID                                NAME                   STATE       TOPOLOGY
  2rqhk5o7evefn0qk8fslon6j43svsn5t  jkeyne-ozqh4hli        ready       Hosted CP
  2rqims6s26e99jenfa3tqjfva10jsrhb  ci-rhcs-hcp-pl-jus-pr  ready       Hosted CP
  2rqioaiugmtvm6eat41mh4ba5t86cj94  ci-rhcs-sts-ad-z5t-pr  ready       Classic (STS)
  2rqiorcv2qjcafo88s20fih0iq46bhna  ci-rhcs-hcp-ad-qam-pr  ready       Hosted CP
  2rqj1rq4ls96t578hm5vd1bsslafmb2d  ci-rhcs-sts-ad-abs-pr  ready       Classic (STS)
  2rqk3knio407qbua91aktnbku4c9m06l  ci-rhcs-sts-pl-lfv-pr  ready       Classic (STS)
  2rqk45c02u7itv92kegl1hs7244voaah  ci-rhcs-sts-ad-nd4-pr  ready       Classic (STS)
  2rqk6macldchotvbnq7p3c9eu2r9022a  ci-rhcs-sts-pl-ifb-pr  installing  Classic (STS)
  2rqkl6dk8ch1f82pi9prrlfuaf5h36kg  ci-rhcs-hcp-pl-g3h-pr  ready       Hosted CP
  2rqkl7vonih08pfvpepleajk26nch7l5  ci-rhcs-sts-pl-ovl-pr  installing  Classic (STS)
  2rqklu7l5ri4vs9rfhcftpqvam78erak  ci-rhcs-hcp-ad-hxf-pr  ready       Hosted CP
  2rqkmhon9ru7fvu35ajodmngdkeo9k87  ci-rhcs-sts-ad-757-pr  installing  Classic (STS)

  STEP: Delete operator-roles @ 07/27/26 14:00:30.703
  time=2026-07-27T14:00:30-04:00 level=info msg=Running command: rosa delete operator-roles -c 2rqkqhgt4vvju7brgnd6dpdsee3bhm07 --mode auto -y
  time=2026-07-27T14:00:50-04:00 level=info msg=Get Combining Stdout and Stderr is :
  INFO: Deleting operator role 'opp75603-ov-openshift-cloud-credential-operator-cloud-credential'
  INFO: Deleting operator role 'opp75603-ov-openshift-cloud-network-config-controller-cloud-cred'
  INFO: Deleting operator role 'opp75603-ov-openshift-cluster-csi-drivers-ebs-cloud-credentials'
  INFO: Deleting operator role 'opp75603-ov-openshift-image-registry-installer-cloud-credentials'
  INFO: Deleting operator role 'opp75603-ov-openshift-ingress-operator-cloud-credentials'
  INFO: Deleting operator role 'opp75603-ov-openshift-machine-api-aws-cloud-credentials'
  INFO: Successfully deleted the operator roles

  STEP: Clean resources @ 07/27/26 14:00:50.438
  time=2026-07-27T14:00:50-04:00 level=info msg=Find prepared account roles with prefix: rosacli-ci-137s
  time=2026-07-27T14:00:50-04:00 level=info msg=Running command: rosa delete account-roles --mode auto --prefix rosacli-ci-137s -y
  time=2026-07-27T14:00:55-04:00 level=info msg=Get Combining Stdout and Stderr is :
  INFO: Deleting classic account roles
  INFO: Deleting account role 'rosacli-ci-137s-Installer-Role'
  INFO: Deleting account role 'rosacli-ci-137s-ControlPlane-Role'
  INFO: Deleting account role 'rosacli-ci-137s-Worker-Role'
  INFO: Deleting account role 'rosacli-ci-137s-Support-Role'
  INFO: Successfully deleted the classic account roles
  WARN: There are no hosted CP account roles to be deleted

  time=2026-07-27T14:00:55-04:00 level=info msg=Delete account roles successfully
  time=2026-07-27T14:00:55-04:00 level=info msg=Rewrite User data file
• [505.141 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 286 Specs in 505.150 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 285 Skipped
PASS

Ginkgo ran 1 suite in 8m28.519908823s
Test Suite Passed
```

### `id:77149`
```
$ TEST_PROFILE="rosa-hcp-shared-vpc-advanced" go run github.com/onsi/ginkgo/v2/ginkgo run -v --timeout 2h --focus "id:77149" tests/e2e/
Running Suite: ROSA CLI e2e tests suite - /home/jkeyne/work/repos/rosa/tests/e2e
================================================================================
Random Seed: 1785245709

Will run 1 of 286 specs
------------------------------
[BeforeSuite]
/home/jkeyne/work/repos/rosa/tests/e2e/e2e_suite_test.go:21
[BeforeSuite] PASSED [0.000 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
Edit cluster validation should can validate cluster registry config patching well - [id:77149] [feature-cluster, Medium, day2, FedRAMP]
/home/jkeyne/work/repos/rosa/tests/e2e/test_rosacli_cluster.go:977
  STEP: Get the cluster @ 07/28/26 09:35:15.514
  STEP: Init the client @ 07/28/26 09:35:15.514
  STEP: edit non-hcp with registry config @ 07/28/26 09:35:15.514
  time=2026-07-28T09:35:15-04:00 level=info msg=Running command: rosa describe cluster -c 2rqhk5o7evefn0qk8fslon6j43svsn5t --output json
  time=2026-07-28T09:35:16-04:00 level=info msg=Get Combining Stdout and Stderr is :
  {
    "additional_trust_bundle": "REDACTED",
    "api": {
      "listening": "external",
      "url": "https://api.jkeyne-ozqh4hli.gdwz.s3.devshift.org:443"
    },
    "autoscaler": {
      "href": "/api/clusters_mgmt/v1/clusters/2rqhk5o7evefn0qk8fslon6j43svsn5t/autoscaler",
      "kind": "ClusterAutoscalerLink"
    },
    "aws": {
      "additional_allowed_principals": [
        "arn:aws:iam::*************:role/jkeyne-ozqh4hli-shared-route53-role",
        "arn:aws:iam::*************:role/jkeyne-ozqh4hli-shared-vpcendpoint-role"
      ],
      "additional_compute_security_group_ids": [
        "sg-05ee388ba67ea2d24",
        "sg-0c5e9b316526cbd35",
        "sg-0be9a03e039122195"
      ],
      "audit_log": {
        "role_arn": "arn:aws:iam::*************:role/jkeyne-ozqh4hli"
      },
      "billing_account_id": "*************",
      "ec2_metadata_http_token*************": "required",
      "etcd_encryption": {
        "kms_key_arn": "arn:aws:kms:us-west-2:*************:key/2f13c88e-7c31-4501-a24c-97a6f7f47370"
      },
      "hcp_internal_communication_hosted_zone_id": "Z05131912GXQFK08C0SCO",
      "kms_key_arn": "arn:aws:kms:us-west-2:*************:key/8dc6d1c8-76c1-484b-89ef-f1b9f67851ee",
      "private_hosted_zone_id": "Z03834902SIUPMM1LWUR8",
      "private_hosted_zone_role_arn": "arn:aws:iam::*************:role/jkeyne-ozqh4hli-shared-route53-role",
      "private_link": false,
      "private_link_configuration": {},
      "sts": {
        "auto_mode": false,
        "enabled": true,
        "instance_iam_roles": {
          "worker_role_arn": "arn:aws:iam::*************:role/jkeyne-ozqh4hli-HCP-ROSA-Worker-Role"
        },
        "managed_policies": true,
        "oidc_config": {
          "creation_timestamp": "2026-07-27T14:05:39Z",
          "href": "/api/clusters_mgmt/v1/oidc_configs/2rqhfcoqpnhjvjgm4ktfunc2m60t4he4",
          "id": "2rqhfcoqpnhjvjgm4ktfunc2m60t4he4",
          "issuer_url": "https://oidc.os1.devshift.org/2rqhfcoqpnhjvjgm4ktfunc2m60t4he4",
          "last_update_timestamp": "2026-07-27T14:15:57Z",
          "last_used_timestamp": "2026-07-27T14:15:57Z",
          "managed": true,
          "organization_id": "1jlfDskrR39egznAq3T18Ul0Xxv",
          "reusable": true
        },
        "oidc_endpoint_url": "https://oidc.os1.devshift.org/2rqhfcoqpnhjvjgm4ktfunc2m60t4he4",
        "operator_iam_roles": [
          {
            "id": "",
            "name": "cloud-credentials",
            "namespace": "openshift-cloud-network-config-controller",
            "role_arn": "arn:aws:iam::*************:role/jkeyne-ozqh4hli-openshift-cloud-network-config-controller-cloud-",
            "service_account": ""
          },
          {
            "id": "",
            "name": "kube-controller-manager",
            "namespace": "kube-system",
            "role_arn": "arn:aws:iam::*************:role/jkeyne-ozqh4hli-kube-system-kube-controller-manager",
            "service_account": ""
          },
          {
            "id": "",
            "name": "capa-controller-manager",
            "namespace": "kube-system",
            "role_arn": "arn:aws:iam::*************:role/jkeyne-ozqh4hli-kube-system-capa-controller-manager",
            "service_account": ""
          },
          {
            "id": "",
            "name": "control-plane-operator",
            "namespace": "kube-system",
            "role_arn": "arn:aws:iam::*************:role/jkeyne-ozqh4hli-kube-system-control-plane-operator",
            "service_account": ""
          },
          {
            "id": "",
            "name": "kms-provider",
            "namespace": "kube-system",
            "role_arn": "arn:aws:iam::*************:role/jkeyne-ozqh4hli-kube-system-kms-provider",
            "service_account": ""
          },
          {
            "id": "",
            "name": "installer-cloud-credentials",
            "namespace": "openshift-image-registry",
            "role_arn": "arn:aws:iam::*************:role/jkeyne-ozqh4hli-openshift-image-registry-installer-cloud-credent",
            "service_account": ""
          },
          {
            "id": "",
            "name": "cloud-credentials",
            "namespace": "openshift-ingress-operator",
            "role_arn": "arn:aws:iam::*************:role/jkeyne-ozqh4hli-openshift-ingress-operator-cloud-credentials",
            "service_account": ""
          },
          {
            "id": "",
            "name": "ebs-cloud-credentials",
            "namespace": "openshift-cluster-csi-drivers",
            "role_arn": "arn:aws:iam::*************:role/jkeyne-ozqh4hli-openshift-cluster-csi-drivers-ebs-cloud-credenti",
            "service_account": ""
          }
        ],
        "operator_role_prefix": "jkeyne-ozqh4hli",
        "role_arn": "arn:aws:iam::*************:role/jkeyne-ozqh4hli-HCP-ROSA-Installer-Role",
        "support_role_arn": "arn:aws:iam::*************:role/jkeyne-ozqh4hli-HCP-ROSA-Support-Role"
      },
      "subnet_ids": [
        "subnet-0860d15e8a23d4b1e",
        "subnet-0b75c1bb03bf9e4cb",
        "subnet-0be2a05c5c88f30df",
        "subnet-0e12b27f1f0dfeb14",
        "subnet-0a4867c3123ab4c4e",
        "subnet-05277da064c16e59a"
      ],
      "tags": {
        "qe-managed": "true",
        "red-hat-clustertype": "rosa",
        "red-hat-managed": "true",
        "test-tag": "tagvalue"
      },
      "vpc_endpoint_role_arn": "arn:aws:iam::*************:role/jkeyne-ozqh4hli-shared-vpcendpoint-role"
    },
    "aws_infrastructure_access_role_grants": {
      "items": []
    },
    "billing_model": "marketplace-aws",
    "byo_oidc": {
      "enabled": false
    },
    "ccs": {
      "disable_scp_checks": false,
      "enabled": true,
      "kind": "CCS"
    },
    "channel": "stable-4.22",
    "cloud_provider": {
      "href": "/api/clusters_mgmt/v1/cloud_providers/aws",
      "id": "aws",
      "kind": "CloudProviderLink"
    },
    "console": {
      "url": "https://console-openshift-console.apps.rosa.jkeyne-ozqh4hli.gdwz.s3.devshift.org"
    },
    "control_plane": {
      "log_forwarders": {
        "items": []
      }
    },
    "creation_timestamp": "2026-07-27T14:15:54Z",
    "delete_protection": {
      "enabled": false
    },
    "disable_user_workload_monitoring": false,
    "display_name": "jkeyne-ozqh4hli",
    "dns": {
      "base_domain": "gdwz.s3.devshift.org"
    },
    "domain_prefix": "jkeyne-ozqh4hli",
    "etcd_encryption": true,
    "expiration_timestamp": "2026-07-29T02:15:51Z",
    "external_auth_config": {
      "enabled": false,
      "external_auths": {
        "items": []
      },
      "href": "/api/clusters_mgmt/v1/clusters/2rqhk5o7evefn0qk8fslon6j43svsn5t/external_auth_config",
      "kind": "ExternalAuthConfig"
    },
    "external_configuration": {
      "labels": {
        "items": []
      },
      "manifests": {
        "items": []
      },
      "syncsets": {
        "items": []
      }
    },
    "external_id": "6e0d64ec-ab2f-4028-9295-26b121871776",
    "fips": true,
    "flavour": {
      "href": "/api/clusters_mgmt/v1/flavours/osd-4",
      "id": "osd-4",
      "kind": "FlavourLink"
    },
    "groups": {
      "items": []
    },
    "href": "/api/clusters_mgmt/v1/clusters/2rqhk5o7evefn0qk8fslon6j43svsn5t",
    "hypershift": {
      "enabled": true
    },
    "id": "2rqhk5o7evefn0qk8fslon6j43svsn5t",
    "identity_providers": {
      "items": []
    },
    "image_registry": {
      "state": "enabled"
    },
    "inflight_checks": {
      "items": []
    },
    "ingresses": {
      "items": []
    },
    "kind": "Cluster",
    "managed": true,
    "managed_service": {
      "enabled": false
    },
    "migrations": [],
    "multi_arch_enabled": true,
    "multi_az": true,
    "name": "jkeyne-ozqh4hli",
    "network": {
      "host_prefix": 23,
      "machine_cidr": "10.0.0.0/16",
      "pod_cidr": "10.128.0.0/14",
      "service_cidr": "172.31.0.0/24",
      "type": "OVNKubernetes"
    },
    "node_drain_grace_period": {
      "unit": "minutes",
      "value": 0
    },
    "node_pools": {
      "items": []
    },
    "nodes": {
      "autoscale_compute": {
        "kind": "MachinePoolAutoscaling",
        "max_replicas": 6,
        "min_replicas": 3
      },
      "availability_zones": [
        "us-west-2a",
        "us-west-2b",
        "us-west-2c"
      ],
      "compute_machine_type": {
        "href": "/api/clusters_mgmt/v1/machine_types/c5.xlarge",
        "id": "c5.xlarge",
        "kind": "MachineTypeLink"
      },
      "compute_root_volume": {
        "aws": {
          "size": 75
        }
      }
    },
    "openshift_version": "4.22.5",
    "product": {
      "href": "/api/clusters_mgmt/v1/products/rosa",
      "id": "rosa",
      "kind": "ProductLink"
    },
    "properties": {
      "rosa_cli_version": "1.2.64",
      "rosa_creator_arn": "arn:aws:iam::*************:user/jkeyne"
    },
    "proxy": {
      "http_proxy": "http://10.0.0.118:8080",
      "https_proxy": "https://10.0.0.118:8080",
      "no_proxy": "quay.io"
    },
    "region": {
      "href": "/api/clusters_mgmt/v1/cloud_providers/aws/regions/us-west-2",
      "id": "us-west-2",
      "kind": "CloudRegionLink"
    },
    "registry_config": {
      "additional_trusted_ca": {
        "test.io": "REDACTED"
      },
      "allowed_registries_for_import": [
        {
          "domain_name": "docker.io"
        },
        {
          "domain_name": "registry.redhat.com"
        },
        {
          "domain_name": "registry.access.redhat.com"
        },
        {
          "domain_name": "quay.io"
        },
        {
          "domain_name": "registry.redhat.io"
        }
      ],
      "platform_allowlist": {
        "href": "/api/clusters_mgmt/v1/registry_allowlists/2dk6hgciso5uope6ciphim414010fkp3",
        "id": "2dk6hgciso5uope6ciphim414010fkp3",
        "kind": "RegistryAllowlistLink"
      },
      "registry_sources": {
        "blocked_registries": [
          "blocked.example.com",
          "*.test"
        ],
        "insecure_registries": [
          "test.com",
          "*.example"
        ]
      }
    },
    "state": "ready",
    "status": {
      "configuration_mode": "full",
      "current_compute": 3,
      "dns_ready": true,
      "kind": "ClusterStatus",
      "limited_support_reason_count": 0,
      "oidc_ready": true,
      "provision_error_code": "",
      "provision_error_message": "",
      "state": "ready"
    },
    "subscription": {
      "href": "/api/accounts_mgmt/v1/subscriptions/3H5dErOLs6vOJSUZPt88vyuWMgu",
      "id": "3H5dErOLs6vOJSUZPt88vyuWMgu",
      "kind": "SubscriptionLink"
    },
    "version": {
      "available_channels": [],
      "available_upgrades": [],
      "channel_group": "stable",
      "end_of_life_timestamp": "2027-10-09T00:00:00Z",
      "href": "/api/clusters_mgmt/v1/versions/openshift-v4.22.5",
      "id": "openshift-v4.22.5",
      "kind": "Version",
      "raw_id": "4.22.5"
    }
  }

  STEP: patch hcp with --registry-config-blocked-registries and --registry-config-allowed-registries at same time @ 07/28/26 09:35:16.627
  time=2026-07-28T09:35:16-04:00 level=info msg=Running command: rosa edit cluster -c 2rqhk5o7evefn0qk8fslon6j43svsn5t --registry-config-blocked-registries test.blocked.com --registry-config-allowed-registries test.com
  time=2026-07-28T09:35:17-04:00 level=info msg=Get Combining Stdout and Stderr is :
  ERR: Allowed registries and blocked registries are mutually exclusive fields

  STEP: patch hcp with invalid value for --registry-config-allowed-registries-for-import flag @ 07/28/26 09:35:17.598
  time=2026-07-28T09:35:17-04:00 level=info msg=Running command: rosa edit cluster -c 2rqhk5o7evefn0qk8fslon6j43svsn5t --registry-config-allowed-registries-for-import test.com:stringType
  time=2026-07-28T09:35:18-04:00 level=info msg=Get Combining Stdout and Stderr is :
  ERR: Expected valid allowed registries for import values: invalid identifier 'test.com:stringType' for 'allowed registries for import'. Should be in a <registry>:<boolean> format. The boolean indicates whether the registry is secure or not

  STEP: Clean the cluster @ 07/28/26 09:35:18.081
• [2.568 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 286 Specs in 2.573 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 285 Skipped
PASS

Ginkgo ran 1 suite in 8.872613994s
Test Suite Passed
```

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
<!-- Required only when breaking changes are introduced -->

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [ ] Any risk, limitation, or follow-up work is documented.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end validation for hosted cluster registry configuration, autoscaler option/flag errors, proxy settings, and STS external ID behavior.
  * Refined error-message and input-expectation checks to better cover invalid and unsupported cases.
  * Strengthened the operator role upgrade flow to select available Y-stream upgrade targets and derive upgrade timing consistently in UTC.
  * Applied consistency/formatting updates across the end-to-end test suite without changing test intent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->