### PR TITLE
ROSAENG-61179 | fix: harden ocm client edge cases

### DIFF
--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -41,7 +41,8 @@ import (
 )
 
 const (
-	legacyIngressSupportLabel = "ext-managed.openshift.io/legacy-ingress-support"
+	legacyIngressSupportLabel   = "ext-managed.openshift.io/legacy-ingress-support"
+	defaultClusterQueryPageSize = 100
 )
 
 var NetworkTypes = []string{"OpenShiftSDN", "OVNKubernetes"}
@@ -269,12 +270,17 @@ func (c *Client) CreateCluster(config Spec) (*cmv1.Cluster, error) {
 		return nil, fmt.Errorf("unable to create cluster spec: %v", err)
 	}
 
+	dryRun := false
+	if config.DryRun != nil {
+		dryRun = *config.DryRun
+	}
+
 	cluster, err := c.ocm.ClustersMgmt().V1().Clusters().
 		Add().
-		Parameter("dryRun", *config.DryRun).
+		Parameter("dryRun", dryRun).
 		Body(spec).
 		Send()
-	if config.DryRun != nil && *config.DryRun {
+	if dryRun {
 		if cluster.Error() != nil {
 			return nil, handleErr(cluster.Error(), err)
 		}
@@ -329,11 +335,12 @@ func (c *Client) queryClusters(query string, count int) (clusters []*cmv1.Cluste
 
 	request := c.ocm.ClustersMgmt().V1().Clusters().List().Search(query)
 	page := 1
+	pageSize := count
+	if count == 0 {
+		pageSize = defaultClusterQueryPageSize
+	}
 	for {
-		clusterRequestList := request.Page(page)
-		if count > 0 {
-			clusterRequestList = clusterRequestList.Size(count)
-		}
+		clusterRequestList := request.Page(page).Size(pageSize)
 		response, err := clusterRequestList.Send()
 		if err != nil {
 			return clusters, err
@@ -343,7 +350,11 @@ func (c *Client) queryClusters(query string, count int) (clusters []*cmv1.Cluste
 			clusters = append(clusters, cluster)
 			return true
 		})
-		if response.Size() != count {
+		if count == 0 {
+			if len(clusters) >= response.Total() {
+				break
+			}
+		} else if response.Size() < pageSize {
 			break
 		}
 		page++

--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -335,8 +335,9 @@ func (c *Client) queryClusters(query string, count int) (clusters []*cmv1.Cluste
 
 	request := c.ocm.ClustersMgmt().V1().Clusters().List().Search(query)
 	page := 1
+	fetchAll := count == 0
 	pageSize := count
-	if count == 0 {
+	if fetchAll {
 		pageSize = defaultClusterQueryPageSize
 	}
 	for {
@@ -350,11 +351,12 @@ func (c *Client) queryClusters(query string, count int) (clusters []*cmv1.Cluste
 			clusters = append(clusters, cluster)
 			return true
 		})
-		if count == 0 {
-			if len(clusters) >= response.Total() {
-				break
-			}
-		} else if response.Size() < pageSize {
+
+		stopPaging := response.Size() < pageSize
+		if fetchAll {
+			stopPaging = len(clusters) >= response.Total()
+		}
+		if stopPaging {
 			break
 		}
 		page++

--- a/pkg/ocm/clusters_client_test.go
+++ b/pkg/ocm/clusters_client_test.go
@@ -61,7 +61,11 @@ var _ = Describe("Cluster API client behavior", func() {
 
 	It("handles CreateCluster when DryRun is nil", func() {
 		apiServer.AppendHandlers(
-			RespondWithJSON(http.StatusCreated, `{"id":"cluster-1","name":"test-cluster"}`),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+				ghttp.VerifyFormKV("dryRun", "false"),
+				RespondWithJSON(http.StatusCreated, `{"id":"cluster-1","name":"test-cluster"}`),
+			),
 		)
 
 		spec := buildMinimalClusterSpec()
@@ -80,20 +84,30 @@ var _ = Describe("Cluster API client behavior", func() {
 
 	It("paginates all results when GetClusters count is zero", func() {
 		apiServer.AppendHandlers(
-			RespondWithJSON(http.StatusOK, `{
-				"kind":"ClusterList",
-				"page":1,
-				"size":1,
-				"total":2,
-				"items":[{"id":"cluster-1","name":"one"}]
-			}`),
-			RespondWithJSON(http.StatusOK, `{
-				"kind":"ClusterList",
-				"page":2,
-				"size":1,
-				"total":2,
-				"items":[{"id":"cluster-2","name":"two"}]
-			}`),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters"),
+				ghttp.VerifyFormKV("page", "1"),
+				ghttp.VerifyFormKV("size", "100"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind":"ClusterList",
+					"page":1,
+					"size":1,
+					"total":2,
+					"items":[{"id":"cluster-1","name":"one"}]
+				}`),
+			),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters"),
+				ghttp.VerifyFormKV("page", "2"),
+				ghttp.VerifyFormKV("size", "100"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind":"ClusterList",
+					"page":2,
+					"size":1,
+					"total":2,
+					"items":[{"id":"cluster-2","name":"two"}]
+				}`),
+			),
 		)
 
 		clusters, err := ocmClient.GetClusters(nil, 0)

--- a/pkg/ocm/clusters_client_test.go
+++ b/pkg/ocm/clusters_client_test.go
@@ -19,7 +19,7 @@ import (
 
 func buildTestOCMClient(apiServerURL string) *Client {
 	accessToken := MakeTokenString("Bearer", 15*time.Minute)
-	logger, err := logging.NewGoLoggerBuilder().Debug(true).Build()
+	logger, err := logging.NewGoLoggerBuilder().Debug(false).Build()
 	Expect(err).NotTo(HaveOccurred())
 
 	connection, err := sdk.NewConnectionBuilder().
@@ -29,7 +29,7 @@ func buildTestOCMClient(apiServerURL string) *Client {
 		Build()
 	Expect(err).NotTo(HaveOccurred())
 
-	return &Client{ocm: connection}
+	return NewClientWithConnection(connection)
 }
 
 func buildMinimalClusterSpec() Spec {
@@ -189,14 +189,37 @@ var _ = Describe("Cluster API client behavior", func() {
 
 	It("updates a cluster after resolving it by key", func() {
 		apiServer.AppendHandlers(
-			RespondWithJSON(http.StatusOK, `{
-				"kind":"ClusterList",
-				"page":1,
-				"size":1,
-				"total":1,
-				"items":[{"id":"cluster-1","name":"one"}]
-			}`),
-			RespondWithJSON(http.StatusOK, `{"id":"cluster-1"}`),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters"),
+				ghttp.VerifyFormKV(
+					"search",
+					"product.id = 'rosa' AND (id = 'cluster-1' OR name = 'cluster-1' OR external_id = 'cluster-1')",
+				),
+				ghttp.VerifyFormKV("page", "1"),
+				ghttp.VerifyFormKV("size", "1"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind":"ClusterList",
+					"page":1,
+					"size":1,
+					"total":1,
+					"items":[{"id":"cluster-1","name":"one"}]
+				}`),
+			),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/cluster-1"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					body, err := io.ReadAll(request.Body)
+					Expect(err).NotTo(HaveOccurred())
+
+					payload := map[string]interface{}{}
+					Expect(json.Unmarshal(body, &payload)).To(Succeed())
+
+					version, ok := payload["version"].(map[string]interface{})
+					Expect(ok).To(BeTrue())
+					Expect(version).To(HaveKeyWithValue("id", "4.15.2"))
+				},
+				RespondWithJSON(http.StatusOK, `{"id":"cluster-1"}`),
+			),
 		)
 
 		err := ocmClient.UpdateCluster("cluster-1", nil, Spec{
@@ -217,14 +240,26 @@ var _ = Describe("Cluster API client behavior", func() {
 
 	It("deletes a cluster after resolving it by key", func() {
 		apiServer.AppendHandlers(
-			RespondWithJSON(http.StatusOK, `{
-				"kind":"ClusterList",
-				"page":1,
-				"size":1,
-				"total":1,
-				"items":[{"id":"cluster-1","name":"one"}]
-			}`),
-			RespondWithJSON(http.StatusOK, `{"kind":"DeleteResponse"}`),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters"),
+				ghttp.VerifyFormKV(
+					"search",
+					"product.id = 'rosa' AND (id = 'cluster-1' OR name = 'cluster-1' OR external_id = 'cluster-1')",
+				),
+				ghttp.VerifyFormKV("page", "1"),
+				ghttp.VerifyFormKV("size", "1"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind":"ClusterList",
+					"page":1,
+					"size":1,
+					"total":1,
+					"items":[{"id":"cluster-1","name":"one"}]
+				}`),
+			),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodDelete, "/api/clusters_mgmt/v1/clusters/cluster-1"),
+				RespondWithJSON(http.StatusOK, `{"kind":"DeleteResponse"}`),
+			),
 		)
 
 		cluster, err := ocmClient.DeleteCluster("cluster-1", false, nil)
@@ -235,15 +270,25 @@ var _ = Describe("Cluster API client behavior", func() {
 
 	It("hibernates a cluster when org capability is enabled", func() {
 		apiServer.AppendHandlers(
-			RespondWithJSON(http.StatusOK, `{
-				"id":"acct-1",
-				"organization":{"id":"org-1","external_id":"ext-1"}
-			}`),
-			RespondWithJSON(http.StatusOK, `{
-				"id":"org-1",
-				"capabilities":[{"name":"capability.organization.hibernate_cluster","value":"true"}]
-			}`),
-			RespondWithJSON(http.StatusOK, `{}`),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/accounts_mgmt/v1/current_account"),
+				RespondWithJSON(http.StatusOK, `{
+					"id":"acct-1",
+					"organization":{"id":"org-1","external_id":"ext-1"}
+				}`),
+			),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/accounts_mgmt/v1/organizations/org-1"),
+				ghttp.VerifyFormKV("fetchCapabilities", "true"),
+				RespondWithJSON(http.StatusOK, `{
+					"id":"org-1",
+					"capabilities":[{"name":"capability.organization.hibernate_cluster","value":"true"}]
+				}`),
+			),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters/cluster-1/hibernate"),
+				RespondWithJSON(http.StatusOK, `{}`),
+			),
 		)
 
 		err := ocmClient.HibernateCluster("cluster-1")
@@ -275,15 +320,25 @@ var _ = Describe("Cluster API client behavior", func() {
 
 	It("resumes a cluster when org capability is enabled", func() {
 		apiServer.AppendHandlers(
-			RespondWithJSON(http.StatusOK, `{
-				"id":"acct-1",
-				"organization":{"id":"org-1","external_id":"ext-1"}
-			}`),
-			RespondWithJSON(http.StatusOK, `{
-				"id":"org-1",
-				"capabilities":[{"name":"capability.organization.hibernate_cluster","value":"true"}]
-			}`),
-			RespondWithJSON(http.StatusOK, `{}`),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/accounts_mgmt/v1/current_account"),
+				RespondWithJSON(http.StatusOK, `{
+					"id":"acct-1",
+					"organization":{"id":"org-1","external_id":"ext-1"}
+				}`),
+			),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/accounts_mgmt/v1/organizations/org-1"),
+				ghttp.VerifyFormKV("fetchCapabilities", "true"),
+				RespondWithJSON(http.StatusOK, `{
+					"id":"org-1",
+					"capabilities":[{"name":"capability.organization.hibernate_cluster","value":"true"}]
+				}`),
+			),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters/cluster-1/resume"),
+				RespondWithJSON(http.StatusOK, `{}`),
+			),
 		)
 
 		err := ocmClient.ResumeCluster("cluster-1")
@@ -315,17 +370,43 @@ var _ = Describe("Cluster API client behavior", func() {
 
 	It("detects clusters using a matching oidc endpoint url", func() {
 		apiServer.AppendHandlers(
-			RespondWithJSON(http.StatusOK, `{
-				"kind":"ClusterList",
-				"page":1,
-				"size":1,
-				"total":1,
-				"items":[{"id":"cluster-1"}]
-			}`),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters"),
+				ghttp.VerifyFormKV("search", "aws.sts.oidc_endpoint_url = 'https://issuer.example.com'"),
+				ghttp.VerifyFormKV("page", "1"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind":"ClusterList",
+					"page":1,
+					"size":1,
+					"total":1,
+					"items":[{"id":"cluster-1"}]
+				}`),
+			),
 		)
 
 		exists, err := ocmClient.HasAClusterUsingOidcEndpointUrl("https://issuer.example.com")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(exists).To(BeTrue())
+	})
+
+	It("returns false when no cluster uses a matching oidc endpoint url", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters"),
+				ghttp.VerifyFormKV("search", "aws.sts.oidc_endpoint_url = 'https://issuer.example.com'"),
+				ghttp.VerifyFormKV("page", "1"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind":"ClusterList",
+					"page":1,
+					"size":0,
+					"total":0,
+					"items":[]
+				}`),
+			),
+		)
+
+		exists, err := ocmClient.HasAClusterUsingOidcEndpointUrl("https://issuer.example.com")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(exists).To(BeFalse())
 	})
 })

--- a/pkg/ocm/clusters_client_test.go
+++ b/pkg/ocm/clusters_client_test.go
@@ -1,0 +1,317 @@
+package ocm
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+
+	"github.com/openshift/rosa/pkg/aws"
+)
+
+func buildTestOCMClient(apiServerURL string) *Client {
+	accessToken := MakeTokenString("Bearer", 15*time.Minute)
+	logger, err := logging.NewGoLoggerBuilder().Debug(true).Build()
+	Expect(err).NotTo(HaveOccurred())
+
+	connection, err := sdk.NewConnectionBuilder().
+		Logger(logger).
+		Tokens(accessToken).
+		URL(apiServerURL).
+		Build()
+	Expect(err).NotTo(HaveOccurred())
+
+	return &Client{ocm: connection}
+}
+
+func buildMinimalClusterSpec() Spec {
+	return Spec{
+		Name:       "test-cluster",
+		Region:     "us-east-1",
+		AWSCreator: &aws.Creator{ARN: "arn:aws:iam::123456789012:user/test-user", AccountID: "123456789012"},
+		AWSAccessKey: &aws.AccessKey{
+			AccessKeyID:     "AKIA1234567890EXAMPLE",
+			SecretAccessKey: "secret",
+		},
+	}
+}
+
+var _ = Describe("Cluster API client behavior", func() {
+	var apiServer *ghttp.Server
+	var ocmClient *Client
+
+	BeforeEach(func() {
+		apiServer = MakeTCPServer()
+		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+		ocmClient = buildTestOCMClient(apiServer.URL())
+	})
+
+	AfterEach(func() {
+		apiServer.Close()
+		Expect(ocmClient.Close()).To(Succeed())
+	})
+
+	It("handles CreateCluster when DryRun is nil", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusCreated, `{"id":"cluster-1","name":"test-cluster"}`),
+		)
+
+		spec := buildMinimalClusterSpec()
+
+		var (
+			cluster *cmv1.Cluster
+			err     error
+		)
+		Expect(func() {
+			cluster, err = ocmClient.CreateCluster(spec)
+		}).NotTo(Panic())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cluster).NotTo(BeNil())
+		Expect(cluster.ID()).To(Equal("cluster-1"))
+	})
+
+	It("paginates all results when GetClusters count is zero", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, `{
+				"kind":"ClusterList",
+				"page":1,
+				"size":1,
+				"total":2,
+				"items":[{"id":"cluster-1","name":"one"}]
+			}`),
+			RespondWithJSON(http.StatusOK, `{
+				"kind":"ClusterList",
+				"page":2,
+				"size":1,
+				"total":2,
+				"items":[{"id":"cluster-2","name":"two"}]
+			}`),
+		)
+
+		clusters, err := ocmClient.GetClusters(nil, 0)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(clusters).To(HaveLen(2))
+		Expect(clusters[0].ID()).To(Equal("cluster-1"))
+		Expect(clusters[1].ID()).To(Equal("cluster-2"))
+	})
+
+	It("paginates while count is greater than zero", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters"),
+				ghttp.VerifyFormKV("page", "1"),
+				ghttp.VerifyFormKV("size", "2"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind":"ClusterList",
+					"page":1,
+					"size":2,
+					"total":3,
+					"items":[{"id":"cluster-1","name":"one"},{"id":"cluster-2","name":"two"}]
+				}`),
+			),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters"),
+				ghttp.VerifyFormKV("page", "2"),
+				ghttp.VerifyFormKV("size", "2"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind":"ClusterList",
+					"page":2,
+					"size":1,
+					"total":3,
+					"items":[{"id":"cluster-3","name":"three"}]
+				}`),
+			),
+		)
+
+		clusters, err := ocmClient.GetClusters(nil, 2)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(clusters).To(HaveLen(3))
+		Expect(clusters[0].ID()).To(Equal("cluster-1"))
+		Expect(clusters[1].ID()).To(Equal("cluster-2"))
+		Expect(clusters[2].ID()).To(Equal("cluster-3"))
+	})
+
+	It("returns an error when count is negative", func() {
+		clusters, err := ocmClient.GetClusters(nil, -1)
+		Expect(err).To(HaveOccurred())
+		Expect(clusters).To(BeNil())
+		Expect(err.Error()).To(ContainSubstring("Invalid Cluster count"))
+	})
+
+	It("sends dryRun query and payload when CreateCluster dry run is requested", func() {
+		dryRun := true
+		spec := buildMinimalClusterSpec()
+		spec.DryRun = &dryRun
+		spec.Version = "4.15.1"
+
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				func(_ http.ResponseWriter, request *http.Request) {
+					Expect(request.URL.Query().Get("dryRun")).To(Equal("true"))
+					body, err := io.ReadAll(request.Body)
+					Expect(err).NotTo(HaveOccurred())
+
+					payload := map[string]interface{}{}
+					Expect(json.Unmarshal(body, &payload)).To(Succeed())
+					Expect(payload["name"]).To(Equal("test-cluster"))
+					Expect(payload).To(HaveKey("version"))
+				},
+				RespondWithJSON(http.StatusCreated, `{"id":"cluster-1","name":"test-cluster"}`),
+			),
+		)
+
+		cluster, err := ocmClient.CreateCluster(spec)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cluster).To(BeNil())
+	})
+
+	It("updates a cluster after resolving it by key", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, `{
+				"kind":"ClusterList",
+				"page":1,
+				"size":1,
+				"total":1,
+				"items":[{"id":"cluster-1","name":"one"}]
+			}`),
+			RespondWithJSON(http.StatusOK, `{"id":"cluster-1"}`),
+		)
+
+		err := ocmClient.UpdateCluster("cluster-1", nil, Spec{
+			Version: "4.15.2",
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("returns empty state when GetClusterState has no body", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, `{}`),
+		)
+
+		state, err := ocmClient.GetClusterState("cluster-1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(state).To(Equal(cmv1.ClusterState("")))
+	})
+
+	It("deletes a cluster after resolving it by key", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, `{
+				"kind":"ClusterList",
+				"page":1,
+				"size":1,
+				"total":1,
+				"items":[{"id":"cluster-1","name":"one"}]
+			}`),
+			RespondWithJSON(http.StatusOK, `{"kind":"DeleteResponse"}`),
+		)
+
+		cluster, err := ocmClient.DeleteCluster("cluster-1", false, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cluster).NotTo(BeNil())
+		Expect(cluster.ID()).To(Equal("cluster-1"))
+	})
+
+	It("hibernates a cluster when org capability is enabled", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, `{
+				"id":"acct-1",
+				"organization":{"id":"org-1","external_id":"ext-1"}
+			}`),
+			RespondWithJSON(http.StatusOK, `{
+				"id":"org-1",
+				"capabilities":[{"name":"capability.organization.hibernate_cluster","value":"true"}]
+			}`),
+			RespondWithJSON(http.StatusOK, `{}`),
+		)
+
+		err := ocmClient.HibernateCluster("cluster-1")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("returns an error when hibernate capability is disabled", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/accounts_mgmt/v1/current_account"),
+				RespondWithJSON(http.StatusOK, `{
+					"id":"acct-1",
+					"organization":{"id":"org-1","external_id":"ext-1"}
+				}`),
+			),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/accounts_mgmt/v1/organizations/org-1"),
+				RespondWithJSON(http.StatusOK, `{
+					"id":"org-1",
+					"capabilities":[{"name":"capability.organization.hibernate_cluster","value":"false"}]
+				}`),
+			),
+		)
+
+		err := ocmClient.HibernateCluster("cluster-1")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("capability.organization.hibernate_cluster"))
+	})
+
+	It("resumes a cluster when org capability is enabled", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, `{
+				"id":"acct-1",
+				"organization":{"id":"org-1","external_id":"ext-1"}
+			}`),
+			RespondWithJSON(http.StatusOK, `{
+				"id":"org-1",
+				"capabilities":[{"name":"capability.organization.hibernate_cluster","value":"true"}]
+			}`),
+			RespondWithJSON(http.StatusOK, `{}`),
+		)
+
+		err := ocmClient.ResumeCluster("cluster-1")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("returns an error when resume capability is disabled", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/accounts_mgmt/v1/current_account"),
+				RespondWithJSON(http.StatusOK, `{
+					"id":"acct-1",
+					"organization":{"id":"org-1","external_id":"ext-1"}
+				}`),
+			),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/accounts_mgmt/v1/organizations/org-1"),
+				RespondWithJSON(http.StatusOK, `{
+					"id":"org-1",
+					"capabilities":[{"name":"capability.organization.hibernate_cluster","value":"false"}]
+				}`),
+			),
+		)
+
+		err := ocmClient.ResumeCluster("cluster-1")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("capability.organization.hibernate_cluster"))
+	})
+
+	It("detects clusters using a matching oidc endpoint url", func() {
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, `{
+				"kind":"ClusterList",
+				"page":1,
+				"size":1,
+				"total":1,
+				"items":[{"id":"cluster-1"}]
+			}`),
+		)
+
+		exists, err := ocmClient.HasAClusterUsingOidcEndpointUrl("https://issuer.example.com")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(exists).To(BeTrue())
+	})
+})

--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -388,6 +388,9 @@ func (c *Client) GetCurrentOrganization() (id string, externalID string, err err
 	if err != nil {
 		return
 	}
+	if acctResponse == nil {
+		return
+	}
 	id = acctResponse.Organization().ID()
 	externalID = acctResponse.Organization().ExternalID()
 

--- a/pkg/ocm/helpers_client_test.go
+++ b/pkg/ocm/helpers_client_test.go
@@ -1,0 +1,162 @@
+package ocm
+
+import (
+	"encoding/json"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+)
+
+var _ = Describe("Helpers API client behavior", func() {
+	var apiServer *ghttp.Server
+	var ocmClient *Client
+
+	BeforeEach(func() {
+		apiServer = MakeTCPServer()
+		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+		ocmClient = buildTestOCMClient(apiServer.URL())
+	})
+
+	AfterEach(func() {
+		apiServer.Close()
+		Expect(ocmClient.Close()).To(Succeed())
+	})
+
+	It("handles missing current account in GetCurrentOrganization", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/accounts_mgmt/v1/current_account"),
+				RespondWithJSON(http.StatusNotFound, `{"reason":"not found"}`),
+			),
+		)
+
+		var (
+			id         string
+			externalID string
+			err        error
+		)
+		Expect(func() {
+			id, externalID, err = ocmClient.GetCurrentOrganization()
+		}).NotTo(Panic())
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(id).To(BeEmpty())
+		Expect(externalID).To(BeEmpty())
+	})
+
+	It("returns current account body when GetCurrentAccount succeeds", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/accounts_mgmt/v1/current_account"),
+				RespondWithJSON(http.StatusOK, `{
+					"id":"acct-1",
+					"organization":{"id":"org-1","external_id":"ext-1"}
+				}`),
+			),
+		)
+
+		account, err := ocmClient.GetCurrentAccount()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(account).NotTo(BeNil())
+		Expect(account.ID()).To(Equal("acct-1"))
+		Expect(account.Organization().ID()).To(Equal("org-1"))
+	})
+
+	It("links a role to organization labels when account is not present yet", func() {
+		roleARN := "arn:aws:iam::123456789012:role/first-role"
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/accounts_mgmt/v1/organizations/org-1/labels/sts_ocm_role"),
+				RespondWithJSON(http.StatusOK, `{"key":"sts_ocm_role","value":""}`),
+			),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/accounts_mgmt/v1/organizations/org-1/labels"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					payload := map[string]string{}
+					Expect(json.NewDecoder(request.Body).Decode(&payload)).To(Succeed())
+					Expect(payload).To(HaveKeyWithValue("key", "sts_ocm_role"))
+					Expect(payload).To(HaveKeyWithValue("value", roleARN))
+				},
+				RespondWithJSON(http.StatusCreated, `{"key":"sts_ocm_role","value":"arn:aws:iam::123456789012:role/first-role"}`),
+			),
+		)
+
+		linked, err := ocmClient.LinkOrgToRole("org-1", roleARN)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(linked).To(BeTrue())
+	})
+
+	It("rejects linking a second role for the same aws account", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/accounts_mgmt/v1/organizations/org-1/labels/sts_ocm_role"),
+				RespondWithJSON(http.StatusOK, `{"key":"sts_ocm_role","value":"arn:aws:iam::123456789012:role/existing-role"}`),
+			),
+		)
+
+		linked, err := ocmClient.LinkOrgToRole("org-1", "arn:aws:iam::123456789012:role/new-role")
+		Expect(err).To(HaveOccurred())
+		Expect(linked).To(BeFalse())
+		Expect(err.Error()).To(ContainSubstring("Only one role can be linked per AWS account per organization"))
+	})
+
+	It("unlinks organization ocm role by deleting label when last entry is removed", func() {
+		roleARN := "arn:aws:iam::123456789012:role/only-role"
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/accounts_mgmt/v1/organizations/org-1/labels/sts_ocm_role"),
+				RespondWithJSON(http.StatusOK, `{"key":"sts_ocm_role","value":"arn:aws:iam::123456789012:role/only-role"}`),
+			),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodDelete, "/api/accounts_mgmt/v1/organizations/org-1/labels/sts_ocm_role"),
+				RespondWithJSON(http.StatusOK, `{}`),
+			),
+		)
+
+		err := ocmClient.UnlinkOCMRoleFromOrg("org-1", roleARN)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("avoids creating duplicate user role links on an account", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/accounts_mgmt/v1/accounts/acct-1/labels/sts_user_role"),
+				RespondWithJSON(http.StatusOK, `{"key":"sts_user_role","value":"arn:aws:iam::123456789012:role/existing"}`),
+			),
+		)
+
+		err := ocmClient.LinkAccountRole("acct-1", "arn:aws:iam::123456789012:role/existing")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("unlinks a user role from account labels and updates remaining roles", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/accounts_mgmt/v1/accounts/acct-1/labels/sts_user_role"),
+				RespondWithJSON(http.StatusOK, `{
+					"key":"sts_user_role",
+					"value":"arn:aws:iam::123456789012:role/remove,arn:aws:iam::123456789012:role/keep"
+				}`),
+			),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPatch, "/api/accounts_mgmt/v1/accounts/acct-1/labels/sts_user_role"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					payload := map[string]string{}
+					Expect(json.NewDecoder(request.Body).Decode(&payload)).To(Succeed())
+					Expect(payload).To(HaveKeyWithValue("key", "sts_user_role"))
+					Expect(payload).To(HaveKeyWithValue("value", "arn:aws:iam::123456789012:role/keep"))
+				},
+				RespondWithJSON(http.StatusOK, `{
+					"key":"sts_user_role",
+					"value":"arn:aws:iam::123456789012:role/keep"
+				}`),
+			),
+		)
+
+		err := ocmClient.UnlinkUserRoleFromAccount("acct-1", "arn:aws:iam::123456789012:role/remove")
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/pkg/ocm/helpers_client_test.go
+++ b/pkg/ocm/helpers_client_test.go
@@ -71,6 +71,24 @@ var _ = Describe("Helpers API client behavior", func() {
 		Expect(account).NotTo(BeNil())
 		Expect(account.ID()).To(Equal("acct-1"))
 		Expect(account.Organization().ID()).To(Equal("org-1"))
+		Expect(account.Organization().ExternalID()).To(Equal("ext-1"))
+	})
+
+	It("returns organization identifiers when GetCurrentOrganization succeeds", func() {
+		appendHandlers(1,
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/accounts_mgmt/v1/current_account"),
+				RespondWithJSON(http.StatusOK, `{
+					"id":"acct-1",
+					"organization":{"id":"org-1","external_id":"ext-1"}
+				}`),
+			),
+		)
+
+		id, externalID, err := ocmClient.GetCurrentOrganization()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(id).To(Equal("org-1"))
+		Expect(externalID).To(Equal("ext-1"))
 	})
 
 	It("links a role to organization labels when account is not present yet", func() {
@@ -109,6 +127,20 @@ var _ = Describe("Helpers API client behavior", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(linked).To(BeFalse())
 		Expect(err.Error()).To(ContainSubstring("Only one role can be linked per AWS account per organization"))
+	})
+
+	It("treats linking the same organization role as idempotent", func() {
+		roleARN := "arn:aws:iam::123456789012:role/existing-role"
+		appendHandlers(1,
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/accounts_mgmt/v1/organizations/org-1/labels/sts_ocm_role"),
+				RespondWithJSON(http.StatusOK, `{"key":"sts_ocm_role","value":"arn:aws:iam::123456789012:role/existing-role"}`),
+			),
+		)
+
+		linked, err := ocmClient.LinkOrgToRole("org-1", roleARN)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(linked).To(BeFalse())
 	})
 
 	It("unlinks organization ocm role by deleting label when last entry is removed", func() {

--- a/pkg/ocm/helpers_client_test.go
+++ b/pkg/ocm/helpers_client_test.go
@@ -13,20 +13,28 @@ import (
 var _ = Describe("Helpers API client behavior", func() {
 	var apiServer *ghttp.Server
 	var ocmClient *Client
+	var expectedRequests int
+
+	appendHandlers := func(requestCount int, handlers ...http.HandlerFunc) {
+		expectedRequests += requestCount
+		apiServer.AppendHandlers(handlers...)
+	}
 
 	BeforeEach(func() {
 		apiServer = MakeTCPServer()
 		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
 		ocmClient = buildTestOCMClient(apiServer.URL())
+		expectedRequests = 0
 	})
 
 	AfterEach(func() {
+		Expect(apiServer.ReceivedRequests()).To(HaveLen(expectedRequests))
 		apiServer.Close()
 		Expect(ocmClient.Close()).To(Succeed())
 	})
 
 	It("handles missing current account in GetCurrentOrganization", func() {
-		apiServer.AppendHandlers(
+		appendHandlers(1,
 			ghttp.CombineHandlers(
 				ghttp.VerifyRequest(http.MethodGet, "/api/accounts_mgmt/v1/current_account"),
 				RespondWithJSON(http.StatusNotFound, `{"reason":"not found"}`),
@@ -48,7 +56,7 @@ var _ = Describe("Helpers API client behavior", func() {
 	})
 
 	It("returns current account body when GetCurrentAccount succeeds", func() {
-		apiServer.AppendHandlers(
+		appendHandlers(1,
 			ghttp.CombineHandlers(
 				ghttp.VerifyRequest(http.MethodGet, "/api/accounts_mgmt/v1/current_account"),
 				RespondWithJSON(http.StatusOK, `{
@@ -67,7 +75,7 @@ var _ = Describe("Helpers API client behavior", func() {
 
 	It("links a role to organization labels when account is not present yet", func() {
 		roleARN := "arn:aws:iam::123456789012:role/first-role"
-		apiServer.AppendHandlers(
+		appendHandlers(2,
 			ghttp.CombineHandlers(
 				ghttp.VerifyRequest(http.MethodGet, "/api/accounts_mgmt/v1/organizations/org-1/labels/sts_ocm_role"),
 				RespondWithJSON(http.StatusOK, `{"key":"sts_ocm_role","value":""}`),
@@ -90,7 +98,7 @@ var _ = Describe("Helpers API client behavior", func() {
 	})
 
 	It("rejects linking a second role for the same aws account", func() {
-		apiServer.AppendHandlers(
+		appendHandlers(1,
 			ghttp.CombineHandlers(
 				ghttp.VerifyRequest(http.MethodGet, "/api/accounts_mgmt/v1/organizations/org-1/labels/sts_ocm_role"),
 				RespondWithJSON(http.StatusOK, `{"key":"sts_ocm_role","value":"arn:aws:iam::123456789012:role/existing-role"}`),
@@ -105,7 +113,7 @@ var _ = Describe("Helpers API client behavior", func() {
 
 	It("unlinks organization ocm role by deleting label when last entry is removed", func() {
 		roleARN := "arn:aws:iam::123456789012:role/only-role"
-		apiServer.AppendHandlers(
+		appendHandlers(2,
 			ghttp.CombineHandlers(
 				ghttp.VerifyRequest(http.MethodGet, "/api/accounts_mgmt/v1/organizations/org-1/labels/sts_ocm_role"),
 				RespondWithJSON(http.StatusOK, `{"key":"sts_ocm_role","value":"arn:aws:iam::123456789012:role/only-role"}`),
@@ -121,7 +129,7 @@ var _ = Describe("Helpers API client behavior", func() {
 	})
 
 	It("avoids creating duplicate user role links on an account", func() {
-		apiServer.AppendHandlers(
+		appendHandlers(1,
 			ghttp.CombineHandlers(
 				ghttp.VerifyRequest(http.MethodGet, "/api/accounts_mgmt/v1/accounts/acct-1/labels/sts_user_role"),
 				RespondWithJSON(http.StatusOK, `{"key":"sts_user_role","value":"arn:aws:iam::123456789012:role/existing"}`),
@@ -133,7 +141,7 @@ var _ = Describe("Helpers API client behavior", func() {
 	})
 
 	It("unlinks a user role from account labels and updates remaining roles", func() {
-		apiServer.AppendHandlers(
+		appendHandlers(2,
 			ghttp.CombineHandlers(
 				ghttp.VerifyRequest(http.MethodGet, "/api/accounts_mgmt/v1/accounts/acct-1/labels/sts_user_role"),
 				RespondWithJSON(http.StatusOK, `{


### PR DESCRIPTION
## PR Summary
Builds the base layer of the [ROSAENG-61179](https://redhat.atlassian.net/browse/ROSAENG-61179) split by hardening core `pkg/ocm` cluster/helper client behavior and adding the shared client-test harness used by the upper stacked PRs.

## Detailed Description of the Issue
This PR is the foundation of the [ROSAENG-61179](https://redhat.atlassian.net/browse/ROSAENG-61179) stacked split. It isolates production fixes in `pkg/ocm/clusters.go` and `pkg/ocm/helpers.go`, together with client-facing Ginkgo coverage that validates those fixes. Follow-on PRs reuse the shared `buildTestOCMClient()` helper introduced here.

**Changed files:** `pkg/ocm/clusters.go`, `pkg/ocm/helpers.go`, `pkg/ocm/clusters_client_test.go`, `pkg/ocm/helpers_client_test.go`

## Related Issues and PRs
- Jira: [ROSAENG-61179](https://issues.redhat.com/browse/ROSAENG-61179)
- Fixes: `N/A`
- Related PR(s):
  - Holding PR: [#3437](https://github.com/openshift/rosa/pull/3437) — CLOSED (superseded by this stacked split)
  - [#3443](https://github.com/openshift/rosa/pull/3443) — MERGED: add-on availability semantics
  - [#3445](https://github.com/openshift/rosa/pull/3445) — OPEN: CRUD/request-contract coverage
  - [#3444](https://github.com/openshift/rosa/pull/3444) — OPEN (draft): lifecycle and version coverage
- Merge order for remaining stack: **#3445**, then **#3444**
- Related design/docs: `N/A`

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [x] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [x] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
- `CreateCluster` could dereference a nil `DryRun` value.
- `GetClusters(..., 0)` did not have fetch-all pagination locked in by tests and could stop early.
- `GetCurrentOrganization` relied on SDK nil-receiver handling when the current account lookup returned no account.

## Behavior After This Change
- `CreateCluster` defaults nil `DryRun` to `false` instead of dereferencing it.
- `GetClusters(..., 0)` paginates until all available cluster results are collected.
- `GetCurrentOrganization` now explicitly returns empty organization identifiers when the current account is missing.
- The shared `buildTestOCMClient()` helper is available for the stacked follow-on coverage PRs.

## How to Test (Step-by-Step)
### Preconditions
- Run from the repo root.
- Use a Go toolchain compatible with `go.mod`. If needed, prefix commands with `GOTOOLCHAIN=auto`.

### Test Steps
1. Run `GOTOOLCHAIN=auto go test ./pkg/ocm -count=1 -ginkgo.focus="Cluster API client behavior|Helpers API client behavior"`.
2. Run `GOTOOLCHAIN=auto make rosa`.

### Expected Results
- The targeted `pkg/ocm` client tests pass.
- The CLI builds successfully.

## Proof of the Fix
- Screenshots: `N/A`
- Videos: `N/A`
- Logs/CLI output:
  - `GOTOOLCHAIN=auto go test ./pkg/ocm -count=1 -ginkgo.focus="Cluster API client behavior|Helpers API client behavior"`
  - `GOTOOLCHAIN=auto make rosa`
- Other artifacts: `N/A`

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
`N/A`

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [ ] `make test` passes.
- [ ] `make lint` passes.
- [x] `make rosa` passes.
- [x] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

[ROSAENG-61179]: https://redhat.atlassian.net/browse/ROSAENG-61179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Cluster listings now reliably retrieve all results when no limit is specified.
  - Cluster creation safely defaults to a standard operation when dry-run settings are unavailable.
  - Organization lookups no longer fail when account information is absent.
  - Cluster updates and deletions resolve targets more consistently.
  - Hibernate/resume capability checks and OIDC endpoint matching are more reliable.
  - Improved validation for organization and account role management, including duplicate and removal scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
