### PR TITLE
ROSAENG-61179 | test: expand ocm lifecycle coverage

### DIFF
--- a/pkg/ocm/gates_test.go
+++ b/pkg/ocm/gates_test.go
@@ -1,0 +1,154 @@
+package ocm
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+)
+
+var _ = Describe("Version gates API client behavior", func() {
+	var apiServer *ghttp.Server
+	var ocmClient *Client
+
+	BeforeEach(func() {
+		apiServer = MakeTCPServer()
+		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+		ocmClient = buildTestOCMClient(apiServer.URL())
+	})
+
+	AfterEach(func() {
+		apiServer.Close()
+		Expect(ocmClient.Close()).To(Succeed())
+	})
+
+	It("paginates all version gate pages and applies the version prefix filter", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/version_gates"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					Expect(request.URL.Query().Get("page")).To(Equal("1"))
+					Expect(request.URL.Query().Get("size")).To(Equal("100"))
+					Expect(request.URL.Query().Get("search")).To(Equal("version_raw_id_prefix = '4.15'"))
+				},
+				RespondWithJSON(http.StatusOK, `{
+					"kind":"VersionGateList",
+					"page":1,
+					"size":100,
+					"total":101,
+					"items":[{"id":"gate-1","sts_only":true}]
+				}`),
+			),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/version_gates"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					Expect(request.URL.Query().Get("page")).To(Equal("2"))
+					Expect(request.URL.Query().Get("size")).To(Equal("100"))
+				},
+				RespondWithJSON(http.StatusOK, `{
+					"kind":"VersionGateList",
+					"page":2,
+					"size":1,
+					"total":101,
+					"items":[{"id":"gate-2","sts_only":false}]
+				}`),
+			),
+		)
+
+		gates, err := ocmClient.ListAllOcpGates("4.15")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(gates).To(HaveLen(2))
+		Expect(gates[0].ID()).To(Equal("gate-1"))
+		Expect(gates[1].ID()).To(Equal("gate-2"))
+	})
+
+	It("returns only STS-only gates", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/version_gates"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind":"VersionGateList",
+					"page":1,
+					"size":2,
+					"total":2,
+					"items":[
+						{"id":"gate-sts","sts_only":true},
+						{"id":"gate-shared","sts_only":false}
+					]
+				}`),
+			),
+		)
+
+		gates, err := ocmClient.ListStsGates("4.15")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(gates).To(HaveLen(1))
+		Expect(gates[0].ID()).To(Equal("gate-sts"))
+		Expect(gates[0].STSOnly()).To(BeTrue())
+	})
+
+	It("returns only non-STS gates", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/version_gates"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind":"VersionGateList",
+					"page":1,
+					"size":2,
+					"total":2,
+					"items":[
+						{"id":"gate-sts","sts_only":true},
+						{"id":"gate-shared","sts_only":false}
+					]
+				}`),
+			),
+		)
+
+		gates, err := ocmClient.ListOcpGates("4.15")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(gates).To(HaveLen(1))
+		Expect(gates[0].ID()).To(Equal("gate-shared"))
+		Expect(gates[0].STSOnly()).To(BeFalse())
+	})
+
+	It("returns an error when listing all gates fails", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/version_gates"),
+				RespondWithJSON(http.StatusInternalServerError, `{
+					"kind":"Error",
+					"id":"500",
+					"href":"/api/errors/500",
+					"code":"CLUSTERS-MGMT-500",
+					"reason":"unable to list version gates"
+				}`),
+			),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/version_gates"),
+				RespondWithJSON(http.StatusInternalServerError, `{
+					"kind":"Error",
+					"id":"500",
+					"href":"/api/errors/500",
+					"code":"CLUSTERS-MGMT-500",
+					"reason":"unable to list version gates"
+				}`),
+			),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/version_gates"),
+				RespondWithJSON(http.StatusInternalServerError, `{
+					"kind":"Error",
+					"id":"500",
+					"href":"/api/errors/500",
+					"code":"CLUSTERS-MGMT-500",
+					"reason":"unable to list version gates"
+				}`),
+			),
+		)
+
+		gates, err := ocmClient.ListAllOcpGates("4.15")
+		Expect(err).To(HaveOccurred())
+		Expect(gates).To(BeNil())
+		Expect(err.Error()).To(ContainSubstring("unable to list version gates"))
+	})
+})

--- a/pkg/ocm/gates_test.go
+++ b/pkg/ocm/gates_test.go
@@ -1,0 +1,155 @@
+package ocm
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+)
+
+var _ = Describe("Version gates API client behavior", func() {
+	var apiServer *ghttp.Server
+	var ocmClient *Client
+
+	BeforeEach(func() {
+		apiServer = MakeTCPServer()
+		apiServer.SetAllowUnhandledRequests(true)
+		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+		ocmClient = buildTestOCMClient(apiServer.URL())
+	})
+
+	AfterEach(func() {
+		apiServer.Close()
+		Expect(ocmClient.Close()).To(Succeed())
+	})
+
+	It("paginates all version gate pages and applies the version prefix filter", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/version_gates"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					Expect(request.URL.Query().Get("page")).To(Equal("1"))
+					Expect(request.URL.Query().Get("size")).To(Equal("100"))
+					Expect(request.URL.Query().Get("search")).To(Equal("version_raw_id_prefix = '4.15'"))
+				},
+				RespondWithJSON(http.StatusOK, `{
+					"kind":"VersionGateList",
+					"page":1,
+					"size":100,
+					"total":101,
+					"items":[{"id":"gate-1","sts_only":true}]
+				}`),
+			),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/version_gates"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					Expect(request.URL.Query().Get("page")).To(Equal("2"))
+					Expect(request.URL.Query().Get("size")).To(Equal("100"))
+				},
+				RespondWithJSON(http.StatusOK, `{
+					"kind":"VersionGateList",
+					"page":2,
+					"size":1,
+					"total":101,
+					"items":[{"id":"gate-2","sts_only":false}]
+				}`),
+			),
+		)
+
+		gates, err := ocmClient.ListAllOcpGates("4.15")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(gates).To(HaveLen(2))
+		Expect(gates[0].ID()).To(Equal("gate-1"))
+		Expect(gates[1].ID()).To(Equal("gate-2"))
+	})
+
+	It("returns only STS-only gates", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/version_gates"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind":"VersionGateList",
+					"page":1,
+					"size":2,
+					"total":2,
+					"items":[
+						{"id":"gate-sts","sts_only":true},
+						{"id":"gate-shared","sts_only":false}
+					]
+				}`),
+			),
+		)
+
+		gates, err := ocmClient.ListStsGates("4.15")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(gates).To(HaveLen(1))
+		Expect(gates[0].ID()).To(Equal("gate-sts"))
+		Expect(gates[0].STSOnly()).To(BeTrue())
+	})
+
+	It("returns only non-STS gates", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/version_gates"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind":"VersionGateList",
+					"page":1,
+					"size":2,
+					"total":2,
+					"items":[
+						{"id":"gate-sts","sts_only":true},
+						{"id":"gate-shared","sts_only":false}
+					]
+				}`),
+			),
+		)
+
+		gates, err := ocmClient.ListOcpGates("4.15")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(gates).To(HaveLen(1))
+		Expect(gates[0].ID()).To(Equal("gate-shared"))
+		Expect(gates[0].STSOnly()).To(BeFalse())
+	})
+
+	It("returns an error when listing all gates fails", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/version_gates"),
+				RespondWithJSON(http.StatusInternalServerError, `{
+					"kind":"Error",
+					"id":"500",
+					"href":"/api/errors/500",
+					"code":"CLUSTERS-MGMT-500",
+					"reason":"unable to list version gates"
+				}`),
+			),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/version_gates"),
+				RespondWithJSON(http.StatusInternalServerError, `{
+					"kind":"Error",
+					"id":"500",
+					"href":"/api/errors/500",
+					"code":"CLUSTERS-MGMT-500",
+					"reason":"unable to list version gates"
+				}`),
+			),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/version_gates"),
+				RespondWithJSON(http.StatusInternalServerError, `{
+					"kind":"Error",
+					"id":"500",
+					"href":"/api/errors/500",
+					"code":"CLUSTERS-MGMT-500",
+					"reason":"unable to list version gates"
+				}`),
+			),
+		)
+
+		gates, err := ocmClient.ListAllOcpGates("4.15")
+		Expect(err).To(HaveOccurred())
+		Expect(gates).To(BeNil())
+		Expect(err.Error()).To(ContainSubstring("unable to list version gates"))
+	})
+})

--- a/pkg/ocm/logs_test.go
+++ b/pkg/ocm/logs_test.go
@@ -1,0 +1,192 @@
+package ocm
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+)
+
+var _ = Describe("Cluster logs API client behavior", func() {
+	var apiServer *ghttp.Server
+	var ocmClient *Client
+
+	BeforeEach(func() {
+		apiServer = MakeTCPServer()
+		apiServer.SetAllowUnhandledRequests(true)
+		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+		ocmClient = buildTestOCMClient(apiServer.URL())
+	})
+
+	AfterEach(func() {
+		apiServer.Close()
+		Expect(ocmClient.Close()).To(Succeed())
+	})
+
+	It("passes the requested tail value when retrieving install logs", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/logs/install"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					Expect(request.URL.Query().Get("tail")).To(Equal("42"))
+				},
+				RespondWithJSON(http.StatusOK, `{"content":"install log line"}`),
+			),
+		)
+
+		logs, err := ocmClient.GetInstallLogs("cluster-1", 42)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(logs).NotTo(BeNil())
+		Expect(logs.Content()).To(ContainSubstring("install log line"))
+	})
+
+	It("translates install log 404 responses into user-facing not-found errors", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-404/logs/install"),
+				RespondWithJSON(http.StatusNotFound, `{
+					"kind":"Error",
+					"id":"404",
+					"href":"/api/errors/404",
+					"code":"CLUSTERS-MGMT-404",
+					"reason":"missing logs"
+				}`),
+			),
+		)
+
+		_, err := ocmClient.GetInstallLogs("cluster-404", 5)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("Failed to get logs for cluster 'cluster-404'"))
+	})
+
+	It("passes the requested tail value when retrieving uninstall logs", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/logs/uninstall"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					Expect(request.URL.Query().Get("tail")).To(Equal("27"))
+				},
+				RespondWithJSON(http.StatusOK, `{"content":"uninstall log line"}`),
+			),
+		)
+
+		logs, err := ocmClient.GetUninstallLogs("cluster-1", 27)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(logs).NotTo(BeNil())
+		Expect(logs.Content()).To(ContainSubstring("uninstall log line"))
+	})
+
+	It("translates uninstall log 404 responses into user-facing not-found errors", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-404/logs/uninstall"),
+				RespondWithJSON(http.StatusNotFound, `{
+					"kind":"Error",
+					"id":"404",
+					"href":"/api/errors/404",
+					"code":"CLUSTERS-MGMT-404",
+					"reason":"missing logs"
+				}`),
+			),
+		)
+
+		_, err := ocmClient.GetUninstallLogs("cluster-404", 5)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("Failed to get logs for cluster 'cluster-404'"))
+	})
+
+	It("uses fixed polling parameters and returns install logs", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/logs/install"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					Expect(request.URL.Query().Get("tail")).To(Equal("100"))
+				},
+				RespondWithJSON(http.StatusOK, `{"content":"polled install log"}`),
+			),
+		)
+
+		callbackCalled := false
+		callback := func(response *cmv1.LogGetResponse) bool {
+			callbackCalled = true
+			Expect(response).NotTo(BeNil())
+			Expect(response.Body()).NotTo(BeNil())
+			Expect(response.Body().Content()).To(ContainSubstring("polled install log"))
+			return true
+		}
+		logs, err := ocmClient.PollInstallLogs("cluster-1", callback)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(callbackCalled).To(BeTrue())
+		Expect(logs).NotTo(BeNil())
+		Expect(logs.Content()).To(ContainSubstring("polled install log"))
+	})
+
+	It("translates poll 404 responses into user-facing not-found errors", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-404/logs/install"),
+				RespondWithJSON(http.StatusNotFound, `{
+					"kind":"Error",
+					"id":"404",
+					"href":"/api/errors/404",
+					"code":"CLUSTERS-MGMT-404",
+					"reason":"missing logs"
+				}`),
+			),
+		)
+
+		callback := func(response *cmv1.LogGetResponse) bool {
+			return true
+		}
+		_, err := ocmClient.PollInstallLogs("cluster-404", callback)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("Failed to poll logs for cluster 'cluster-404'"))
+	})
+
+	It("translates uninstall poll 404 responses into user-facing not-found errors", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-404/logs/uninstall"),
+				RespondWithJSON(http.StatusNotFound, `{
+					"kind":"Error",
+					"id":"404",
+					"href":"/api/errors/404",
+					"code":"CLUSTERS-MGMT-404",
+					"reason":"missing logs"
+				}`),
+			),
+		)
+
+		callback := func(response *cmv1.LogGetResponse) bool {
+			return true
+		}
+		_, err := ocmClient.PollUninstallLogs("cluster-404", callback)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("Failed to poll logs for cluster 'cluster-404'"))
+	})
+
+	It("wraps polling errors for uninstall logs", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/logs/uninstall"),
+				RespondWithJSON(http.StatusInternalServerError, `{
+					"kind":"Error",
+					"id":"500",
+					"href":"/api/errors/500",
+					"code":"CLUSTERS-MGMT-500",
+					"reason":"poll backend failure"
+				}`),
+			),
+		)
+
+		callback := func(response *cmv1.LogGetResponse) bool {
+			return true
+		}
+		_, err := ocmClient.PollUninstallLogs("cluster-1", callback)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("Failed to poll logs for cluster 'cluster-1'"))
+	})
+})

--- a/pkg/ocm/logs_test.go
+++ b/pkg/ocm/logs_test.go
@@ -1,0 +1,186 @@
+package ocm
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+)
+
+var _ = Describe("Cluster logs API client behavior", func() {
+	var apiServer *ghttp.Server
+	var ocmClient *Client
+
+	BeforeEach(func() {
+		apiServer = MakeTCPServer()
+		apiServer.SetAllowUnhandledRequests(true)
+		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+		ocmClient = buildTestOCMClient(apiServer.URL())
+	})
+
+	AfterEach(func() {
+		apiServer.Close()
+		Expect(ocmClient.Close()).To(Succeed())
+	})
+
+	It("passes the requested tail value when retrieving install logs", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/logs/install"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					Expect(request.URL.Query().Get("tail")).To(Equal("42"))
+				},
+				RespondWithJSON(http.StatusOK, `{"content":"install log line"}`),
+			),
+		)
+
+		logs, err := ocmClient.GetInstallLogs("cluster-1", 42)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(logs).NotTo(BeNil())
+		Expect(logs.Content()).To(ContainSubstring("install log line"))
+	})
+
+	It("translates install log 404 responses into user-facing not-found errors", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-404/logs/install"),
+				RespondWithJSON(http.StatusNotFound, `{
+					"kind":"Error",
+					"id":"404",
+					"href":"/api/errors/404",
+					"code":"CLUSTERS-MGMT-404",
+					"reason":"missing logs"
+				}`),
+			),
+		)
+
+		_, err := ocmClient.GetInstallLogs("cluster-404", 5)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("Failed to get logs for cluster 'cluster-404'"))
+	})
+
+	It("passes the requested tail value when retrieving uninstall logs", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/logs/uninstall"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					Expect(request.URL.Query().Get("tail")).To(Equal("27"))
+				},
+				RespondWithJSON(http.StatusOK, `{"content":"uninstall log line"}`),
+			),
+		)
+
+		logs, err := ocmClient.GetUninstallLogs("cluster-1", 27)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(logs).NotTo(BeNil())
+		Expect(logs.Content()).To(ContainSubstring("uninstall log line"))
+	})
+
+	It("translates uninstall log 404 responses into user-facing not-found errors", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-404/logs/uninstall"),
+				RespondWithJSON(http.StatusNotFound, `{
+					"kind":"Error",
+					"id":"404",
+					"href":"/api/errors/404",
+					"code":"CLUSTERS-MGMT-404",
+					"reason":"missing logs"
+				}`),
+			),
+		)
+
+		_, err := ocmClient.GetUninstallLogs("cluster-404", 5)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("Failed to get logs for cluster 'cluster-404'"))
+	})
+
+	It("uses fixed polling parameters and returns install logs", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/logs/install"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					Expect(request.URL.Query().Get("tail")).To(Equal("100"))
+				},
+				RespondWithJSON(http.StatusOK, `{"content":"polled install log"}`),
+			),
+		)
+
+		callback := func(response *cmv1.LogGetResponse) bool {
+			return true
+		}
+		logs, err := ocmClient.PollInstallLogs("cluster-1", callback)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(logs).NotTo(BeNil())
+		Expect(logs.Content()).To(ContainSubstring("polled install log"))
+	})
+
+	It("translates poll 404 responses into user-facing not-found errors", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-404/logs/install"),
+				RespondWithJSON(http.StatusNotFound, `{
+					"kind":"Error",
+					"id":"404",
+					"href":"/api/errors/404",
+					"code":"CLUSTERS-MGMT-404",
+					"reason":"missing logs"
+				}`),
+			),
+		)
+
+		callback := func(response *cmv1.LogGetResponse) bool {
+			return true
+		}
+		_, err := ocmClient.PollInstallLogs("cluster-404", callback)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("Failed to poll logs for cluster 'cluster-404'"))
+	})
+
+	It("translates uninstall poll 404 responses into user-facing not-found errors", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-404/logs/uninstall"),
+				RespondWithJSON(http.StatusNotFound, `{
+					"kind":"Error",
+					"id":"404",
+					"href":"/api/errors/404",
+					"code":"CLUSTERS-MGMT-404",
+					"reason":"missing logs"
+				}`),
+			),
+		)
+
+		callback := func(response *cmv1.LogGetResponse) bool {
+			return true
+		}
+		_, err := ocmClient.PollUninstallLogs("cluster-404", callback)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("Failed to poll logs for cluster 'cluster-404'"))
+	})
+
+	It("wraps polling errors for uninstall logs", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/logs/uninstall"),
+				RespondWithJSON(http.StatusInternalServerError, `{
+					"kind":"Error",
+					"id":"500",
+					"href":"/api/errors/500",
+					"code":"CLUSTERS-MGMT-500",
+					"reason":"poll backend failure"
+				}`),
+			),
+		)
+
+		callback := func(response *cmv1.LogGetResponse) bool {
+			return true
+		}
+		_, err := ocmClient.PollUninstallLogs("cluster-1", callback)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("Failed to poll logs for cluster 'cluster-1'"))
+	})
+})

--- a/pkg/ocm/upgrades_test.go
+++ b/pkg/ocm/upgrades_test.go
@@ -1,0 +1,256 @@
+package ocm
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+)
+
+var _ = Describe("Upgrade policies API client behavior", func() {
+	var apiServer *ghttp.Server
+	var ocmClient *Client
+
+	BeforeEach(func() {
+		apiServer = MakeTCPServer()
+		apiServer.SetAllowUnhandledRequests(true)
+		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+		ocmClient = buildTestOCMClient(apiServer.URL())
+	})
+
+	AfterEach(func() {
+		apiServer.Close()
+		Expect(ocmClient.Close()).To(Succeed())
+	})
+
+	It("paginates upgrade policy listings", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/upgrade_policies"),
+				ghttp.VerifyFormKV("page", "1"),
+				ghttp.VerifyFormKV("size", "100"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind":"UpgradePolicyList",
+					"page":1,
+					"size":100,
+					"total":101,
+					"items":[{"id":"policy-1","upgrade_type":"OSD"}]
+				}`),
+			),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/upgrade_policies"),
+				ghttp.VerifyFormKV("page", "2"),
+				ghttp.VerifyFormKV("size", "100"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind":"UpgradePolicyList",
+					"page":2,
+					"size":1,
+					"total":101,
+					"items":[{"id":"policy-2","upgrade_type":"OSD"}]
+				}`),
+			),
+		)
+
+		policies, err := ocmClient.GetUpgradePolicies("cluster-1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(policies).To(HaveLen(2))
+		Expect(policies[0].ID()).To(Equal("policy-1"))
+		Expect(policies[1].ID()).To(Equal("policy-2"))
+	})
+
+	It("returns the scheduled OSD upgrade and its state", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/upgrade_policies"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind":"UpgradePolicyList",
+					"page":1,
+					"size":2,
+					"total":2,
+					"items":[
+						{"id":"policy-control-plane","upgrade_type":"CONTROL_PLANE"},
+						{"id":"policy-osd","upgrade_type":"OSD"}
+					]
+				}`),
+			),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/upgrade_policies/policy-osd/state"),
+				RespondWithJSON(http.StatusOK, `{
+					"description":"scheduled for tonight",
+					"value":"scheduled"
+				}`),
+			),
+		)
+
+		policy, state, err := ocmClient.GetScheduledUpgrade("cluster-1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(policy).NotTo(BeNil())
+		Expect(policy.ID()).To(Equal("policy-osd"))
+		Expect(state).NotTo(BeNil())
+		Expect(state.Value()).To(Equal(cmv1.UpgradePolicyStateValue("scheduled")))
+	})
+
+	It("returns false when no scheduled OSD upgrade exists", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/upgrade_policies"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind":"UpgradePolicyList",
+					"page":1,
+					"size":1,
+					"total":1,
+					"items":[{"id":"policy-control-plane","upgrade_type":"CONTROL_PLANE"}]
+				}`),
+			),
+		)
+
+		cancelled, err := ocmClient.CancelUpgrade("cluster-1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cancelled).To(BeFalse())
+	})
+
+	It("deletes the scheduled OSD upgrade when cancelling", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/upgrade_policies"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind":"UpgradePolicyList",
+					"page":1,
+					"size":1,
+					"total":1,
+					"items":[{"id":"policy-osd","upgrade_type":"OSD"}]
+				}`),
+			),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/upgrade_policies/policy-osd/state"),
+				RespondWithJSON(http.StatusOK, `{
+					"description":"scheduled for tonight",
+					"value":"scheduled"
+				}`),
+			),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodDelete, "/api/clusters_mgmt/v1/clusters/cluster-1/upgrade_policies/policy-osd"),
+				RespondWithJSON(http.StatusOK, `{}`),
+			),
+		)
+
+		cancelled, err := ocmClient.CancelUpgrade("cluster-1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cancelled).To(BeTrue())
+	})
+
+	It("parses missing classic gate agreements from dry-run errors", func() {
+		upgradePolicy, err := cmv1.NewUpgradePolicy().Version("4.16.10").Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters/cluster-1/upgrade_policies"),
+				ghttp.VerifyFormKV("dryRun", "true"),
+				RespondWithJSON(http.StatusBadRequest, `{
+					"kind":"Error",
+					"id":"400",
+					"href":"/api/errors/400",
+					"code":"CLUSTERS-MGMT-400",
+					"reason":"missing gate agreements",
+					"details":[{"id":"gate-a","sts_only":false}]
+				}`),
+			),
+		)
+
+		gates, err := ocmClient.GetMissingGateAgreementsClassic("cluster-1", upgradePolicy)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(gates).To(HaveLen(1))
+		Expect(gates[0].ID()).To(Equal("gate-a"))
+	})
+
+	It("returns the backend reason when classic gate details are invalid", func() {
+		upgradePolicy, err := cmv1.NewUpgradePolicy().Version("4.16.10").Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters/cluster-1/upgrade_policies"),
+				ghttp.VerifyFormKV("dryRun", "true"),
+				RespondWithJSON(http.StatusBadRequest, `{
+					"kind":"Error",
+					"id":"400",
+					"href":"/api/errors/400",
+					"code":"CLUSTERS-MGMT-400",
+					"reason":"invalid version gate payload",
+					"details":[{"id":""}]
+				}`),
+			),
+		)
+
+		gates, err := ocmClient.GetMissingGateAgreementsClassic("cluster-1", upgradePolicy)
+		Expect(err).To(HaveOccurred())
+		Expect(gates).To(BeEmpty())
+		Expect(err.Error()).To(ContainSubstring("invalid version gate payload"))
+	})
+
+	It("parses missing hypershift gate agreements from dry-run errors", func() {
+		upgradePolicy, err := cmv1.NewControlPlaneUpgradePolicy().Version("4.16.10").Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters/cluster-1/control_plane/upgrade_policies"),
+				ghttp.VerifyFormKV("dryRun", "true"),
+				RespondWithJSON(http.StatusBadRequest, `{
+					"kind":"Error",
+					"id":"400",
+					"href":"/api/errors/400",
+					"code":"CLUSTERS-MGMT-400",
+					"reason":"missing gate agreements",
+					"details":[{"id":"gate-hcp","sts_only":true}]
+				}`),
+			),
+		)
+
+		gates, err := ocmClient.GetMissingGateAgreementsHypershift("cluster-1", upgradePolicy)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(gates).To(HaveLen(1))
+		Expect(gates[0].ID()).To(Equal("gate-hcp"))
+	})
+
+	It("returns backend reason when hypershift gate details are invalid", func() {
+		upgradePolicy, err := cmv1.NewControlPlaneUpgradePolicy().Version("4.16.10").Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters/cluster-1/control_plane/upgrade_policies"),
+				ghttp.VerifyFormKV("dryRun", "true"),
+				RespondWithJSON(http.StatusBadRequest, `{
+					"kind":"Error",
+					"id":"400",
+					"href":"/api/errors/400",
+					"code":"CLUSTERS-MGMT-400",
+					"reason":"invalid hypershift version gate payload",
+					"details":[{"id":""}]
+				}`),
+			),
+		)
+
+		gates, err := ocmClient.GetMissingGateAgreementsHypershift("cluster-1", upgradePolicy)
+		Expect(err).To(HaveOccurred())
+		Expect(gates).To(BeEmpty())
+		Expect(err.Error()).To(ContainSubstring("invalid hypershift version gate payload"))
+	})
+
+	It("acknowledges version gates successfully", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters/cluster-1/gate_agreements"),
+				RespondWithJSON(http.StatusCreated, `{"id":"agreement-1"}`),
+			),
+		)
+
+		err := ocmClient.AckVersionGate("cluster-1", "gate-1")
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/pkg/ocm/upgrades_test.go
+++ b/pkg/ocm/upgrades_test.go
@@ -1,0 +1,311 @@
+package ocm
+
+import (
+	"encoding/json"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+)
+
+var _ = Describe("Upgrade policies API client behavior", func() {
+	var apiServer *ghttp.Server
+	var ocmClient *Client
+
+	BeforeEach(func() {
+		apiServer = MakeTCPServer()
+		apiServer.SetAllowUnhandledRequests(true)
+		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+		ocmClient = buildTestOCMClient(apiServer.URL())
+	})
+
+	AfterEach(func() {
+		apiServer.Close()
+		Expect(ocmClient.Close()).To(Succeed())
+	})
+
+	It("paginates upgrade policy listings", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/upgrade_policies"),
+				ghttp.VerifyFormKV("page", "1"),
+				ghttp.VerifyFormKV("size", "100"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind":"UpgradePolicyList",
+					"page":1,
+					"size":100,
+					"total":101,
+					"items":[{"id":"policy-1","upgrade_type":"OSD"}]
+				}`),
+			),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/upgrade_policies"),
+				ghttp.VerifyFormKV("page", "2"),
+				ghttp.VerifyFormKV("size", "100"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind":"UpgradePolicyList",
+					"page":2,
+					"size":1,
+					"total":101,
+					"items":[{"id":"policy-2","upgrade_type":"OSD"}]
+				}`),
+			),
+		)
+
+		policies, err := ocmClient.GetUpgradePolicies("cluster-1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(policies).To(HaveLen(2))
+		Expect(policies[0].ID()).To(Equal("policy-1"))
+		Expect(policies[1].ID()).To(Equal("policy-2"))
+	})
+
+	It("returns an error when listing upgrade policies fails", func() {
+		for i := 0; i < 3; i++ {
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/upgrade_policies"),
+					RespondWithJSON(http.StatusInternalServerError, `{
+						"kind":"Error",
+						"id":"500",
+						"href":"/api/errors/500",
+						"code":"CLUSTERS-MGMT-500",
+						"reason":"unable to list upgrade policies"
+					}`),
+				),
+			)
+		}
+
+		policies, err := ocmClient.GetUpgradePolicies("cluster-1")
+		Expect(err).To(HaveOccurred())
+		Expect(policies).To(BeNil())
+		Expect(err.Error()).To(ContainSubstring("unable to list upgrade policies"))
+		Expect(apiServer.ReceivedRequests()).NotTo(BeEmpty())
+	})
+
+	It("propagates upgrade policy list errors from GetScheduledUpgrade", func() {
+		for i := 0; i < 3; i++ {
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/upgrade_policies"),
+					RespondWithJSON(http.StatusInternalServerError, `{
+						"kind":"Error",
+						"id":"500",
+						"href":"/api/errors/500",
+						"code":"CLUSTERS-MGMT-500",
+						"reason":"unable to list upgrade policies"
+					}`),
+				),
+			)
+		}
+
+		policy, state, err := ocmClient.GetScheduledUpgrade("cluster-1")
+		Expect(err).To(HaveOccurred())
+		Expect(policy).To(BeNil())
+		Expect(state).To(BeNil())
+		Expect(err.Error()).To(ContainSubstring("unable to list upgrade policies"))
+		Expect(apiServer.ReceivedRequests()).NotTo(BeEmpty())
+	})
+
+	It("returns the scheduled OSD upgrade and its state", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/upgrade_policies"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind":"UpgradePolicyList",
+					"page":1,
+					"size":2,
+					"total":2,
+					"items":[
+						{"id":"policy-control-plane","upgrade_type":"CONTROL_PLANE"},
+						{"id":"policy-osd","upgrade_type":"OSD"}
+					]
+				}`),
+			),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/upgrade_policies/policy-osd/state"),
+				RespondWithJSON(http.StatusOK, `{
+					"description":"scheduled for tonight",
+					"value":"scheduled"
+				}`),
+			),
+		)
+
+		policy, state, err := ocmClient.GetScheduledUpgrade("cluster-1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(policy).NotTo(BeNil())
+		Expect(policy.ID()).To(Equal("policy-osd"))
+		Expect(state).NotTo(BeNil())
+		Expect(state.Value()).To(Equal(cmv1.UpgradePolicyStateValue("scheduled")))
+	})
+
+	It("returns false when no scheduled OSD upgrade exists", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/upgrade_policies"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind":"UpgradePolicyList",
+					"page":1,
+					"size":1,
+					"total":1,
+					"items":[{"id":"policy-control-plane","upgrade_type":"CONTROL_PLANE"}]
+				}`),
+			),
+		)
+
+		cancelled, err := ocmClient.CancelUpgrade("cluster-1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cancelled).To(BeFalse())
+	})
+
+	It("deletes the scheduled OSD upgrade when cancelling", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/upgrade_policies"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind":"UpgradePolicyList",
+					"page":1,
+					"size":1,
+					"total":1,
+					"items":[{"id":"policy-osd","upgrade_type":"OSD"}]
+				}`),
+			),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/upgrade_policies/policy-osd/state"),
+				RespondWithJSON(http.StatusOK, `{
+					"description":"scheduled for tonight",
+					"value":"scheduled"
+				}`),
+			),
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodDelete, "/api/clusters_mgmt/v1/clusters/cluster-1/upgrade_policies/policy-osd"),
+				RespondWithJSON(http.StatusOK, `{}`),
+			),
+		)
+
+		cancelled, err := ocmClient.CancelUpgrade("cluster-1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cancelled).To(BeTrue())
+	})
+
+	It("parses missing classic gate agreements from dry-run errors", func() {
+		upgradePolicy, err := cmv1.NewUpgradePolicy().Version("4.16.10").Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters/cluster-1/upgrade_policies"),
+				ghttp.VerifyFormKV("dryRun", "true"),
+				RespondWithJSON(http.StatusBadRequest, `{
+					"kind":"Error",
+					"id":"400",
+					"href":"/api/errors/400",
+					"code":"CLUSTERS-MGMT-400",
+					"reason":"missing gate agreements",
+					"details":[{"id":"gate-a","sts_only":false}]
+				}`),
+			),
+		)
+
+		gates, err := ocmClient.GetMissingGateAgreementsClassic("cluster-1", upgradePolicy)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(gates).To(HaveLen(1))
+		Expect(gates[0].ID()).To(Equal("gate-a"))
+	})
+
+	It("returns the backend reason when classic gate details are invalid", func() {
+		upgradePolicy, err := cmv1.NewUpgradePolicy().Version("4.16.10").Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters/cluster-1/upgrade_policies"),
+				ghttp.VerifyFormKV("dryRun", "true"),
+				RespondWithJSON(http.StatusBadRequest, `{
+					"kind":"Error",
+					"id":"400",
+					"href":"/api/errors/400",
+					"code":"CLUSTERS-MGMT-400",
+					"reason":"invalid version gate payload",
+					"details":[{"id":""}]
+				}`),
+			),
+		)
+
+		gates, err := ocmClient.GetMissingGateAgreementsClassic("cluster-1", upgradePolicy)
+		Expect(err).To(HaveOccurred())
+		Expect(gates).To(BeEmpty())
+		Expect(err.Error()).To(ContainSubstring("invalid version gate payload"))
+	})
+
+	It("parses missing hypershift gate agreements from dry-run errors", func() {
+		upgradePolicy, err := cmv1.NewControlPlaneUpgradePolicy().Version("4.16.10").Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters/cluster-1/control_plane/upgrade_policies"),
+				ghttp.VerifyFormKV("dryRun", "true"),
+				RespondWithJSON(http.StatusBadRequest, `{
+					"kind":"Error",
+					"id":"400",
+					"href":"/api/errors/400",
+					"code":"CLUSTERS-MGMT-400",
+					"reason":"missing gate agreements",
+					"details":[{"id":"gate-hcp","sts_only":true}]
+				}`),
+			),
+		)
+
+		gates, err := ocmClient.GetMissingGateAgreementsHypershift("cluster-1", upgradePolicy)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(gates).To(HaveLen(1))
+		Expect(gates[0].ID()).To(Equal("gate-hcp"))
+	})
+
+	It("returns backend reason when hypershift gate details are invalid", func() {
+		upgradePolicy, err := cmv1.NewControlPlaneUpgradePolicy().Version("4.16.10").Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters/cluster-1/control_plane/upgrade_policies"),
+				ghttp.VerifyFormKV("dryRun", "true"),
+				RespondWithJSON(http.StatusBadRequest, `{
+					"kind":"Error",
+					"id":"400",
+					"href":"/api/errors/400",
+					"code":"CLUSTERS-MGMT-400",
+					"reason":"invalid hypershift version gate payload",
+					"details":[{"id":""}]
+				}`),
+			),
+		)
+
+		gates, err := ocmClient.GetMissingGateAgreementsHypershift("cluster-1", upgradePolicy)
+		Expect(err).To(HaveOccurred())
+		Expect(gates).To(BeEmpty())
+		Expect(err.Error()).To(ContainSubstring("invalid hypershift version gate payload"))
+	})
+
+	It("acknowledges version gates successfully", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters/cluster-1/gate_agreements"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					payload := map[string]interface{}{}
+					Expect(json.NewDecoder(request.Body).Decode(&payload)).To(Succeed())
+					Expect(payload).To(HaveKeyWithValue(
+						"version_gate", HaveKeyWithValue("id", "gate-1"),
+					))
+				},
+				RespondWithJSON(http.StatusCreated, `{"id":"agreement-1"}`),
+			),
+		)
+
+		err := ocmClient.AckVersionGate("cluster-1", "gate-1")
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/pkg/ocm/versions_test.go
+++ b/pkg/ocm/versions_test.go
@@ -147,9 +147,12 @@ var _ = Describe("OCMClient", func() {
 	Context("Describe version list", func() {
 		It("Expects a version list", func() {
 			apiServer.AppendHandlers(
-				RespondWithJSON(
-					http.StatusOK,
-					VersionsListResponse,
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					RespondWithJSON(
+						http.StatusOK,
+						VersionsListResponse,
+					),
 				),
 			)
 
@@ -160,9 +163,18 @@ var _ = Describe("OCMClient", func() {
 
 		It("Expects a valid Hypershift Version", func() {
 			apiServer.AppendHandlers(
-				RespondWithJSON(
-					http.StatusOK,
-					VersionsListResponse,
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					func(_ http.ResponseWriter, request *http.Request) {
+						Expect(request.URL.Query().Get("product")).To(Equal(HcpProduct))
+						Expect(request.URL.Query().Get("search")).To(Equal(
+							"raw_id='4.14.9' AND channel_group = 'stable'",
+						))
+					},
+					RespondWithJSON(
+						http.StatusOK,
+						VersionsListResponse,
+					),
 				),
 			)
 
@@ -173,15 +185,93 @@ var _ = Describe("OCMClient", func() {
 
 		It("Expects a non supported Hypershift Version", func() {
 			apiServer.AppendHandlers(
-				RespondWithJSON(
-					http.StatusOK,
-					NonSupportedHypershiftVersionsListResponse,
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					func(_ http.ResponseWriter, request *http.Request) {
+						Expect(request.URL.Query().Get("product")).To(Equal(HcpProduct))
+						Expect(request.URL.Query().Get("search")).To(Equal(
+							"raw_id='4.13.0' AND channel_group = 'stable'",
+						))
+					},
+					RespondWithJSON(
+						http.StatusOK,
+						NonSupportedHypershiftVersionsListResponse,
+					),
 				),
 			)
 
 			vs, err := ocmClient.ValidateHypershiftVersion("4.13.0", DefaultChannelGroup)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(vs).To(BeFalse())
+		})
+
+		It("returns latest version major.minor", func() {
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					RespondWithJSON(
+						http.StatusOK,
+						`{
+							"kind":"VersionList",
+							"page":1,
+							"size":1,
+							"total":1,
+							"items":[{"id":"4.16.3","raw_id":"4.16.3","channel_group":"stable","rosa_enabled":true}]
+						}`,
+					),
+				),
+			)
+
+			version, err := ocmClient.GetLatestVersion(DefaultChannelGroup)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(Equal("4.16"))
+		})
+
+		It("returns error when latest version cannot be resolved", func() {
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					RespondWithJSON(
+						http.StatusOK,
+						`{
+							"kind":"VersionList",
+							"page":1,
+							"size":0,
+							"total":0,
+							"items":[]
+						}`,
+					),
+				),
+			)
+
+			_, err := ocmClient.GetLatestVersion(DefaultChannelGroup)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("there are no OpenShift versions available"))
+		})
+
+		It("passes product to GetVersionsWithProduct requests", func() {
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					func(_ http.ResponseWriter, request *http.Request) {
+						Expect(request.URL.Query().Get("product")).To(Equal(HcpProduct))
+					},
+					RespondWithJSON(
+						http.StatusOK,
+						`{
+							"kind":"VersionList",
+							"page":1,
+							"size":1,
+							"total":1,
+							"items":[{"id":"4.16.3","raw_id":"4.16.3","channel_group":"stable","rosa_enabled":true}]
+						}`,
+					),
+				),
+			)
+
+			versions, err := ocmClient.GetVersionsWithProduct(HcpProduct, DefaultChannelGroup, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(versions).To(HaveLen(1))
 		})
 	})
 })
@@ -341,6 +431,22 @@ var _ = Describe("Minimal http tokens required version", Ordered, func() {
 					"is not supported: %v", "bad version", "malformed version: bad version"),
 			),
 		)
+	})
+})
+
+var _ = Describe("GetAvailableUpgradesByCluster", func() {
+	It("returns descending upgrades for cluster versions", func() {
+		cluster, err := cmv1.NewCluster().
+			Version(cmv1.NewVersion().AvailableUpgrades("4.14.1", "4.14.3", "4.14.2")).
+			Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		upgrades := GetAvailableUpgradesByCluster(cluster)
+		Expect(upgrades).To(Equal([]string{"4.14.3", "4.14.2", "4.14.1"}))
+	})
+
+	It("returns empty upgrades for nil cluster", func() {
+		Expect(GetAvailableUpgradesByCluster(nil)).To(BeEmpty())
 	})
 })
 

--- a/pkg/ocm/versions_test.go
+++ b/pkg/ocm/versions_test.go
@@ -147,9 +147,12 @@ var _ = Describe("OCMClient", func() {
 	Context("Describe version list", func() {
 		It("Expects a version list", func() {
 			apiServer.AppendHandlers(
-				RespondWithJSON(
-					http.StatusOK,
-					VersionsListResponse,
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					RespondWithJSON(
+						http.StatusOK,
+						VersionsListResponse,
+					),
 				),
 			)
 
@@ -160,9 +163,12 @@ var _ = Describe("OCMClient", func() {
 
 		It("Expects a valid Hypershift Version", func() {
 			apiServer.AppendHandlers(
-				RespondWithJSON(
-					http.StatusOK,
-					VersionsListResponse,
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					RespondWithJSON(
+						http.StatusOK,
+						VersionsListResponse,
+					),
 				),
 			)
 
@@ -173,15 +179,87 @@ var _ = Describe("OCMClient", func() {
 
 		It("Expects a non supported Hypershift Version", func() {
 			apiServer.AppendHandlers(
-				RespondWithJSON(
-					http.StatusOK,
-					NonSupportedHypershiftVersionsListResponse,
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					RespondWithJSON(
+						http.StatusOK,
+						NonSupportedHypershiftVersionsListResponse,
+					),
 				),
 			)
 
 			vs, err := ocmClient.ValidateHypershiftVersion("4.13.0", DefaultChannelGroup)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(vs).To(BeFalse())
+		})
+
+		It("returns latest version major.minor", func() {
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					RespondWithJSON(
+						http.StatusOK,
+						`{
+							"kind":"VersionList",
+							"page":1,
+							"size":1,
+							"total":1,
+							"items":[{"id":"4.16.3","raw_id":"4.16.3","channel_group":"stable","rosa_enabled":true}]
+						}`,
+					),
+				),
+			)
+
+			version, err := ocmClient.GetLatestVersion(DefaultChannelGroup)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(Equal("4.16"))
+		})
+
+		It("returns error when latest version cannot be resolved", func() {
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					RespondWithJSON(
+						http.StatusOK,
+						`{
+							"kind":"VersionList",
+							"page":1,
+							"size":0,
+							"total":0,
+							"items":[]
+						}`,
+					),
+				),
+			)
+
+			_, err := ocmClient.GetLatestVersion(DefaultChannelGroup)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("there are no OpenShift versions available"))
+		})
+
+		It("passes product to GetVersionsWithProduct requests", func() {
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+					func(_ http.ResponseWriter, request *http.Request) {
+						Expect(request.URL.Query().Get("product")).To(Equal(HcpProduct))
+					},
+					RespondWithJSON(
+						http.StatusOK,
+						`{
+							"kind":"VersionList",
+							"page":1,
+							"size":1,
+							"total":1,
+							"items":[{"id":"4.16.3","raw_id":"4.16.3","channel_group":"stable","rosa_enabled":true}]
+						}`,
+					),
+				),
+			)
+
+			versions, err := ocmClient.GetVersionsWithProduct(HcpProduct, DefaultChannelGroup, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(versions).To(HaveLen(1))
 		})
 	})
 })
@@ -304,6 +382,22 @@ var _ = Describe("Minimal http tokens required version", Ordered, func() {
 					"is not supported: %v", "bad version", "malformed version: bad version"),
 			),
 		)
+	})
+})
+
+var _ = Describe("GetAvailableUpgradesByCluster", func() {
+	It("returns descending upgrades for cluster versions", func() {
+		cluster, err := cmv1.NewCluster().
+			Version(cmv1.NewVersion().AvailableUpgrades("4.14.1", "4.14.3", "4.14.2")).
+			Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		upgrades := GetAvailableUpgradesByCluster(cluster)
+		Expect(upgrades).To(Equal([]string{"4.14.3", "4.14.2", "4.14.1"}))
+	})
+
+	It("returns empty upgrades for nil cluster", func() {
+		Expect(GetAvailableUpgradesByCluster(nil)).To(BeEmpty())
 	})
 })
 


### PR DESCRIPTION
## PR Summary
Splits lifecycle-oriented `pkg/ocm` coverage into a focused review layer for version gates, cluster logs, upgrade policies, and version listing behavior.

## Detailed Description of the Issue
This PR is the lifecycle/version layer of the [ROSAENG-61179](https://redhat.atlassian.net/browse/ROSAENG-61179) split. It extends Ginkgo coverage for gate, log, upgrade, and version client flows, including pagination, error handling, and request-contract assertions. It depends on `buildTestOCMClient()` from [#3442](https://github.com/openshift/rosa/pull/3442), which is already merged into `master`.

**Changed files:** `pkg/ocm/gates_test.go`, `pkg/ocm/logs_test.go`, `pkg/ocm/upgrades_test.go`, `pkg/ocm/versions_test.go`

**Note:** This branch may need a rebase onto current `master` before merge (after [#3443](https://github.com/openshift/rosa/pull/3443) landed).

## Related Issues and PRs
- Jira: [ROSAENG-61179](https://issues.redhat.com/browse/ROSAENG-61179)
- Fixes: `N/A`
- Related PR(s):
  - Holding PR: [#3437](https://github.com/openshift/rosa/pull/3437) — CLOSED (superseded by this stacked split)
  - [#3442](https://github.com/openshift/rosa/pull/3442) — MERGED: core client hardening and shared test harness
  - [#3443](https://github.com/openshift/rosa/pull/3443) — MERGED: add-on availability semantics
  - [#3445](https://github.com/openshift/rosa/pull/3445) — OPEN: CRUD/request-contract coverage (merge before this PR)
- Merge order: **#3445**, then **#3444** (this PR). All stack PRs target `master`.
- Related design/docs: `N/A`

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [x] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
- Lifecycle-oriented `pkg/ocm` coverage for gates, logs, upgrades, and versions was bundled into the holding branch instead of a focused review slice.

## Behavior After This Change
- Gate, log, upgrade, and version client tests are isolated in this PR with explicit request-contract and error-path coverage.
- No production code changes in this PR.

## How to Test (Step-by-Step)
### Preconditions
- Run from the repo root.
- Use a Go toolchain compatible with `go.mod`. If needed, prefix commands with `GOTOOLCHAIN=auto`.
- Rebase onto current `master` if the PR branch is behind.

### Test Steps
1. Run `GOTOOLCHAIN=auto go test ./pkg/ocm -count=1 -ginkgo.focus="Version gates API client behavior|Cluster logs API client behavior|Upgrade policies API client behavior|GetAvailableUpgradesByCluster|Versions"`.

### Expected Results
- The lifecycle/version `pkg/ocm` specs pass.

## Proof of the Fix
- Screenshots: `N/A`
- Videos: `N/A`
- Logs/CLI output:
  - `GOTOOLCHAIN=auto go test ./pkg/ocm -count=1 -ginkgo.focus="Version gates API client behavior|Cluster logs API client behavior|Upgrade policies API client behavior|GetAvailableUpgradesByCluster|Versions"`
- Other artifacts: `N/A`

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
`N/A`

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [ ] `make test` passes.
- [ ] `make lint` passes.
- [ ] `make rosa` passes.
- [x] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

[ROSAENG-61179]: https://redhat.atlassian.net/browse/ROSAENG-61179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded version-gate coverage for pagination, version-prefix and STS filtering, and API error handling.
  - Added coverage for installation and uninstallation log retrieval, polling, query parameters, and user-facing errors.
  - Added upgrade workflow tests covering policies, scheduled upgrades, cancellations, dry-run gate agreements, and acknowledgements.
  - Improved version API coverage for request parameters, latest-version selection, upgrade ordering, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
