### PR TITLE
ROSAENG-62788 | fix: derive policy version from cluster upgrade version

### DIFF
--- a/cmd/upgrade/roles/cmd.go
+++ b/cmd/upgrade/roles/cmd.go
@@ -54,8 +54,8 @@ var args struct {
 var Cmd = &cobra.Command{
 	Use:     "roles",
 	Aliases: []string{},
-	Short:   "Upgrade cluster-specific IAM roles to the latest version.",
-	Long:    "Upgrade cluster-specific IAM roles to the latest version before upgrading your cluster.",
+	Short:   "Upgrade cluster-specific IAM roles for a target OpenShift version.",
+	Long:    "Upgrade cluster-specific IAM roles to a compatible version before upgrading your cluster.",
 	Example: `  # Upgrade cluster roles for ROSA STS clusters
 		rosa upgrade roles -c <cluster_key>`,
 	Args: cobra.MaximumNArgs(2),
@@ -193,9 +193,13 @@ func run(cmd *cobra.Command, argv []string) {
 		return
 	}
 
-	policyVersion := args.policyUpgradeversion
-	isPolicyVersionChosen := policyVersion != ""
 	channelGroup := args.channelGroup
+	policyVersion, isPolicyVersionChosen, err := resolvePolicyVersionForUpgrade(
+		args.policyUpgradeversion, clusterUpgradeVersion)
+	if err != nil {
+		reporter.Errorf("%s", err)
+		os.Exit(1)
+	}
 	policyVersion, err = ocmClient.GetPolicyVersion(policyVersion, channelGroup)
 	if err != nil {
 		reporter.Errorf("Error getting version: %s", err)
@@ -1109,6 +1113,20 @@ func upgradeMissingOperatorRole(
 		}
 	}
 	return nil
+}
+
+func resolvePolicyVersionForUpgrade(policyVersion, clusterUpgradeVersion string) (string, bool, error) {
+	if policyVersion != "" {
+		return policyVersion, true, nil
+	}
+	if clusterUpgradeVersion != "" {
+		parsed, err := ocm.ParseVersion(clusterUpgradeVersion)
+		if err != nil {
+			return "", false, fmt.Errorf("error parsing cluster upgrade version: %w", err)
+		}
+		return parsed, true, nil
+	}
+	return "", false, nil
 }
 
 func checkPolicyAndClusterVersionCompatibility(policyVersion, clusterVersion string) (err error) {

--- a/cmd/upgrade/roles/cmd_test.go
+++ b/cmd/upgrade/roles/cmd_test.go
@@ -12,6 +12,35 @@ import (
 	awsmock "github.com/openshift/rosa/pkg/aws"
 )
 
+var _ = Describe("resolvePolicyVersionForUpgrade", func() {
+	It("derives policy version from cluster upgrade version when policy is empty", func() {
+		policyVersion, chosen, err := resolvePolicyVersionForUpgrade("", "4.21.3")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(policyVersion).To(Equal("4.21"))
+		Expect(chosen).To(BeTrue())
+	})
+
+	It("returns an error for a malformed cluster upgrade version", func() {
+		_, _, err := resolvePolicyVersionForUpgrade("", "not-a-version")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("error parsing cluster upgrade version"))
+	})
+
+	It("preserves explicit policy version even when cluster version differs", func() {
+		policyVersion, chosen, err := resolvePolicyVersionForUpgrade("4.20", "4.21.3")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(policyVersion).To(Equal("4.20"))
+		Expect(chosen).To(BeTrue())
+	})
+
+	It("returns empty and not chosen when both inputs are empty", func() {
+		policyVersion, chosen, err := resolvePolicyVersionForUpgrade("", "")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(policyVersion).To(BeEmpty())
+		Expect(chosen).To(BeFalse())
+	})
+})
+
 var _ = Describe("generateClusterUpgradeInfo", func() {
 	It("OK: Returns the cluster upgrade info string successfully", func() {
 		info := generateClusterUpgradeInfo("cluster-key-01", "4.15.0", "auto")


### PR DESCRIPTION
Currently, when run the rosa upgrade roles with --policy-version, it will upgrade the policy to the correct version.
But if run it with `rosa upgrade cluster --version ${cluster_version}`, the policy version for the roles will be updated but not follow the specified version. Will just update to the latest supported version.

Fix this when rosa upgrade cluster, the role update will follow the same version.

<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
Supported ticket prefixes:
OCM-XXXXX, ROSAENG-XXXX
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For contributor workflow, see: ./CONTRIBUTING.md
For repo-local agent guidance, see: ./AGENTS.md
-->

## PR Summary
<!-- brief text of 1 or 2 lines with the most important changes and outcomes -->

## Detailed Description of the Issue
<!-- Describe the root problem, scope, impact, and user/business context -->

## Related Issues and PRs
<!-- Link all tracking items and related code changes -->
- Jira: [ROSAENG-62788](https://redhat.atlassian.net/browse/ROSAENG-62788)
- Fixes: `derive policy version from cluster upgrade version`
- Related PR(s): n/a
- Related design/docs: n/a


## Type of Change
<!-- Check the primary type this PR represents -->
- [ ] feat - adds a new user-facing capability.
- [x] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
<!-- What users or systems experienced before this change -->

When upgrading cluster from older Y version to a new Y version, it will upgrade the policy version to the latest support version regardless the upgrade cluster version. 

## Behavior After This Change
<!-- What changes now, including user-visible and non-user-visible behavior -->

`rosa upgrade cluster --version` will upgrade the policy version to the same version as target cluster.

## How to Test (Step-by-Step)
<!-- Provide reproducible validation instructions -->
### Preconditions
<!-- Required setup, environment, credentials, flags, cluster state, etc. -->

### Test Steps
1. Create an old version of cluster with account-roles, like 4.20
$ rosa create account-roles --version 4.20 --prefix test-roles -m auto -y
$ rosa create cluster --version 4.20.30 --sts # with the new created roles 
Wait the cluster to be ready
2. Set the channel of the cluster to a new Y release
$ rosa edit cluster -c xxxx --channel fast-4.21
3. Perform the upgrade cluster with dry-run
$ rosa upgrade cluster -c xxxx --version 4.21.26 -m auto -y --dry-run


### Expected Results
The account roles/operator roles policy version should be upgraded to the version 4.21 rather than the latest available version 4.22

## Proof of the Fix
<!-- Attach evidence that demonstrates the changed behavior -->
- Screenshots:
- Videos:
- Logs/CLI output:
- Other artifacts:

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
<!-- Required only when breaking changes are introduced -->

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [ ] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [ ] `make test` passes.
- [ ] `make lint` passes.
- [ ] `make rosa` passes.
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [ ] Any risk, limitation, or follow-up work is documented.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- The roles upgrade command now selects the appropriate policy version from the target OpenShift upgrade version when no policy version is explicitly provided.
- Improved handling and reporting of invalid upgrade-version input.
- Explicitly supplied policy versions continue to be honored.

## Documentation
- Updated the roles command help text to clarify that it upgrades IAM roles for a specified target OpenShift version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[ROSAENG-62788]: https://redhat.atlassian.net/browse/ROSAENG-62788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQs