### PR TITLE
ROSAENG-61168 | test: use writable temp dir for manual-mode upgrade in e2e

### DIFF
--- a/tests/e2e/test_rosacli_upgrade.go
+++ b/tests/e2e/test_rosacli_upgrade.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -544,6 +545,16 @@ var _ = Describe("Cluster Upgrade testing",
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Upgrade wide AMI roles in manual mode")
+				tmpDir, err := os.MkdirTemp("", "rosa-upgrade-manual-*")
+				Expect(err).To(BeNil())
+				defer func() {
+					cleanupErr := os.RemoveAll(tmpDir)
+					Expect(cleanupErr).ToNot(HaveOccurred())
+				}()
+				originalDir := rosaClient.Runner.GetDir()
+				rosaClient.Runner.SetDir(tmpDir)
+				defer rosaClient.Runner.SetDir(originalDir)
+
 				if profile.ClusterConfig.HCP {
 					By("upgrade HCP cluster wide AMI roles in manual mode")
 					output1, err := ocmResourceService.UpgradeRoles(


### PR DESCRIPTION
## PR Summary

Fix the OCP-75445 periodic CI test failure by ensuring the manual-mode upgrade test writes generated policy files to a writable temp directory instead of a potentially read-only working directory.

## Detailed Description of the Issue

The `rosa upgrade roles --mode manual` command writes generated policy JSON files to the current working directory. The e2e test `OCP-75445` invoked this command without ensuring its working directory was writable, causing `open openshift_ingress_operator_cloud_credentials_policy.json: permission denied` inside the CI container.

## Related Issues and PRs

- Jira: [ROSAENG-61168](https://issues.redhat.com/browse/ROSAENG-61168)
- Related: PR #3428 (fixed [ROSAENG-61037](https://redhat.atlassian.net/browse/ROSAENG-61037) separately)

## Type of Change

- [x] test - adds or updates tests only.

## Previous Behavior

OCP-75445 ran `rosa upgrade roles --mode manual` from a non-writable working directory inside the CI container, producing `permission denied` when the CLI attempted to write generated policy JSON files.

## Behavior After This Change

A writable temp directory is created before invoking the manual-mode upgrade command. The runner is pointed at it via the existing `SetDir()` method. Cleanup and directory restoration are deferred.

## How to Test (Step-by-Step)

### Preconditions

- Access to periodic CI job `periodic-ci-openshift-rosa-master-e2e-rosa-sts-upgrade-y-stream-f3`.

### Test Steps

1. Merge this PR.
2. Wait for the next periodic run of the upgrade job.
3. Verify OCP-75445 passes.

### Expected Results

OCP-75445 passes without `permission denied` errors when writing generated policy files.

## Proof of the Fix

- Local verification: `make fmt-check` passes, `go build ./tests/e2e/...` compiles cleanly.
- The test failure was reproduced by inspecting the container security context (read-only cwd). The fix follows the same `os.MkdirTemp` + `SetDir()` pattern used in other manual-mode tests (`test_rosacli_account_roles.go`, `test_rosacli_operator_roles.go`).

## Breaking Changes

- [x] No breaking changes

## Developer Verification Checklist

- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

[ROSAENG-61168]: https://redhat.atlassian.net/browse/ROSAENG-61168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ROSAENG-61037]: https://redhat.atlassian.net/browse/ROSAENG-61037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROSAENG-61037]: https://redhat.atlassian.net/browse/ROSAENG-61037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Tests**
  * Improved test isolation for the upgrade flow by running the scenario in a temporary working directory.
  * Added automatic cleanup for the temporary workspace and ensured the original working directory is restored after the test completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->