### PR TITLE
ROSAENG-6320 | feat: Adding an option to "rosa version" to show build info

### DIFF
--- a/cmd/rosa/structure_test/command_args/rosa/version/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/version/command_args.yml
@@ -1,2 +1,3 @@
 - name: client
 - name: verbose
+- name: build

--- a/cmd/version/cmd.go
+++ b/cmd/version/cmd.go
@@ -55,6 +55,15 @@ func NewRosaVersionCommand() *cobra.Command {
 		false,
 		"Display verbose version information, including download locations",
 	)
+	buildFlag := "build"
+	cmd.Flags().BoolVarP(
+		&o.build,
+		buildFlag,
+		"b",
+		false,
+		"Display build version information, including git commit and build time",
+	)
+	cmd.Flags().MarkHidden(buildFlag)
 	return cmd
 }
 

--- a/cmd/version/cmd_test.go
+++ b/cmd/version/cmd_test.go
@@ -126,23 +126,31 @@ var _ = Describe("RosaVersionOptions", func() {
 		})
 
 		It("should print version information correctly", func() {
-			// todo move this to a helper func for capturing output of a func
-			var stdout []byte
-			var err error
-
-			rout, wout, _ := os.Pipe()
+			rout, wout, pipeErr := os.Pipe()
+			Expect(pipeErr).ToNot(HaveOccurred())
 			tmpout := os.Stdout
 			defer func() {
 				os.Stdout = tmpout
 			}()
 			os.Stdout = wout
 
+			type result struct {
+				versionErr error
+				closeErr   error
+			}
+			ch := make(chan result, 1)
 			go func() {
-				err = opts.Version()
-				wout.Close()
+				vErr := opts.Version()
+				cErr := wout.Close()
+				ch <- result{versionErr: vErr, closeErr: cErr}
 			}()
-			Expect(err).To(BeNil())
-			stdout, _ = io.ReadAll(rout)
+
+			stdout, readErr := io.ReadAll(rout)
+			Expect(readErr).ToNot(HaveOccurred())
+
+			res := <-ch
+			Expect(res.versionErr).ToNot(HaveOccurred())
+			Expect(res.closeErr).ToNot(HaveOccurred())
 
 			// Verify the outputs
 			Expect(string(stdout)).To(ContainSubstring(info.DefaultVersion))
@@ -154,12 +162,66 @@ var _ = Describe("RosaVersionOptions", func() {
 			}
 		})
 	})
+
+	When("Both clientOnly and build are true", func() {
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+			mockVerify = rosa.NewMockVerifyRosa(ctrl)
+
+			rpt := reporter.CreateReporter()
+
+			opts = &RosaVersionOptions{
+				verifyRosa: mockVerify,
+				reporter:   rpt,
+
+				args: &RosaVersionUserOptions{
+					clientOnly: true,
+					verbose:    false,
+					build:      true,
+				},
+			}
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
+		})
+
+		It("should print version information correctly", func() {
+			rout, wout, pipeErr := os.Pipe()
+			Expect(pipeErr).ToNot(HaveOccurred())
+			tmpout := os.Stdout
+			defer func() {
+				os.Stdout = tmpout
+			}()
+			os.Stdout = wout
+
+			type result struct {
+				versionErr error
+				closeErr   error
+			}
+			ch := make(chan result, 1)
+			go func() {
+				vErr := opts.Version()
+				cErr := wout.Close()
+				ch <- result{versionErr: vErr, closeErr: cErr}
+			}()
+
+			stdout, readErr := io.ReadAll(rout)
+			Expect(readErr).ToNot(HaveOccurred())
+
+			res := <-ch
+			Expect(res.versionErr).ToNot(HaveOccurred())
+			Expect(res.closeErr).ToNot(HaveOccurred())
+
+			// Verify the outputs
+			Expect(string(stdout)).To(ContainSubstring(info.DefaultVersion))
+			Expect(string(stdout)).To(ContainSubstring("Build info: local"))
+		})
+	})
 })
 
 var _ = Describe("NewRosaVersionCommand", func() {
-	var (
-		cmd *cobra.Command
-	)
+	var cmd *cobra.Command
 
 	BeforeEach(func() {
 		cmd = NewRosaVersionCommand()
@@ -186,5 +248,14 @@ var _ = Describe("NewRosaVersionCommand", func() {
 		Expect(verboseFlag.Name).To(Equal("verbose"))
 		Expect(verboseFlag.Shorthand).To(Equal("v"))
 		Expect(verboseFlag.Usage).To(Equal("Display verbose version information, including download locations"))
+	})
+
+	It("should add build flag", func() {
+		buildFlag := cmd.Flag("build")
+		Expect(buildFlag).NotTo(BeNil())
+		Expect(buildFlag.Name).To(Equal("build"))
+		Expect(buildFlag.Shorthand).To(Equal("b"))
+		Expect(buildFlag.Hidden).To(BeTrue())
+		Expect(buildFlag.Usage).To(Equal("Display build version information, including git commit and build time"))
 	})
 })

--- a/cmd/version/options.go
+++ b/cmd/version/options.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"fmt"
+	"runtime/debug"
 
 	verify "github.com/openshift/rosa/cmd/verify/rosa"
 	"github.com/openshift/rosa/pkg/info"
@@ -12,6 +13,7 @@ import (
 type RosaVersionUserOptions struct {
 	clientOnly bool
 	verbose    bool
+	build      bool
 }
 
 func NewRosaVersionUserOptions() *RosaVersionUserOptions {
@@ -45,6 +47,41 @@ func (o *RosaVersionOptions) Version() error {
 		o.reporter.Infof("Information and download locations:\n\t%s\n\t%s\n",
 			version.ConsoleLatestFolder,
 			version.DownloadLatestMirrorFolder)
+	}
+
+	if o.args.build {
+		buildInfo, ok := debug.ReadBuildInfo()
+		if ok {
+			var revision string
+			var buildTime string
+			var dirty bool
+
+			for _, setting := range buildInfo.Settings {
+				switch setting.Key {
+				case "vcs.revision":
+					revision = setting.Value
+				case "vcs.time":
+					buildTime = setting.Value
+				case "vcs.modified":
+					dirty = setting.Value == "true"
+				}
+			}
+
+			if revision == "" {
+				revision = info.Build
+			}
+			buildMsg := revision
+			if dirty {
+				buildMsg += " (dirty)"
+			}
+			if buildTime != "" {
+				buildMsg += " " + buildTime
+			}
+
+			o.reporter.Infof("Build info: %s", buildMsg)
+		} else {
+			o.reporter.Infof("Build info: %s", info.Build)
+		}
 	}
 
 	if !o.args.clientOnly {

--- a/cmd/version/options_test.go
+++ b/cmd/version/options_test.go
@@ -19,10 +19,12 @@ var _ = Describe("RosaVersionOptions", func() {
 				userOptions = RosaVersionUserOptions{
 					verbose:    true,
 					clientOnly: true,
+					build:      true,
 				}
 				expectedArgs = RosaVersionUserOptions{
 					verbose:    true,
 					clientOnly: true,
+					build:      true,
 				}
 				o.BindAndValidate(&userOptions)
 				Expect(o.args).To(Equal(&expectedArgs))


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
Supported ticket prefixes:
OCM-XXXXX, ROSAENG-XXXX
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For contributor workflow, see: ./CONTRIBUTING.md
For repo-local agent guidance, see: ./AGENTS.md
-->

## PR Summary
Adds a new `--build` hidden argument to `rosa version` that shows the build info of the `rosa` binary (git commit, build date, and whether or not the repo was "dirty" at the time of build)

## Detailed Description of the Issue
This is to make it easier to verify what code is included in a given `rosa` binary. This will be especially useful when doing testing leading up to releases as we often need to test a lot of features, and the actual version number won't necessarily be being updated each time. 

## Related Issues and PRs
<!-- Link all tracking items and related code changes -->
- Jira: https://redhat.atlassian.net/browse/ROSAENG-6320
- Fixes: `#`
- Related PR(s):
- Related design/docs:

## Type of Change
<!-- Check the primary type this PR represents -->
- [x] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
We'd compile the binary with `info.Build` containing the commit SHA, but we wouldn't actually expose that variable anywhere, so the only way to find it was to parse the actual `rosa` binary to find the value, or use a tool like `go version -m` to find it 

## Behavior After This Change
Now users can run `rosa version --build` to get find the build info of the binary their running. The new code first checks the stdlib `runtime/debug` package to get the debug build info that Golang embeds into binaries since 1.18. If for some reason that fails, then it falls back to the `info.Build` variable which will either have a commit SHA if it was compiled using the makefile, or it will at least say `local` as a final fallback. If the code can get the debug info, then it also includes the timestamp of when the build was made, and also whether or not the git repo had any local modifications

### dirty branch
```
$ touch test.txt
$ make
go build -ldflags="-X github.com/openshift/rosa/pkg/info.Build=24ddc390d" ./cmd/rosa
$ ./rosa version --build
I: 1.2.64
I: Build info: 24ddc390dce0c0560d8e9af4f715c62d7c3bba4e (dirty) 2026-07-29T14:24:08Z
I: Your ROSA CLI is up to date.
```

### clean branch
```
$ ./rosa version --build
I: 1.2.64
I: Build info: 24ddc390dce0c0560d8e9af4f715c62d7c3bba4e 2026-07-29T14:24:08Z
I: Your ROSA CLI is up to date.

$ ./rosa version --build --verbose
I: 1.2.64
I: Information and download locations:
        https://console.redhat.com/openshift/downloads#tool-rosa
        https://mirror.openshift.com/pub/cgw/rosa/latest/

I: Build info: 24ddc390dce0c0560d8e9af4f715c62d7c3bba4e 2026-07-29T14:24:08Z
I: Your ROSA CLI is up to date.

$ ./rosa version --build --verbose --client
I: 1.2.64
I: Information and download locations:
        https://console.redhat.com/openshift/downloads#tool-rosa
        https://mirror.openshift.com/pub/cgw/rosa/latest/

I: Build info: 24ddc390dce0c0560d8e9af4f715c62d7c3bba4e 2026-07-29T14:24:08Z
```

### help message (to show that the option is hidden)
```
$ ./rosa version --help
Prints the version number of the tool.

Usage:
  rosa version [flags]

Flags:
      --client    Client version only (no remote version check)
  -v, --verbose   Display verbose version information, including download locations
  -h, --help      help for version

Global Flags:
      --color string   Surround certain characters with escape sequences to display them in color on the terminal. Allowed options are [auto never always] (default "auto")
      --debug          Enable debug mode.
```

### without `--build`
```
$ ./rosa version
I: 1.2.64
I: Your ROSA CLI is up to date.
```

## How to Test (Step-by-Step)
1. Build the rosa binary (`make rosa`)
4. Run `rosa version` to make sure the default output is the same as before
5. Run `rosa version --build` to see the new output (see above)

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
<!-- Required only when breaking changes are introduced -->

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [ ] Any risk, limitation, or follow-up work is documented.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hidden `--build` (`-b`) support to the version command.
  * Version output can now include build details such as commit, build time, and repository modification status.

* **Bug Fixes**
  * Added coverage to ensure build information is displayed correctly and build options are handled as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->