### PR TITLE
ROSAENG-6320 | fix: Update "--build" argument to only show git commit

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,6 +8,8 @@ builds:
   - main: ./cmd/rosa
     env:
       - CGO_ENABLED=0
+    ldflags:
+      - -X github.com/openshift/rosa/pkg/info.Build={{ .ShortCommit }}
     goos:
       - linux
       - windows

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1784190466 AS builder
 COPY --chown=1001:0 . .
 
-ENV GOFLAGS=-buildvcs=false
 RUN git config --global --add safe.directory /opt/app-root/src && \
     make release
 

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ coverage-changed-files:
 
 .PHONY: install
 install:
-	go install ./cmd/rosa
+	go install -ldflags="-X github.com/openshift/rosa/pkg/info.Build=$(shell git rev-parse --short HEAD)" ./cmd/rosa
 
 .PHONY: fmt
 fmt: $(GCI)

--- a/cmd/version/cmd.go
+++ b/cmd/version/cmd.go
@@ -61,7 +61,7 @@ func NewRosaVersionCommand() *cobra.Command {
 		buildFlag,
 		"b",
 		false,
-		"Display build version information, including git commit and build time",
+		"Display extra build info, primarily the git commit the binary was built from",
 	)
 	cmd.Flags().MarkHidden(buildFlag)
 	return cmd

--- a/cmd/version/cmd_test.go
+++ b/cmd/version/cmd_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime/debug"
 
 	"go.uber.org/mock/gomock"
 
@@ -163,7 +164,7 @@ var _ = Describe("RosaVersionOptions", func() {
 		})
 	})
 
-	When("Both clientOnly and build are true", func() {
+	When("Both clientOnly and build are true and build info is unavailable", func() {
 		BeforeEach(func() {
 			ctrl = gomock.NewController(GinkgoT())
 			mockVerify = rosa.NewMockVerifyRosa(ctrl)
@@ -171,8 +172,9 @@ var _ = Describe("RosaVersionOptions", func() {
 			rpt := reporter.CreateReporter()
 
 			opts = &RosaVersionOptions{
-				verifyRosa: mockVerify,
-				reporter:   rpt,
+				verifyRosa:    mockVerify,
+				reporter:      rpt,
+				readBuildInfo: func() (*debug.BuildInfo, bool) { return nil, false },
 
 				args: &RosaVersionUserOptions{
 					clientOnly: true,
@@ -215,10 +217,117 @@ var _ = Describe("RosaVersionOptions", func() {
 
 			// Verify the outputs
 			Expect(string(stdout)).To(ContainSubstring(info.DefaultVersion))
-			Expect(string(stdout)).To(ContainSubstring("Build info: local"))
+			Expect(string(stdout)).To(ContainSubstring(fmt.Sprintf("Git commit: %s", info.Build)))
+		})
+	})
+
+	When("Both clientOnly and build are true and build info is available", func() {
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+			mockVerify = rosa.NewMockVerifyRosa(ctrl)
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
+		})
+
+		It("should print git commit info", func() {
+			rpt := reporter.CreateReporter()
+			opts = &RosaVersionOptions{
+				verifyRosa:    mockVerify,
+				reporter:      rpt,
+				readBuildInfo: fakeBuildInfo("abc1234"),
+				args: &RosaVersionUserOptions{
+					clientOnly: true,
+					build:      true,
+				},
+			}
+
+			rout, wout, pipeErr := os.Pipe()
+			Expect(pipeErr).ToNot(HaveOccurred())
+			tmpout := os.Stdout
+			defer func() {
+				os.Stdout = tmpout
+			}()
+			os.Stdout = wout
+
+			type result struct {
+				versionErr error
+				closeErr   error
+			}
+			ch := make(chan result, 1)
+			go func() {
+				vErr := opts.Version()
+				cErr := wout.Close()
+				ch <- result{versionErr: vErr, closeErr: cErr}
+			}()
+
+			stdout, readErr := io.ReadAll(rout)
+			Expect(readErr).ToNot(HaveOccurred())
+
+			res := <-ch
+			Expect(res.versionErr).ToNot(HaveOccurred())
+			Expect(res.closeErr).ToNot(HaveOccurred())
+
+			Expect(string(stdout)).To(ContainSubstring("Git commit: abc1234"))
+			Expect(string(stdout)).ToNot(ContainSubstring(fmt.Sprintf("Git commit: %s", info.Build)))
+		})
+
+		It("should fall back to info.Build when revision is empty", func() {
+			rpt := reporter.CreateReporter()
+			opts = &RosaVersionOptions{
+				verifyRosa:    mockVerify,
+				reporter:      rpt,
+				readBuildInfo: fakeBuildInfo(""),
+				args: &RosaVersionUserOptions{
+					clientOnly: true,
+					build:      true,
+				},
+			}
+
+			rout, wout, pipeErr := os.Pipe()
+			Expect(pipeErr).ToNot(HaveOccurred())
+			tmpout := os.Stdout
+			defer func() {
+				os.Stdout = tmpout
+			}()
+			os.Stdout = wout
+
+			type result struct {
+				versionErr error
+				closeErr   error
+			}
+			ch := make(chan result, 1)
+			go func() {
+				vErr := opts.Version()
+				cErr := wout.Close()
+				ch <- result{versionErr: vErr, closeErr: cErr}
+			}()
+
+			stdout, readErr := io.ReadAll(rout)
+			Expect(readErr).ToNot(HaveOccurred())
+
+			res := <-ch
+			Expect(res.versionErr).ToNot(HaveOccurred())
+			Expect(res.closeErr).ToNot(HaveOccurred())
+
+			Expect(string(stdout)).To(ContainSubstring(fmt.Sprintf("Git commit: %s", info.Build)))
 		})
 	})
 })
+
+func fakeBuildInfo(revision string) func() (*debug.BuildInfo, bool) {
+	return func() (*debug.BuildInfo, bool) {
+		bi := &debug.BuildInfo{}
+		if revision != "" {
+			bi.Settings = append(bi.Settings, debug.BuildSetting{
+				Key:   "vcs.revision",
+				Value: revision,
+			})
+		}
+		return bi, true
+	}
+}
 
 var _ = Describe("NewRosaVersionCommand", func() {
 	var cmd *cobra.Command
@@ -256,6 +365,6 @@ var _ = Describe("NewRosaVersionCommand", func() {
 		Expect(buildFlag.Name).To(Equal("build"))
 		Expect(buildFlag.Shorthand).To(Equal("b"))
 		Expect(buildFlag.Hidden).To(BeTrue())
-		Expect(buildFlag.Usage).To(Equal("Display build version information, including git commit and build time"))
+		Expect(buildFlag.Usage).To(Equal("Display extra build info, primarily the git commit the binary was built from"))
 	})
 })

--- a/cmd/version/options.go
+++ b/cmd/version/options.go
@@ -21,8 +21,9 @@ func NewRosaVersionUserOptions() *RosaVersionUserOptions {
 }
 
 type RosaVersionOptions struct {
-	reporter   *reporter.Object
-	verifyRosa verify.VerifyRosa
+	reporter      *reporter.Object
+	verifyRosa    verify.VerifyRosa
+	readBuildInfo func() (*debug.BuildInfo, bool)
 
 	args *RosaVersionUserOptions
 }
@@ -34,9 +35,10 @@ func NewRosaVersionOptions() (*RosaVersionOptions, error) {
 	}
 
 	return &RosaVersionOptions{
-		verifyRosa: verifyRosa,
-		reporter:   reporter.CreateReporter(),
-		args:       NewRosaVersionUserOptions(),
+		verifyRosa:    verifyRosa,
+		reporter:      reporter.CreateReporter(),
+		readBuildInfo: debug.ReadBuildInfo,
+		args:          NewRosaVersionUserOptions(),
 	}, nil
 }
 
@@ -50,37 +52,22 @@ func (o *RosaVersionOptions) Version() error {
 	}
 
 	if o.args.build {
-		buildInfo, ok := debug.ReadBuildInfo()
+		buildInfo, ok := o.readBuildInfo()
 		if ok {
 			var revision string
-			var buildTime string
-			var dirty bool
 
 			for _, setting := range buildInfo.Settings {
-				switch setting.Key {
-				case "vcs.revision":
+				if setting.Key == "vcs.revision" {
 					revision = setting.Value
-				case "vcs.time":
-					buildTime = setting.Value
-				case "vcs.modified":
-					dirty = setting.Value == "true"
 				}
 			}
 
 			if revision == "" {
 				revision = info.Build
 			}
-			buildMsg := revision
-			if dirty {
-				buildMsg += " (dirty)"
-			}
-			if buildTime != "" {
-				buildMsg += " " + buildTime
-			}
-
-			o.reporter.Infof("Build info: %s", buildMsg)
+			o.reporter.Infof("Git commit: %s", revision)
 		} else {
-			o.reporter.Infof("Build info: %s", info.Build)
+			o.reporter.Infof("Git commit: %s", info.Build)
 		}
 	}
 

--- a/hack/build_cli.sh
+++ b/hack/build_cli.sh
@@ -16,7 +16,7 @@ do
         extension=".exe"
     fi
     tmpdir=$(mktemp -d)
-    GOOS="${os}" GOARCH="${arch}" go build -o "${tmpdir}/rosa${extension}" ./cmd/rosa
+    GOOS="${os}" GOARCH="${arch}" go build -ldflags="-X github.com/openshift/rosa/pkg/info.Build=$(git rev-parse --short HEAD)" -o "${tmpdir}/rosa${extension}" ./cmd/rosa
     tar -czf "releases/rosa_${os}_${arch}.tar.gz" -C "${tmpdir}" "rosa${extension}"
     rm -rf "${tmpdir}"
   done

--- a/images/Dockerfile.e2e
+++ b/images/Dockerfile.e2e
@@ -4,7 +4,6 @@ WORKDIR /rosa
 USER root
 ENV GOBIN=/go/bin
 ENV PATH="/go/bin:${PATH}"
-ENV GOFLAGS=-buildvcs=false
 RUN mkdir -p /go/bin
 COPY . .
 RUN git config --global --add safe.directory /rosa


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
Supported ticket prefixes:
OCM-XXXXX, ROSAENG-XXXX
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For contributor workflow, see: ./CONTRIBUTING.md
For repo-local agent guidance, see: ./AGENTS.md
-->

## PR Summary
Addressing Lucas' comments here: https://github.com/openshift/rosa/pull/3435#issuecomment-5119820344
1. Instead of figuring out a clearer way to show that the date is just the date of the commit, I decided the commit SHA is the only part I care about, so now it only shows the commit SHA
2. I made it so that release builds should also include the build info now. I both removed the `-buildvcs=false` flag and added the `ldflags` configs to set the `info.Build` variable. I can go back and disable `-buildvcs` if there's any concerns with enabling that in release builds
3. Improved test coverage of the new argument

## Detailed Description of the Issue
<!-- Describe the root problem, scope, impact, and user/business context -->

## Related Issues and PRs
<!-- Link all tracking items and related code changes -->
- Jira: https://redhat.atlassian.net/browse/ROSAENG-6320


## Type of Change
<!-- Check the primary type this PR represents -->
- [ ] feat - adds a new user-facing capability.
- [x] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
<!-- What users or systems experienced before this change -->

## Behavior After This Change
<!-- What changes now, including user-visible and non-user-visible behavior -->
```
jkeyne@jkeyne-thinkpadp1gen7:~/work/repos/rosa$ make
go build -ldflags="-X github.com/openshift/rosa/pkg/info.Build=bedae9a35" ./cmd/rosa
jkeyne@jkeyne-thinkpadp1gen7:~/work/repos/rosa$ ./rosa version -b
I: 1.2.64
I: Git commit: bedae9a3588c94cdd21e9a06cde7ad4d4f44c33f
I: Your ROSA CLI is up to date.
jkeyne@jkeyne-thinkpadp1gen7:~/work/repos/rosa$ docker build . -t rosa-test
[+] Building 213.1s (11/11) FINISHED                                                                                                                                         docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                   0.0s
 => => transferring dockerfile: 739B                                                                                                                                                   0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                                                       0.3s
 => [internal] load metadata for registry.access.redhat.com/ubi9/go-toolset:1.26.5-1783931515                                                                                          0.2s
 => [internal] load .dockerignore                                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                                        0.0s
 => [internal] load build context                                                                                                                                                      0.7s
 => => transferring context: 122.80MB                                                                                                                                                  0.7s
 => CACHED [builder 1/3] FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1783931515@sha256:c6b19c92a8613bcfdf69ef00a6ea94ac689ec76d07758d71416c1faa6f35f431                     0.0s
 => => resolve registry.access.redhat.com/ubi9/go-toolset:1.26.5-1783931515@sha256:c6b19c92a8613bcfdf69ef00a6ea94ac689ec76d07758d71416c1faa6f35f431                                    0.0s
 => CACHED [stage-2 1/2] FROM docker.io/library/alpine:latest@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b                                                  0.0s
 => => resolve docker.io/library/alpine:latest@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b                                                                 0.0s
 => [builder 2/3] COPY --chown=1001:0 . .                                                                                                                                              2.1s
 => [builder 3/3] RUN git config --global --add safe.directory /opt/app-root/src &&     make release                                                                                 203.5s
 => [stage-2 2/2] COPY --from=builder /opt/app-root/src/releases /releases                                                                                                             0.0s
 => exporting to image                                                                                                                                                                 5.8s
 => => exporting layers                                                                                                                                                                5.2s
 => => exporting manifest sha256:8305169a10cb7d77f90d8b1f4ef4777477b2d3a91d605bedb2f83e878409d72d                                                                                      0.0s
 => => exporting config sha256:fd849e01d96f28d464b205e0e890c74893b2b6c97984180b1a5f91d4221df99c                                                                                        0.0s
 => => exporting attestation manifest sha256:18d919d7051ace38d05d3d2be477de2fb28d0e5370304d733afa1c4ae6ee28bf                                                                          0.0s
 => => exporting manifest list sha256:90d3fe51123fdad1a64494fc05c0573feaf69e796e17e8a8b797c7dc3535677b                                                                                 0.0s
 => => naming to docker.io/library/rosa-test:latest                                                                                                                                    0.0s
 => => unpacking to docker.io/library/rosa-test:latest                                                                                                                                 0.5s
jkeyne@jkeyne-thinkpadp1gen7:~/work/repos/rosa$ docker run --rm -it rosa-test
/ # cd releases/
/releases # tar xvf rosa_linux_amd64.tar.gz
rosa
/releases # ./rosa version -b
I: 1.2.64
I: Git commit: bedae9a3588c94cdd21e9a06cde7ad4d4f44c33f
I: Your ROSA CLI is up to date.
/releases #
```

## How to Test (Step-by-Step)
<!-- Provide reproducible validation instructions -->
### Preconditions
<!-- Required setup, environment, credentials, flags, cluster state, etc. -->

### Test Steps
1.
4.
5.

### Expected Results
<!-- What should happen after running the steps above -->

## Proof of the Fix
<!-- Attach evidence that demonstrates the changed behavior -->
- Screenshots:
- Videos:
- Logs/CLI output:
- Other artifacts:

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
<!-- Required only when breaking changes are introduced -->

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [ ] Any risk, limitation, or follow-up work is documented.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Build metadata now records the current Git commit in released and locally installed CLI binaries.
  - The version command’s build information reports the Git commit, with a fallback value when detailed build metadata is unavailable.

- **Documentation**
  - Updated the `--build` option description to clarify that it primarily displays the Git commit.

- **Tests**
  - Expanded coverage for version output across available and unavailable build metadata scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->