### PR TITLE
ROSAENG-62387 | fix(test): align OCP-45509 proxy dry-run assertion

### DIFF
--- a/tests/e2e/test_rosacli_cluster.go
+++ b/tests/e2e/test_rosacli_cluster.go
@@ -2208,7 +2208,7 @@ var _ = Describe("Create cluster with invalid options will",
 				)
 				Expect(err).To(HaveOccurred())
 				Expect(output.String()).Should(ContainSubstring(
-					"number of subnets for a 'single AZ' 'cluster' should be '2', instead received: '0'"),
+					"cluster_wide_proxy is only supported if subnetIDs exist"),
 				)
 
 				By("Prepare vpc with subnets")


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
Supported ticket prefixes:
OCM-XXXXX, ROSAENG-XXXX
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For contributor workflow, see: ./CONTRIBUTING.md
For repo-local agent guidance, see: ./AGENTS.md
-->

## PR Summary
Update OCP-45509 day1-negative assertion to match the current OCM error when creating a classic cluster with proxy flags and no subnet IDs.

## Detailed Description of the Issue
`periodic-ci-openshift-rosa-master-e2e-rosa-day1-negative-f7` has consistently failed OCP-45509. The test expected the obsolete local message `number of subnets for a 'single AZ' 'cluster' should be '2', instead received: '0'`. With `CreateDryRun` (`--yes`), the CLI reaches OCM and returns `cluster_wide_proxy is only supported if subnetIDs exist`.

## Related Issues and PRs
- Jira: [ROSAENG-62387](https://redhat.atlassian.net/browse/ROSAENG-62387)
- Fixes: N/A
- Related PR(s): N/A
- Related design/docs: N/A

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [x] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
OCP-45509 failed when proxy-without-subnets dry-run returned `cluster_wide_proxy is only supported if subnetIDs exist` instead of the expected single-AZ subnet-count string.

## Behavior After This Change
OCP-45509 asserts on the current OCM validation message for proxy without subnet IDs.

## How to Test (Step-by-Step)
### Preconditions
- Day1-negative e2e environment with valid OCM/AWS credentials
- ROSA CLI built from this branch

### Test Steps
1. Run day1-negative coverage for OCP-45509, or the full `day1-negative` label filter used by the periodic job.
2. Confirm the proxy-without-subnets dry-run path fails with `cluster_wide_proxy is only supported if subnetIDs exist`.

### Expected Results
OCP-45509 passes. No other day1-negative assertions are changed by this PR.

## Proof of the Fix
- Screenshots: N/A
- Videos: N/A
- Logs/CLI output: Persistent failure across four periodics (Jun 29–Jul 20) with the new OCM message; assertion updated to match.
- Other artifacts: N/A

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

Made with [Cursor](https://cursor.com)

[ROSAENG-62387]: https://redhat.atlassian.net/browse/ROSAENG-62387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated cluster creation validation messaging for proxy settings when subnet IDs are missing.
  * Error output now clearly indicates that cluster-wide proxy configuration requires subnet IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->