### PR TITLE
ROSAENG-63034 | test: version-gate subnet-per-AZ e2e tests for CPO dedup fix

### DIFF
--- a/tests/e2e/test_rosacli_cluster.go
+++ b/tests/e2e/test_rosacli_cluster.go
@@ -3308,13 +3308,28 @@ var _ = Describe("HCP cluster creation subnets validation",
 				Expect(err).ToNot(HaveOccurred())
 				Expect(out.String()).To(ContainSubstring(successOutput))
 
+				// CPO versions 4.22.4+, 4.21.25+, 4.20.31+ handle duplicate subnets
+				// per AZ (OCPBUGS-82443), so the preflight guardrail is relaxed.
+				versionStr := rosalCommand.GetFlagValue("--version", true)
+				major, minor, patch, vErr := helper.ParseVersion(versionStr)
+				subnetDedupSupported := vErr == nil && major == 4 &&
+					((minor > 22) ||
+						(minor == 22 && patch >= 4) ||
+						(minor == 21 && patch >= 25) ||
+						(minor == 20 && patch >= 31))
+
 				By("Create a public cluster with 2 private subnets from same AZ and 1 public subnet")
 				subnets = []string{subnetMap["private"][0], additionalPrivateSubnet.ID, subnetMap["public"][0]}
 				rosalCommand.ReplaceFlagValue(map[string]string{"--subnet-ids": strings.Join(subnets, ",")})
 				out, err = rosaClient.Runner.RunCMD(strings.Split(rosalCommand.GetFullCommand(), " "))
-				Expect(err).To(HaveOccurred())
-				Expect(out.String()).To(ContainSubstring(failOutput_1))
-				Expect(out.String()).To(ContainSubstring(failOutput_2))
+				if subnetDedupSupported {
+					Expect(err).ToNot(HaveOccurred())
+					Expect(out.String()).To(ContainSubstring(successOutput))
+				} else {
+					Expect(err).To(HaveOccurred())
+					Expect(out.String()).To(ContainSubstring(failOutput_1))
+					Expect(out.String()).To(ContainSubstring(failOutput_2))
+				}
 
 				By("Create a public cluster with 4 private subnets (2 subnets from same AZ) and 1 public subnet")
 				subnets = []string{
@@ -3326,9 +3341,14 @@ var _ = Describe("HCP cluster creation subnets validation",
 				}
 				rosalCommand.ReplaceFlagValue(map[string]string{"--subnet-ids": strings.Join(subnets, ",")})
 				out, err = rosaClient.Runner.RunCMD(strings.Split(rosalCommand.GetFullCommand(), " "))
-				Expect(err).To(HaveOccurred())
-				Expect(out.String()).To(ContainSubstring(failOutput_1))
-				Expect(out.String()).To(ContainSubstring(failOutput_2))
+				if subnetDedupSupported {
+					Expect(err).ToNot(HaveOccurred())
+					Expect(out.String()).To(ContainSubstring(successOutput))
+				} else {
+					Expect(err).To(HaveOccurred())
+					Expect(out.String()).To(ContainSubstring(failOutput_1))
+					Expect(out.String()).To(ContainSubstring(failOutput_2))
+				}
 
 				By("Create a public cluster with 1 private subnet and 2 public subnet from same AZ")
 				subnets = []string{subnetMap["private"][0], subnetMap["public"][0], additionalPublicSubnet.ID}
@@ -3356,9 +3376,14 @@ var _ = Describe("HCP cluster creation subnets validation",
 				subnets = []string{subnetMap["private"][0], additionalPrivateSubnet.ID}
 				rosalCommand.ReplaceFlagValue(map[string]string{"--subnet-ids": strings.Join(subnets, ",")})
 				out, err = rosaClient.Runner.RunCMD(strings.Split(rosalCommand.GetFullCommand(), " "))
-				Expect(err).To(HaveOccurred())
-				Expect(out.String()).To(ContainSubstring(failOutput_1))
-				Expect(out.String()).To(ContainSubstring(failOutput_2))
+				if subnetDedupSupported {
+					Expect(err).ToNot(HaveOccurred())
+					Expect(out.String()).To(ContainSubstring(successOutput))
+				} else {
+					Expect(err).To(HaveOccurred())
+					Expect(out.String()).To(ContainSubstring(failOutput_1))
+					Expect(out.String()).To(ContainSubstring(failOutput_2))
+				}
 
 				By("Create a private cluster with 4 private subnets (2 subnets from same AZ)")
 				subnets = []string{
@@ -3369,9 +3394,14 @@ var _ = Describe("HCP cluster creation subnets validation",
 				}
 				rosalCommand.ReplaceFlagValue(map[string]string{"--subnet-ids": strings.Join(subnets, ",")})
 				out, err = rosaClient.Runner.RunCMD(strings.Split(rosalCommand.GetFullCommand(), " "))
-				Expect(err).To(HaveOccurred())
-				Expect(out.String()).To(ContainSubstring(failOutput_1))
-				Expect(out.String()).To(ContainSubstring(failOutput_2))
+				if subnetDedupSupported {
+					Expect(err).ToNot(HaveOccurred())
+					Expect(out.String()).To(ContainSubstring(successOutput))
+				} else {
+					Expect(err).To(HaveOccurred())
+					Expect(out.String()).To(ContainSubstring(failOutput_1))
+					Expect(out.String()).To(ContainSubstring(failOutput_2))
+				}
 
 				By("Create a private cluster with 1 private subnet and 1 public subnet")
 				subnets = []string{subnetMap["private"][0], subnetMap["public"][0]}


### PR DESCRIPTION
## PR Summary

Version-gate 4 same-AZ subnet e2e test scenarios to account for the CPO subnet dedup fix (OCPBUGS-82443). Tests now expect success on fixed OCP versions instead of always expecting 400.

## Detailed Description of the Issue

The subnet-per-AZ preflight validation was relaxed in clusters-service ([ROSAENG-58045](https://redhat.atlassian.net/browse/ROSAENG-58045)) for OCP versions 4.22.4+, 4.21.25+, 4.20.31+. The ROSA CLI e2e tests in test_rosacli_cluster.go test cluster creation with same-AZ subnets using --dry-run and version: "latest", which now resolves to a fixed version. These tests fail because they always expect a 400 error.

## Related Issues and PRs

- Jira: [ROSAENG-63034](https://redhat.atlassian.net/browse/ROSAENG-63034)
- Related PR(s):
  - clusters-service guardrail relaxation: https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/11512 (merged)
  - ocm-backend-tests update: https://gitlab.cee.redhat.com/service/ocm-backend-tests/-/merge_requests/2051

## Type of Change

- [x] test - adds or updates tests only.

## Previous Behavior

All 4 same-AZ subnet test scenarios always expected a 400 error with "more than one private subnet" message.

## Behavior After This Change

Tests extract the version from the rosalCommand and version-gate expectations:
- Fixed versions (4.22.4+, 4.21.25+, 4.20.31+): expect success
- Unfixed versions: expect 400 with the original error

## How to Test (Step-by-Step)

### Preconditions

ROSA CLI e2e test environment

### Test Steps

1. Run test [id:72538] against a cluster with version >= 4.22.4
2. Run test [id:72538] against a cluster with version < 4.22.4

### Expected Results

- Fixed versions: all 4 same-AZ scenarios pass (dry-run succeeds)
- Unfixed versions: all 4 same-AZ scenarios fail with 400 (existing behavior)

## Breaking Changes

- [x] No breaking changes

## Developer Verification Checklist

- [x] Commit subject/title follows [JIRA-TICKET] | [TYPE]: <MESSAGE>.
- [x] PR description clearly explains both what changed and why.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] make install-hooks has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [x] make test passes.
- [x] make lint passes.
- [x] make rosa passes.
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [ ] Any risk, limitation, or follow-up work is documented.

[ROSAENG-63034]: https://redhat.atlassian.net/browse/ROSAENG-63034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ROSAENG-58045]: https://redhat.atlassian.net/browse/ROSAENG-58045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HCP cluster subnet validation to support duplicate private subnets within an availability zone on supported platform versions.
  * Preserved validation errors for older or unrecognized platform versions to ensure compatibility and predictable cluster creation behavior.

* **Tests**
  * Expanded coverage for version-specific subnet validation and cluster creation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->