### PR TITLE
ROSAENG-61179 | test: add ocm wrapper request-contract coverage

### DIFF
--- a/pkg/ocm/dns_domain_test.go
+++ b/pkg/ocm/dns_domain_test.go
@@ -1,0 +1,86 @@
+package ocm
+
+import (
+	"encoding/json"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+)
+
+var _ = Describe("DNS Domains", Ordered, func() {
+	var apiServer *ghttp.Server
+	var ocmClient *Client
+
+	BeforeEach(func() {
+		apiServer = MakeTCPServer()
+		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+		ocmClient = buildTestOCMClient(apiServer.URL())
+	})
+
+	AfterEach(func() {
+		apiServer.Close()
+		Expect(ocmClient.Close()).To(Succeed())
+	})
+
+	It("lists DNS domains with search and order parameters", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/dns_domains"),
+				ghttp.VerifyFormKV("search", "name like 'example'"),
+				ghttp.VerifyFormKV("order", "organization.id asc"),
+				ghttp.VerifyFormKV("page", "1"),
+				ghttp.VerifyFormKV("size", "-1"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind": "DNSDomainList",
+					"page": 1,
+					"size": 1,
+					"total": 1,
+					"items": [{"id":"dns-1","user_defined":true}]
+				}`),
+			),
+		)
+
+		domains, err := ocmClient.ListDNSDomains("name like 'example'")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(domains).To(HaveLen(1))
+		Expect(domains[0].ID()).To(Equal("dns-1"))
+	})
+
+	It("creates DNS domains", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/dns_domains"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					payload := map[string]interface{}{}
+					Expect(json.NewDecoder(request.Body).Decode(&payload)).To(Succeed())
+					Expect(payload).To(HaveKeyWithValue("id", "dns-2"))
+					Expect(payload).To(HaveKeyWithValue("user_defined", true))
+				},
+				RespondWithJSON(http.StatusCreated, `{"id":"dns-2","user_defined":true}`),
+			),
+		)
+		domainInput, err := cmv1.NewDNSDomain().ID("dns-2").UserDefined(true).Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		created, err := ocmClient.CreateDNSDomain(domainInput)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(created).NotTo(BeNil())
+		Expect(created.ID()).To(Equal("dns-2"))
+	})
+
+	It("deletes DNS domains", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodDelete, "/api/clusters_mgmt/v1/dns_domains/dns-2"),
+				RespondWithJSON(http.StatusNoContent, ``),
+			),
+		)
+
+		err := ocmClient.DeleteDNSDomain("dns-2")
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/pkg/ocm/dns_domain_test.go
+++ b/pkg/ocm/dns_domain_test.go
@@ -1,0 +1,84 @@
+package ocm
+
+import (
+	"encoding/json"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+)
+
+var _ = Describe("DNS Domains", Ordered, func() {
+	var apiServer *ghttp.Server
+	var ocmClient *Client
+
+	BeforeEach(func() {
+		apiServer = MakeTCPServer()
+		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+		ocmClient = buildTestOCMClient(apiServer.URL())
+	})
+
+	AfterEach(func() {
+		apiServer.Close()
+		Expect(ocmClient.Close()).To(Succeed())
+	})
+
+	It("lists DNS domains with search and order parameters", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/dns_domains"),
+				ghttp.VerifyFormKV("search", "name like 'example'"),
+				ghttp.VerifyFormKV("order", "organization.id asc"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind": "DNSDomainList",
+					"page": 1,
+					"size": 1,
+					"total": 1,
+					"items": [{"id":"dns-1","user_defined":true}]
+				}`),
+			),
+		)
+
+		domains, err := ocmClient.ListDNSDomains("name like 'example'")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(domains).To(HaveLen(1))
+		Expect(domains[0].ID()).To(Equal("dns-1"))
+	})
+
+	It("creates DNS domains", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/dns_domains"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					payload := map[string]interface{}{}
+					Expect(json.NewDecoder(request.Body).Decode(&payload)).To(Succeed())
+					Expect(payload).To(HaveKeyWithValue("id", "dns-2"))
+					Expect(payload).To(HaveKeyWithValue("user_defined", true))
+				},
+				RespondWithJSON(http.StatusCreated, `{"id":"dns-2","user_defined":true}`),
+			),
+		)
+		domainInput, err := cmv1.NewDNSDomain().ID("dns-2").UserDefined(true).Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		created, err := ocmClient.CreateDNSDomain(domainInput)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(created).NotTo(BeNil())
+		Expect(created.ID()).To(Equal("dns-2"))
+	})
+
+	It("deletes DNS domains", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodDelete, "/api/clusters_mgmt/v1/dns_domains/dns-2"),
+				RespondWithJSON(http.StatusNoContent, ``),
+			),
+		)
+
+		err := ocmClient.DeleteDNSDomain("dns-2")
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/pkg/ocm/ingresses_test.go
+++ b/pkg/ocm/ingresses_test.go
@@ -1,0 +1,166 @@
+package ocm
+
+import (
+	"encoding/json"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+)
+
+var _ = Describe("Ingresses", Ordered, func() {
+	const clusterID = "cluster-1"
+
+	var apiServer *ghttp.Server
+	var ocmClient *Client
+
+	BeforeEach(func() {
+		apiServer = MakeTCPServer()
+		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+		ocmClient = buildTestOCMClient(apiServer.URL())
+	})
+
+	AfterEach(func() {
+		apiServer.Close()
+		Expect(ocmClient.Close()).To(Succeed())
+	})
+
+	Describe("GetIngress", func() {
+		const ingressesBody = `{
+			"kind": "IngressList",
+			"page": 1,
+			"size": 2,
+			"total": 2,
+			"items": [
+				{"id": "default-ingress", "default": true},
+				{"id": "custom-ingress", "default": false}
+			]
+		}`
+
+		It("returns the default ingress for apps", func() {
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/ingresses"),
+					RespondWithJSON(http.StatusOK, ingressesBody),
+				),
+			)
+
+			ingress, err := ocmClient.GetIngress(clusterID, "apps")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ingress).NotTo(BeNil())
+			Expect(ingress.ID()).To(Equal("default-ingress"))
+		})
+
+		It("returns the non-default ingress for apps2", func() {
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/ingresses"),
+					RespondWithJSON(http.StatusOK, ingressesBody),
+				),
+			)
+
+			ingress, err := ocmClient.GetIngress(clusterID, "apps2")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ingress).NotTo(BeNil())
+			Expect(ingress.ID()).To(Equal("custom-ingress"))
+		})
+
+		It("returns ingress by explicit id lookup", func() {
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/ingresses"),
+					RespondWithJSON(http.StatusOK, ingressesBody),
+				),
+			)
+
+			ingress, err := ocmClient.GetIngress(clusterID, "custom-ingress")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ingress).NotTo(BeNil())
+			Expect(ingress.ID()).To(Equal("custom-ingress"))
+		})
+
+		It("returns not found error when ingress key has no match", func() {
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/ingresses"),
+					RespondWithJSON(http.StatusOK, ingressesBody),
+				),
+			)
+
+			ingress, err := ocmClient.GetIngress(clusterID, "missing")
+			Expect(err).To(HaveOccurred())
+			Expect(ingress).To(BeNil())
+			Expect(err.Error()).To(ContainSubstring("Failed to get ingress 'missing' for cluster 'cluster-1'"))
+		})
+	})
+
+	Describe("GetIngresses", func() {
+		It("returns ingress list", func() {
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/ingresses"),
+					RespondWithJSON(http.StatusOK, `{
+						"kind": "IngressList",
+						"page": 1,
+						"size": 1,
+						"total": 1,
+						"items": [{"id": "ingress-1", "default": true}]
+					}`),
+				),
+			)
+
+			ingresses, err := ocmClient.GetIngresses(clusterID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ingresses).To(HaveLen(1))
+			Expect(ingresses[0].ID()).To(Equal("ingress-1"))
+		})
+	})
+
+	Describe("UpdateIngress", func() {
+		It("updates and returns ingress", func() {
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/cluster-1/ingresses/ingress-1"),
+					func(_ http.ResponseWriter, request *http.Request) {
+						payload := map[string]interface{}{}
+						Expect(json.NewDecoder(request.Body).Decode(&payload)).To(Succeed())
+						Expect(payload).To(HaveKeyWithValue("id", "ingress-1"))
+						Expect(payload).To(HaveKeyWithValue("default", false))
+					},
+					RespondWithJSON(http.StatusOK, `{
+						"id": "ingress-1",
+						"default": false
+					}`),
+				),
+			)
+
+			ingress, err := cmv1.NewIngress().
+				ID("ingress-1").
+				Default(false).
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			updated, err := ocmClient.UpdateIngress(clusterID, ingress)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updated).NotTo(BeNil())
+			Expect(updated.ID()).To(Equal("ingress-1"))
+		})
+	})
+
+	Describe("DeleteIngress", func() {
+		It("deletes ingress", func() {
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodDelete, "/api/clusters_mgmt/v1/clusters/cluster-1/ingresses/ingress-1"),
+					RespondWithJSON(http.StatusNoContent, ""),
+				),
+			)
+
+			err := ocmClient.DeleteIngress(clusterID, "ingress-1")
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/pkg/ocm/ingresses_test.go
+++ b/pkg/ocm/ingresses_test.go
@@ -1,0 +1,167 @@
+package ocm
+
+import (
+	"encoding/json"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+)
+
+var _ = Describe("Ingresses", Ordered, func() {
+	const clusterID = "cluster-1"
+
+	var apiServer *ghttp.Server
+	var ocmClient *Client
+
+	BeforeEach(func() {
+		apiServer = MakeTCPServer()
+		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+		ocmClient = buildTestOCMClient(apiServer.URL())
+	})
+
+	AfterEach(func() {
+		apiServer.Close()
+		Expect(ocmClient.Close()).To(Succeed())
+	})
+
+	Describe("GetIngress", func() {
+		const ingressesBody = `{
+			"kind": "IngressList",
+			"page": 1,
+			"size": 2,
+			"total": 2,
+			"items": [
+				{"id": "default-ingress", "default": true},
+				{"id": "custom-ingress", "default": false}
+			]
+		}`
+
+		It("returns the default ingress for apps", func() {
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/ingresses"),
+					RespondWithJSON(http.StatusOK, ingressesBody),
+				),
+			)
+
+			ingress, err := ocmClient.GetIngress(clusterID, "apps")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ingress).NotTo(BeNil())
+			Expect(ingress.ID()).To(Equal("default-ingress"))
+		})
+
+		It("returns the non-default ingress for apps2", func() {
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/ingresses"),
+					RespondWithJSON(http.StatusOK, ingressesBody),
+				),
+			)
+
+			ingress, err := ocmClient.GetIngress(clusterID, "apps2")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ingress).NotTo(BeNil())
+			Expect(ingress.ID()).To(Equal("custom-ingress"))
+		})
+
+		It("returns ingress by explicit id lookup", func() {
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/ingresses"),
+					RespondWithJSON(http.StatusOK, ingressesBody),
+				),
+			)
+
+			ingress, err := ocmClient.GetIngress(clusterID, "custom-ingress")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ingress).NotTo(BeNil())
+			Expect(ingress.ID()).To(Equal("custom-ingress"))
+		})
+
+		It("returns not found error when ingress key has no match", func() {
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/ingresses"),
+					RespondWithJSON(http.StatusOK, ingressesBody),
+				),
+			)
+
+			ingress, err := ocmClient.GetIngress(clusterID, "missing")
+			Expect(err).To(HaveOccurred())
+			Expect(ingress).To(BeNil())
+			Expect(err.Error()).To(ContainSubstring("Failed to get ingress 'missing' for cluster 'cluster-1'"))
+		})
+	})
+
+	Describe("GetIngresses", func() {
+		It("returns ingress list", func() {
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/ingresses"),
+					RespondWithJSON(http.StatusOK, `{
+						"kind": "IngressList",
+						"page": 1,
+						"size": 1,
+						"total": 1,
+						"items": [{"id": "ingress-1", "default": true}]
+					}`),
+				),
+			)
+
+			ingresses, err := ocmClient.GetIngresses(clusterID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ingresses).To(HaveLen(1))
+			Expect(ingresses[0].ID()).To(Equal("ingress-1"))
+		})
+	})
+
+	Describe("UpdateIngress", func() {
+		It("updates and returns ingress", func() {
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/cluster-1/ingresses/ingress-1"),
+					func(_ http.ResponseWriter, request *http.Request) {
+						payload := map[string]interface{}{}
+						Expect(json.NewDecoder(request.Body).Decode(&payload)).To(Succeed())
+						Expect(payload).To(HaveKeyWithValue("id", "ingress-1"))
+						Expect(payload).To(HaveKeyWithValue("default", false))
+					},
+					RespondWithJSON(http.StatusOK, `{
+						"id": "ingress-1",
+						"default": true
+					}`),
+				),
+			)
+
+			ingress, err := cmv1.NewIngress().
+				ID("ingress-1").
+				Default(false).
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			updated, err := ocmClient.UpdateIngress(clusterID, ingress)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updated).NotTo(BeNil())
+			Expect(updated.ID()).To(Equal("ingress-1"))
+			Expect(updated.Default()).To(BeTrue())
+		})
+	})
+
+	Describe("DeleteIngress", func() {
+		It("deletes ingress", func() {
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodDelete, "/api/clusters_mgmt/v1/clusters/cluster-1/ingresses/ingress-1"),
+					RespondWithJSON(http.StatusNoContent, ""),
+				),
+			)
+
+			err := ocmClient.DeleteIngress(clusterID, "ingress-1")
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/pkg/ocm/nodepools_test.go
+++ b/pkg/ocm/nodepools_test.go
@@ -2,6 +2,7 @@ package ocm
 
 import (
 	"bytes"
+	"encoding/json"
 	"net/http"
 	"time"
 
@@ -107,5 +108,197 @@ var _ = Describe("Node pool warnings", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(createdNodePool).ToNot(BeNil())
 		Expect(createdNodePool.ID()).To(Equal("test-nodepool"))
+	})
+})
+
+var _ = Describe("NodePools", Ordered, func() {
+	const clusterID = "cluster-1"
+
+	var apiServer *ghttp.Server
+	var ocmClient *Client
+
+	BeforeEach(func() {
+		apiServer = MakeTCPServer()
+		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+		ocmClient = buildTestOCMClient(apiServer.URL())
+	})
+
+	AfterEach(func() {
+		apiServer.Close()
+		Expect(ocmClient.Close()).To(Succeed())
+	})
+
+	It("finds node pools using a kubelet config name", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/node_pools"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind": "NodePoolList",
+					"page": 1,
+					"size": 3,
+					"total": 3,
+					"items": [
+						{"id":"np-1","kubelet_configs":["kc-a","kc-b"]},
+						{"id":"np-2","kubelet_configs":["kc-b"]},
+						{"id":"np-3","kubelet_configs":[]}
+					]
+				}`),
+			),
+		)
+
+		found, err := ocmClient.FindNodePoolsUsingKubeletConfig(clusterID, "kc-b")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(HaveLen(2))
+		Expect(found[0].ID()).To(Equal("np-1"))
+		Expect(found[1].ID()).To(Equal("np-2"))
+	})
+
+	It("returns an error when listing node pools fails during kubelet search", func() {
+		for i := 0; i < 3; i++ {
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/node_pools"),
+					RespondWithJSON(http.StatusInternalServerError, `{"reason":"broken"}`),
+				),
+			)
+		}
+
+		found, err := ocmClient.FindNodePoolsUsingKubeletConfig(clusterID, "kc-b")
+		Expect(err).To(HaveOccurred())
+		Expect(found).To(BeEmpty())
+	})
+
+	It("returns an empty list when no node pool uses kubelet config", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/node_pools"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind": "NodePoolList",
+					"page": 1,
+					"size": 2,
+					"total": 2,
+					"items": [
+						{"id":"np-1","kubelet_configs":["kc-a"]},
+						{"id":"np-2","kubelet_configs":["kc-c"]}
+					]
+				}`),
+			),
+		)
+
+		found, err := ocmClient.FindNodePoolsUsingKubeletConfig(clusterID, "kc-b")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeEmpty())
+	})
+
+	It("returns exists=false,nil error when node pool is not found", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/node_pools/missing"),
+				RespondWithJSON(http.StatusNotFound, `{"reason":"not found"}`),
+			),
+		)
+
+		nodePool, exists, err := ocmClient.GetNodePool(clusterID, "missing")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(exists).To(BeFalse())
+		Expect(nodePool).To(BeNil())
+	})
+
+	It("returns node pool and exists=true when node pool exists", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/node_pools/np-1"),
+				RespondWithJSON(http.StatusOK, `{"id":"np-1","kubelet_configs":["kc-a"]}`),
+			),
+		)
+
+		nodePool, exists, err := ocmClient.GetNodePool(clusterID, "np-1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(exists).To(BeTrue())
+		Expect(nodePool).NotTo(BeNil())
+		Expect(nodePool.ID()).To(Equal("np-1"))
+		Expect(nodePool.KubeletConfigs()).To(Equal([]string{"kc-a"}))
+	})
+
+	It("creates node pools", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters/cluster-1/node_pools"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					payload := map[string]interface{}{}
+					Expect(json.NewDecoder(request.Body).Decode(&payload)).To(Succeed())
+					Expect(payload).To(HaveKeyWithValue("id", "np-created"))
+					Expect(payload).To(HaveKeyWithValue("kubelet_configs", []interface{}{"kc-a"}))
+				},
+				RespondWithJSON(http.StatusCreated, `{"id":"np-created","kubelet_configs":["kc-a","kc-b"]}`),
+			),
+		)
+		input, err := cmv1.NewNodePool().ID("np-created").KubeletConfigs("kc-a").Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		created, err := ocmClient.CreateNodePool(clusterID, input)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(created).NotTo(BeNil())
+		Expect(created.ID()).To(Equal("np-created"))
+		Expect(created.KubeletConfigs()).To(Equal([]string{"kc-a", "kc-b"}))
+	})
+
+	It("lists node pools", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/node_pools"),
+				ghttp.VerifyFormKV("page", "1"),
+				ghttp.VerifyFormKV("size", "-1"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind":"NodePoolList",
+					"page":1,
+					"size":1,
+					"total":1,
+					"items":[{"id":"np-created","kubelet_configs":["kc-a"]}]
+				}`),
+			),
+		)
+
+		nodePools, err := ocmClient.GetNodePools(clusterID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(nodePools).To(HaveLen(1))
+		Expect(nodePools[0].ID()).To(Equal("np-created"))
+		Expect(nodePools[0].KubeletConfigs()).To(Equal([]string{"kc-a"}))
+	})
+
+	It("updates node pools", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/cluster-1/node_pools/np-created"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					payload := map[string]interface{}{}
+					Expect(json.NewDecoder(request.Body).Decode(&payload)).To(Succeed())
+					Expect(payload).To(HaveKeyWithValue("id", "np-created"))
+					Expect(payload).To(HaveKeyWithValue("kubelet_configs", []interface{}{"kc-a", "kc-b"}))
+				},
+				RespondWithJSON(http.StatusOK, `{"id":"np-created","kubelet_configs":["kc-a","kc-b","kc-c"]}`),
+			),
+		)
+
+		updateInput, err := cmv1.NewNodePool().ID("np-created").KubeletConfigs("kc-a", "kc-b").Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		updated, err := ocmClient.UpdateNodePool(clusterID, updateInput)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updated).NotTo(BeNil())
+		Expect(updated.ID()).To(Equal("np-created"))
+		Expect(updated.KubeletConfigs()).To(Equal([]string{"kc-a", "kc-b", "kc-c"}))
+	})
+
+	It("deletes node pools", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodDelete, "/api/clusters_mgmt/v1/clusters/cluster-1/node_pools/np-created"),
+				RespondWithJSON(http.StatusNoContent, ``),
+			),
+		)
+
+		err := ocmClient.DeleteNodePool(clusterID, "np-created")
+		Expect(err).NotTo(HaveOccurred())
 	})
 })

--- a/pkg/ocm/nodepools_test.go
+++ b/pkg/ocm/nodepools_test.go
@@ -1,0 +1,197 @@
+package ocm
+
+import (
+	"encoding/json"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+)
+
+var _ = Describe("NodePools", Ordered, func() {
+	const clusterID = "cluster-1"
+
+	var apiServer *ghttp.Server
+	var ocmClient *Client
+
+	BeforeEach(func() {
+		apiServer = MakeTCPServer()
+		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+		ocmClient = buildTestOCMClient(apiServer.URL())
+	})
+
+	AfterEach(func() {
+		apiServer.Close()
+		Expect(ocmClient.Close()).To(Succeed())
+	})
+
+	It("finds node pools using a kubelet config name", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/node_pools"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind": "NodePoolList",
+					"page": 1,
+					"size": 3,
+					"total": 3,
+					"items": [
+						{"id":"np-1","kubelet_configs":["kc-a","kc-b"]},
+						{"id":"np-2","kubelet_configs":["kc-b"]},
+						{"id":"np-3","kubelet_configs":[]}
+					]
+				}`),
+			),
+		)
+
+		found, err := ocmClient.FindNodePoolsUsingKubeletConfig(clusterID, "kc-b")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(HaveLen(2))
+		Expect(found[0].ID()).To(Equal("np-1"))
+		Expect(found[1].ID()).To(Equal("np-2"))
+	})
+
+	It("returns an error when listing node pools fails during kubelet search", func() {
+		for i := 0; i < 3; i++ {
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/node_pools"),
+					RespondWithJSON(http.StatusInternalServerError, `{"reason":"broken"}`),
+				),
+			)
+		}
+
+		found, err := ocmClient.FindNodePoolsUsingKubeletConfig(clusterID, "kc-b")
+		Expect(err).To(HaveOccurred())
+		Expect(found).To(BeEmpty())
+	})
+
+	It("returns an empty list when no node pool uses kubelet config", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/node_pools"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind": "NodePoolList",
+					"page": 1,
+					"size": 2,
+					"total": 2,
+					"items": [
+						{"id":"np-1","kubelet_configs":["kc-a"]},
+						{"id":"np-2","kubelet_configs":["kc-c"]}
+					]
+				}`),
+			),
+		)
+
+		found, err := ocmClient.FindNodePoolsUsingKubeletConfig(clusterID, "kc-b")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeEmpty())
+	})
+
+	It("returns exists=false,nil error when node pool is not found", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/node_pools/missing"),
+				RespondWithJSON(http.StatusNotFound, `{"reason":"not found"}`),
+			),
+		)
+
+		nodePool, exists, err := ocmClient.GetNodePool(clusterID, "missing")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(exists).To(BeFalse())
+		Expect(nodePool).To(BeNil())
+	})
+
+	It("returns node pool and exists=true when node pool exists", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/node_pools/np-1"),
+				RespondWithJSON(http.StatusOK, `{"id":"np-1","kubelet_configs":["kc-a"]}`),
+			),
+		)
+
+		nodePool, exists, err := ocmClient.GetNodePool(clusterID, "np-1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(exists).To(BeTrue())
+		Expect(nodePool).NotTo(BeNil())
+		Expect(nodePool.ID()).To(Equal("np-1"))
+	})
+
+	It("creates node pools", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters/cluster-1/node_pools"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					payload := map[string]interface{}{}
+					Expect(json.NewDecoder(request.Body).Decode(&payload)).To(Succeed())
+					Expect(payload).To(HaveKeyWithValue("id", "np-created"))
+				},
+				RespondWithJSON(http.StatusCreated, `{"id":"np-created","kubelet_configs":["kc-a"]}`),
+			),
+		)
+		input, err := cmv1.NewNodePool().ID("np-created").Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		created, err := ocmClient.CreateNodePool(clusterID, input)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(created).NotTo(BeNil())
+		Expect(created.ID()).To(Equal("np-created"))
+	})
+
+	It("lists node pools", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/node_pools"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind":"NodePoolList",
+					"page":1,
+					"size":1,
+					"total":1,
+					"items":[{"id":"np-created","kubelet_configs":["kc-a"]}]
+				}`),
+			),
+		)
+
+		nodePools, err := ocmClient.GetNodePools(clusterID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(nodePools).To(HaveLen(1))
+		Expect(nodePools[0].ID()).To(Equal("np-created"))
+	})
+
+	It("updates node pools", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPatch, "/api/clusters_mgmt/v1/clusters/cluster-1/node_pools/np-created"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					payload := map[string]interface{}{}
+					Expect(json.NewDecoder(request.Body).Decode(&payload)).To(Succeed())
+					Expect(payload).To(HaveKeyWithValue("id", "np-created"))
+					Expect(payload).To(HaveKeyWithValue("kubelet_configs", []interface{}{"kc-a", "kc-b"}))
+				},
+				RespondWithJSON(http.StatusOK, `{"id":"np-created","kubelet_configs":["kc-a","kc-b"]}`),
+			),
+		)
+
+		updateInput, err := cmv1.NewNodePool().ID("np-created").KubeletConfigs("kc-a", "kc-b").Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		updated, err := ocmClient.UpdateNodePool(clusterID, updateInput)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updated).NotTo(BeNil())
+		Expect(updated.KubeletConfigs()).To(Equal([]string{"kc-a", "kc-b"}))
+	})
+
+	It("deletes node pools", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodDelete, "/api/clusters_mgmt/v1/clusters/cluster-1/node_pools/np-created"),
+				RespondWithJSON(http.StatusNoContent, ``),
+			),
+		)
+
+		err := ocmClient.DeleteNodePool(clusterID, "np-created")
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/pkg/ocm/oidc_config_test.go
+++ b/pkg/ocm/oidc_config_test.go
@@ -1,0 +1,152 @@
+package ocm
+
+import (
+	"encoding/json"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+)
+
+var _ = Describe("Oidc Config", Ordered, func() {
+	const awsAccountID = "123456789012"
+
+	var apiServer *ghttp.Server
+	var ocmClient *Client
+
+	BeforeEach(func() {
+		apiServer = MakeTCPServer()
+		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+		ocmClient = buildTestOCMClient(apiServer.URL())
+	})
+
+	AfterEach(func() {
+		apiServer.Close()
+		Expect(ocmClient.Close()).To(Succeed())
+	})
+
+	It("lists OIDC configs with expected search query", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/oidc_configs"),
+				ghttp.VerifyFormKV("search", "aws.account_id='123456789012' or aws.account_id=''"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind": "OidcConfigList",
+					"page": 1,
+					"size": 1,
+					"total": 1,
+					"items": [{"id": "oidc-1", "secret": "s"}]
+				}`),
+			),
+		)
+
+		configs, err := ocmClient.ListOidcConfigs(awsAccountID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(configs).To(HaveLen(1))
+		Expect(configs[0].ID()).To(Equal("oidc-1"))
+	})
+
+	It("fetches OIDC thumbprint", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/aws_inquiries/oidc_thumbprint"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					payload := map[string]interface{}{}
+					Expect(json.NewDecoder(request.Body).Decode(&payload)).To(Succeed())
+					Expect(payload).To(HaveKeyWithValue("oidc_config_id", "oidc-1"))
+				},
+				RespondWithJSON(http.StatusOK, `{
+					"id": "thumb-1",
+					"thumbprint": "ABCD"
+				}`),
+			),
+		)
+
+		input, err := cmv1.NewOidcThumbprintInput().OidcConfigId("oidc-1").Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		thumbprint, err := ocmClient.FetchOidcThumbprint(input)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(thumbprint).NotTo(BeNil())
+		Expect(thumbprint.Thumbprint()).To(Equal("ABCD"))
+	})
+
+	It("returns error when fetching OIDC thumbprint fails", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/aws_inquiries/oidc_thumbprint"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					payload := map[string]interface{}{}
+					Expect(json.NewDecoder(request.Body).Decode(&payload)).To(Succeed())
+					Expect(payload).To(HaveKeyWithValue("oidc_config_id", "missing-oidc"))
+				},
+				RespondWithJSON(http.StatusBadRequest, `{"reason":"invalid issuer"}`),
+			),
+		)
+
+		input, err := cmv1.NewOidcThumbprintInput().OidcConfigId("missing-oidc").Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		thumbprint, fetchErr := ocmClient.FetchOidcThumbprint(input)
+		Expect(fetchErr).To(HaveOccurred())
+		Expect(thumbprint).To(BeNil())
+	})
+
+	It("gets OIDC configs", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/oidc_configs/oidc-1"),
+				RespondWithJSON(http.StatusOK, `{"id":"oidc-1","secret_arn":"arn:aws:secretsmanager:us-east-1:123:secret:one"}`),
+			),
+		)
+
+		config, err := ocmClient.GetOidcConfig("oidc-1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(config).NotTo(BeNil())
+		Expect(config.ID()).To(Equal("oidc-1"))
+	})
+
+	It("creates OIDC configs", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/oidc_configs"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					payload := map[string]interface{}{}
+					Expect(json.NewDecoder(request.Body).Decode(&payload)).To(Succeed())
+					Expect(payload).To(HaveKeyWithValue("id", "oidc-2"))
+					Expect(payload).To(HaveKeyWithValue(
+						"secret_arn",
+						"arn:aws:secretsmanager:us-east-1:123:secret:two",
+					))
+				},
+				RespondWithJSON(http.StatusCreated, `{"id":"oidc-2","secret_arn":"arn:aws:secretsmanager:us-east-1:123:secret:two"}`),
+			),
+		)
+
+		createInput, err := cmv1.NewOidcConfig().
+			ID("oidc-2").
+			SecretArn("arn:aws:secretsmanager:us-east-1:123:secret:two").
+			Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		created, err := ocmClient.CreateOidcConfig(createInput)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(created).NotTo(BeNil())
+		Expect(created.ID()).To(Equal("oidc-2"))
+	})
+
+	It("deletes OIDC configs", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodDelete, "/api/clusters_mgmt/v1/oidc_configs/oidc-2"),
+				RespondWithJSON(http.StatusNoContent, ``),
+			),
+		)
+
+		err := ocmClient.DeleteOidcConfig("oidc-2")
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/pkg/ocm/oidc_config_test.go
+++ b/pkg/ocm/oidc_config_test.go
@@ -1,0 +1,154 @@
+package ocm
+
+import (
+	"encoding/json"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+)
+
+var _ = Describe("Oidc Config", Ordered, func() {
+	const awsAccountID = "123456789012"
+
+	var apiServer *ghttp.Server
+	var ocmClient *Client
+
+	BeforeEach(func() {
+		apiServer = MakeTCPServer()
+		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+		ocmClient = buildTestOCMClient(apiServer.URL())
+	})
+
+	AfterEach(func() {
+		apiServer.Close()
+		Expect(ocmClient.Close()).To(Succeed())
+	})
+
+	It("lists OIDC configs with expected search query", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/oidc_configs"),
+				ghttp.VerifyFormKV("search", "aws.account_id='123456789012' or aws.account_id=''"),
+				ghttp.VerifyFormKV("page", "1"),
+				ghttp.VerifyFormKV("size", "-1"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind": "OidcConfigList",
+					"page": 1,
+					"size": 1,
+					"total": 1,
+					"items": [{"id": "oidc-1", "secret": "s"}]
+				}`),
+			),
+		)
+
+		configs, err := ocmClient.ListOidcConfigs(awsAccountID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(configs).To(HaveLen(1))
+		Expect(configs[0].ID()).To(Equal("oidc-1"))
+	})
+
+	It("fetches OIDC thumbprint", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/aws_inquiries/oidc_thumbprint"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					payload := map[string]interface{}{}
+					Expect(json.NewDecoder(request.Body).Decode(&payload)).To(Succeed())
+					Expect(payload).To(HaveKeyWithValue("oidc_config_id", "oidc-1"))
+				},
+				RespondWithJSON(http.StatusOK, `{
+					"id": "thumb-1",
+					"thumbprint": "ABCD"
+				}`),
+			),
+		)
+
+		input, err := cmv1.NewOidcThumbprintInput().OidcConfigId("oidc-1").Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		thumbprint, err := ocmClient.FetchOidcThumbprint(input)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(thumbprint).NotTo(BeNil())
+		Expect(thumbprint.Thumbprint()).To(Equal("ABCD"))
+	})
+
+	It("returns error when fetching OIDC thumbprint fails", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/aws_inquiries/oidc_thumbprint"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					payload := map[string]interface{}{}
+					Expect(json.NewDecoder(request.Body).Decode(&payload)).To(Succeed())
+					Expect(payload).To(HaveKeyWithValue("oidc_config_id", "missing-oidc"))
+				},
+				RespondWithJSON(http.StatusBadRequest, `{"reason":"invalid issuer"}`),
+			),
+		)
+
+		input, err := cmv1.NewOidcThumbprintInput().OidcConfigId("missing-oidc").Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		thumbprint, fetchErr := ocmClient.FetchOidcThumbprint(input)
+		Expect(fetchErr).To(HaveOccurred())
+		Expect(thumbprint).To(BeNil())
+	})
+
+	It("gets OIDC configs", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/oidc_configs/oidc-1"),
+				RespondWithJSON(http.StatusOK, `{"id":"oidc-1","secret_arn":"arn:aws:secretsmanager:us-east-1:123:secret:one"}`),
+			),
+		)
+
+		config, err := ocmClient.GetOidcConfig("oidc-1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(config).NotTo(BeNil())
+		Expect(config.ID()).To(Equal("oidc-1"))
+	})
+
+	It("creates OIDC configs", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/oidc_configs"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					payload := map[string]interface{}{}
+					Expect(json.NewDecoder(request.Body).Decode(&payload)).To(Succeed())
+					Expect(payload).To(HaveKeyWithValue("id", "oidc-2"))
+					Expect(payload).To(HaveKeyWithValue(
+						"secret_arn",
+						"arn:aws:secretsmanager:us-east-1:123:secret:two",
+					))
+				},
+				RespondWithJSON(http.StatusCreated, `{"id":"oidc-2","secret_arn":"arn:aws:secretsmanager:us-east-1:123:secret:two"}`),
+			),
+		)
+
+		createInput, err := cmv1.NewOidcConfig().
+			ID("oidc-2").
+			SecretArn("arn:aws:secretsmanager:us-east-1:123:secret:two").
+			Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		created, err := ocmClient.CreateOidcConfig(createInput)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(created).NotTo(BeNil())
+		Expect(created.ID()).To(Equal("oidc-2"))
+	})
+
+	It("deletes OIDC configs", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodDelete, "/api/clusters_mgmt/v1/oidc_configs/oidc-2"),
+				RespondWithJSON(http.StatusNoContent, ``),
+			),
+		)
+
+		err := ocmClient.DeleteOidcConfig("oidc-2")
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/pkg/ocm/users_test.go
+++ b/pkg/ocm/users_test.go
@@ -1,0 +1,133 @@
+package ocm
+
+import (
+	"encoding/json"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+)
+
+var _ = Describe("Users", Ordered, func() {
+	const (
+		clusterID = "cluster-1"
+		groupID   = "dedicated-admins"
+		username  = "alice"
+	)
+
+	var apiServer *ghttp.Server
+	var ocmClient *Client
+
+	BeforeEach(func() {
+		apiServer = MakeTCPServer()
+		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+		ocmClient = buildTestOCMClient(apiServer.URL())
+	})
+
+	AfterEach(func() {
+		apiServer.Close()
+		Expect(ocmClient.Close()).To(Succeed())
+	})
+
+	It("gets an existing user", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/groups/dedicated-admins/users/alice"),
+				RespondWithJSON(http.StatusOK, `{"id":"user-1"}`),
+			),
+		)
+
+		user, err := ocmClient.GetUser(clusterID, groupID, username)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(user).NotTo(BeNil())
+		Expect(user.ID()).To(Equal("user-1"))
+	})
+
+	It("returns nil,nil when user is not found", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/groups/dedicated-admins/users/missing"),
+				RespondWithJSON(http.StatusNotFound, `{"reason":"not found"}`),
+			),
+		)
+
+		user, err := ocmClient.GetUser(clusterID, groupID, "missing")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(user).To(BeNil())
+	})
+
+	It("returns an error when user lookup fails with non-404 status", func() {
+		for i := 0; i < 3; i++ {
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/groups/dedicated-admins/users/alice"),
+					RespondWithJSON(http.StatusInternalServerError, `{"reason":"internal error"}`),
+				),
+			)
+		}
+
+		user, err := ocmClient.GetUser(clusterID, groupID, username)
+		Expect(err).To(HaveOccurred())
+		Expect(user).To(BeNil())
+	})
+
+	It("lists users", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/groups/dedicated-admins/users"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind": "UserList",
+					"page": 1,
+					"size": 2,
+					"total": 2,
+					"items": [
+						{"id":"user-1"},
+						{"id":"user-2"}
+					]
+				}`),
+			),
+		)
+
+		users, err := ocmClient.GetUsers(clusterID, groupID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(users).To(HaveLen(2))
+		Expect(users[0].ID()).To(Equal("user-1"))
+		Expect(users[1].ID()).To(Equal("user-2"))
+	})
+
+	It("creates users", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters/cluster-1/groups/dedicated-admins/users"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					payload := map[string]interface{}{}
+					Expect(json.NewDecoder(request.Body).Decode(&payload)).To(Succeed())
+					Expect(payload).To(HaveKeyWithValue("id", "user-3"))
+				},
+				RespondWithJSON(http.StatusCreated, `{"id":"user-3"}`),
+			),
+		)
+		createInput, err := cmv1.NewUser().ID("user-3").Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		created, err := ocmClient.CreateUser(clusterID, groupID, createInput)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(created).NotTo(BeNil())
+		Expect(created.ID()).To(Equal("user-3"))
+	})
+
+	It("deletes users", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodDelete, "/api/clusters_mgmt/v1/clusters/cluster-1/groups/dedicated-admins/users/user-3"),
+				RespondWithJSON(http.StatusNoContent, ``),
+			),
+		)
+
+		err := ocmClient.DeleteUser(clusterID, groupID, "user-3")
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/pkg/ocm/users_test.go
+++ b/pkg/ocm/users_test.go
@@ -1,0 +1,189 @@
+package ocm
+
+import (
+	"encoding/json"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+)
+
+var _ = Describe("Users", Ordered, func() {
+	const (
+		clusterID = "cluster-1"
+		groupID   = "dedicated-admins"
+		username  = "alice"
+	)
+
+	var apiServer *ghttp.Server
+	var ocmClient *Client
+
+	BeforeEach(func() {
+		apiServer = MakeTCPServer()
+		apiServer.SetUnhandledRequestStatusCode(http.StatusInternalServerError)
+		ocmClient = buildTestOCMClient(apiServer.URL())
+	})
+
+	AfterEach(func() {
+		apiServer.Close()
+		Expect(ocmClient.Close()).To(Succeed())
+	})
+
+	It("gets an existing user", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/groups/dedicated-admins/users/alice"),
+				RespondWithJSON(http.StatusOK, `{"id":"user-1"}`),
+			),
+		)
+
+		user, err := ocmClient.GetUser(clusterID, groupID, username)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(user).NotTo(BeNil())
+		Expect(user.ID()).To(Equal("user-1"))
+	})
+
+	It("returns nil,nil when user is not found", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/groups/dedicated-admins/users/missing"),
+				RespondWithJSON(http.StatusNotFound, `{"reason":"not found"}`),
+			),
+		)
+
+		user, err := ocmClient.GetUser(clusterID, groupID, "missing")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(user).To(BeNil())
+	})
+
+	It("returns an error when user lookup fails with non-404 status", func() {
+		for i := 0; i < 3; i++ {
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/groups/dedicated-admins/users/alice"),
+					RespondWithJSON(http.StatusInternalServerError, `{"reason":"internal error"}`),
+				),
+			)
+		}
+
+		user, err := ocmClient.GetUser(clusterID, groupID, username)
+		Expect(err).To(HaveOccurred())
+		Expect(user).To(BeNil())
+		Expect(apiServer.ReceivedRequests()).NotTo(BeEmpty())
+	})
+
+	It("lists users", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/groups/dedicated-admins/users"),
+				ghttp.VerifyFormKV("page", "1"),
+				ghttp.VerifyFormKV("size", "-1"),
+				RespondWithJSON(http.StatusOK, `{
+					"kind": "UserList",
+					"page": 1,
+					"size": 2,
+					"total": 2,
+					"items": [
+						{"id":"user-1"},
+						{"id":"user-2"}
+					]
+				}`),
+			),
+		)
+
+		users, err := ocmClient.GetUsers(clusterID, groupID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(users).To(HaveLen(2))
+		Expect(users[0].ID()).To(Equal("user-1"))
+		Expect(users[1].ID()).To(Equal("user-2"))
+	})
+
+	It("creates users", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters/cluster-1/groups/dedicated-admins/users"),
+				func(_ http.ResponseWriter, request *http.Request) {
+					payload := map[string]interface{}{}
+					Expect(json.NewDecoder(request.Body).Decode(&payload)).To(Succeed())
+					Expect(payload).To(HaveKeyWithValue("id", "user-3"))
+				},
+				RespondWithJSON(http.StatusCreated, `{"id":"user-3"}`),
+			),
+		)
+		createInput, err := cmv1.NewUser().ID("user-3").Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		created, err := ocmClient.CreateUser(clusterID, groupID, createInput)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(created).NotTo(BeNil())
+		Expect(created.ID()).To(Equal("user-3"))
+	})
+
+	It("deletes users", func() {
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodDelete, "/api/clusters_mgmt/v1/clusters/cluster-1/groups/dedicated-admins/users/user-3"),
+				RespondWithJSON(http.StatusNoContent, ``),
+			),
+		)
+
+		err := ocmClient.DeleteUser(clusterID, groupID, "user-3")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(apiServer.ReceivedRequests()).To(HaveLen(1))
+	})
+
+	It("returns an error when listing users fails", func() {
+		for i := 0; i < 3; i++ {
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/cluster-1/groups/dedicated-admins/users"),
+					ghttp.VerifyFormKV("page", "1"),
+					ghttp.VerifyFormKV("size", "-1"),
+					RespondWithJSON(http.StatusInternalServerError, `{"reason":"internal error"}`),
+				),
+			)
+		}
+
+		users, err := ocmClient.GetUsers(clusterID, groupID)
+		Expect(err).To(HaveOccurred())
+		Expect(users).To(BeNil())
+		Expect(apiServer.ReceivedRequests()).NotTo(BeEmpty())
+	})
+
+	It("returns an error when creating a user fails", func() {
+		for i := 0; i < 3; i++ {
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters/cluster-1/groups/dedicated-admins/users"),
+					RespondWithJSON(http.StatusForbidden, `{"reason":"forbidden"}`),
+				),
+			)
+		}
+
+		createInput, err := cmv1.NewUser().ID("user-3").Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		created, err := ocmClient.CreateUser(clusterID, groupID, createInput)
+		Expect(err).To(HaveOccurred())
+		Expect(created).To(BeNil())
+		Expect(apiServer.ReceivedRequests()).NotTo(BeEmpty())
+	})
+
+	It("returns an error when deleting a user fails", func() {
+		for i := 0; i < 3; i++ {
+			apiServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodDelete, "/api/clusters_mgmt/v1/clusters/cluster-1/groups/dedicated-admins/users/user-3"),
+					RespondWithJSON(http.StatusInternalServerError, `{"reason":"internal error"}`),
+				),
+			)
+		}
+
+		err := ocmClient.DeleteUser(clusterID, groupID, "user-3")
+		Expect(err).To(HaveOccurred())
+		Expect(apiServer.ReceivedRequests()).NotTo(BeEmpty())
+	})
+})


### PR DESCRIPTION
## PR Summary
Splits the CRUD-style `pkg/ocm` request-contract coverage into a focused review layer for DNS domains, ingresses, node pools, OIDC configs, and users.

## Detailed Description of the Issue
This PR is the CRUD/request-shape layer of the [ROSAENG-61179](https://redhat.atlassian.net/browse/ROSAENG-61179) split. It adds Ginkgo coverage that validates endpoint contracts, query parameters, request payloads, error paths, and wrapper return behavior for selected `pkg/ocm` clients. It reuses `buildTestOCMClient()` from [#3442](https://github.com/openshift/rosa/pull/3442), which is already merged into `master`.

**Changed files:** `pkg/ocm/dns_domain_test.go`, `pkg/ocm/ingresses_test.go`, `pkg/ocm/nodepools_test.go`, `pkg/ocm/oidc_config_test.go`, `pkg/ocm/users_test.go`

## Related Issues and PRs
- Jira: [ROSAENG-61179](https://issues.redhat.com/browse/ROSAENG-61179)
- Fixes: `N/A`
- Related PR(s):
  - Holding PR: [#3437](https://github.com/openshift/rosa/pull/3437) — CLOSED (superseded by this stacked split)
  - [#3442](https://github.com/openshift/rosa/pull/3442) — MERGED: core client hardening and shared test harness
  - [#3443](https://github.com/openshift/rosa/pull/3443) — MERGED: add-on availability semantics
  - [#3444](https://github.com/openshift/rosa/pull/3444) — OPEN (draft): lifecycle and version coverage
- Merge order: **#3445** (this PR), then **#3444**. All stack PRs target `master`.
- Related design/docs: `N/A`

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [x] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
- CRUD-style OCM client coverage for DNS domains, ingresses, node pools, OIDC configs, and users lived in the large holding branch instead of a dedicated review slice.
- Request-contract assertions for pagination query parameters, error paths, and response-vs-request validation were incomplete or missing.

## Behavior After This Change
- DNS domain, ingress, node pool, OIDC config, and user wrappers have focused request-contract tests with explicit HTTP method/path/query/body checks.
- `nodepools_test.go` keeps the existing `Node pool warnings` suite from `master` and adds a new `NodePools` CRUD suite.
- No production code changes in this PR.

## How to Test (Step-by-Step)
### Preconditions
- Run from the repo root.
- Use a Go toolchain compatible with `go.mod`. If needed, prefix commands with `GOTOOLCHAIN=auto`.

### Test Steps
1. Run `GOTOOLCHAIN=auto go test ./pkg/ocm -count=1 -ginkgo.focus="DNS Domains|Ingresses|NodePools|Oidc Config|Users"`.
2. Run `GOTOOLCHAIN=auto make rosa`.

### Expected Results
- The CRUD/request-contract `pkg/ocm` specs pass.
- The CLI builds successfully.

## Proof of the Fix
- Screenshots: `N/A`
- Videos: `N/A`
- Logs/CLI output:
  - `GOTOOLCHAIN=auto go test ./pkg/ocm -count=1 -ginkgo.focus="DNS Domains|Ingresses|NodePools|Oidc Config|Users"`
  - Pre-push on this branch: format, build, lint, coverage, and unit tests passed.
- Other artifacts: `N/A`

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
`N/A`

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [x] `make test` passes (via pre-push unit/integration checks).
- [x] `make lint` passes (via pre-push).
- [x] `make rosa` passes (via pre-push build).
- [x] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

[ROSAENG-61179]: https://redhat.atlassian.net/browse/ROSAENG-61179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added comprehensive mock-server coverage for DNS domains, ingresses, node pools, OIDC configurations, and users.
  - Verified create, retrieve, update, list, and delete workflows, including request methods, paths, query parameters, and payloads.
  - Added validation for pagination, resource identification, response decoding, empty results, missing resources, and API failures.
  - Expanded checks for propagated client errors and OIDC thumbprint handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
