### PR TITLE
ROSAENG-61179 | test: expand pkg/ocm coverage

### DIFF
--- a/pkg/ocm/addons.go
+++ b/pkg/ocm/addons.go
@@ -226,11 +226,15 @@ func (c *Client) GetAvailableAddOns() ([]*AddOnResource, error) {
 
 	// Populate enabled add-ons with if they are available for the current org
 	addOnsResponse.Items().Each(func(addOn *asv1.Addon) bool {
-		addOnResource := &AddOnResource{
-			AddOn: addOn,
-		}
-		// Free add-ons are always available
+		// Free add-ons should remain available even without quota metadata.
 		available := addOn.ResourceCost() == 0
+		addOnResource := &AddOnResource{
+			AddOn:     addOn,
+			Available: available,
+		}
+		if available {
+			addOnResource.AZType = ANY
+		}
 
 		// Only return add-ons for which the org has quota
 		quotaCosts.Each(func(quotaCost *amsv1.QuotaCost) bool {
@@ -296,9 +300,10 @@ func (c *Client) GetClusterAddOns(cluster *cmv1.Cluster) ([]*ClusterAddOn, error
 	// Populate add-on installations with all add-on metadata
 	for _, addOnResource := range addOnResources {
 		// Ensure add-on is compatible with the cluster's availability zones
-		if !(addOnResource.AZType == ANY ||
+		isCompatibleAZ := addOnResource.AZType == ANY ||
 			(cluster.MultiAZ() && addOnResource.AZType == "multi") ||
-			(!cluster.MultiAZ() && addOnResource.AZType == "single")) {
+			(!cluster.MultiAZ() && addOnResource.AZType == "single")
+		if !isCompatibleAZ {
 			continue
 		}
 		clusterAddOn := ClusterAddOn{

--- a/pkg/ocm/addons_test.go
+++ b/pkg/ocm/addons_test.go
@@ -1,0 +1,317 @@
+package ocm
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+)
+
+var _ = Describe("Addons API client behavior", func() {
+	var apiServer *ghttp.Server
+	var ocmClient *Client
+
+	BeforeEach(func() {
+		apiServer = MakeTCPServer()
+		apiServer.SetAllowUnhandledRequests(true)
+		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+		ocmClient = buildTestOCMClient(apiServer.URL())
+	})
+
+	AfterEach(func() {
+		apiServer.Close()
+		Expect(ocmClient.Close()).To(Succeed())
+	})
+
+	It("rejects unsupported billing models during add-on installation", func() {
+		err := ocmClient.InstallAddOn("cluster-1", "addon-a", nil, AddOnBilling{
+			BillingModel:     "invalid-model",
+			BillingAccountID: "123456789012",
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not an valid billing model"))
+	})
+
+	It("sends add-on billing and parameter payload during installation", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				func(_ http.ResponseWriter, request *http.Request) {
+					body, err := io.ReadAll(request.Body)
+					Expect(err).NotTo(HaveOccurred())
+
+					payload := map[string]interface{}{}
+					Expect(json.Unmarshal(body, &payload)).To(Succeed())
+
+					addon := payload["addon"].(map[string]interface{})
+					Expect(addon["id"]).To(Equal("addon-a"))
+
+					billing := payload["billing"].(map[string]interface{})
+					Expect(billing["billing_model"]).To(Equal("marketplace"))
+					Expect(billing["billing_marketplace_account"]).To(Equal("123456789012"))
+
+					parameters := payload["parameters"].(map[string]interface{})
+					items := parameters["items"].([]interface{})
+					Expect(items).To(HaveLen(2))
+				},
+				RespondWithJSON(http.StatusCreated, `{}`),
+			),
+		)
+
+		err := ocmClient.InstallAddOn("cluster-1", "addon-a", []AddOnParam{
+			{Key: "foo", Val: "bar"},
+			{Key: "baz", Val: "qux"},
+		}, AddOnBilling{
+			BillingModel:     "marketplace",
+			BillingAccountID: "123456789012",
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("returns add-on installation details", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, `{
+				"id":"addon-a",
+				"addon":{"id":"addon-a"},
+				"billing":{"billing_model":"standard","billing_marketplace_account":"123456789012"}
+			}`),
+		)
+
+		installation, err := ocmClient.GetAddOnInstallation("cluster-1", "addon-a")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(installation).NotTo(BeNil())
+		Expect(installation.ID()).To(Equal("addon-a"))
+		Expect(installation.Addon().ID()).To(Equal("addon-a"))
+	})
+
+	It("filters incompatible add-ons and keeps quota-constrained entries", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, `{
+				"id":"acct-1",
+				"organization":{"id":"org-1"}
+			}`),
+			RespondWithJSON(http.StatusOK, `{
+				"kind":"QuotaCostList",
+				"page":1,
+				"size":1,
+				"total":1,
+				"items":[{
+					"allowed":1,
+					"consumed":1,
+					"related_resources":[
+						{
+							"resource_name":"addon-a",
+							"cost":1,
+							"availability_zone_type":"single",
+							"product":"rosa",
+							"cloud_provider":"aws",
+							"byoc":"byoc"
+						},
+						{
+							"resource_name":"addon-c",
+							"cost":1,
+							"availability_zone_type":"single",
+							"product":"other",
+							"cloud_provider":"aws",
+							"byoc":"byoc"
+						}
+					]
+				}]
+			}`),
+			RespondWithJSON(http.StatusOK, `{
+				"kind":"AddonList",
+				"page":1,
+				"size":3,
+				"total":3,
+				"items":[
+					{"id":"addon-a","name":"Addon A","resource_name":"addon-a","resource_cost":1},
+					{"id":"addon-free","name":"Addon Free","resource_name":"addon-free","resource_cost":0},
+					{"id":"addon-c","name":"Addon C","resource_name":"addon-c","resource_cost":1}
+				]
+			}`),
+		)
+
+		addons, err := ocmClient.GetAvailableAddOns()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(addons).To(HaveLen(2))
+		Expect(addons[0].AddOn.ID()).To(Equal("addon-a"))
+		Expect(addons[0].Available).To(BeFalse())
+		Expect(addons[0].AZType).To(Equal("single"))
+		Expect(addons[1].AddOn.ID()).To(Equal("addon-free"))
+		Expect(addons[1].Available).To(BeTrue())
+	})
+
+	It("excludes add-ons incompatible with cluster AZ topology", func() {
+		cluster, err := cmv1.NewCluster().ID("cluster-1").MultiAZ(false).Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, `{
+				"id":"acct-1",
+				"organization":{"id":"org-1"}
+			}`),
+			RespondWithJSON(http.StatusOK, `{
+				"kind":"QuotaCostList",
+				"page":1,
+				"size":1,
+				"total":1,
+				"items":[{
+					"allowed":2,
+					"consumed":0,
+					"related_resources":[
+						{
+							"resource_name":"addon-single",
+							"cost":1,
+							"availability_zone_type":"single",
+							"product":"rosa",
+							"cloud_provider":"aws",
+							"byoc":"byoc"
+						},
+						{
+							"resource_name":"addon-multi",
+							"cost":1,
+							"availability_zone_type":"multi",
+							"product":"rosa",
+							"cloud_provider":"aws",
+							"byoc":"byoc"
+						}
+					]
+				}]
+			}`),
+			RespondWithJSON(http.StatusOK, `{
+				"kind":"AddonList",
+				"page":1,
+				"size":2,
+				"total":2,
+				"items":[
+					{"id":"addon-single","name":"Addon Single","resource_name":"addon-single","resource_cost":1},
+					{"id":"addon-multi","name":"Addon Multi","resource_name":"addon-multi","resource_cost":1}
+				]
+			}`),
+			RespondWithJSON(http.StatusOK, `{
+				"kind":"AddonInstallationList",
+				"page":1,
+				"size":1,
+				"total":1,
+				"items":[{"addon":{"id":"addon-single"}}]
+			}`),
+		)
+
+		clusterAddons, err := ocmClient.GetClusterAddOns(cluster)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(clusterAddons).To(HaveLen(1))
+		Expect(clusterAddons[0].ID).To(Equal("addon-single"))
+		Expect(clusterAddons[0].State).To(Equal("installing"))
+	})
+
+	It("keeps free add-ons in cluster add-on results without quota metadata", func() {
+		cluster, err := cmv1.NewCluster().ID("cluster-1").MultiAZ(false).Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, `{
+				"id":"acct-1",
+				"organization":{"id":"org-1"}
+			}`),
+			RespondWithJSON(http.StatusOK, `{
+				"kind":"QuotaCostList",
+				"page":1,
+				"size":0,
+				"total":0,
+				"items":[]
+			}`),
+			RespondWithJSON(http.StatusOK, `{
+				"kind":"AddonList",
+				"page":1,
+				"size":1,
+				"total":1,
+				"items":[
+					{"id":"addon-free","name":"Addon Free","resource_name":"addon-free","resource_cost":0}
+				]
+			}`),
+			RespondWithJSON(http.StatusOK, `{
+				"kind":"AddonInstallationList",
+				"page":1,
+				"size":0,
+				"total":0,
+				"items":[]
+			}`),
+		)
+
+		clusterAddons, err := ocmClient.GetClusterAddOns(cluster)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(clusterAddons).To(HaveLen(1))
+		Expect(clusterAddons[0].ID).To(Equal("addon-free"))
+		Expect(clusterAddons[0].State).To(Equal("not installed"))
+	})
+
+	It("returns error when current account lookup fails for available add-ons", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusInternalServerError, `{
+				"kind":"Error",
+				"id":"500",
+				"href":"/api/errors/500",
+				"code":"ACCOUNTS-MGMT-500",
+				"reason":"failed to load current account"
+			}`),
+			RespondWithJSON(http.StatusInternalServerError, `{
+				"kind":"Error",
+				"id":"500",
+				"href":"/api/errors/500",
+				"code":"ACCOUNTS-MGMT-500",
+				"reason":"failed to load current account"
+			}`),
+			RespondWithJSON(http.StatusInternalServerError, `{
+				"kind":"Error",
+				"id":"500",
+				"href":"/api/errors/500",
+				"code":"ACCOUNTS-MGMT-500",
+				"reason":"failed to load current account"
+			}`),
+		)
+
+		addons, err := ocmClient.GetAvailableAddOns()
+		Expect(err).To(HaveOccurred())
+		Expect(addons).To(BeNil())
+		Expect(err.Error()).To(ContainSubstring("failed to load current account"))
+	})
+
+	It("returns error when quota cost lookup fails for available add-ons", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, `{
+				"id":"acct-1",
+				"organization":{"id":"org-1"}
+			}`),
+			RespondWithJSON(http.StatusInternalServerError, `{
+				"kind":"Error",
+				"id":"500",
+				"href":"/api/errors/500",
+				"code":"ACCOUNTS-MGMT-500",
+				"reason":"failed to load quota cost"
+			}`),
+			RespondWithJSON(http.StatusInternalServerError, `{
+				"kind":"Error",
+				"id":"500",
+				"href":"/api/errors/500",
+				"code":"ACCOUNTS-MGMT-500",
+				"reason":"failed to load quota cost"
+			}`),
+			RespondWithJSON(http.StatusInternalServerError, `{
+				"kind":"Error",
+				"id":"500",
+				"href":"/api/errors/500",
+				"code":"ACCOUNTS-MGMT-500",
+				"reason":"failed to load quota cost"
+			}`),
+		)
+
+		addons, err := ocmClient.GetAvailableAddOns()
+		Expect(err).To(HaveOccurred())
+		Expect(addons).To(BeNil())
+		Expect(err.Error()).To(ContainSubstring("failed to load quota cost"))
+	})
+})

--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -269,9 +269,14 @@ func (c *Client) CreateCluster(config Spec) (*cmv1.Cluster, error) {
 		return nil, fmt.Errorf("unable to create cluster spec: %v", err)
 	}
 
+	dryRun := false
+	if config.DryRun != nil {
+		dryRun = *config.DryRun
+	}
+
 	cluster, err := c.ocm.ClustersMgmt().V1().Clusters().
 		Add().
-		Parameter("dryRun", *config.DryRun).
+		Parameter("dryRun", dryRun).
 		Body(spec).
 		Send()
 	if config.DryRun != nil && *config.DryRun {
@@ -329,11 +334,12 @@ func (c *Client) queryClusters(query string, count int) (clusters []*cmv1.Cluste
 
 	request := c.ocm.ClustersMgmt().V1().Clusters().List().Search(query)
 	page := 1
+	pageSize := count
+	if count == 0 {
+		pageSize = 100
+	}
 	for {
-		clusterRequestList := request.Page(page)
-		if count > 0 {
-			clusterRequestList = clusterRequestList.Size(count)
-		}
+		clusterRequestList := request.Page(page).Size(pageSize)
 		response, err := clusterRequestList.Send()
 		if err != nil {
 			return clusters, err
@@ -343,7 +349,11 @@ func (c *Client) queryClusters(query string, count int) (clusters []*cmv1.Cluste
 			clusters = append(clusters, cluster)
 			return true
 		})
-		if response.Size() != count {
+		if count == 0 {
+			if len(clusters) >= response.Total() {
+				break
+			}
+		} else if response.Size() < pageSize {
 			break
 		}
 		page++

--- a/pkg/ocm/clusters_client_test.go
+++ b/pkg/ocm/clusters_client_test.go
@@ -1,0 +1,229 @@
+package ocm
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+
+	"github.com/openshift/rosa/pkg/aws"
+)
+
+func buildTestOCMClient(apiServerURL string) *Client {
+	accessToken := MakeTokenString("Bearer", 15*time.Minute)
+	logger, err := logging.NewGoLoggerBuilder().Debug(true).Build()
+	Expect(err).NotTo(HaveOccurred())
+
+	connection, err := sdk.NewConnectionBuilder().
+		Logger(logger).
+		Tokens(accessToken).
+		URL(apiServerURL).
+		Build()
+	Expect(err).NotTo(HaveOccurred())
+
+	return &Client{ocm: connection}
+}
+
+func buildMinimalClusterSpec() Spec {
+	return Spec{
+		Name:       "test-cluster",
+		Region:     "us-east-1",
+		AWSCreator: &aws.Creator{ARN: "arn:aws:iam::123456789012:user/test-user", AccountID: "123456789012"},
+		AWSAccessKey: &aws.AccessKey{
+			AccessKeyID:     "AKIA1234567890EXAMPLE",
+			SecretAccessKey: "secret",
+		},
+	}
+}
+
+var _ = Describe("Cluster API client behavior", func() {
+	var apiServer *ghttp.Server
+	var ocmClient *Client
+
+	BeforeEach(func() {
+		apiServer = MakeTCPServer()
+		apiServer.SetAllowUnhandledRequests(true)
+		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+		ocmClient = buildTestOCMClient(apiServer.URL())
+	})
+
+	AfterEach(func() {
+		apiServer.Close()
+		Expect(ocmClient.Close()).To(Succeed())
+	})
+
+	It("handles CreateCluster when DryRun is nil", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusCreated, `{"id":"cluster-1","name":"test-cluster"}`),
+		)
+
+		spec := buildMinimalClusterSpec()
+
+		var (
+			cluster *cmv1.Cluster
+			err     error
+		)
+		Expect(func() {
+			cluster, err = ocmClient.CreateCluster(spec)
+		}).NotTo(Panic())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cluster).NotTo(BeNil())
+		Expect(cluster.ID()).To(Equal("cluster-1"))
+	})
+
+	It("paginates all results when GetClusters count is zero", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, `{
+				"kind":"ClusterList",
+				"page":1,
+				"size":1,
+				"total":2,
+				"items":[{"id":"cluster-1","name":"one"}]
+			}`),
+			RespondWithJSON(http.StatusOK, `{
+				"kind":"ClusterList",
+				"page":2,
+				"size":1,
+				"total":2,
+				"items":[{"id":"cluster-2","name":"two"}]
+			}`),
+		)
+
+		clusters, err := ocmClient.GetClusters(nil, 0)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(clusters).To(HaveLen(2))
+		Expect(clusters[0].ID()).To(Equal("cluster-1"))
+		Expect(clusters[1].ID()).To(Equal("cluster-2"))
+	})
+
+	It("sends dryRun query and payload when CreateCluster dry run is requested", func() {
+		dryRun := true
+		spec := buildMinimalClusterSpec()
+		spec.DryRun = &dryRun
+		spec.Version = "4.15.1"
+
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				func(_ http.ResponseWriter, request *http.Request) {
+					Expect(request.URL.Query().Get("dryRun")).To(Equal("true"))
+					body, err := io.ReadAll(request.Body)
+					Expect(err).NotTo(HaveOccurred())
+
+					payload := map[string]interface{}{}
+					Expect(json.Unmarshal(body, &payload)).To(Succeed())
+					Expect(payload["name"]).To(Equal("test-cluster"))
+					Expect(payload).To(HaveKey("version"))
+				},
+				RespondWithJSON(http.StatusCreated, `{"id":"cluster-1","name":"test-cluster"}`),
+			),
+		)
+
+		cluster, err := ocmClient.CreateCluster(spec)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cluster).To(BeNil())
+	})
+
+	It("updates a cluster after resolving it by key", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, `{
+				"kind":"ClusterList",
+				"page":1,
+				"size":1,
+				"total":1,
+				"items":[{"id":"cluster-1","name":"one"}]
+			}`),
+			RespondWithJSON(http.StatusOK, `{"id":"cluster-1"}`),
+		)
+
+		err := ocmClient.UpdateCluster("cluster-1", nil, Spec{
+			Version: "4.15.2",
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("returns empty state when GetClusterState has no body", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, `{}`),
+		)
+
+		state, err := ocmClient.GetClusterState("cluster-1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(state).To(Equal(cmv1.ClusterState("")))
+	})
+
+	It("deletes a cluster after resolving it by key", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, `{
+				"kind":"ClusterList",
+				"page":1,
+				"size":1,
+				"total":1,
+				"items":[{"id":"cluster-1","name":"one"}]
+			}`),
+			RespondWithJSON(http.StatusOK, `{"kind":"DeleteResponse"}`),
+		)
+
+		cluster, err := ocmClient.DeleteCluster("cluster-1", false, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cluster).NotTo(BeNil())
+		Expect(cluster.ID()).To(Equal("cluster-1"))
+	})
+
+	It("hibernates a cluster when org capability is enabled", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, `{
+				"id":"acct-1",
+				"organization":{"id":"org-1","external_id":"ext-1"}
+			}`),
+			RespondWithJSON(http.StatusOK, `{
+				"id":"org-1",
+				"capabilities":[{"name":"capability.organization.hibernate_cluster","value":"true"}]
+			}`),
+			RespondWithJSON(http.StatusOK, `{}`),
+		)
+
+		err := ocmClient.HibernateCluster("cluster-1")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("resumes a cluster when org capability is enabled", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, `{
+				"id":"acct-1",
+				"organization":{"id":"org-1","external_id":"ext-1"}
+			}`),
+			RespondWithJSON(http.StatusOK, `{
+				"id":"org-1",
+				"capabilities":[{"name":"capability.organization.hibernate_cluster","value":"true"}]
+			}`),
+			RespondWithJSON(http.StatusOK, `{}`),
+		)
+
+		err := ocmClient.ResumeCluster("cluster-1")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("detects clusters using a matching oidc endpoint url", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, `{
+				"kind":"ClusterList",
+				"page":1,
+				"size":1,
+				"total":1,
+				"items":[{"id":"cluster-1"}]
+			}`),
+		)
+
+		exists, err := ocmClient.HasAClusterUsingOidcEndpointUrl("https://issuer.example.com")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(exists).To(BeTrue())
+	})
+})

--- a/pkg/ocm/dns_domain_test.go
+++ b/pkg/ocm/dns_domain_test.go
@@ -1,6 +1,7 @@
 package ocm
 
 import (
+	"encoding/json"
 	"net/http"
 	"time"
 
@@ -20,7 +21,6 @@ var _ = Describe("DNS Domains", Ordered, func() {
 	BeforeEach(func() {
 		ssoServer = MakeTCPServer()
 		apiServer = MakeTCPServer()
-		apiServer.SetAllowUnhandledRequests(true)
 		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
 
 		accessToken := MakeTokenString("Bearer", 15*time.Minute)
@@ -48,6 +48,7 @@ var _ = Describe("DNS Domains", Ordered, func() {
 	It("lists DNS domains with search and order parameters", func() {
 		apiServer.AppendHandlers(
 			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/dns_domains"),
 				ghttp.VerifyFormKV("search", "name like 'example'"),
 				ghttp.VerifyFormKV("order", "organization.id asc"),
 				RespondWithJSON(http.StatusOK, `{
@@ -67,8 +68,24 @@ var _ = Describe("DNS Domains", Ordered, func() {
 	})
 
 	It("creates and deletes DNS domains", func() {
-		apiServer.AppendHandlers(RespondWithJSON(http.StatusCreated, `{"id":"dns-2","user_defined":true}`))
-		apiServer.AppendHandlers(RespondWithJSON(http.StatusNoContent, ``))
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/dns_domains"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					payload := map[string]interface{}{}
+					Expect(json.NewDecoder(request.Body).Decode(&payload)).To(Succeed())
+					Expect(payload).To(HaveKeyWithValue("id", "dns-2"))
+					Expect(payload).To(HaveKeyWithValue("user_defined", true))
+				},
+				RespondWithJSON(http.StatusCreated, `{"id":"dns-2","user_defined":true}`),
+			),
+		)
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodDelete, "/api/clusters_mgmt/v1/dns_domains/dns-2"),
+				RespondWithJSON(http.StatusNoContent, ``),
+			),
+		)
 
 		domainInput, err := cmv1.NewDNSDomain().ID("dns-2").UserDefined(true).Build()
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/ocm/dns_domain_test.go
+++ b/pkg/ocm/dns_domain_test.go
@@ -1,0 +1,84 @@
+package ocm
+
+import (
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+)
+
+var _ = Describe("DNS Domains", Ordered, func() {
+	var ssoServer, apiServer *ghttp.Server
+	var ocmClient *Client
+
+	BeforeEach(func() {
+		ssoServer = MakeTCPServer()
+		apiServer = MakeTCPServer()
+		apiServer.SetAllowUnhandledRequests(true)
+		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+
+		accessToken := MakeTokenString("Bearer", 15*time.Minute)
+		ssoServer.AppendHandlers(RespondWithAccessToken(accessToken))
+
+		logger, err := logging.NewGoLoggerBuilder().Debug(true).Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		connection, err := sdk.NewConnectionBuilder().
+			Logger(logger).
+			Tokens(accessToken).
+			URL(apiServer.URL()).
+			Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		ocmClient = NewClientWithConnection(connection)
+	})
+
+	AfterEach(func() {
+		ssoServer.Close()
+		apiServer.Close()
+		Expect(ocmClient.Close()).To(Succeed())
+	})
+
+	It("lists DNS domains with search and order parameters", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyFormKV("search", "name like 'example'"),
+				ghttp.VerifyFormKV("order", "organization.id asc"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind": "DNSDomainList",
+					"page": 1,
+					"size": 1,
+					"total": 1,
+					"items": [{"id":"dns-1","user_defined":true}]
+				}`),
+			),
+		)
+
+		domains, err := ocmClient.ListDNSDomains("name like 'example'")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(domains).To(HaveLen(1))
+		Expect(domains[0].ID()).To(Equal("dns-1"))
+	})
+
+	It("creates and deletes DNS domains", func() {
+		apiServer.AppendHandlers(RespondWithJSON(http.StatusCreated, `{"id":"dns-2","user_defined":true}`))
+		apiServer.AppendHandlers(RespondWithJSON(http.StatusNoContent, ``))
+
+		domainInput, err := cmv1.NewDNSDomain().ID("dns-2").UserDefined(true).Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		created, err := ocmClient.CreateDNSDomain(domainInput)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(created).NotTo(BeNil())
+		Expect(created.ID()).To(Equal("dns-2"))
+
+		err = ocmClient.DeleteDNSDomain("dns-2")
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/pkg/ocm/gates_test.go
+++ b/pkg/ocm/gates_test.go
@@ -1,0 +1,138 @@
+package ocm
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+)
+
+var _ = Describe("Version gates API client behavior", func() {
+	var apiServer *ghttp.Server
+	var ocmClient *Client
+
+	BeforeEach(func() {
+		apiServer = MakeTCPServer()
+		apiServer.SetAllowUnhandledRequests(true)
+		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+		ocmClient = buildTestOCMClient(apiServer.URL())
+	})
+
+	AfterEach(func() {
+		apiServer.Close()
+		Expect(ocmClient.Close()).To(Succeed())
+	})
+
+	It("paginates all version gate pages and applies the version prefix filter", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				func(_ http.ResponseWriter, request *http.Request) {
+					Expect(request.URL.Query().Get("page")).To(Equal("1"))
+					Expect(request.URL.Query().Get("size")).To(Equal("100"))
+					Expect(request.URL.Query().Get("search")).To(Equal("version_raw_id_prefix = '4.15'"))
+				},
+				RespondWithJSON(http.StatusOK, `{
+					"kind":"VersionGateList",
+					"page":1,
+					"size":100,
+					"total":101,
+					"items":[{"id":"gate-1","sts_only":true}]
+				}`),
+			),
+			ghttp.CombineHandlers(
+				func(_ http.ResponseWriter, request *http.Request) {
+					Expect(request.URL.Query().Get("page")).To(Equal("2"))
+					Expect(request.URL.Query().Get("size")).To(Equal("100"))
+				},
+				RespondWithJSON(http.StatusOK, `{
+					"kind":"VersionGateList",
+					"page":2,
+					"size":1,
+					"total":101,
+					"items":[{"id":"gate-2","sts_only":false}]
+				}`),
+			),
+		)
+
+		gates, err := ocmClient.ListAllOcpGates("4.15")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(gates).To(HaveLen(2))
+		Expect(gates[0].ID()).To(Equal("gate-1"))
+		Expect(gates[1].ID()).To(Equal("gate-2"))
+	})
+
+	It("returns only STS-only gates", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, `{
+				"kind":"VersionGateList",
+				"page":1,
+				"size":2,
+				"total":2,
+				"items":[
+					{"id":"gate-sts","sts_only":true},
+					{"id":"gate-shared","sts_only":false}
+				]
+			}`),
+		)
+
+		gates, err := ocmClient.ListStsGates("4.15")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(gates).To(HaveLen(1))
+		Expect(gates[0].ID()).To(Equal("gate-sts"))
+		Expect(gates[0].STSOnly()).To(BeTrue())
+	})
+
+	It("returns only non-STS gates", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, `{
+				"kind":"VersionGateList",
+				"page":1,
+				"size":2,
+				"total":2,
+				"items":[
+					{"id":"gate-sts","sts_only":true},
+					{"id":"gate-shared","sts_only":false}
+				]
+			}`),
+		)
+
+		gates, err := ocmClient.ListOcpGates("4.15")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(gates).To(HaveLen(1))
+		Expect(gates[0].ID()).To(Equal("gate-shared"))
+		Expect(gates[0].STSOnly()).To(BeFalse())
+	})
+
+	It("returns an error when listing all gates fails", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusInternalServerError, `{
+				"kind":"Error",
+				"id":"500",
+				"href":"/api/errors/500",
+				"code":"CLUSTERS-MGMT-500",
+				"reason":"unable to list version gates"
+			}`),
+			RespondWithJSON(http.StatusInternalServerError, `{
+				"kind":"Error",
+				"id":"500",
+				"href":"/api/errors/500",
+				"code":"CLUSTERS-MGMT-500",
+				"reason":"unable to list version gates"
+			}`),
+			RespondWithJSON(http.StatusInternalServerError, `{
+				"kind":"Error",
+				"id":"500",
+				"href":"/api/errors/500",
+				"code":"CLUSTERS-MGMT-500",
+				"reason":"unable to list version gates"
+			}`),
+		)
+
+		gates, err := ocmClient.ListAllOcpGates("4.15")
+		Expect(err).To(HaveOccurred())
+		Expect(gates).To(BeNil())
+		Expect(err.Error()).To(ContainSubstring("unable to list version gates"))
+	})
+})

--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -388,6 +388,9 @@ func (c *Client) GetCurrentOrganization() (id string, externalID string, err err
 	if err != nil {
 		return
 	}
+	if acctResponse == nil {
+		return
+	}
 	id = acctResponse.Organization().ID()
 	externalID = acctResponse.Organization().ExternalID()
 

--- a/pkg/ocm/helpers_client_test.go
+++ b/pkg/ocm/helpers_client_test.go
@@ -1,0 +1,120 @@
+package ocm
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+)
+
+var _ = Describe("Helpers API client behavior", func() {
+	var apiServer *ghttp.Server
+	var ocmClient *Client
+
+	BeforeEach(func() {
+		apiServer = MakeTCPServer()
+		apiServer.SetAllowUnhandledRequests(true)
+		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+		ocmClient = buildTestOCMClient(apiServer.URL())
+	})
+
+	AfterEach(func() {
+		apiServer.Close()
+		Expect(ocmClient.Close()).To(Succeed())
+	})
+
+	It("handles missing current account in GetCurrentOrganization", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusNotFound, `{"reason":"not found"}`),
+		)
+
+		var (
+			id         string
+			externalID string
+			err        error
+		)
+		Expect(func() {
+			id, externalID, err = ocmClient.GetCurrentOrganization()
+		}).NotTo(Panic())
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(id).To(BeEmpty())
+		Expect(externalID).To(BeEmpty())
+	})
+
+	It("returns current account body when GetCurrentAccount succeeds", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, `{
+				"id":"acct-1",
+				"organization":{"id":"org-1","external_id":"ext-1"}
+			}`),
+		)
+
+		account, err := ocmClient.GetCurrentAccount()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(account).NotTo(BeNil())
+		Expect(account.ID()).To(Equal("acct-1"))
+		Expect(account.Organization().ID()).To(Equal("org-1"))
+	})
+
+	It("links a role to organization labels when account is not present yet", func() {
+		roleARN := "arn:aws:iam::123456789012:role/first-role"
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, `{"key":"sts_ocm_role","value":""}`),
+			RespondWithJSON(http.StatusCreated, `{"key":"sts_ocm_role","value":"arn:aws:iam::123456789012:role/first-role"}`),
+		)
+
+		linked, err := ocmClient.LinkOrgToRole("org-1", roleARN)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(linked).To(BeTrue())
+	})
+
+	It("rejects linking a second role for the same aws account", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, `{"key":"sts_ocm_role","value":"arn:aws:iam::123456789012:role/existing-role"}`),
+		)
+
+		linked, err := ocmClient.LinkOrgToRole("org-1", "arn:aws:iam::123456789012:role/new-role")
+		Expect(err).To(HaveOccurred())
+		Expect(linked).To(BeFalse())
+		Expect(err.Error()).To(ContainSubstring("Only one role can be linked per AWS account per organization"))
+	})
+
+	It("unlinks organization ocm role by deleting label when last entry is removed", func() {
+		roleARN := "arn:aws:iam::123456789012:role/only-role"
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, `{"key":"sts_ocm_role","value":"arn:aws:iam::123456789012:role/only-role"}`),
+			RespondWithJSON(http.StatusOK, `{}`),
+		)
+
+		err := ocmClient.UnlinkOCMRoleFromOrg("org-1", roleARN)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("avoids creating duplicate user role links on an account", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, `{"key":"sts_user_role","value":"arn:aws:iam::123456789012:role/existing"}`),
+		)
+
+		err := ocmClient.LinkAccountRole("acct-1", "arn:aws:iam::123456789012:role/existing")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("unlinks a user role from account labels and updates remaining roles", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, `{
+				"key":"sts_user_role",
+				"value":"arn:aws:iam::123456789012:role/remove,arn:aws:iam::123456789012:role/keep"
+			}`),
+			RespondWithJSON(http.StatusOK, `{
+				"key":"sts_user_role",
+				"value":"arn:aws:iam::123456789012:role/keep"
+			}`),
+		)
+
+		err := ocmClient.UnlinkUserRoleFromAccount("acct-1", "arn:aws:iam::123456789012:role/remove")
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/pkg/ocm/helpers_client_test.go
+++ b/pkg/ocm/helpers_client_test.go
@@ -1,6 +1,7 @@
 package ocm
 
 import (
+	"encoding/json"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -15,7 +16,6 @@ var _ = Describe("Helpers API client behavior", func() {
 
 	BeforeEach(func() {
 		apiServer = MakeTCPServer()
-		apiServer.SetAllowUnhandledRequests(true)
 		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
 		ocmClient = buildTestOCMClient(apiServer.URL())
 	})
@@ -27,7 +27,10 @@ var _ = Describe("Helpers API client behavior", func() {
 
 	It("handles missing current account in GetCurrentOrganization", func() {
 		apiServer.AppendHandlers(
-			RespondWithJSON(http.StatusNotFound, `{"reason":"not found"}`),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/accounts_mgmt/v1/current_account"),
+				RespondWithJSON(http.StatusNotFound, `{"reason":"not found"}`),
+			),
 		)
 
 		var (
@@ -46,10 +49,13 @@ var _ = Describe("Helpers API client behavior", func() {
 
 	It("returns current account body when GetCurrentAccount succeeds", func() {
 		apiServer.AppendHandlers(
-			RespondWithJSON(http.StatusOK, `{
-				"id":"acct-1",
-				"organization":{"id":"org-1","external_id":"ext-1"}
-			}`),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/accounts_mgmt/v1/current_account"),
+				RespondWithJSON(http.StatusOK, `{
+					"id":"acct-1",
+					"organization":{"id":"org-1","external_id":"ext-1"}
+				}`),
+			),
 		)
 
 		account, err := ocmClient.GetCurrentAccount()
@@ -62,8 +68,20 @@ var _ = Describe("Helpers API client behavior", func() {
 	It("links a role to organization labels when account is not present yet", func() {
 		roleARN := "arn:aws:iam::123456789012:role/first-role"
 		apiServer.AppendHandlers(
-			RespondWithJSON(http.StatusOK, `{"key":"sts_ocm_role","value":""}`),
-			RespondWithJSON(http.StatusCreated, `{"key":"sts_ocm_role","value":"arn:aws:iam::123456789012:role/first-role"}`),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/accounts_mgmt/v1/organizations/org-1/labels/sts_ocm_role"),
+				RespondWithJSON(http.StatusOK, `{"key":"sts_ocm_role","value":""}`),
+			),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/accounts_mgmt/v1/organizations/org-1/labels"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					payload := map[string]string{}
+					Expect(json.NewDecoder(request.Body).Decode(&payload)).To(Succeed())
+					Expect(payload).To(HaveKeyWithValue("key", "sts_ocm_role"))
+					Expect(payload).To(HaveKeyWithValue("value", roleARN))
+				},
+				RespondWithJSON(http.StatusCreated, `{"key":"sts_ocm_role","value":"arn:aws:iam::123456789012:role/first-role"}`),
+			),
 		)
 
 		linked, err := ocmClient.LinkOrgToRole("org-1", roleARN)
@@ -73,7 +91,10 @@ var _ = Describe("Helpers API client behavior", func() {
 
 	It("rejects linking a second role for the same aws account", func() {
 		apiServer.AppendHandlers(
-			RespondWithJSON(http.StatusOK, `{"key":"sts_ocm_role","value":"arn:aws:iam::123456789012:role/existing-role"}`),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/accounts_mgmt/v1/organizations/org-1/labels/sts_ocm_role"),
+				RespondWithJSON(http.StatusOK, `{"key":"sts_ocm_role","value":"arn:aws:iam::123456789012:role/existing-role"}`),
+			),
 		)
 
 		linked, err := ocmClient.LinkOrgToRole("org-1", "arn:aws:iam::123456789012:role/new-role")
@@ -85,8 +106,14 @@ var _ = Describe("Helpers API client behavior", func() {
 	It("unlinks organization ocm role by deleting label when last entry is removed", func() {
 		roleARN := "arn:aws:iam::123456789012:role/only-role"
 		apiServer.AppendHandlers(
-			RespondWithJSON(http.StatusOK, `{"key":"sts_ocm_role","value":"arn:aws:iam::123456789012:role/only-role"}`),
-			RespondWithJSON(http.StatusOK, `{}`),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/accounts_mgmt/v1/organizations/org-1/labels/sts_ocm_role"),
+				RespondWithJSON(http.StatusOK, `{"key":"sts_ocm_role","value":"arn:aws:iam::123456789012:role/only-role"}`),
+			),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodDelete, "/api/accounts_mgmt/v1/organizations/org-1/labels/sts_ocm_role"),
+				RespondWithJSON(http.StatusOK, `{}`),
+			),
 		)
 
 		err := ocmClient.UnlinkOCMRoleFromOrg("org-1", roleARN)
@@ -95,7 +122,10 @@ var _ = Describe("Helpers API client behavior", func() {
 
 	It("avoids creating duplicate user role links on an account", func() {
 		apiServer.AppendHandlers(
-			RespondWithJSON(http.StatusOK, `{"key":"sts_user_role","value":"arn:aws:iam::123456789012:role/existing"}`),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/accounts_mgmt/v1/accounts/acct-1/labels/sts_user_role"),
+				RespondWithJSON(http.StatusOK, `{"key":"sts_user_role","value":"arn:aws:iam::123456789012:role/existing"}`),
+			),
 		)
 
 		err := ocmClient.LinkAccountRole("acct-1", "arn:aws:iam::123456789012:role/existing")
@@ -104,14 +134,26 @@ var _ = Describe("Helpers API client behavior", func() {
 
 	It("unlinks a user role from account labels and updates remaining roles", func() {
 		apiServer.AppendHandlers(
-			RespondWithJSON(http.StatusOK, `{
-				"key":"sts_user_role",
-				"value":"arn:aws:iam::123456789012:role/remove,arn:aws:iam::123456789012:role/keep"
-			}`),
-			RespondWithJSON(http.StatusOK, `{
-				"key":"sts_user_role",
-				"value":"arn:aws:iam::123456789012:role/keep"
-			}`),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/accounts_mgmt/v1/accounts/acct-1/labels/sts_user_role"),
+				RespondWithJSON(http.StatusOK, `{
+					"key":"sts_user_role",
+					"value":"arn:aws:iam::123456789012:role/remove,arn:aws:iam::123456789012:role/keep"
+				}`),
+			),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPatch, "/api/accounts_mgmt/v1/accounts/acct-1/labels/sts_user_role"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					payload := map[string]string{}
+					Expect(json.NewDecoder(request.Body).Decode(&payload)).To(Succeed())
+					Expect(payload).To(HaveKeyWithValue("key", "sts_user_role"))
+					Expect(payload).To(HaveKeyWithValue("value", "arn:aws:iam::123456789012:role/keep"))
+				},
+				RespondWithJSON(http.StatusOK, `{
+					"key":"sts_user_role",
+					"value":"arn:aws:iam::123456789012:role/keep"
+				}`),
+			),
 		)
 
 		err := ocmClient.UnlinkUserRoleFromAccount("acct-1", "arn:aws:iam::123456789012:role/remove")

--- a/pkg/ocm/ingresses_test.go
+++ b/pkg/ocm/ingresses_test.go
@@ -1,6 +1,7 @@
 package ocm
 
 import (
+	"encoding/json"
 	"net/http"
 	"time"
 
@@ -22,7 +23,6 @@ var _ = Describe("Ingresses", Ordered, func() {
 	BeforeEach(func() {
 		ssoServer = MakeTCPServer()
 		apiServer = MakeTCPServer()
-		apiServer.SetAllowUnhandledRequests(true)
 		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
 
 		accessToken := MakeTokenString("Bearer", 15*time.Minute)
@@ -60,7 +60,12 @@ var _ = Describe("Ingresses", Ordered, func() {
 		}`
 
 		It("returns the default ingress for apps", func() {
-			apiServer.AppendHandlers(RespondWithJSON(http.StatusOK, ingressesBody))
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/ingresses"),
+					RespondWithJSON(http.StatusOK, ingressesBody),
+				),
+			)
 
 			ingress, err := ocmClient.GetIngress(clusterID, "apps")
 			Expect(err).NotTo(HaveOccurred())
@@ -69,7 +74,12 @@ var _ = Describe("Ingresses", Ordered, func() {
 		})
 
 		It("returns the non-default ingress for apps2", func() {
-			apiServer.AppendHandlers(RespondWithJSON(http.StatusOK, ingressesBody))
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/ingresses"),
+					RespondWithJSON(http.StatusOK, ingressesBody),
+				),
+			)
 
 			ingress, err := ocmClient.GetIngress(clusterID, "apps2")
 			Expect(err).NotTo(HaveOccurred())
@@ -78,7 +88,12 @@ var _ = Describe("Ingresses", Ordered, func() {
 		})
 
 		It("returns ingress by explicit id lookup", func() {
-			apiServer.AppendHandlers(RespondWithJSON(http.StatusOK, ingressesBody))
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/ingresses"),
+					RespondWithJSON(http.StatusOK, ingressesBody),
+				),
+			)
 
 			ingress, err := ocmClient.GetIngress(clusterID, "custom-ingress")
 			Expect(err).NotTo(HaveOccurred())
@@ -87,7 +102,12 @@ var _ = Describe("Ingresses", Ordered, func() {
 		})
 
 		It("returns not found error when ingress key has no match", func() {
-			apiServer.AppendHandlers(RespondWithJSON(http.StatusOK, ingressesBody))
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/ingresses"),
+					RespondWithJSON(http.StatusOK, ingressesBody),
+				),
+			)
 
 			ingress, err := ocmClient.GetIngress(clusterID, "missing")
 			Expect(err).To(HaveOccurred())
@@ -98,13 +118,18 @@ var _ = Describe("Ingresses", Ordered, func() {
 
 	Describe("GetIngresses", func() {
 		It("returns ingress list", func() {
-			apiServer.AppendHandlers(RespondWithJSON(http.StatusOK, `{
-				"kind": "IngressList",
-				"page": 1,
-				"size": 1,
-				"total": 1,
-				"items": [{"id": "ingress-1", "default": true}]
-			}`))
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/ingresses"),
+					RespondWithJSON(http.StatusOK, `{
+						"kind": "IngressList",
+						"page": 1,
+						"size": 1,
+						"total": 1,
+						"items": [{"id": "ingress-1", "default": true}]
+					}`),
+				),
+			)
 
 			ingresses, err := ocmClient.GetIngresses(clusterID)
 			Expect(err).NotTo(HaveOccurred())
@@ -115,10 +140,21 @@ var _ = Describe("Ingresses", Ordered, func() {
 
 	Describe("UpdateIngress", func() {
 		It("updates and returns ingress", func() {
-			apiServer.AppendHandlers(RespondWithJSON(http.StatusOK, `{
-				"id": "ingress-1",
-				"default": false
-			}`))
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/cluster-1/ingresses/ingress-1"),
+					func(_ http.ResponseWriter, request *http.Request) {
+						payload := map[string]interface{}{}
+						Expect(json.NewDecoder(request.Body).Decode(&payload)).To(Succeed())
+						Expect(payload).To(HaveKeyWithValue("id", "ingress-1"))
+						Expect(payload).To(HaveKeyWithValue("default", false))
+					},
+					RespondWithJSON(http.StatusOK, `{
+						"id": "ingress-1",
+						"default": false
+					}`),
+				),
+			)
 
 			ingress, err := cmv1.NewIngress().
 				ID("ingress-1").
@@ -135,7 +171,12 @@ var _ = Describe("Ingresses", Ordered, func() {
 
 	Describe("DeleteIngress", func() {
 		It("deletes ingress", func() {
-			apiServer.AppendHandlers(RespondWithJSON(http.StatusNoContent, ""))
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodDelete, "/api/clusters_mgmt/v1/clusters/cluster-1/ingresses/ingress-1"),
+					RespondWithJSON(http.StatusNoContent, ""),
+				),
+			)
 
 			err := ocmClient.DeleteIngress(clusterID, "ingress-1")
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/ocm/ingresses_test.go
+++ b/pkg/ocm/ingresses_test.go
@@ -1,0 +1,144 @@
+package ocm
+
+import (
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+)
+
+var _ = Describe("Ingresses", Ordered, func() {
+	const clusterID = "cluster-1"
+
+	var ssoServer, apiServer *ghttp.Server
+	var ocmClient *Client
+
+	BeforeEach(func() {
+		ssoServer = MakeTCPServer()
+		apiServer = MakeTCPServer()
+		apiServer.SetAllowUnhandledRequests(true)
+		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+
+		accessToken := MakeTokenString("Bearer", 15*time.Minute)
+		ssoServer.AppendHandlers(RespondWithAccessToken(accessToken))
+
+		logger, err := logging.NewGoLoggerBuilder().Debug(true).Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		connection, err := sdk.NewConnectionBuilder().
+			Logger(logger).
+			Tokens(accessToken).
+			URL(apiServer.URL()).
+			Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		ocmClient = NewClientWithConnection(connection)
+	})
+
+	AfterEach(func() {
+		ssoServer.Close()
+		apiServer.Close()
+		Expect(ocmClient.Close()).To(Succeed())
+	})
+
+	Describe("GetIngress", func() {
+		const ingressesBody = `{
+			"kind": "IngressList",
+			"page": 1,
+			"size": 2,
+			"total": 2,
+			"items": [
+				{"id": "default-ingress", "default": true},
+				{"id": "custom-ingress", "default": false}
+			]
+		}`
+
+		It("returns the default ingress for apps", func() {
+			apiServer.AppendHandlers(RespondWithJSON(http.StatusOK, ingressesBody))
+
+			ingress, err := ocmClient.GetIngress(clusterID, "apps")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ingress).NotTo(BeNil())
+			Expect(ingress.ID()).To(Equal("default-ingress"))
+		})
+
+		It("returns the non-default ingress for apps2", func() {
+			apiServer.AppendHandlers(RespondWithJSON(http.StatusOK, ingressesBody))
+
+			ingress, err := ocmClient.GetIngress(clusterID, "apps2")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ingress).NotTo(BeNil())
+			Expect(ingress.ID()).To(Equal("custom-ingress"))
+		})
+
+		It("returns ingress by explicit id lookup", func() {
+			apiServer.AppendHandlers(RespondWithJSON(http.StatusOK, ingressesBody))
+
+			ingress, err := ocmClient.GetIngress(clusterID, "custom-ingress")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ingress).NotTo(BeNil())
+			Expect(ingress.ID()).To(Equal("custom-ingress"))
+		})
+
+		It("returns not found error when ingress key has no match", func() {
+			apiServer.AppendHandlers(RespondWithJSON(http.StatusOK, ingressesBody))
+
+			ingress, err := ocmClient.GetIngress(clusterID, "missing")
+			Expect(err).To(HaveOccurred())
+			Expect(ingress).To(BeNil())
+			Expect(err.Error()).To(ContainSubstring("Failed to get ingress 'missing' for cluster 'cluster-1'"))
+		})
+	})
+
+	Describe("GetIngresses", func() {
+		It("returns ingress list", func() {
+			apiServer.AppendHandlers(RespondWithJSON(http.StatusOK, `{
+				"kind": "IngressList",
+				"page": 1,
+				"size": 1,
+				"total": 1,
+				"items": [{"id": "ingress-1", "default": true}]
+			}`))
+
+			ingresses, err := ocmClient.GetIngresses(clusterID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ingresses).To(HaveLen(1))
+			Expect(ingresses[0].ID()).To(Equal("ingress-1"))
+		})
+	})
+
+	Describe("UpdateIngress", func() {
+		It("updates and returns ingress", func() {
+			apiServer.AppendHandlers(RespondWithJSON(http.StatusOK, `{
+				"id": "ingress-1",
+				"default": false
+			}`))
+
+			ingress, err := cmv1.NewIngress().
+				ID("ingress-1").
+				Default(false).
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			updated, err := ocmClient.UpdateIngress(clusterID, ingress)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updated).NotTo(BeNil())
+			Expect(updated.ID()).To(Equal("ingress-1"))
+		})
+	})
+
+	Describe("DeleteIngress", func() {
+		It("deletes ingress", func() {
+			apiServer.AppendHandlers(RespondWithJSON(http.StatusNoContent, ""))
+
+			err := ocmClient.DeleteIngress(clusterID, "ingress-1")
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/pkg/ocm/logs_test.go
+++ b/pkg/ocm/logs_test.go
@@ -1,0 +1,168 @@
+package ocm
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+)
+
+var _ = Describe("Cluster logs API client behavior", func() {
+	var apiServer *ghttp.Server
+	var ocmClient *Client
+
+	BeforeEach(func() {
+		apiServer = MakeTCPServer()
+		apiServer.SetAllowUnhandledRequests(true)
+		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+		ocmClient = buildTestOCMClient(apiServer.URL())
+	})
+
+	AfterEach(func() {
+		apiServer.Close()
+		Expect(ocmClient.Close()).To(Succeed())
+	})
+
+	It("passes the requested tail value when retrieving install logs", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				func(_ http.ResponseWriter, request *http.Request) {
+					Expect(request.URL.Query().Get("tail")).To(Equal("42"))
+				},
+				RespondWithJSON(http.StatusOK, `{"content":"install log line"}`),
+			),
+		)
+
+		logs, err := ocmClient.GetInstallLogs("cluster-1", 42)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(logs).NotTo(BeNil())
+		Expect(logs.Content()).To(ContainSubstring("install log line"))
+	})
+
+	It("translates install log 404 responses into user-facing not-found errors", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusNotFound, `{
+				"kind":"Error",
+				"id":"404",
+				"href":"/api/errors/404",
+				"code":"CLUSTERS-MGMT-404",
+				"reason":"missing logs"
+			}`),
+		)
+
+		_, err := ocmClient.GetInstallLogs("cluster-404", 5)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("Failed to get logs for cluster 'cluster-404'"))
+	})
+
+	It("passes the requested tail value when retrieving uninstall logs", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				func(_ http.ResponseWriter, request *http.Request) {
+					Expect(request.URL.Query().Get("tail")).To(Equal("27"))
+				},
+				RespondWithJSON(http.StatusOK, `{"content":"uninstall log line"}`),
+			),
+		)
+
+		logs, err := ocmClient.GetUninstallLogs("cluster-1", 27)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(logs).NotTo(BeNil())
+		Expect(logs.Content()).To(ContainSubstring("uninstall log line"))
+	})
+
+	It("translates uninstall log 404 responses into user-facing not-found errors", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusNotFound, `{
+				"kind":"Error",
+				"id":"404",
+				"href":"/api/errors/404",
+				"code":"CLUSTERS-MGMT-404",
+				"reason":"missing logs"
+			}`),
+		)
+
+		_, err := ocmClient.GetUninstallLogs("cluster-404", 5)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("Failed to get logs for cluster 'cluster-404'"))
+	})
+
+	It("uses fixed polling parameters and returns install logs", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				func(_ http.ResponseWriter, request *http.Request) {
+					Expect(request.URL.Query().Get("tail")).To(Equal("100"))
+				},
+				RespondWithJSON(http.StatusOK, `{"content":"polled install log"}`),
+			),
+		)
+
+		callback := func(response *cmv1.LogGetResponse) bool {
+			return true
+		}
+		logs, err := ocmClient.PollInstallLogs("cluster-1", callback)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(logs).NotTo(BeNil())
+		Expect(logs.Content()).To(ContainSubstring("polled install log"))
+	})
+
+	It("translates poll 404 responses into user-facing not-found errors", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusNotFound, `{
+				"kind":"Error",
+				"id":"404",
+				"href":"/api/errors/404",
+				"code":"CLUSTERS-MGMT-404",
+				"reason":"missing logs"
+			}`),
+		)
+
+		callback := func(response *cmv1.LogGetResponse) bool {
+			return true
+		}
+		_, err := ocmClient.PollInstallLogs("cluster-404", callback)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("Failed to poll logs for cluster 'cluster-404'"))
+	})
+
+	It("translates uninstall poll 404 responses into user-facing not-found errors", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusNotFound, `{
+				"kind":"Error",
+				"id":"404",
+				"href":"/api/errors/404",
+				"code":"CLUSTERS-MGMT-404",
+				"reason":"missing logs"
+			}`),
+		)
+
+		callback := func(response *cmv1.LogGetResponse) bool {
+			return true
+		}
+		_, err := ocmClient.PollUninstallLogs("cluster-404", callback)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("Failed to poll logs for cluster 'cluster-404'"))
+	})
+
+	It("wraps polling errors for uninstall logs", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusInternalServerError, `{
+				"kind":"Error",
+				"id":"500",
+				"href":"/api/errors/500",
+				"code":"CLUSTERS-MGMT-500",
+				"reason":"poll backend failure"
+			}`),
+		)
+
+		callback := func(response *cmv1.LogGetResponse) bool {
+			return true
+		}
+		_, err := ocmClient.PollUninstallLogs("cluster-1", callback)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("Failed to poll logs for cluster 'cluster-1'"))
+	})
+})

--- a/pkg/ocm/nodepools_test.go
+++ b/pkg/ocm/nodepools_test.go
@@ -1,6 +1,7 @@
 package ocm
 
 import (
+	"encoding/json"
 	"net/http"
 	"time"
 
@@ -22,7 +23,6 @@ var _ = Describe("NodePools", Ordered, func() {
 	BeforeEach(func() {
 		ssoServer = MakeTCPServer()
 		apiServer = MakeTCPServer()
-		apiServer.SetAllowUnhandledRequests(true)
 		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
 
 		accessToken := MakeTokenString("Bearer", 15*time.Minute)
@@ -48,17 +48,22 @@ var _ = Describe("NodePools", Ordered, func() {
 	})
 
 	It("finds node pools using a kubelet config name", func() {
-		apiServer.AppendHandlers(RespondWithJSON(http.StatusOK, `{
-			"kind": "NodePoolList",
-			"page": 1,
-			"size": 3,
-			"total": 3,
-			"items": [
-				{"id":"np-1","kubelet_configs":["kc-a","kc-b"]},
-				{"id":"np-2","kubelet_configs":["kc-b"]},
-				{"id":"np-3","kubelet_configs":[]}
-			]
-		}`))
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/node_pools"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind": "NodePoolList",
+					"page": 1,
+					"size": 3,
+					"total": 3,
+					"items": [
+						{"id":"np-1","kubelet_configs":["kc-a","kc-b"]},
+						{"id":"np-2","kubelet_configs":["kc-b"]},
+						{"id":"np-3","kubelet_configs":[]}
+					]
+				}`),
+			),
+		)
 
 		found, err := ocmClient.FindNodePoolsUsingKubeletConfig(clusterID, "kc-b")
 		Expect(err).NotTo(HaveOccurred())
@@ -68,7 +73,14 @@ var _ = Describe("NodePools", Ordered, func() {
 	})
 
 	It("returns an error when listing node pools fails during kubelet search", func() {
-		apiServer.AppendHandlers(RespondWithJSON(http.StatusInternalServerError, `{"reason":"broken"}`))
+		for i := 0; i < 3; i++ {
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/node_pools"),
+					RespondWithJSON(http.StatusInternalServerError, `{"reason":"broken"}`),
+				),
+			)
+		}
 
 		found, err := ocmClient.FindNodePoolsUsingKubeletConfig(clusterID, "kc-b")
 		Expect(err).To(HaveOccurred())
@@ -76,16 +88,21 @@ var _ = Describe("NodePools", Ordered, func() {
 	})
 
 	It("returns an empty list when no node pool uses kubelet config", func() {
-		apiServer.AppendHandlers(RespondWithJSON(http.StatusOK, `{
-			"kind": "NodePoolList",
-			"page": 1,
-			"size": 2,
-			"total": 2,
-			"items": [
-				{"id":"np-1","kubelet_configs":["kc-a"]},
-				{"id":"np-2","kubelet_configs":["kc-c"]}
-			]
-		}`))
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/node_pools"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind": "NodePoolList",
+					"page": 1,
+					"size": 2,
+					"total": 2,
+					"items": [
+						{"id":"np-1","kubelet_configs":["kc-a"]},
+						{"id":"np-2","kubelet_configs":["kc-c"]}
+					]
+				}`),
+			),
+		)
 
 		found, err := ocmClient.FindNodePoolsUsingKubeletConfig(clusterID, "kc-b")
 		Expect(err).NotTo(HaveOccurred())
@@ -93,7 +110,12 @@ var _ = Describe("NodePools", Ordered, func() {
 	})
 
 	It("returns exists=false,nil error when node pool is not found", func() {
-		apiServer.AppendHandlers(RespondWithJSON(http.StatusNotFound, `{"reason":"not found"}`))
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/node_pools/missing"),
+				RespondWithJSON(http.StatusNotFound, `{"reason":"not found"}`),
+			),
+		)
 
 		nodePool, exists, err := ocmClient.GetNodePool(clusterID, "missing")
 		Expect(err).NotTo(HaveOccurred())
@@ -102,7 +124,12 @@ var _ = Describe("NodePools", Ordered, func() {
 	})
 
 	It("returns node pool and exists=true when node pool exists", func() {
-		apiServer.AppendHandlers(RespondWithJSON(http.StatusOK, `{"id":"np-1","kubelet_configs":["kc-a"]}`))
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/node_pools/np-1"),
+				RespondWithJSON(http.StatusOK, `{"id":"np-1","kubelet_configs":["kc-a"]}`),
+			),
+		)
 
 		nodePool, exists, err := ocmClient.GetNodePool(clusterID, "np-1")
 		Expect(err).NotTo(HaveOccurred())
@@ -112,16 +139,47 @@ var _ = Describe("NodePools", Ordered, func() {
 	})
 
 	It("supports basic node pool CRUD wrappers", func() {
-		apiServer.AppendHandlers(RespondWithJSON(http.StatusCreated, `{"id":"np-created","kubelet_configs":["kc-a"]}`))
-		apiServer.AppendHandlers(RespondWithJSON(http.StatusOK, `{
-			"kind":"NodePoolList",
-			"page":1,
-			"size":1,
-			"total":1,
-			"items":[{"id":"np-created","kubelet_configs":["kc-a"]}]
-		}`))
-		apiServer.AppendHandlers(RespondWithJSON(http.StatusOK, `{"id":"np-created","kubelet_configs":["kc-a","kc-b"]}`))
-		apiServer.AppendHandlers(RespondWithJSON(http.StatusNoContent, ``))
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters/cluster-1/node_pools"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					payload := map[string]interface{}{}
+					Expect(json.NewDecoder(request.Body).Decode(&payload)).To(Succeed())
+					Expect(payload).To(HaveKeyWithValue("id", "np-created"))
+				},
+				RespondWithJSON(http.StatusCreated, `{"id":"np-created","kubelet_configs":["kc-a"]}`),
+			),
+		)
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/node_pools"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind":"NodePoolList",
+					"page":1,
+					"size":1,
+					"total":1,
+					"items":[{"id":"np-created","kubelet_configs":["kc-a"]}]
+				}`),
+			),
+		)
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/cluster-1/node_pools/np-created"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					payload := map[string]interface{}{}
+					Expect(json.NewDecoder(request.Body).Decode(&payload)).To(Succeed())
+					Expect(payload).To(HaveKeyWithValue("id", "np-created"))
+					Expect(payload).To(HaveKeyWithValue("kubelet_configs", []interface{}{"kc-a", "kc-b"}))
+				},
+				RespondWithJSON(http.StatusOK, `{"id":"np-created","kubelet_configs":["kc-a","kc-b"]}`),
+			),
+		)
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodDelete, "/api/clusters_mgmt/v1/clusters/cluster-1/node_pools/np-created"),
+				RespondWithJSON(http.StatusNoContent, ``),
+			),
+		)
 
 		input, err := cmv1.NewNodePool().ID("np-created").Build()
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/ocm/nodepools_test.go
+++ b/pkg/ocm/nodepools_test.go
@@ -1,0 +1,150 @@
+package ocm
+
+import (
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+)
+
+var _ = Describe("NodePools", Ordered, func() {
+	const clusterID = "cluster-1"
+
+	var ssoServer, apiServer *ghttp.Server
+	var ocmClient *Client
+
+	BeforeEach(func() {
+		ssoServer = MakeTCPServer()
+		apiServer = MakeTCPServer()
+		apiServer.SetAllowUnhandledRequests(true)
+		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+
+		accessToken := MakeTokenString("Bearer", 15*time.Minute)
+		ssoServer.AppendHandlers(RespondWithAccessToken(accessToken))
+
+		logger, err := logging.NewGoLoggerBuilder().Debug(true).Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		connection, err := sdk.NewConnectionBuilder().
+			Logger(logger).
+			Tokens(accessToken).
+			URL(apiServer.URL()).
+			Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		ocmClient = NewClientWithConnection(connection)
+	})
+
+	AfterEach(func() {
+		ssoServer.Close()
+		apiServer.Close()
+		Expect(ocmClient.Close()).To(Succeed())
+	})
+
+	It("finds node pools using a kubelet config name", func() {
+		apiServer.AppendHandlers(RespondWithJSON(http.StatusOK, `{
+			"kind": "NodePoolList",
+			"page": 1,
+			"size": 3,
+			"total": 3,
+			"items": [
+				{"id":"np-1","kubelet_configs":["kc-a","kc-b"]},
+				{"id":"np-2","kubelet_configs":["kc-b"]},
+				{"id":"np-3","kubelet_configs":[]}
+			]
+		}`))
+
+		found, err := ocmClient.FindNodePoolsUsingKubeletConfig(clusterID, "kc-b")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(HaveLen(2))
+		Expect(found[0].ID()).To(Equal("np-1"))
+		Expect(found[1].ID()).To(Equal("np-2"))
+	})
+
+	It("returns an error when listing node pools fails during kubelet search", func() {
+		apiServer.AppendHandlers(RespondWithJSON(http.StatusInternalServerError, `{"reason":"broken"}`))
+
+		found, err := ocmClient.FindNodePoolsUsingKubeletConfig(clusterID, "kc-b")
+		Expect(err).To(HaveOccurred())
+		Expect(found).To(BeEmpty())
+	})
+
+	It("returns an empty list when no node pool uses kubelet config", func() {
+		apiServer.AppendHandlers(RespondWithJSON(http.StatusOK, `{
+			"kind": "NodePoolList",
+			"page": 1,
+			"size": 2,
+			"total": 2,
+			"items": [
+				{"id":"np-1","kubelet_configs":["kc-a"]},
+				{"id":"np-2","kubelet_configs":["kc-c"]}
+			]
+		}`))
+
+		found, err := ocmClient.FindNodePoolsUsingKubeletConfig(clusterID, "kc-b")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeEmpty())
+	})
+
+	It("returns exists=false,nil error when node pool is not found", func() {
+		apiServer.AppendHandlers(RespondWithJSON(http.StatusNotFound, `{"reason":"not found"}`))
+
+		nodePool, exists, err := ocmClient.GetNodePool(clusterID, "missing")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(exists).To(BeFalse())
+		Expect(nodePool).To(BeNil())
+	})
+
+	It("returns node pool and exists=true when node pool exists", func() {
+		apiServer.AppendHandlers(RespondWithJSON(http.StatusOK, `{"id":"np-1","kubelet_configs":["kc-a"]}`))
+
+		nodePool, exists, err := ocmClient.GetNodePool(clusterID, "np-1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(exists).To(BeTrue())
+		Expect(nodePool).NotTo(BeNil())
+		Expect(nodePool.ID()).To(Equal("np-1"))
+	})
+
+	It("supports basic node pool CRUD wrappers", func() {
+		apiServer.AppendHandlers(RespondWithJSON(http.StatusCreated, `{"id":"np-created","kubelet_configs":["kc-a"]}`))
+		apiServer.AppendHandlers(RespondWithJSON(http.StatusOK, `{
+			"kind":"NodePoolList",
+			"page":1,
+			"size":1,
+			"total":1,
+			"items":[{"id":"np-created","kubelet_configs":["kc-a"]}]
+		}`))
+		apiServer.AppendHandlers(RespondWithJSON(http.StatusOK, `{"id":"np-created","kubelet_configs":["kc-a","kc-b"]}`))
+		apiServer.AppendHandlers(RespondWithJSON(http.StatusNoContent, ``))
+
+		input, err := cmv1.NewNodePool().ID("np-created").Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		created, err := ocmClient.CreateNodePool(clusterID, input)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(created).NotTo(BeNil())
+		Expect(created.ID()).To(Equal("np-created"))
+
+		nodePools, err := ocmClient.GetNodePools(clusterID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(nodePools).To(HaveLen(1))
+		Expect(nodePools[0].ID()).To(Equal("np-created"))
+
+		updateInput, err := cmv1.NewNodePool().ID("np-created").KubeletConfigs("kc-a", "kc-b").Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		updated, err := ocmClient.UpdateNodePool(clusterID, updateInput)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updated).NotTo(BeNil())
+		Expect(updated.KubeletConfigs()).To(Equal([]string{"kc-a", "kc-b"}))
+
+		err = ocmClient.DeleteNodePool(clusterID, "np-created")
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/pkg/ocm/oidc_config_test.go
+++ b/pkg/ocm/oidc_config_test.go
@@ -1,6 +1,7 @@
 package ocm
 
 import (
+	"encoding/json"
 	"net/http"
 	"time"
 
@@ -22,7 +23,6 @@ var _ = Describe("Oidc Config", Ordered, func() {
 	BeforeEach(func() {
 		ssoServer = MakeTCPServer()
 		apiServer = MakeTCPServer()
-		apiServer.SetAllowUnhandledRequests(true)
 		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
 
 		accessToken := MakeTokenString("Bearer", 15*time.Minute)
@@ -50,6 +50,7 @@ var _ = Describe("Oidc Config", Ordered, func() {
 	It("lists OIDC configs with expected search query", func() {
 		apiServer.AppendHandlers(
 			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/oidc_configs"),
 				ghttp.VerifyFormKV("search", "aws.account_id='123456789012' or aws.account_id=''"),
 				RespondWithJSON(http.StatusOK, `{
 					"kind": "OidcConfigList",
@@ -68,10 +69,20 @@ var _ = Describe("Oidc Config", Ordered, func() {
 	})
 
 	It("fetches OIDC thumbprint", func() {
-		apiServer.AppendHandlers(RespondWithJSON(http.StatusOK, `{
-			"id": "thumb-1",
-			"thumbprint": "ABCD"
-		}`))
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/aws_inquiries/oidc_thumbprint"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					payload := map[string]interface{}{}
+					Expect(json.NewDecoder(request.Body).Decode(&payload)).To(Succeed())
+					Expect(payload).To(HaveKeyWithValue("oidc_config_id", "oidc-1"))
+				},
+				RespondWithJSON(http.StatusOK, `{
+					"id": "thumb-1",
+					"thumbprint": "ABCD"
+				}`),
+			),
+		)
 
 		input, err := cmv1.NewOidcThumbprintInput().OidcConfigId("oidc-1").Build()
 		Expect(err).NotTo(HaveOccurred())
@@ -83,7 +94,17 @@ var _ = Describe("Oidc Config", Ordered, func() {
 	})
 
 	It("returns error when fetching OIDC thumbprint fails", func() {
-		apiServer.AppendHandlers(RespondWithJSON(http.StatusBadRequest, `{"reason":"invalid issuer"}`))
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/aws_inquiries/oidc_thumbprint"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					payload := map[string]interface{}{}
+					Expect(json.NewDecoder(request.Body).Decode(&payload)).To(Succeed())
+					Expect(payload).To(HaveKeyWithValue("oidc_config_id", "missing-oidc"))
+				},
+				RespondWithJSON(http.StatusBadRequest, `{"reason":"invalid issuer"}`),
+			),
+		)
 
 		input, err := cmv1.NewOidcThumbprintInput().OidcConfigId("missing-oidc").Build()
 		Expect(err).NotTo(HaveOccurred())
@@ -94,9 +115,33 @@ var _ = Describe("Oidc Config", Ordered, func() {
 	})
 
 	It("supports basic OIDC config CRUD wrappers", func() {
-		apiServer.AppendHandlers(RespondWithJSON(http.StatusOK, `{"id":"oidc-1","secret_arn":"arn:aws:secretsmanager:us-east-1:123:secret:one"}`))
-		apiServer.AppendHandlers(RespondWithJSON(http.StatusCreated, `{"id":"oidc-2","secret_arn":"arn:aws:secretsmanager:us-east-1:123:secret:two"}`))
-		apiServer.AppendHandlers(RespondWithJSON(http.StatusNoContent, ``))
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/oidc_configs/oidc-1"),
+				RespondWithJSON(http.StatusOK, `{"id":"oidc-1","secret_arn":"arn:aws:secretsmanager:us-east-1:123:secret:one"}`),
+			),
+		)
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/oidc_configs"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					payload := map[string]interface{}{}
+					Expect(json.NewDecoder(request.Body).Decode(&payload)).To(Succeed())
+					Expect(payload).To(HaveKeyWithValue("id", "oidc-2"))
+					Expect(payload).To(HaveKeyWithValue(
+						"secret_arn",
+						"arn:aws:secretsmanager:us-east-1:123:secret:two",
+					))
+				},
+				RespondWithJSON(http.StatusCreated, `{"id":"oidc-2","secret_arn":"arn:aws:secretsmanager:us-east-1:123:secret:two"}`),
+			),
+		)
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodDelete, "/api/clusters_mgmt/v1/oidc_configs/oidc-2"),
+				RespondWithJSON(http.StatusNoContent, ``),
+			),
+		)
 
 		config, err := ocmClient.GetOidcConfig("oidc-1")
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/ocm/oidc_config_test.go
+++ b/pkg/ocm/oidc_config_test.go
@@ -1,0 +1,120 @@
+package ocm
+
+import (
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+)
+
+var _ = Describe("Oidc Config", Ordered, func() {
+	const awsAccountID = "123456789012"
+
+	var ssoServer, apiServer *ghttp.Server
+	var ocmClient *Client
+
+	BeforeEach(func() {
+		ssoServer = MakeTCPServer()
+		apiServer = MakeTCPServer()
+		apiServer.SetAllowUnhandledRequests(true)
+		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+
+		accessToken := MakeTokenString("Bearer", 15*time.Minute)
+		ssoServer.AppendHandlers(RespondWithAccessToken(accessToken))
+
+		logger, err := logging.NewGoLoggerBuilder().Debug(true).Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		connection, err := sdk.NewConnectionBuilder().
+			Logger(logger).
+			Tokens(accessToken).
+			URL(apiServer.URL()).
+			Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		ocmClient = NewClientWithConnection(connection)
+	})
+
+	AfterEach(func() {
+		ssoServer.Close()
+		apiServer.Close()
+		Expect(ocmClient.Close()).To(Succeed())
+	})
+
+	It("lists OIDC configs with expected search query", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyFormKV("search", "aws.account_id='123456789012' or aws.account_id=''"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind": "OidcConfigList",
+					"page": 1,
+					"size": 1,
+					"total": 1,
+					"items": [{"id": "oidc-1", "secret": "s"}]
+				}`),
+			),
+		)
+
+		configs, err := ocmClient.ListOidcConfigs(awsAccountID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(configs).To(HaveLen(1))
+		Expect(configs[0].ID()).To(Equal("oidc-1"))
+	})
+
+	It("fetches OIDC thumbprint", func() {
+		apiServer.AppendHandlers(RespondWithJSON(http.StatusOK, `{
+			"id": "thumb-1",
+			"thumbprint": "ABCD"
+		}`))
+
+		input, err := cmv1.NewOidcThumbprintInput().OidcConfigId("oidc-1").Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		thumbprint, err := ocmClient.FetchOidcThumbprint(input)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(thumbprint).NotTo(BeNil())
+		Expect(thumbprint.Thumbprint()).To(Equal("ABCD"))
+	})
+
+	It("returns error when fetching OIDC thumbprint fails", func() {
+		apiServer.AppendHandlers(RespondWithJSON(http.StatusBadRequest, `{"reason":"invalid issuer"}`))
+
+		input, err := cmv1.NewOidcThumbprintInput().OidcConfigId("missing-oidc").Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		thumbprint, fetchErr := ocmClient.FetchOidcThumbprint(input)
+		Expect(fetchErr).To(HaveOccurred())
+		Expect(thumbprint).To(BeNil())
+	})
+
+	It("supports basic OIDC config CRUD wrappers", func() {
+		apiServer.AppendHandlers(RespondWithJSON(http.StatusOK, `{"id":"oidc-1","secret_arn":"arn:aws:secretsmanager:us-east-1:123:secret:one"}`))
+		apiServer.AppendHandlers(RespondWithJSON(http.StatusCreated, `{"id":"oidc-2","secret_arn":"arn:aws:secretsmanager:us-east-1:123:secret:two"}`))
+		apiServer.AppendHandlers(RespondWithJSON(http.StatusNoContent, ``))
+
+		config, err := ocmClient.GetOidcConfig("oidc-1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(config).NotTo(BeNil())
+		Expect(config.ID()).To(Equal("oidc-1"))
+
+		createInput, err := cmv1.NewOidcConfig().
+			ID("oidc-2").
+			SecretArn("arn:aws:secretsmanager:us-east-1:123:secret:two").
+			Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		created, err := ocmClient.CreateOidcConfig(createInput)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(created).NotTo(BeNil())
+		Expect(created.ID()).To(Equal("oidc-2"))
+
+		err = ocmClient.DeleteOidcConfig("oidc-2")
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/pkg/ocm/upgrades_test.go
+++ b/pkg/ocm/upgrades_test.go
@@ -1,0 +1,209 @@
+package ocm
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+)
+
+var _ = Describe("Upgrade policies API client behavior", func() {
+	var apiServer *ghttp.Server
+	var ocmClient *Client
+
+	BeforeEach(func() {
+		apiServer = MakeTCPServer()
+		apiServer.SetAllowUnhandledRequests(true)
+		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+		ocmClient = buildTestOCMClient(apiServer.URL())
+	})
+
+	AfterEach(func() {
+		apiServer.Close()
+		Expect(ocmClient.Close()).To(Succeed())
+	})
+
+	It("paginates upgrade policy listings", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, `{
+				"kind":"UpgradePolicyList",
+				"page":1,
+				"size":100,
+				"total":101,
+				"items":[{"id":"policy-1","upgrade_type":"OSD"}]
+			}`),
+			RespondWithJSON(http.StatusOK, `{
+				"kind":"UpgradePolicyList",
+				"page":2,
+				"size":1,
+				"total":101,
+				"items":[{"id":"policy-2","upgrade_type":"OSD"}]
+			}`),
+		)
+
+		policies, err := ocmClient.GetUpgradePolicies("cluster-1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(policies).To(HaveLen(2))
+		Expect(policies[0].ID()).To(Equal("policy-1"))
+		Expect(policies[1].ID()).To(Equal("policy-2"))
+	})
+
+	It("returns the scheduled OSD upgrade and its state", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, `{
+				"kind":"UpgradePolicyList",
+				"page":1,
+				"size":2,
+				"total":2,
+				"items":[
+					{"id":"policy-control-plane","upgrade_type":"CONTROL_PLANE"},
+					{"id":"policy-osd","upgrade_type":"OSD"}
+				]
+			}`),
+			RespondWithJSON(http.StatusOK, `{
+				"description":"scheduled for tonight",
+				"value":"scheduled"
+			}`),
+		)
+
+		policy, state, err := ocmClient.GetScheduledUpgrade("cluster-1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(policy).NotTo(BeNil())
+		Expect(policy.ID()).To(Equal("policy-osd"))
+		Expect(state).NotTo(BeNil())
+		Expect(state.Value()).To(Equal(cmv1.UpgradePolicyStateValue("scheduled")))
+	})
+
+	It("returns false when no scheduled OSD upgrade exists", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, `{
+				"kind":"UpgradePolicyList",
+				"page":1,
+				"size":1,
+				"total":1,
+				"items":[{"id":"policy-control-plane","upgrade_type":"CONTROL_PLANE"}]
+			}`),
+		)
+
+		cancelled, err := ocmClient.CancelUpgrade("cluster-1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cancelled).To(BeFalse())
+	})
+
+	It("deletes the scheduled OSD upgrade when cancelling", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, `{
+				"kind":"UpgradePolicyList",
+				"page":1,
+				"size":1,
+				"total":1,
+				"items":[{"id":"policy-osd","upgrade_type":"OSD"}]
+			}`),
+			RespondWithJSON(http.StatusOK, `{
+				"description":"scheduled for tonight",
+				"value":"scheduled"
+			}`),
+			RespondWithJSON(http.StatusOK, `{}`),
+		)
+
+		cancelled, err := ocmClient.CancelUpgrade("cluster-1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cancelled).To(BeTrue())
+	})
+
+	It("parses missing classic gate agreements from dry-run errors", func() {
+		upgradePolicy, err := cmv1.NewUpgradePolicy().Version("4.16.10").Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusBadRequest, `{
+				"kind":"Error",
+				"id":"400",
+				"href":"/api/errors/400",
+				"code":"CLUSTERS-MGMT-400",
+				"reason":"missing gate agreements",
+				"details":[{"id":"gate-a","sts_only":false}]
+			}`),
+		)
+
+		gates, err := ocmClient.GetMissingGateAgreementsClassic("cluster-1", upgradePolicy)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(gates).To(HaveLen(1))
+		Expect(gates[0].ID()).To(Equal("gate-a"))
+	})
+
+	It("returns the backend reason when classic gate details are invalid", func() {
+		upgradePolicy, err := cmv1.NewUpgradePolicy().Version("4.16.10").Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusBadRequest, `{
+				"kind":"Error",
+				"id":"400",
+				"href":"/api/errors/400",
+				"code":"CLUSTERS-MGMT-400",
+				"reason":"invalid version gate payload",
+				"details":[{"id":""}]
+			}`),
+		)
+
+		gates, err := ocmClient.GetMissingGateAgreementsClassic("cluster-1", upgradePolicy)
+		Expect(err).To(HaveOccurred())
+		Expect(gates).To(BeEmpty())
+		Expect(err.Error()).To(ContainSubstring("invalid version gate payload"))
+	})
+
+	It("parses missing hypershift gate agreements from dry-run errors", func() {
+		upgradePolicy, err := cmv1.NewControlPlaneUpgradePolicy().Version("4.16.10").Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusBadRequest, `{
+				"kind":"Error",
+				"id":"400",
+				"href":"/api/errors/400",
+				"code":"CLUSTERS-MGMT-400",
+				"reason":"missing gate agreements",
+				"details":[{"id":"gate-hcp","sts_only":true}]
+			}`),
+		)
+
+		gates, err := ocmClient.GetMissingGateAgreementsHypershift("cluster-1", upgradePolicy)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(gates).To(HaveLen(1))
+		Expect(gates[0].ID()).To(Equal("gate-hcp"))
+	})
+
+	It("returns backend reason when hypershift gate details are invalid", func() {
+		upgradePolicy, err := cmv1.NewControlPlaneUpgradePolicy().Version("4.16.10").Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusBadRequest, `{
+				"kind":"Error",
+				"id":"400",
+				"href":"/api/errors/400",
+				"code":"CLUSTERS-MGMT-400",
+				"reason":"invalid hypershift version gate payload",
+				"details":[{"id":""}]
+			}`),
+		)
+
+		gates, err := ocmClient.GetMissingGateAgreementsHypershift("cluster-1", upgradePolicy)
+		Expect(err).To(HaveOccurred())
+		Expect(gates).To(BeEmpty())
+		Expect(err.Error()).To(ContainSubstring("invalid hypershift version gate payload"))
+	})
+
+	It("acknowledges version gates successfully", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusCreated, `{"id":"agreement-1"}`),
+		)
+
+		err := ocmClient.AckVersionGate("cluster-1", "gate-1")
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/pkg/ocm/users_test.go
+++ b/pkg/ocm/users_test.go
@@ -1,0 +1,113 @@
+package ocm
+
+import (
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+)
+
+var _ = Describe("Users", Ordered, func() {
+	const (
+		clusterID = "cluster-1"
+		groupID   = "dedicated-admins"
+		username  = "alice"
+	)
+
+	var ssoServer, apiServer *ghttp.Server
+	var ocmClient *Client
+
+	BeforeEach(func() {
+		ssoServer = MakeTCPServer()
+		apiServer = MakeTCPServer()
+		apiServer.SetAllowUnhandledRequests(true)
+		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+
+		accessToken := MakeTokenString("Bearer", 15*time.Minute)
+		ssoServer.AppendHandlers(RespondWithAccessToken(accessToken))
+
+		logger, err := logging.NewGoLoggerBuilder().Debug(true).Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		connection, err := sdk.NewConnectionBuilder().
+			Logger(logger).
+			Tokens(accessToken).
+			URL(apiServer.URL()).
+			Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		ocmClient = NewClientWithConnection(connection)
+	})
+
+	AfterEach(func() {
+		ssoServer.Close()
+		apiServer.Close()
+		Expect(ocmClient.Close()).To(Succeed())
+	})
+
+	It("gets an existing user", func() {
+		apiServer.AppendHandlers(RespondWithJSON(http.StatusOK, `{"id":"user-1"}`))
+
+		user, err := ocmClient.GetUser(clusterID, groupID, username)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(user).NotTo(BeNil())
+		Expect(user.ID()).To(Equal("user-1"))
+	})
+
+	It("returns nil,nil when user is not found", func() {
+		apiServer.AppendHandlers(RespondWithJSON(http.StatusNotFound, `{"reason":"not found"}`))
+
+		user, err := ocmClient.GetUser(clusterID, groupID, "missing")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(user).To(BeNil())
+	})
+
+	It("returns an error when user lookup fails with non-404 status", func() {
+		apiServer.AppendHandlers(RespondWithJSON(http.StatusInternalServerError, `{"reason":"internal error"}`))
+
+		user, err := ocmClient.GetUser(clusterID, groupID, username)
+		Expect(err).To(HaveOccurred())
+		Expect(user).To(BeNil())
+	})
+
+	It("lists users", func() {
+		apiServer.AppendHandlers(RespondWithJSON(http.StatusOK, `{
+			"kind": "UserList",
+			"page": 1,
+			"size": 2,
+			"total": 2,
+			"items": [
+				{"id":"user-1"},
+				{"id":"user-2"}
+			]
+		}`))
+
+		users, err := ocmClient.GetUsers(clusterID, groupID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(users).To(HaveLen(2))
+		Expect(users[0].ID()).To(Equal("user-1"))
+		Expect(users[1].ID()).To(Equal("user-2"))
+	})
+
+	It("creates and deletes users", func() {
+		apiServer.AppendHandlers(RespondWithJSON(http.StatusCreated, `{"id":"user-3"}`))
+		apiServer.AppendHandlers(RespondWithJSON(http.StatusNoContent, ``))
+
+		createInput, err := cmv1.NewUser().ID("user-3").Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		created, err := ocmClient.CreateUser(clusterID, groupID, createInput)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(created).NotTo(BeNil())
+		Expect(created.ID()).To(Equal("user-3"))
+
+		err = ocmClient.DeleteUser(clusterID, groupID, "charlie")
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/pkg/ocm/users_test.go
+++ b/pkg/ocm/users_test.go
@@ -1,6 +1,7 @@
 package ocm
 
 import (
+	"encoding/json"
 	"net/http"
 	"time"
 
@@ -26,7 +27,6 @@ var _ = Describe("Users", Ordered, func() {
 	BeforeEach(func() {
 		ssoServer = MakeTCPServer()
 		apiServer = MakeTCPServer()
-		apiServer.SetAllowUnhandledRequests(true)
 		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
 
 		accessToken := MakeTokenString("Bearer", 15*time.Minute)
@@ -52,7 +52,12 @@ var _ = Describe("Users", Ordered, func() {
 	})
 
 	It("gets an existing user", func() {
-		apiServer.AppendHandlers(RespondWithJSON(http.StatusOK, `{"id":"user-1"}`))
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/groups/dedicated-admins/users/alice"),
+				RespondWithJSON(http.StatusOK, `{"id":"user-1"}`),
+			),
+		)
 
 		user, err := ocmClient.GetUser(clusterID, groupID, username)
 		Expect(err).NotTo(HaveOccurred())
@@ -61,7 +66,12 @@ var _ = Describe("Users", Ordered, func() {
 	})
 
 	It("returns nil,nil when user is not found", func() {
-		apiServer.AppendHandlers(RespondWithJSON(http.StatusNotFound, `{"reason":"not found"}`))
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/groups/dedicated-admins/users/missing"),
+				RespondWithJSON(http.StatusNotFound, `{"reason":"not found"}`),
+			),
+		)
 
 		user, err := ocmClient.GetUser(clusterID, groupID, "missing")
 		Expect(err).NotTo(HaveOccurred())
@@ -69,7 +79,14 @@ var _ = Describe("Users", Ordered, func() {
 	})
 
 	It("returns an error when user lookup fails with non-404 status", func() {
-		apiServer.AppendHandlers(RespondWithJSON(http.StatusInternalServerError, `{"reason":"internal error"}`))
+		for i := 0; i < 3; i++ {
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/groups/dedicated-admins/users/alice"),
+					RespondWithJSON(http.StatusInternalServerError, `{"reason":"internal error"}`),
+				),
+			)
+		}
 
 		user, err := ocmClient.GetUser(clusterID, groupID, username)
 		Expect(err).To(HaveOccurred())
@@ -77,16 +94,21 @@ var _ = Describe("Users", Ordered, func() {
 	})
 
 	It("lists users", func() {
-		apiServer.AppendHandlers(RespondWithJSON(http.StatusOK, `{
-			"kind": "UserList",
-			"page": 1,
-			"size": 2,
-			"total": 2,
-			"items": [
-				{"id":"user-1"},
-				{"id":"user-2"}
-			]
-		}`))
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/groups/dedicated-admins/users"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind": "UserList",
+					"page": 1,
+					"size": 2,
+					"total": 2,
+					"items": [
+						{"id":"user-1"},
+						{"id":"user-2"}
+					]
+				}`),
+			),
+		)
 
 		users, err := ocmClient.GetUsers(clusterID, groupID)
 		Expect(err).NotTo(HaveOccurred())
@@ -96,8 +118,23 @@ var _ = Describe("Users", Ordered, func() {
 	})
 
 	It("creates and deletes users", func() {
-		apiServer.AppendHandlers(RespondWithJSON(http.StatusCreated, `{"id":"user-3"}`))
-		apiServer.AppendHandlers(RespondWithJSON(http.StatusNoContent, ``))
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters/cluster-1/groups/dedicated-admins/users"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					payload := map[string]interface{}{}
+					Expect(json.NewDecoder(request.Body).Decode(&payload)).To(Succeed())
+					Expect(payload).To(HaveKeyWithValue("id", "user-3"))
+				},
+				RespondWithJSON(http.StatusCreated, `{"id":"user-3"}`),
+			),
+		)
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodDelete, "/api/clusters_mgmt/v1/clusters/cluster-1/groups/dedicated-admins/users/charlie"),
+				RespondWithJSON(http.StatusNoContent, ``),
+			),
+		)
 
 		createInput, err := cmv1.NewUser().ID("user-3").Build()
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/ocm/versions_test.go
+++ b/pkg/ocm/versions_test.go
@@ -183,6 +183,68 @@ var _ = Describe("OCMClient", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(vs).To(BeFalse())
 		})
+
+		It("returns latest version major.minor", func() {
+			apiServer.AppendHandlers(
+				RespondWithJSON(
+					http.StatusOK,
+					`{
+						"kind":"VersionList",
+						"page":1,
+						"size":1,
+						"total":1,
+						"items":[{"id":"4.16.3","raw_id":"4.16.3","channel_group":"stable","rosa_enabled":true}]
+					}`,
+				),
+			)
+
+			version, err := ocmClient.GetLatestVersion(DefaultChannelGroup)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(Equal("4.16"))
+		})
+
+		It("returns error when latest version cannot be resolved", func() {
+			apiServer.AppendHandlers(
+				RespondWithJSON(
+					http.StatusOK,
+					`{
+						"kind":"VersionList",
+						"page":1,
+						"size":0,
+						"total":0,
+						"items":[]
+					}`,
+				),
+			)
+
+			_, err := ocmClient.GetLatestVersion(DefaultChannelGroup)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("there are no OpenShift versions available"))
+		})
+
+		It("passes product to GetVersionsWithProduct requests", func() {
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					func(_ http.ResponseWriter, request *http.Request) {
+						Expect(request.URL.Query().Get("product")).To(Equal(HcpProduct))
+					},
+					RespondWithJSON(
+						http.StatusOK,
+						`{
+							"kind":"VersionList",
+							"page":1,
+							"size":1,
+							"total":1,
+							"items":[{"id":"4.16.3","raw_id":"4.16.3","channel_group":"stable","rosa_enabled":true}]
+						}`,
+					),
+				),
+			)
+
+			versions, err := ocmClient.GetVersionsWithProduct(HcpProduct, DefaultChannelGroup, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(versions).To(HaveLen(1))
+		})
 	})
 })
 
@@ -304,6 +366,22 @@ var _ = Describe("Minimal http tokens required version", Ordered, func() {
 					"is not supported: %v", "bad version", "malformed version: bad version"),
 			),
 		)
+	})
+})
+
+var _ = Describe("GetAvailableUpgradesByCluster", func() {
+	It("returns descending upgrades for cluster versions", func() {
+		cluster, err := cmv1.NewCluster().
+			Version(cmv1.NewVersion().AvailableUpgrades("4.14.1", "4.14.3", "4.14.2")).
+			Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		upgrades := GetAvailableUpgradesByCluster(cluster)
+		Expect(upgrades).To(Equal([]string{"4.14.3", "4.14.2", "4.14.1"}))
+	})
+
+	It("returns empty upgrades for nil cluster", func() {
+		Expect(GetAvailableUpgradesByCluster(nil)).To(BeEmpty())
 	})
 })
 


### PR DESCRIPTION
## PR Summary
Expands `pkg/ocm` unit coverage across the [ROSAENG-61179](https://redhat.atlassian.net/browse/ROSAENG-61179) target set and locks in the edge cases uncovered while adding that coverage.
The change also hardens a few real `pkg/ocm` behaviors around nil `DryRun`, fetch-all cluster pagination, missing current-account handling, and zero-cost add-on availability.

## Detailed Description of the Issue
`ROSAENG-61179` targets the `pkg/ocm` coverage batch that still had large gaps across `clusters.go`, `helpers.go`, `versions.go`, and several low/zero-test service files. The lack of coverage left meaningful API-wrapper and edge-path behavior unverified, and while closing those gaps the new tests exposed a small set of real production issues that needed to be fixed in the same scope. The follow-up review pass also tightened the new HTTP-backed tests so wrong request methods, paths, queries, or payloads fail instead of being silently accepted.

## Related Issues and PRs
- Jira: [ROSAENG-61179](https://issues.redhat.com/browse/ROSAENG-61179)
- Fixes: `N/A`
- Related PR(s): `N/A`
- Related design/docs: `N/A`

## Type of Change
- [x] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [x] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
- Many `pkg/ocm` flows in this Jira batch had little or no direct unit coverage.
- `CreateCluster` could dereference a nil `DryRun` value.
- `GetClusters(..., 0)` did not have fetch-all pagination locked in by tests and could stop early.
- `GetCurrentOrganization` relied on SDK nil-receiver handling when the current account lookup returned no account.
- Zero-cost add-ons without quota metadata could be reported as unavailable or disappear from cluster add-on results.

## Behavior After This Change
- `pkg/ocm` now has focused Ginkgo coverage for the targeted cluster, helper, version, and service-wrapper flows from `ROSAENG-61179`.
- `CreateCluster` defaults nil `DryRun` to `false` instead of dereferencing it.
- `GetClusters(..., 0)` paginates until all available cluster results are collected.
- `GetCurrentOrganization` now explicitly returns empty organization identifiers when the current account is missing.
- Zero-cost add-ons remain available and cluster-visible even when quota metadata is absent, defaulting to `AZType = ANY` until quota metadata overrides that default.

## How to Test (Step-by-Step)
### Preconditions
- Run from the repo root.
- Use a Go `1.26.3` compatible toolchain. If the local default toolchain is older, prefix commands with `GOTOOLCHAIN=auto`.

### Test Steps
1. Run `GOTOOLCHAIN=auto go test ./pkg/ocm -count=1`.
2. Run `GOTOOLCHAIN=auto make rosa`.
3. Run `GOTOOLCHAIN=auto make basic-checks`.

### Expected Results
- The `pkg/ocm` suite passes.
- The CLI builds successfully.
- `basic-checks` passes format, lint, changed-files coverage, and unit/integration tests.

## Proof of the Fix
- Screenshots: `N/A`
- Videos: `N/A`
- Logs/CLI output:
  - `GOTOOLCHAIN=auto go test ./pkg/ocm -count=1`
  - `GOTOOLCHAIN=auto make lint`
  - `GOTOOLCHAIN=auto make rosa`
  - `GOTOOLCHAIN=auto make test`
  - `GOTOOLCHAIN=auto make basic-checks`
- Other artifacts: `N/A`

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
`N/A`

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [x] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

[ROSAENG-61179]: https://redhat.atlassian.net/browse/ROSAENG-61179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Free add-ons are now correctly identified as available, even when quota metadata is unavailable.
  - Cluster listings more reliably support retrieving all clusters and handling paginated results.

- **Bug Fixes**
  - Cluster creation no longer fails when dry-run settings are omitted.
  - Current organization lookup safely handles missing account information.
  - Add-ons incompatible with a cluster’s availability zones are excluded consistently.

- **Tests**
  - Expanded coverage across clusters, add-ons, users, node pools, DNS domains, ingress, logs, upgrades, and OIDC configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->