### PR TITLE
ROSAENG-62807 | fix(test): lengthen id:70370 inflight-check wait

### DIFF
--- a/tests/e2e/test_rosacli_network_verifier.go
+++ b/tests/e2e/test_rosacli_network_verifier.go
@@ -7,7 +7,9 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/wait"
 
+	//nolint:staticcheck
 	. "github.com/onsi/ginkgo/v2"
+	//nolint:staticcheck
 	. "github.com/onsi/gomega"
 	"github.com/openshift-online/ocm-common/pkg/test/vpc_client"
 
@@ -74,7 +76,7 @@ var _ = Describe("Network verifier",
 						break
 					}
 				}
-				subnets := strings.Replace(subnetsNetworkInfo, " ", "", -1)
+				subnets := strings.ReplaceAll(subnetsNetworkInfo, " ", "")
 				region := clusterDetail.Region
 				installerRoleArn := clusterDetail.STSRoleArn
 
@@ -161,7 +163,7 @@ var _ = Describe("Network verifier",
 						break
 					}
 				}
-				subnets := strings.Replace(subnetsNetworkInfo, " ", "", -1)
+				subnets := strings.ReplaceAll(subnetsNetworkInfo, " ", "")
 				region := clusterDetail.Region
 				isBYOVPC, err := clusterService.IsBYOVPCCluster(clusterID)
 				Expect(err).To(BeNil())
@@ -239,7 +241,7 @@ var _ = Describe("Network verifier",
 						break
 					}
 				}
-				subnets := strings.Replace(subnetsNetworkInfo, " ", "", -1)
+				subnets := strings.ReplaceAll(subnetsNetworkInfo, " ", "")
 				region := clusterDetail.Region
 				var vpcClient *vpc_client.VPC
 
@@ -279,20 +281,26 @@ var _ = Describe("Network verifier",
 				err = wait.PollUntilContextTimeout(
 					context.Background(),
 					20*time.Second,
-					300*time.Second,
+					600*time.Second,
 					false,
 					func(context.Context) (bool, error) {
 						clusterDetail, err = clusterService.DescribeClusterAndReflect(clusterID)
-						if !strings.Contains(clusterDetail.FailedInflightChecks,
-							"rosa verify network -c ") {
+						if err != nil {
 							return false, err
 						}
-						return true, err
+						// Wait for the subnet failure details from this verifier run, not only
+						// the generic "rosa verify network -c" footer that appears for any
+						// failed egress inflight (see cmd/describe/cluster).
+						if !strings.Contains(clusterDetail.FailedInflightChecks,
+							"Invalid configurations on subnet") {
+							return false, nil
+						}
+						return true, nil
 					})
-				Expect(err).To(BeNil())
-
-				clusterDetail, err = clusterService.DescribeClusterAndReflect(clusterID)
-				Expect(clusterDetail.FailedInflightChecks).To(ContainSubstring("Invalid configurations on subnet"))
+				helper.AssertWaitPollNoErr(err,
+					"Subnet invalid-configuration inflight details not synced after network verifier within 600s")
+				Expect(clusterDetail.FailedInflightChecks).
+					To(ContainSubstring("Invalid configurations on subnet"))
 			})
 
 	})


### PR DESCRIPTION
## PR Summary
Lengthen and harden the id:70370 FailedInflightChecks wait so network-verifier sync flakes are less likely on `rosa-hcp-advanced-f3`.

## Detailed Description of the Issue
Jul 19 `rosa-hcp-advanced-f3` failed id:70370 with `context deadline exceeded` while waiting for `FailedInflightChecks` to reflect network verifier results. The inflight sync poll used a bare `Expect(err).To(BeNil())` and a 300s window.

This change reuses an **existing e2e wait pattern** already used elsewhere:
- In the **same file** (`test_rosacli_network_verifier.go`), the network-verifier status polls already use `PollUntilContextTimeout` + `helper.AssertWaitPollNoErr(...)`.
- The same helper pattern appears in other e2e tests (e.g. `test_rosacli_account_roles.go`, `test_rosacli_cluster.go`, `test_rosacli_network_resources.go`).

The fix aligns the inflight-check poll with that established pattern rather than introducing a new wait style.

## Related Issues and PRs
- Jira: [ROSAENG-62807](https://redhat.atlassian.net/browse/ROSAENG-62807) (sub-task of [ROSAENG-62643](https://redhat.atlassian.net/browse/ROSAENG-62643))
- Fixes: N/A
- Related PR(s): N/A
- Related design/docs: N/A

## Type of Change
- [x] test - adds or updates tests only.

## Previous Behavior
Inflight-check sync waited 300s and failed with an opaque poll timeout (`Expect(err).To(BeNil())`).

## Behavior After This Change
- Wait extended to 600s
- Uses `helper.AssertWaitPollNoErr` (same pattern as the status polls above and other e2e tests) with a clear message
- Safer poll: return describe errors properly; do not treat missing inflight text as a hard error mid-poll
- Lint hygiene in the touched file: `//nolint:staticcheck` for Ginkgo/Gomega dot imports; `strings.ReplaceAll`

## How to Test (Step-by-Step)
### Preconditions
ROSA HCP advanced / BYO VPC cluster profile with network verifier destructive coverage (id:70370).

### Test Steps
1. Review diff in `tests/e2e/test_rosacli_network_verifier.go`
2. Local: `make pre-push-checks` (already run via hook)
3. Optionally run id:70370 in the destructive step of an HCP advanced job

### Expected Results
Inflight sync wait either succeeds within 600s or fails with a clear AssertWaitPollNoErr message.

## Proof of the Fix
- Pre-push checks passed (fmt, build, lint, coverage, unit/integration)
- Evidence job (failure mode): https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-rosa-master-e2e-rosa-hcp-advanced-f3/2078895107674738688

## Breaking Changes
- [x] No breaking changes

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] Related docs updated or N/A.
- [x] Structure tests / command args updated or N/A (test-only).
- [x] Local verification run (`make pre-push-checks`).
- [x] Risks/limitations noted (timeout bump may mask slower OCM sync; revisit if still flaky).

[ROSAENG-62807]: https://redhat.atlassian.net/browse/ROSAENG-62807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROSAENG-62643]: https://redhat.atlassian.net/browse/ROSAENG-62643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network verification reliability by normalizing subnet IDs more consistently.
  * Increased the polling timeout for unreachable-subnet scenarios to reduce flaky failures.
  * Refined failure handling and diagnostics when cluster inflight checks fail, and reused captured results to avoid redundant checks.
* **Chores**
  * Suppressed static analysis warnings in network verification end-to-end tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->