### PR TITLE
ROSAENG-62805 | fix(test): fail-fast destroy when uninstall times out

### DIFF
--- a/tests/utils/handler/cluster_handler.go
+++ b/tests/utils/handler/cluster_handler.go
@@ -1211,52 +1211,67 @@ func (ch *clusterHandler) CreateCluster(waitForClusterReady bool) (err error) {
 	return err
 }
 
-func (ch *clusterHandler) destroyCluster() (errors []error) {
+// destroyCluster deletes the cluster and waits for uninstall to finish.
+// clusterRemoved is true when there is no cluster left to block follow-on
+// cleanup (already gone, or uninstall completed). It is false when delete or
+// uninstall failed and the cluster may still exist — callers should skip
+// resource cleanup that requires the cluster to be gone.
+func (ch *clusterHandler) destroyCluster() (errors []error, clusterRemoved bool) {
 	var clusterID string
 	if ch.clusterDetail != nil && ch.clusterDetail.ClusterID != "" {
 		clusterID = ch.clusterDetail.ClusterID
 	} else if ch.resourcesHandler != nil && ch.resourcesHandler.resources.ClusterID != "" {
 		clusterID = ch.resourcesHandler.resources.ClusterID
 	}
-	if clusterID != "" {
-		clusterService := ch.rosaClient.Cluster
-		output, errDeleteCluster := clusterService.DeleteCluster(clusterID, "-y")
-		if errDeleteCluster != nil {
-			if strings.Contains(output.String(), fmt.Sprintf("There is no cluster with identifier or name '%s'", clusterID)) {
-				log.Logger.Infof("Cluster %s not exists.", clusterID)
-			} else {
-				log.Logger.Errorf("Error happened when delete cluster: %s", output.String())
-				errors = append(errors, errDeleteCluster)
-			}
-		} else {
-			log.Logger.Infof("Waiting for the cluster %s to be uninstalled", clusterID)
-			err := clusterService.WaitForClusterPassUninstalled(clusterID, 2, config.Test.GlobalENV.ClusterWaitingTime)
-			if err != nil {
-				log.Logger.Errorf("Error happened when waiting cluster uninstall: %s", err.Error())
-				errors = append(errors, err)
-			} else {
-				log.Logger.Infof("Delete cluster %s successfully.", clusterID)
-			}
+	if clusterID == "" {
+		// Nothing to uninstall; allow prepared-resource cleanup to proceed.
+		return nil, true
+	}
 
-			// Remove OIDC provider
-			if ch.profile.ClusterConfig.STS && ch.profile.ClusterConfig.OIDCConfig != "managed" {
-				_, err = ch.rosaClient.OCMResource.DeleteOIDCProvider("-c", clusterID, "-y", "--mode", "auto")
-				if err != nil {
-					log.Logger.Errorf("Error happened when delete oidc provider: %s", err.Error())
-					errors = append(errors, err)
-				}
-				log.Logger.Infof("Delete oidc provider successfully")
-			}
+	clusterService := ch.rosaClient.Cluster
+	output, errDeleteCluster := clusterService.DeleteCluster(clusterID, "-y")
+	if errDeleteCluster != nil {
+		if strings.Contains(output.String(), fmt.Sprintf("There is no cluster with identifier or name '%s'", clusterID)) {
+			log.Logger.Infof("Cluster %s not exists.", clusterID)
+			return nil, true
+		}
+		log.Logger.Errorf("Error happened when delete cluster: %s", output.String())
+		return []error{errDeleteCluster}, false
+	}
+
+	log.Logger.Infof("Waiting for the cluster %s to be uninstalled", clusterID)
+	err := clusterService.WaitForClusterPassUninstalled(clusterID, 2, config.Test.GlobalENV.ClusterWaitingTime)
+	if err != nil {
+		log.Logger.Errorf("Error happened when waiting cluster uninstall: %s", err.Error())
+		// Fail fast: do not attempt OIDC/provider cleanup while the cluster may
+		// still exist; that only produces noisy secondary errors.
+		return []error{err}, false
+	}
+	log.Logger.Infof("Delete cluster %s successfully.", clusterID)
+
+	// Remove OIDC provider only after uninstall completed.
+	if ch.profile.ClusterConfig.STS && ch.profile.ClusterConfig.OIDCConfig != "managed" {
+		_, err = ch.rosaClient.OCMResource.DeleteOIDCProvider("-c", clusterID, "-y", "--mode", "auto")
+		if err != nil {
+			log.Logger.Errorf("Error happened when delete oidc provider: %s", err.Error())
+			errors = append(errors, err)
+		} else {
+			log.Logger.Infof("Delete oidc provider successfully")
 		}
 	}
-	return
+	return errors, true
 }
 
 func (ch *clusterHandler) Destroy() (errors []error) {
-	// destroy cluster
-	errDestroyCluster := ch.destroyCluster()
+	errDestroyCluster, clusterRemoved := ch.destroyCluster()
 	if len(errDestroyCluster) > 0 {
 		errors = append(errors, errDestroyCluster...)
+	}
+
+	if !clusterRemoved {
+		log.Logger.Warnf(
+			"Skipping prepared resource cleanup because the cluster was not fully removed")
+		return errors
 	}
 
 	// Destroy ch.resourcesHandler.Prepared user data


### PR DESCRIPTION
## PR Summary
Fail-fast cluster destroy when uninstall does not complete: skip OIDC provider and prepared-resource cleanup so stuck uninstalls surface one clear error instead of cascading IAM/OIDC noise. The destroy step (and job) still fail.

## Detailed Description of the Issue
On `rosa-hcp-advanced-f3`, destroy sometimes times out waiting for uninstall (~60m). The harness then still attempted OIDC provider deletion and `DestroyResources()`, which fail because the cluster is still present — producing secondary errors and follow-on destroy-post failures (see [ROSAENG-62643](https://redhat.atlassian.net/browse/ROSAENG-62643) plan item 3).

## Related Issues and PRs
- Jira: [ROSAENG-62805](https://redhat.atlassian.net/browse/ROSAENG-62805) (sub-task of [ROSAENG-62643](https://redhat.atlassian.net/browse/ROSAENG-62643))
- Fixes: N/A
- Related PR(s): N/A
- Related design/docs: N/A

## Type of Change
- [x] fix - resolves an incorrect behavior or bug.
- [x] test - adds or updates tests only.

## Previous Behavior
After uninstall wait failure, destroy still ran OIDC cleanup and always ran `DestroyResources()`, cascading noisy secondary failures.

## Behavior After This Change
- `destroyCluster()` returns `(errors, clusterRemoved)`
- Uninstall wait failure → return immediately (no OIDC delete)
- `Destroy()` skips prepared resource cleanup when `clusterRemoved == false`
- Destroy still fails the step (job stays red on stuck uninstall)
- Unit coverage for `skipPreparedResourceCleanup`

This does **not** root-cause hung uninstall (OCM/Hive); it only improves failure signal.

## How to Test (Step-by-Step)
### Preconditions
N/A for unit path; e2e destroy timeout is environment-dependent.

### Test Steps
1. Review `tests/utils/handler/cluster_handler.go`
2. `go test ./tests/utils/handler/`
3. `make pre-push-checks`

### Expected Results
Handler tests pass; on uninstall timeout, logs show skip of prepared resource cleanup and a single destroy error path.

## Proof of the Fix
- `make fmt` / `make fmt-check` / `make lint` OK
- CodeRabbit local (`-t committed`): 0 findings
- `make pre-push-checks` OK (standalone); push hook OK on retry after unrelated `pkg/ocm` flake
- Evidence job (failure mode): https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-rosa-master-e2e-rosa-hcp-advanced-f3/2079982247187845120

## Breaking Changes
- [x] No breaking changes

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] Related docs updated or N/A.
- [x] Structure tests / command args updated or N/A.
- [x] Local verification run (`make pre-push-checks`).
- [x] Risks/limitations noted (does not fix hung uninstall; #4 destroy-post skip is separate).

Made with [Cursor](https://cursor.com)

[ROSAENG-62643]: https://redhat.atlassian.net/browse/ROSAENG-62643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROSAENG-62805]: https://redhat.atlassian.net/browse/ROSAENG-62805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROSAENG-62643]: https://redhat.atlassian.net/browse/ROSAENG-62643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster deletion reliability when identifiers are missing or cluster resources are already unavailable.
  * Cleanup now accurately reflects whether a cluster was removed.
  * Prevented follow-up cleanup from running when deletion or uninstall does not complete successfully.
  * OIDC provider cleanup now occurs only after the cluster has been successfully uninstalled.
  * Reduced the risk of removing prepared resources while a cluster may still exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->