### PR TITLE
ROSAENG-62488 | refactor: Establish target architecure for separating CLI and core/library logic

### DIFF
--- a/guidelines/ARCHITECTURE.md
+++ b/guidelines/ARCHITECTURE.md
@@ -1,19 +1,316 @@
 # ROSA CLI Architecture
 
-## High-Level Shape
+## High-Level Shape (current state)
+
+Today the codebase is organized as follows. The [Target Architecture](#target-architecture)
+section below describes where each concern is moving; output, prompting, and
+reporter code currently in `pkg/` is being migrated to `internal/cli/`.
 
 - `cmd/rosa/` owns Cobra command registration, flag wiring, and help text.
-- `pkg/` owns business logic, service integrations, helpers, output shaping, and interactive flows.
+- `pkg/` owns business logic, service integrations, and helpers. It also
+  currently contains output, prompting, and reporter code that will move to
+  `internal/cli/` as the migration progresses.
 - `pkg/aws/` and `pkg/ocm/` are the main external-system boundaries; their interfaces and mocks are reused across commands and tests.
-- `pkg/output/`, `pkg/reporter/`, and `pkg/interactive/` define most user-facing output, error, and prompt behavior.
+- `pkg/output/`, `pkg/reporter/`, and `pkg/interactive/` currently define most
+  user-facing output, error, and prompt behavior. In the target architecture
+  these are CLI-layer concerns under `internal/cli/`.
 - `cmd/docs/` and `make generate-docs` cover generated CLI docs.
 - `cmd/rosa/structure_test/` guards the command tree and supported flag contracts.
 
 ## Command Layering
 
-- Keep new command files thin: parse flags, connect dependencies, and delegate the substantive logic into `pkg/`.
-- Reuse the nearest comparable command area before introducing a new command pattern; machinepool commands are the preferred reference for newer structure.
-- Legacy command areas are not fully normalized. Follow the entrypoint and exit pattern already used nearby unless the task explicitly intends a broader refactor.
+### Target Architecture
+
+The repository is moving toward a two-layer architecture that cleanly separates CLI presentation from reusable core logic. The goal is to allow non-CLI consumers (automation tools, TUIs, REST APIs, or other first- and third-party applications) to import and use ROSA's core operations without pulling in Cobra, terminal prompting, or formatted output.
+
+The strict test for where code belongs: **would this logic be equally useful in a TUI, a headless program, a CLI, or a REST API?** If the answer is no, it belongs in the CLI layer.
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                       CLI Layer                              │
+│  Owns: Cobra wiring, flag parsing, interactive prompting,    │
+│        output rendering, confirmation dialogs, spinners,     │
+│        workflow orchestration, os.Exit, manual-mode command  │
+│        string generation                                     │
+│                                                              │
+│  ┌────────────┐  ┌──────────────┐                            │
+│  │   cmd/     │  │ internal/cli │                            │
+│  │            │  │              │                            │
+│  │ Thin Cobra │  │ Shared CLI   │                            │
+│  │ commands   │  │ helpers:     │                            │
+│  │            │  │ - flags      │                            │
+│  │ - wiring   │  │ - prompting  │                            │
+│  │ - Run func │  │ - rendering  │                            │
+│  │ - os.Exit  │  │ - reporters  │                            │
+│  │            │  │ - runtime    │                            │
+│  └─────┬──────┘  └──────┬───────┘                            │
+│        │                │                                    │
+│        └───── calls ────┘                                    │
+└──────────────────┬───────────────────────────────────────────┘
+                   │
+                   │  Accepts resolved values and returns
+                   │  data structures + errors. Never prompts,
+                   │  never formats, never exits.
+                   │
+┌──────────────────▼───────────────────────────────────────────┐
+│                    Core / Library Layer                      │
+│  Owns: Business logic, domain types, validation, service     │
+│        operations, SDK integrations, constants               │
+│                                                              │
+│  ┌────────────┐  ┌──────────────┐                            │
+│  │   pkg/     │  │internal/core │                            │
+│  │            │  │              │                            │
+│  │ Public API │  │ Private impl │                            │
+│  │            │  │              │                            │
+│  │ - domain   │  │ - AWS client │                            │
+│  │   types    │  │ - OCM client │                            │
+│  │ - service  │  │ - config     │                            │
+│  │   ops      │  │ - logging    │                            │
+│  │ - valid-   │  │ - caching    │                            │
+│  │   ation    │  │ - version    │                            │
+│  │ - consts   │  │   checks     │                            │
+│  └────────────┘  └──────────────┘                            │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### Directory Responsibilities
+
+Each directory mirrors the layer it belongs to:
+
+#### `cmd/` : CLI Layer (public commands)
+
+Thin Cobra command files. Each command file should:
+
+- Define the `cobra.Command` struct (use, short, long, example, args).
+- Wire flags onto the command.
+- Provide a `Run` function that resolves flag/interactive values into plain Go
+  types, then delegates to a core-layer service function.
+- Handle `os.Exit`, reporter output, and error presentation.
+
+A command file should **not** contain business logic, validation rules, SDK calls,
+or data transformation. If a `Run` function is growing beyond flag resolution and
+delegation, logic is leaking up.
+
+##### Sibling Command Imports
+
+A `cmd/` package may import another `cmd/` package **only for command
+registration** (wiring subcommands onto a parent). Beyond registration:
+
+1. A `cmd/` package must not call another command package's `Cmd.Run()`,
+   mutate another command's flags via `Cmd.Flags().Set()`, or read another
+   command's package-global state.
+2. When two commands need the same operation, extract it into `pkg/` or
+   `internal/core/`. Both commands call the core function with resolved values.
+3. Shared constants and helper functions currently exported from `cmd/`
+   packages (e.g., `ClusterAdminUsername`, `FindIDPWithAdmin`) should migrate
+   to `pkg/` so they are available without `cmd/`-to-`cmd/` imports.
+
+#### `internal/cli/` : CLI Layer (shared CLI infrastructure)
+
+Shared CLI-specific code that multiple `cmd/` files need but that no library consumer
+would ever import. This includes:
+
+- **Flag plumbing**: `--region`, `--profile`, `--debug`, `--color`, `--output`,
+  `--interactive`, `--yes`, `--govcloud`, `--cluster` flag definitions.
+- **Interactive prompting**: `survey`-based `GetString`, `GetBool`, `GetOption`, etc.
+- **Output rendering**: JSON/YAML/table formatting, `Print`/`PrintWarn`/`PrintError`,
+  `StructuredReporter`, fixed-width display string builders, tabwriter output.
+- **Terminal awareness**: TTY/ANSI capability detection, terminal-width queries,
+  and console layout calculations. Core functions return structured data; only the
+  CLI layer decides how to fit it on screen.
+- **Reporters**: Terminal-aware colored Info/Warn/Error/Debug output to stdout/stderr.
+- **Runtime**: The `Runtime` struct bundling Reporter + Logger + OCMClient + AWSClient,
+  `DefaultRunner`/`RuntimeVisitor` Cobra wrappers, and lifecycle management.
+- **Command registration**: The command registry that wires subcommands to root.
+- **Manual-mode command builders**: `commandbuilder` packages that generate human-readable `aws ...` or `rosa ...` strings for copy-paste.
+- **Argument parsing**: Unknown-flag handling, pflag normalization, region deprecation.
+- **Shell completion**: Completion registration, completion callbacks, and
+  `cobra.ShellCompDirective` usage.
+
+#### `pkg/` : Core Layer (public API)
+
+Stable, exported packages that any consumer can import. These define the domain:
+
+- **Domain types**: Machine pool options, autoscaler config, kubelet config, IAM
+  service account types, log forwarding config, break-glass credentials, etc.
+- **Service operations**: Create/edit/delete/list/describe for machine pools, node
+  pools, ingresses, kubelet configs, autoscalers, external auth providers, etc.
+  These accept resolved values (not `*cobra.Command`) and return data structures
+  and errors (not formatted strings or `os.Exit`).
+- **Validation**: Label/taint parsing, replica range checks, duration format
+  validation, URL validation, version feature gates.
+- **Constants**: Tag keys, property keys, environment variable names.
+
+A function in `pkg/` must **never**:
+- Import Cobra, pflag, survey, or the reporter/output/interactive packages.
+- Call `os.Exit`.
+- Write to `os.Stdout` or `os.Stderr`.
+- Read global state like `interactive.Enabled()` or `fedramp.Enabled()`.
+- Build fixed-width display strings or formatted human-readable output.
+- Prompt the user for input.
+
+If a function needs environment-specific configuration (e.g., FedRAMP mode), it
+receives that as a parameter, not by reading package-level state.
+
+#### `internal/core/` : Core Layer (private implementation)
+
+Internal packages that support `pkg/` but are not part of the public contract:
+
+- **AWS client**: SDK v2 wrapping for IAM, STS, EC2, S3, CloudFormation, etc.
+- **OCM client**: OpenShift Cluster Manager API client for clusters, node pools,
+  IDPs, upgrades, versions, gates, etc.
+- **Config**: OCM configuration load/save, keyring access, JWT parsing.
+- **Logging**: Logger factories, SDK logger adapters, HTTP debug dumpers.
+- **Caching**: File-backed TTL cache for version lists.
+- **Networking**: CloudFormation stack creation/polling for VPC setup.
+- **Version checking**: Mirror.openshift.com retrieval, version comparison.
+
+These packages may be promoted to `pkg/` if external demand warrants a stable API
+around them.
+
+### What Lives Where : Quick Reference
+
+| Concern | Owner | Examples |
+|---------|-------|----------|
+| Cobra `Command` struct, `Use`, `Short`, `Long` | `cmd/` | `cmd/create/machinepool/cmd.go` |
+| Flag definitions (`--replicas`, `--name`, etc.) | `cmd/` or `internal/cli/` | `AddClusterFlag`, `AddFlag` |
+| Interactive prompting (`GetString`, `GetBool`) | `internal/cli/` | `interactive.GetString(...)` |
+| Confirmation dialogs (`--yes`, `confirm.Prompt`) | `internal/cli/` | `confirm.Confirm(...)` |
+| Output rendering (JSON/YAML/table, display strings) | `internal/cli/` | `output.Print(...)`, `PrintAutoscaler` |
+| Reporter (Info/Warn/Error/Debug to terminal) | `internal/cli/` | `reporter.Infof(...)` |
+| Manual-mode AWS CLI command generation | `internal/cli/` | `commandbuilder.NewCommand(...)` |
+| `os.Exit` | `cmd/` or `internal/cli/` | `cmd/` Run functions, `rosa.DefaultRunner` error path |
+| Workflow orchestration (resolve flags, prompt, call service, render) | `cmd/` Run function | `CreateMachinepoolRunner` |
+| Business logic (create pool, validate labels, build OCM request) | `pkg/` | `machinepool.CreateMachinePool(...)` |
+| Domain types and validation | `pkg/` | `machinepool.Options`, `ValidateLabels` |
+| Constants (tag keys, property keys, env var names) | `pkg/` | `aws/tags`, `properties`, `constants` |
+| AWS SDK operations | `internal/core/` | `aws.Client.CreateRole(...)` |
+| OCM API operations | `internal/core/` | `ocm.Client.CreateCluster(...)` |
+
+### Current State
+
+The codebase does not yet follow this target architecture. Today:
+
+- Many `pkg/` packages accept `*cobra.Command` parameters, call `interactive.GetString`,
+  check `output.HasFlag()`, call `reporter.Errorf` + `os.Exit(1)`, and build formatted
+  display strings.
+- Several `pkg/options/` packages build complete `cobra.Command` structs; these are
+  `cmd/` code living in the wrong place.
+- The `pkg/rosa.Runtime` struct bundles CLI-specific lifecycle (Reporter, Cobra runner
+  wrappers) with general-purpose client access.
+- About 16 sites across 15 `cmd/` files call a sibling command's `Cmd.Run()`
+  or mutate its flags via `Cmd.Flags().Set()`. `cmd/create/cluster` is the
+  largest hub, chaining into `describe/cluster`, `create/operatorroles`,
+  `create/oidcprovider`, and `logs/install`.
+- The `internal/` directory exists but does not yet follow the target structure.
+  Today it contains `internal/ocmrole/` (OCM role creation logic with CLI
+  dependencies). In the target architecture, packages under `internal/` should
+  be organized into `internal/core/` (private core implementation) or
+  `internal/cli/` (shared CLI infrastructure).
+
+The migration is incremental. See [`pkg-architecture.md`](refactor/pkg-architecture.md) for
+the per-package classification and split work required.
+
+### Migration Guidelines
+
+When working on existing code:
+
+- **New commands** should follow the target pattern: thin `cmd/` file that resolves
+  inputs and delegates to a `pkg/` service function that accepts plain Go types and
+  returns data + errors.
+- **Existing commands** being modified should move in the target direction when the
+  change scope justifies it, but a bug fix does not require a full layer separation.
+- **New `pkg/` functions** must not introduce new CLI dependencies. If a function
+  needs a value that comes from a flag or interactive prompt, accept it as a parameter.
+- **New `internal/` packages** should be placed under `internal/core/` or
+  `internal/cli/` according to the layer they belong to. Existing `internal/`
+  packages that predate this structure will be reorganized as they are modified.
+
+### Backward Compatibility
+
+The migration is an internal restructuring. User-facing behavior must be
+preserved unless an intentional change is explicitly scoped, reviewed, and
+documented in the PR.
+
+**Preserved contract:**
+
+- **Flags**: Names, types, defaults, and semantics stay the same.
+- **Exit codes**: All error paths currently use exit code 1. When extracting
+  `os.Exit(1)` from core code, the `cmd/` layer must translate the returned
+  error back to `os.Exit(1)`. Do not introduce new exit codes during migration.
+- **JSON/YAML output**: The shape of `--output json` and `--output yaml`
+  responses must not change. Scripts and automation depend on these structures.
+- **Interactive prompts**: Question text, option lists, and default values must
+  remain the same.
+
+**Allowed cosmetic changes:**
+
+- Error message casing and punctuation may be normalized to satisfy linter
+  rules (e.g., lowercasing error strings for `staticcheck ST1005`) when a file
+  is already being modified. These are lint-driven corrections, not semantic
+  changes. When changing error messages, update all tests that assert on the
+  exact string.
+
+### Boundary Rules
+
+The layer boundary is a hard line. These rules are not aspirational and apply to
+all new code immediately, and to modified code as scope permits:
+
+1. **Core layer functions accept resolved values.** A machine pool creation function
+   receives a struct of options, not a `*cobra.Command` to extract flags from.
+2. **Core layer functions return data and errors.** They never call `os.Exit`, print
+   to stdout/stderr, or build display strings.
+3. **The CLI layer owns all user interaction.** Prompting, confirmation, spinners,
+   progress bars, and output formatting live exclusively in `cmd/` or `internal/cli/`.
+4. **No global state in the core layer.** Functions do not read `interactive.Enabled()`,
+   `fedramp.Enabled()`, `output.HasFlag()`, or similar package-level booleans.
+   Configuration is passed as parameters.
+5. **Display strings are not data.** Functions that need to communicate structured
+   results return structs, slices, or maps. The CLI layer formats them for display.
+
+### Import Direction
+
+Dependencies flow downward: **CLI layer → Core layer**. Never the reverse.
+
+The table below is the normative reference. Each cell states whether the row
+package **may** or **must not** import the column package.
+
+| Importer ↓ \ Target → | `cmd/` | `internal/cli/` | `pkg/` | `internal/core/` |
+|------------------------|--------|------------------|--------|-------------------|
+| **`cmd/`**             | **registration only** | **may** | **may** | **may** |
+| **`internal/cli/`**    | **must not** | —          | **may** | **may**          |
+| **`pkg/`**             | **must not** | **must not** | —     | **may**          |
+| **`internal/core/`**   | **must not** | **must not** | **may** | —              |
+
+Reading the table:
+
+- **`cmd/`** may import from any other layer. It is the top of the dependency graph.
+- **`internal/cli/`** may import from `pkg/` and `internal/core/`, but never from
+  `cmd/`. Shared CLI infrastructure serves commands; it does not know about
+  specific commands.
+- **`pkg/`** may import from `internal/core/`, but never from `cmd/` or
+  `internal/cli/`. This is the rule that keeps the public API free of CLI concerns.
+- **`internal/core/`** may import from `pkg/` (for shared types and constants) but
+  never from `cmd/` or `internal/cli/`. It is the bottom of the dependency graph.
+
+The bidirectional permission between `pkg/` and `internal/core/` is intentional.
+Both are core-layer directories with different visibility, and Go's compiler
+enforces acyclicity at the package level, preventing any actual import cycle.
+
+Prohibited imports must never appear in `pkg/` or `internal/core/`
+import statements:
+
+- `github.com/spf13/cobra`
+- `github.com/spf13/pflag`
+- `github.com/AlecAivazis/survey`
+- Any package under `internal/cli/` (once it exists)
+- Any package currently classified as CLI Presentation in
+  [`pkg-architecture.md`](refactor/pkg-architecture.md): `reporter`, `output`,
+  `interactive`, `arguments`, `color`, `debug`, `commands`, `rosa` (runtime),
+  `options/*`, `aws/profile`, `aws/region`, `aws/commandbuilder`
+
+This list applies to **new code immediately**. Existing violations are resolved
+incrementally.
 
 ## External Boundaries
 

--- a/guidelines/refactor/pkg-architecture.md
+++ b/guidelines/refactor/pkg-architecture.md
@@ -1,0 +1,156 @@
+# Package Classification: `pkg/`
+
+This document classifies every package under `pkg/` to guide the separation of reusable core/library code from CLI-specific implementation.
+
+The test applied to each package: **would this logic be equally useful in a TUI, a headless program, a CLI, or a REST API?** If the answer is "no," it is not core API.
+
+This is a **north star** document. Each package is placed where it _should_ live once its CLI concerns are extracted. Packages that are not yet clean are marked **Needs split** with details in the [Split Work Required](#split-work-required) section at the end.
+
+## Categories
+
+| Label | Meaning | Target Location |
+|-------|---------|-----------------|
+| **Public Core API** | Domain logic, service operations, validation, types, and constants that any consumer needs regardless of presentation. Zero CLI, terminal, or formatting dependencies. | `pkg/` (stable, exported) |
+| **Private Core Implementation** | Internal plumbing that supports the core API: SDK client wrappers, caching, config loading, logging adapters, HTTP helpers. Useful across consumers but not a stable public contract. | `internal/core/` |
+| **CLI Presentation / Interaction** | Packages that exist because there is a terminal: Cobra/pflag wiring, interactive prompts, colored output, reporter, output formatting, command registration, manual-mode command-string generation. | `cmd/` (commands) or `internal/cli/` (shared CLI code) |
+| **Test-Only Support** | Test helpers, mocks, matchers. Not shipped. | `internal/testing/` or colocated |
+
+---
+
+## Public Core API
+
+Target location: `pkg/` (stable, exported). Each entry shows **target name** with current name in parentheses when they differ.
+
+| Target | Status | Description |
+|--------|--------|-------------|
+| `pkg/aws/tags` | Clean | Tag key constants (`rosa_cluster_name`, `red-hat-managed`, etc.) and EC2 tag-matching utilities. |
+| `pkg/breakglasscredential` | Needs split | Break-glass credential creation via OCM and expiration parsing. |
+| `pkg/clusterautoscaler` | Needs split | Autoscaler OCM config building and validation rules (min/max ranges, duration formats). |
+| `pkg/clusterregistryconfig` | Needs split | Registry config spec building for hosted clusters and validation rules. |
+| `pkg/constants` | Needs split | Environment variable names (`ROSA_TOKEN`, `AWS_PROFILE`, `OCM_CONFIG`, etc.). OIDC flag-name and help-message constants in `oidc_constants.go` are CLI-specific and should be separated. |
+| `pkg/externalauthprovider` | Needs split | External auth provider creation via OCM, URL validation, and claim mapping logic. |
+| `pkg/fedramp` | Needs split | FedRAMP/GovCloud environment configuration: URL and token endpoint mappings per environment. |
+| `pkg/utils` (`pkg/helper`) | Needs split | General-purpose utilities: random labels, string/slice operations, shell quoting, file saving, `IsBYOVPC` check. |
+| `pkg/utils/urlutil` (`pkg/helper/url`) | Clean | URL validation utilities: credential character checks, IPv6 literal host detection. |
+| `pkg/utils/fileutil` (`pkg/input`) | Needs split | YAML/JSON file unmarshalling and input helpers. |
+| `pkg/utils/versions` (`pkg/helper/versions`) | Needs split | Version list retrieval from OCM, comparison, filtering, and segment normalization (`FormatMajorMinorPatch`). Returns version strings and errors. Used by multiple `cmd/` and `pkg/` packages. |
+| `pkg/autonode` (`pkg/helper/autonode`) | Needs split | AutoNode IAM role configuration and validation logic. |
+| `pkg/download` (`pkg/helper/download`) | Needs split | HTTP file download with temp-file atomic rename and structured error wrapping (`formatDownloadError`). Returns errors, not display strings. Terminal progress rendering (`WriteCounter`, `PrintProgress`) moves to `internal/cli/`. |
+| `pkg/machinepool` (merge `helper/features`) | — | Version-gated feature support checks. Only used by `pkg/machinepool`; merge as unexported functions. |
+| `pkg/machinepool` (merge `helper/machinepools`) | Needs split | Label, taint, and tag parsing and validation (`ParseLabels`, `ParseTaints`, `ValidateNodeDrainGracePeriod`, etc.). Reusable logic merges into `pkg/machinepool`; CLI orchestration (`GetTaints`, `GetAwsTags`, `GetLabelMap` with `*cobra.Command`, `interactive.GetString`, `r.Reporter.Errorf`, `os.Exit`) moves to `internal/cli/`. |
+| `pkg/operatorroles` (split from `pkg/helper/roles`) | Needs split | Reusable operator role logic: role name generation, ARN validation, managed policy validation, Red Hat managed tag checks. Extracted from `pkg/helper/roles`; CLI orchestration stays in `internal/cli/roles`. |
+| `pkg/rolepolicybinding` (`pkg/helper/rolepolicybindings`) | Needs split | Role-policy binding status checking, missing-binding detection, and `TransformToRolePolicyDetails`. |
+| `pkg/iamserviceaccount` | Clean | Types, validation, trust policy generation, tag construction, and role name generation for IAM service accounts. |
+| `pkg/ingress` | Needs split | Ingress describe/list service with OCM API calls. |
+| `pkg/kubeletconfig` | Needs split | KubeletConfig pod pids limit validation and OCM CRUD operations. |
+| `pkg/logforwarding` | Needs split | Log forwarding config types, YAML unmarshalling, and OCM builder binding. |
+| `pkg/machinepool` | Needs split | Machine pool and node pool CRUD via OCM, replica/autoscaling validation, spot instance logic, root disk sizing, version compatibility checks. Most entangled package. |
+| `pkg/properties` | Clean | OCM cluster property key constants (`rosa_cli_version`, `fake_cluster`, etc.). |
+| `pkg/version` | Needs split | Version retrieval from mirror.openshift.com, comparison logic, cache-backed version list. Reusable API for TUIs, automation, and other non-CLI consumers. Cobra-accepting functions (`ShouldRunCheck`) and `output.HasFlag()` checks move to `internal/cli/`. |
+
+## Private Core Implementation
+
+Target location: `internal/core/`. Each entry shows **target name** with current name in parentheses when they differ.
+
+| Target | Status | Description |
+|--------|--------|-------------|
+| `internal/core/aws` (`pkg/aws`) | Needs split | AWS SDK v2 client wrapping IAM, STS, EC2, S3, CloudFormation, Organizations, SecretsManager, ServiceQuotas. |
+| `internal/core/aws/api_interface` (`pkg/aws/api_interface`) | Clean | Go interfaces mirroring AWS SDK v2 service clients. Abstraction for mocking and dependency injection. |
+| `internal/core/buildinfo` (`pkg/info`) | Clean | Build metadata: `DefaultVersion`, build hash, `DefaultUserAgent`. Used by `aws` and `ocm` clients for user-agent strings. |
+| `internal/core/httputil` (`pkg/clients`) | Clean | Minimal HTTP client interface wrapping `net/http`. Testing seam used by `pkg/version`. |
+| `internal/core/ocm` (`pkg/ocm`) | Needs split | OCM API client: clusters, node pools, machine pools, IDPs, ingresses, upgrades, addons, billing, OIDC, kubelet configs, versions, gates. |
+| `internal/core/ocmconfig` (`pkg/config`) | Clean | OCM client configuration: load/save from file or keyring, JWT token parsing, connection builder. |
+| `internal/core/policy` (`pkg/policy`) | Needs split | IAM policy attach/detach operations and quota validation. Manual-mode command string generation (`ManualAttachArbitraryPolicy`, `ManualDetachArbitraryPolicy`) moves to `internal/cli/`. |
+| `internal/core/rosalog` (`pkg/logging`) | Clean | Logger factories: logrus setup, AWS SDK logger adapter, OCM SDK logger adapter, HTTP debug round-tripper. |
+| `internal/core/sharedvpcroles` (`pkg/roles`) | Needs split | Shared VPC role policy helpers and input validation. |
+| `internal/core/versioncache` (`pkg/cache`) | Clean | File-backed gob cache with TTL expiration. Version list caching. |
+| `internal/core/vpcnetwork` (`pkg/network`) | Clean | CloudFormation stack creation and polling for VPC network setup. |
+
+## CLI Presentation / Interaction
+
+Target location: `cmd/` (commands) or `internal/cli/` (shared CLI code). Each entry shows **target name** with current name in parentheses when they differ.
+
+| Target | Description |
+|--------|-------------|
+| `internal/cli/arguments` (`pkg/arguments`) | CLI flag parsing, unknown-flag handling, region deprecation warnings, pflag normalization. |
+| `internal/cli/color` (`pkg/color`) | Manages the `--color` flag and terminal color detection. |
+| `internal/cli/commandbuilder` (`pkg/aws/commandbuilder`) | Builds human-readable AWS CLI command strings (e.g., `aws iam create-role ...`) for "manual mode" output. |
+| `internal/cli/commandbuilder/roles` (`pkg/aws/commandbuilder/helper/roles`) | Generates manual-mode AWS CLI commands for operator roles. |
+| `internal/cli/commands` (`pkg/commands`) | Single-function command registry wiring all subcommands onto root `cobra.Command`. |
+| `internal/cli/debug` (`pkg/debug`) | Adds the `--debug` pflag and tracks its boolean state. |
+| `internal/cli/interactive` (`pkg/interactive`) | `survey`-based `GetString`, `GetBool`, `GetInt`, `GetOption`, `GetPassword`, validation combinators, `--interactive` pflag. |
+| `internal/cli/interactive/confirm` (`pkg/interactive/confirm`) | `--yes` flag and confirmation prompts using `survey`. |
+| `internal/cli/interactive/consts` (`pkg/interactive/consts`) | Single constant (`SkipSelectionOption`) used exclusively by the interactive layer. |
+| `internal/cli/interactive/logforwarding` (`pkg/interactive/logforwarding`) | Interactive prompts for CloudWatch/S3 log forwarding config. |
+| `internal/cli/interactive/oidc` (`pkg/interactive/oidc`) | Interactive OIDC config ID selection with terminal prompts. |
+| `internal/cli/interactive/roles` (`pkg/interactive/roles`) | Interactive installer role ARN selection with AWS lookups, spinner, and `os.Exit`. |
+| `internal/cli/interactive/securitygroups` (`pkg/interactive/securitygroups`) | Interactive security group ID selection with `os.Exit`. |
+| `internal/cli/ocmoutput` (`pkg/ocm/output`) | Output formatting for node pools and machine pools: autoscaling display, replica counts, labels, tags. Builds fixed-width display strings. |
+| `internal/cli/output` (`pkg/output`) | Output formatting subsystem: `--output` flag (json/yaml), `Print`/`PrintWarn`/`PrintError` to stdout/stderr, OCM resource marshalling, `StructuredReporter`. Absorbs `pkg/object` as `output.Data` (`map[string]any`); delete standalone `pkg/object/` package. |
+| `internal/cli/profile` (`pkg/aws/profile`) | Adds the `--profile` pflag. |
+| `internal/cli/region` (`pkg/aws/region`) | Adds the `--region` pflag. |
+| `internal/cli/reporter` (`pkg/reporter`) | `Logger` interface and terminal-aware reporter printing colored messages to stdout/stderr. |
+| `internal/cli/roles` (`pkg/helper/roles`) | Needs split. CLI workflow orchestration: auto/manual mode branching, `confirm.Prompt`, `r.Reporter.*`, `fmt.Println`, `os.Exit`. Reusable logic (role name generation, ARN validation, managed policy validation, tag checks) moves to `pkg/operatorroles`. |
+| `internal/cli/runtime` (`pkg/rosa`) | Central `Runtime` struct bundling Reporter, Logger, OCMClient, AWSClient, plus `DefaultRunner`/`RuntimeVisitor` Cobra wrappers. The CLI lifecycle harness. |
+| `cmd/` (`pkg/options/iamserviceaccount`) | Builds full `cobra.Command` structs and wires flags for IAM service account create/delete/describe. |
+| `cmd/` (`pkg/options/machinepool`) | Builds `cobra.Command` and wires flags for machine pool creation. |
+| `cmd/` (`pkg/options/network`) | Builds `cobra.Command` and instantiates `reporter.CreateReporter()`. |
+
+## Test-Only Support
+
+Target location: `internal/testing/` or colocated with the package under test.
+
+| Target | Description |
+|--------|-------------|
+| colocated (`pkg/aws/api_interface/api_interface_tests`) | Test companions for the api_interface package. |
+| colocated (`pkg/aws/mocks`) | Generated gomock implementations of AWS api_interface types. |
+| `internal/testing/` (`pkg/test`) | Test helpers: output capture, OCM mock server setup, mock runtime builders, command structure verification, flag arg generation/verification. |
+| `internal/testing/matchers` (`pkg/test/matchers`) | Custom Gomega matcher (`MatchExpected`). |
+
+---
+
+## Split Work Required
+
+Every package marked **Needs split** above has CLI concerns to extract. See
+[Boundary Rules](../ARCHITECTURE.md#boundary-rules) for the rationale behind each
+rule; this section lists only what must move.
+
+### Public Core API → extract to CLI layer
+
+| Target | Extract to CLI Layer |
+|--------|----------------------|
+| `pkg/breakglasscredential` | Cobra flag definitions, `interactive.GetString`, pflag `Changed()` checks, formatted output strings. |
+| `pkg/clusterautoscaler` | Cobra/pflag flag definitions, ~25 interactive prompt sites, `output.PrintBool`/`output.PrintStringSlice`, `PrintAutoscaler` display builder. |
+| `pkg/clusterregistryconfig` | Cobra/pflag flag definitions, ~8 interactive prompt sites, `interactive.Enabled()` checks. |
+| `pkg/constants` | OIDC flag-name and help-message constants (`InstallerRoleArnFlag`, `InformOperatorRolesOutput`, etc.). Env var names stay. |
+| `pkg/externalauthprovider` | Cobra/pflag flag definitions, ~10 interactive prompt sites, `interactive.Enabled()` checks. |
+| `pkg/fedramp` | `--govcloud`/`--admin` pflag definitions, `Enabled()` global reader, `HasFlag`/`HasAdminFlag` accepting `*cobra.Command`. URL/token endpoint data stays. |
+| `pkg/utils` (`pkg/helper`) | `DisplaySpinnerWithDelay` (`reporter.IsTerminal()`, `reporter.Infof()`). All other helpers are clean. |
+| `pkg/utils/versions` (`pkg/helper/versions`) | `rosa.Runtime` dependency. Accept OCM client and logger as parameters. |
+| `pkg/autonode` (`pkg/helper/autonode`) | `*cobra.Command` parameter, `interactive.GetBool`/`GetString`, `fedramp.Enabled()`. |
+| `pkg/download` (`pkg/helper/download`) | `WriteCounter.PrintProgress()` (`fmt.Printf`), `Download()` `fmt.Print("\n")`. Accept progress callback or `io.Writer`. |
+| `pkg/machinepool` (merge `helper/machinepools`) | `GetTaints`, `GetAwsTags`, `GetLabelMap`: `*cobra.Command` parameter, `interactive.Enabled()`, `interactive.GetString`, `r.Reporter.Errorf` + `os.Exit(1)` (6 sites). These three functions move to `internal/cli/`; pure parsing and validation functions merge into `pkg/machinepool`. |
+| `pkg/machinepool` | ~60 `interactive.*` sites, `confirm.*`, `output.*`, `r.Reporter.*`, `os.Exit(1)` (3 sites), `tabwriter`/`fmt.Print`, display strings. Most entangled package. |
+| `pkg/rolepolicybinding` (`pkg/helper/rolepolicybindings`) | Display strings containing `rosa attach policy` CLI commands. Return structured data instead. |
+| `pkg/ingress` | `output.HasFlag()`, `output.Print()`, `fmt.Print()`, `*pflag.FlagSet` parameter, display strings. |
+| `pkg/utils/fileutil` (`pkg/input`) | `CheckIfHypershiftClusterOrExit`: `os.Exit` via `exitFunc`, `r.Reporter.Errorf`. Return error instead. |
+| `pkg/kubeletconfig` | `interactive.GetString`/`GetInt`, `confirm.ConfirmRaw`, `interactive.Enable()` mutation, `r.Reporter.Infof`, display strings. |
+| `pkg/logforwarding` | `LogForwarderObjectAsString` display builder, `FlagName`/`LogFwdConfigHelpMessage` CLI constants, `ConstructPodGroupsInteractiveOptions`. |
+| `pkg/version` | `ShouldRunCheck` accepting `*cobra.Command`, `output.HasFlag()`. Version retrieval and comparison stay in `pkg/`. |
+
+### Private Core Implementation → extract to CLI layer
+
+| Target | Extract to CLI Layer |
+|--------|----------------------|
+| `internal/core/aws` (`pkg/aws`) | `os.Exit` (7 sites via `CreateNewClientOrExit` and `helpers.go`), `fedramp.Enabled()` (3 sites), `fmt.Printf` error output (4 sites). |
+| `internal/core/ocm` (`pkg/ocm`) | Cobra `--cluster` flag with shell completion, `reporter.IsTerminal()`, `output.HasFlag()`, `os.Exit(1)` (2 sites), `CreateNewClientOrExit`. |
+| `internal/core/policy` (`pkg/policy`) | `reporter.Logger` parameter on `AutoAttachArbitraryPolicy`. `ManualAttachArbitraryPolicy` and `ManualDetachArbitraryPolicy` generate `aws iam ...` command strings for terminal display; move to `internal/cli/`. `AutoDetachArbitraryPolicy` returns human-readable status messages; return structured results instead. |
+| `internal/core/sharedvpcroles` (`pkg/roles`) | `rosa.Runtime` and `arguments` (CLI flag package) dependencies. |
+
+### CLI Presentation → already CLI, needs cleanup
+
+| Target | Cleanup Required |
+|--------|-----------------|
+| `internal/cli/roles` (`pkg/helper/roles`) | Split the package. Move reusable logic to `pkg/operatorroles`: `GeOperatorRolePrefixFromClusterName`, `GetOperatorRoleName`, `CheckHasRedHatManagedTag`, `ValidateUnmanagedAccountRoles`, `ValidateAdditionalAllowedPrincipals`, and the managed policy validation functions (decoupled from `r.Reporter`). Keep CLI orchestration in `internal/cli/roles`: auto/manual mode branching (`createOperatorRole`), `confirm.Prompt` (`upgradeMissingOperatorRole`), `BuildMissingOperatorRoleCommand`, `r.Reporter.*`, `fmt.Println`, `os.Exit(1)` (2 sites). |
+
+For boundary rationale, see [Boundary Rules](../ARCHITECTURE.md#boundary-rules).


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
Supported ticket prefixes:
OCM-XXXXX, ROSAENG-XXXX
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For contributor workflow, see: ./CONTRIBUTING.md
For repo-local agent guidance, see: ./AGENTS.md
-->

## PR Summary
Document the target two-layer architecture for ROSA CLI and add tracking files for the incremental migration in `guidelines/refactor/`.

## Detailed Description of the Issue

Expands the Command Layering section of guidelines/ARCHITECTURE.md from a brief three-line guideline into a full architectural specification. The new content defines the target two-layer split (CLI layer in `cmd/` and `internal/cmd/`; Core/Library layer in `pkg/` and `internal/pkg/`), documents directory responsibilities, establishes boundary rules and import direction constraints, and provides a quick-reference table for where common concerns belong. It also describes the current state and sets migration guidelines for new and modified code.

Two new tracking files are added under `guidelines/refactor/`:
- `layer-violations.md` catalogs ~370 existing sites where CLI concerns have leaked into core `pkg/` packages
- `pkg-classification.md` records the per-package classification (core vs. CLI-classified) and the split work required for each.
 
These files are co-located with` ARCHITECTURE.md` and grouped under `refactor/` so they're easy to find and easy to remove once the migration is complete.

No code changes — documentation and guidelines only.

## Related Issues and PRs
<!-- Link all tracking items and related code changes -->
- Jira:
  - [ROSAENG-62486](https://redhat.atlassian.net/browse/ROSAENG-62486)
  - [ROSAENG-62487](https://redhat.atlassian.net/browse/ROSAENG-62487)
  - [ROSAENG-62488](https://redhat.atlassian.net/browse/ROSAENG-62488)
  - [ROSAENG-62489](https://redhat.atlassian.net/browse/ROSAENG-62489)
- Related design/docs: [Refactor CLI to enforce layer boundaries](https://redhat.atlassian.net/wiki/spaces/ROSACLITF/pages/432213369/ROSA+CLI+Refactor+CLI+to+enforce+layer+boundaries#Phase-1%3A-Define-and-Guard-the-Boundary)

## Type of Change
<!-- Check the primary type this PR represents -->
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [x] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Developer Verification Checklist
- [ ] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [ ] PR description clearly explains both **what** changed and **why**.
- [ ] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [ ] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [ ] `make test` passes.
- [ ] `make lint` passes.
- [ ] `make rosa` passes.
- [x] Documentation or repo-local agent guidance was added/updated where appropriate.
- [ ] Any risk, limitation, or follow-up work is documented.


[ROSAENG-62486]: https://redhat.atlassian.net/browse/ROSAENG-62486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added architecture guidance defining boundaries between command-line presentation and reusable application logic.
  * Documented current layering violations, including CLI dependencies, terminal output, prompts, and process exits.
  * Added package classification and migration guidance for organizing core, private, CLI, and test-only components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->