### PR TITLE
ROSAENG-62490 | refactor: Add lint rules to enforce environmental boundaries

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,8 @@ run:
 linters:
   default: none
   enable:
+    - depguard
+    - forbidigo
     - goconst
     - govet
     - ineffassign
@@ -30,6 +32,48 @@ linters:
     - unconvert
     - unused
   settings:
+    depguard:
+      rules:
+        core-no-cli-deps:
+          deny:
+            - pkg: "github.com/spf13/cobra"
+              desc: "pkg/ is core layer -- must not import cobra"
+            - pkg: "github.com/spf13/pflag"
+              desc: "pkg/ is core layer -- must not import pflag"
+            - pkg: "github.com/AlecAivazis/survey"
+              desc: "pkg/ is core layer -- must not import survey"
+            - pkg: "github.com/openshift/rosa/pkg/reporter"
+              desc: "pkg/ is core layer -- must not import CLI presenter reporter"
+            - pkg: "github.com/openshift/rosa/pkg/output"
+              desc: "pkg/ is core layer -- must not import CLI presenter output"
+            - pkg: "github.com/openshift/rosa/pkg/interactive"
+              desc: "pkg/ is core layer -- must not import CLI presenter interactive"
+            - pkg: "github.com/openshift/rosa/pkg/arguments"
+              desc: "pkg/ is core layer -- must not import CLI presenter arguments"
+            - pkg: "github.com/openshift/rosa/pkg/color"
+              desc: "pkg/ is core layer -- must not import CLI presenter color"
+            - pkg: "github.com/openshift/rosa/pkg/debug"
+              desc: "pkg/ is core layer -- must not import CLI presenter debug"
+            - pkg: "github.com/openshift/rosa/pkg/commands"
+              desc: "pkg/ is core layer -- must not import CLI presenter commands"
+            - pkg: "github.com/openshift/rosa/pkg/rosa"
+              desc: "pkg/ is core layer -- must not import CLI runtime rosa"
+            - pkg: "github.com/openshift/rosa/pkg/options"
+              desc: "pkg/ is core layer -- must not import CLI presenter options"
+            - pkg: "github.com/openshift/rosa/pkg/aws/profile"
+              desc: "pkg/ is core layer -- must not import CLI presenter aws/profile"
+            - pkg: "github.com/openshift/rosa/pkg/aws/region"
+              desc: "pkg/ is core layer -- must not import CLI presenter aws/region"
+            - pkg: "github.com/openshift/rosa/pkg/ocm/output"
+              desc: "pkg/ is core layer -- must not import CLI presenter ocm/output"
+            - pkg: "github.com/openshift/rosa/pkg/aws/commandbuilder"
+              desc: "pkg/ is core layer -- must not import CLI presenter aws/commandbuilder"
+    forbidigo:
+      forbid:
+        - pattern: "^fmt\\.Print(f|ln)?$"
+          msg: "pkg/ must not write to stdout -- return data and let the caller render"
+        - pattern: "^os\\.Exit$"
+          msg: "pkg/ must not call os.Exit -- return an error instead"
     goconst:
       ignore-tests: true
       match-constant: false
@@ -51,6 +95,14 @@ linters:
       - path: tests/utils/
         linters:
           - goconst
+      - path-except: "^pkg/"
+        linters:
+          - depguard
+          - forbidigo
+      - path: "^pkg/(arguments|color|commands|debug|interactive|output|reporter|rosa|options|test|aws/(commandbuilder|profile|region)|ocm/output)/"
+        linters:
+          - depguard
+          - forbidigo
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,15 +21,69 @@ run:
 linters:
   default: none
   enable:
+    - depguard
+    - forbidigo
     - goconst
     - govet
     - ineffassign
     - lll
     - misspell
+    - nolintlint
     - staticcheck
     - unconvert
     - unused
   settings:
+    depguard:
+      rules:
+        core-no-cli-deps:
+          deny:
+            - pkg: "github.com/spf13/cobra"
+              desc: "core layer must not import cobra"
+            - pkg: "github.com/spf13/pflag"
+              desc: "core layer must not import pflag"
+            - pkg: "github.com/AlecAivazis/survey"
+              desc: "core layer must not import survey"
+            - pkg: "github.com/openshift/rosa/cmd"
+              desc: "core layer must not import cmd/"
+            - pkg: "github.com/openshift/rosa/internal/cli"
+              desc: "core layer must not import internal/cli/"
+            - pkg: "github.com/openshift/rosa/pkg/reporter"
+              desc: "core layer must not import CLI presenter reporter"
+            - pkg: "github.com/openshift/rosa/pkg/output"
+              desc: "core layer must not import CLI presenter output"
+            - pkg: "github.com/openshift/rosa/pkg/interactive"
+              desc: "core layer must not import CLI presenter interactive"
+            - pkg: "github.com/openshift/rosa/pkg/arguments"
+              desc: "core layer must not import CLI presenter arguments"
+            - pkg: "github.com/openshift/rosa/pkg/color"
+              desc: "core layer must not import CLI presenter color"
+            - pkg: "github.com/openshift/rosa/pkg/debug"
+              desc: "core layer must not import CLI presenter debug"
+            - pkg: "github.com/openshift/rosa/pkg/commands"
+              desc: "core layer must not import CLI presenter commands"
+            - pkg: "github.com/openshift/rosa/pkg/rosa"
+              desc: "core layer must not import CLI runtime rosa"
+            - pkg: "github.com/openshift/rosa/pkg/options"
+              desc: "core layer must not import CLI presenter options"
+            - pkg: "github.com/openshift/rosa/pkg/aws/profile"
+              desc: "core layer must not import CLI presenter aws/profile"
+            - pkg: "github.com/openshift/rosa/pkg/aws/region"
+              desc: "core layer must not import CLI presenter aws/region"
+            - pkg: "github.com/openshift/rosa/pkg/ocm/output"
+              desc: "core layer must not import CLI presenter ocm/output"
+            - pkg: "github.com/openshift/rosa/pkg/aws/commandbuilder"
+              desc: "core layer must not import CLI presenter aws/commandbuilder"
+    forbidigo:
+      forbid:
+        - pattern: "^fmt\\.Print(f|ln)?$"
+          msg: "core layer must not write to stdout -- return data and let the caller render"
+        - pattern: "^fmt\\.Fprint(f|ln)?$"
+          msg: "core layer must not write to stdout -- return data and let the caller render"
+        - pattern: "^os\\.Exit$"
+          msg: "core layer must not call os.Exit -- return an error instead"
+    nolintlint:
+      require-specific: true
+      allow-unused: false
     goconst:
       ignore-tests: true
       match-constant: false
@@ -51,6 +105,17 @@ linters:
       - path: tests/utils/
         linters:
           - goconst
+      - path-except: "^(pkg|internal/core)/"
+        linters:
+          - depguard
+          - forbidigo
+      - source: "^// https?://"
+        linters:
+          - lll
+      - path: "^pkg/(arguments|color|commands|debug|interactive|output|reporter|rosa|options|test|aws/(commandbuilder|profile|region)|ocm/output)/"
+        linters:
+          - depguard
+          - forbidigo
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -87,7 +87,7 @@ const (
 	listInputMessage          = "Format should be a comma-separated list."
 	listBillingAccountMessage = "To see the list of billing account options, you can use interactive mode by passing '-i'."
 
-	// nolint:lll
+	//nolint:lll
 	createVpcForHcpDoc = "https://docs.openshift.com/rosa/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html#rosa-hcp-creating-vpc"
 
 	duplicateIamRoleArnErrorMsg = "ROSA IAM roles must have unique ARNs " +

--- a/cmd/create/dnsdomains/cmd.go
+++ b/cmd/create/dnsdomains/cmd.go
@@ -17,7 +17,7 @@ limitations under the License.
 package dnsdomains
 
 import (
-	// nolint:gosec
+	//nolint:gosec
 	"os"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"

--- a/cmd/create/network/cloudformation.go
+++ b/cmd/create/network/cloudformation.go
@@ -1,7 +1,8 @@
 package network
 
 // This file is used for binary builds
-// nolint:lll
+//
+//nolint:lll
 const CloudFormationTemplateFile = `
 AWSTemplateFormatVersion: '2010-09-09'
 Description: CloudFormation template to create a ROSA Quickstart default VPC.

--- a/cmd/dlt/oidcconfig/cmd.go
+++ b/cmd/dlt/oidcconfig/cmd.go
@@ -49,7 +49,6 @@ var Cmd = &cobra.Command{
 }
 
 const (
-	//nolint
 	OidcConfigIdFlag          = "oidc-config-id"
 	prefixForPrivateKeySecret = "rosa-private-key-"
 )

--- a/cmd/edit/ingress/flags.go
+++ b/cmd/edit/ingress/flags.go
@@ -92,7 +92,6 @@ func addIngressV2Flags(flags *pflag.FlagSet) {
 		&args.componentRoutes,
 		componentRoutesFlag,
 		"",
-		//nolint:lll
 		"Component route settings. Specify one or more routes to update; routes not specified remain unchanged. "+
 			"Available keys are [oauth, console, downloads] (HCP clusters support console and downloads only). "+
 			"Each route requires a hostname and tlsSecretRef. To clear a route, set both to empty values. "+

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -54,15 +54,15 @@ import (
 	"github.com/zgalor/weberr"
 
 	client "github.com/openshift/rosa/pkg/aws/api_interface"
-	"github.com/openshift/rosa/pkg/aws/profile"
-	regionflag "github.com/openshift/rosa/pkg/aws/region"
+	"github.com/openshift/rosa/pkg/aws/profile"           //nolint:depguard
+	regionflag "github.com/openshift/rosa/pkg/aws/region" //nolint:depguard
 	"github.com/openshift/rosa/pkg/aws/tags"
 	"github.com/openshift/rosa/pkg/fedramp"
 	"github.com/openshift/rosa/pkg/helper"
 	"github.com/openshift/rosa/pkg/iamserviceaccount"
 	"github.com/openshift/rosa/pkg/info"
 	"github.com/openshift/rosa/pkg/logging"
-	"github.com/openshift/rosa/pkg/reporter"
+	"github.com/openshift/rosa/pkg/reporter" //nolint:depguard
 )
 
 var (
@@ -272,7 +272,7 @@ func CreateNewClientOrExit(logger *logrus.Logger, reporter reporter.Logger) Clie
 		Build()
 	if err != nil {
 		reporter.Errorf("Failed to create AWS client: %v", err)
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo
 	}
 
 	return awsClient
@@ -959,14 +959,14 @@ func (c *awsClient) ValidateAccessKeys(AccessKey *AccessKey) error {
 			if awserr.IsInvalidTokenException(err) {
 				wait := time.Duration((i * 200)) * time.Millisecond
 				waited := time.Since(start)
-				logger.Debug(fmt.Printf("InvalidClientTokenId, waited %.2f\n", waited.Seconds()))
+				logger.Debug(fmt.Sprintf("InvalidClientTokenId, waited %.2f\n", waited.Seconds()))
 				time.Sleep(wait)
 			}
 
 			if awserr.IsAccessDeniedException(err) {
 				wait := time.Duration((i * 200)) * time.Millisecond
 				waited := time.Since(start)
-				logger.Debug(fmt.Printf("AccessDenied, waited %.2f\n", waited.Seconds()))
+				logger.Debug(fmt.Sprintf("AccessDenied, waited %.2f\n", waited.Seconds()))
 				time.Sleep(wait)
 			}
 

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -54,15 +54,15 @@ import (
 	"github.com/zgalor/weberr"
 
 	client "github.com/openshift/rosa/pkg/aws/api_interface"
-	"github.com/openshift/rosa/pkg/aws/profile"
-	regionflag "github.com/openshift/rosa/pkg/aws/region"
+	"github.com/openshift/rosa/pkg/aws/profile"           //nolint:depguard
+	regionflag "github.com/openshift/rosa/pkg/aws/region" //nolint:depguard
 	"github.com/openshift/rosa/pkg/aws/tags"
 	"github.com/openshift/rosa/pkg/fedramp"
 	"github.com/openshift/rosa/pkg/helper"
 	"github.com/openshift/rosa/pkg/iamserviceaccount"
 	"github.com/openshift/rosa/pkg/info"
 	"github.com/openshift/rosa/pkg/logging"
-	"github.com/openshift/rosa/pkg/reporter"
+	"github.com/openshift/rosa/pkg/reporter" //nolint:depguard
 )
 
 var (
@@ -272,7 +272,7 @@ func CreateNewClientOrExit(logger *logrus.Logger, reporter reporter.Logger) Clie
 		Build()
 	if err != nil {
 		reporter.Errorf("Failed to create AWS client: %v", err)
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo
 	}
 
 	return awsClient
@@ -959,14 +959,14 @@ func (c *awsClient) ValidateAccessKeys(AccessKey *AccessKey) error {
 			if awserr.IsInvalidTokenException(err) {
 				wait := time.Duration((i * 200)) * time.Millisecond
 				waited := time.Since(start)
-				logger.Debug(fmt.Printf("InvalidClientTokenId, waited %.2f\n", waited.Seconds()))
+				logger.Debug(fmt.Printf("InvalidClientTokenId, waited %.2f\n", waited.Seconds())) //nolint:forbidigo
 				time.Sleep(wait)
 			}
 
 			if awserr.IsAccessDeniedException(err) {
 				wait := time.Duration((i * 200)) * time.Millisecond
 				waited := time.Since(start)
-				logger.Debug(fmt.Printf("AccessDenied, waited %.2f\n", waited.Seconds()))
+				logger.Debug(fmt.Printf("AccessDenied, waited %.2f\n", waited.Seconds())) //nolint:forbidigo
 				time.Sleep(wait)
 			}
 

--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -25,14 +25,14 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/zgalor/weberr"
 
-	"github.com/openshift/rosa/pkg/arguments"
+	"github.com/openshift/rosa/pkg/arguments" //nolint:depguard
 	client "github.com/openshift/rosa/pkg/aws/api_interface"
-	awscb "github.com/openshift/rosa/pkg/aws/commandbuilder"
+	awscb "github.com/openshift/rosa/pkg/aws/commandbuilder" //nolint:depguard
 	"github.com/openshift/rosa/pkg/aws/tags"
 	"github.com/openshift/rosa/pkg/constants"
 	"github.com/openshift/rosa/pkg/fedramp"
 	"github.com/openshift/rosa/pkg/helper"
-	rprtr "github.com/openshift/rosa/pkg/reporter"
+	rprtr "github.com/openshift/rosa/pkg/reporter" //nolint:depguard
 )
 
 // AWS accepted role name: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html
@@ -58,7 +58,8 @@ var (
 // second,is for IPv4 CIDR range validation
 // third pattern is to validate domains
 // and the fifth petterrn is to be able to remove the existing no-proxy value by typing empty string ("").
-// nolint
+//
+//nolint:lll
 var UserNoProxyRE = regexp.MustCompile(
 	`^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$|^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$|^(.?[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$|^""$`,
 )
@@ -189,16 +190,16 @@ func GetAWSClientForUserRegion(reporter rprtr.Logger, logger *logrus.Logger,
 	awsRegionInUserConfig, err := GetRegion(arguments.GetRegion())
 	if err != nil {
 		reporter.Errorf("Error getting region: %v", err)
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo
 	}
 	if awsRegionInUserConfig == "" {
 		reporter.Errorf("AWS Region not set")
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo
 	}
 	if !helper.Contains(supportedRegions, awsRegionInUserConfig) {
 		reporter.Errorf("Unsupported region '%s', available regions: %s",
 			awsRegionInUserConfig, helper.SliceToSortedString(supportedRegions))
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo
 	}
 
 	// Create the AWS client:
@@ -209,7 +210,7 @@ func GetAWSClientForUserRegion(reporter rprtr.Logger, logger *logrus.Logger,
 		Build()
 	if err != nil {
 		reporter.Errorf("Error creating aws client for stack validation: %v", err)
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo
 	}
 	regionUsedForInit, err := client.GetClusterRegionTagForUser(AdminUserName)
 	if err != nil || regionUsedForInit == "" {
@@ -220,7 +221,7 @@ func GetAWSClientForUserRegion(reporter rprtr.Logger, logger *logrus.Logger,
 		if !helper.Contains(supportedRegions, regionUsedForInit) {
 			reporter.Errorf("Unsupported region '%s', available regions: %s",
 				regionUsedForInit, helper.SliceToSortedString(supportedRegions))
-			os.Exit(1)
+			os.Exit(1) //nolint:forbidigo
 		}
 		// Create the AWS client with the region used in the init
 		// So we can check for the stack in that region
@@ -231,7 +232,7 @@ func GetAWSClientForUserRegion(reporter rprtr.Logger, logger *logrus.Logger,
 			Build()
 		if err != nil {
 			reporter.Errorf("Error creating aws client for stack validation: %v", err)
-			os.Exit(1)
+			os.Exit(1) //nolint:forbidigo
 		}
 		return awsClient
 	}

--- a/pkg/aws/helpers.go
+++ b/pkg/aws/helpers.go
@@ -25,14 +25,14 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/zgalor/weberr"
 
-	"github.com/openshift/rosa/pkg/arguments"
+	"github.com/openshift/rosa/pkg/arguments" //nolint:depguard
 	client "github.com/openshift/rosa/pkg/aws/api_interface"
-	awscb "github.com/openshift/rosa/pkg/aws/commandbuilder"
+	awscb "github.com/openshift/rosa/pkg/aws/commandbuilder" //nolint:depguard
 	"github.com/openshift/rosa/pkg/aws/tags"
 	"github.com/openshift/rosa/pkg/constants"
 	"github.com/openshift/rosa/pkg/fedramp"
 	"github.com/openshift/rosa/pkg/helper"
-	rprtr "github.com/openshift/rosa/pkg/reporter"
+	rprtr "github.com/openshift/rosa/pkg/reporter" //nolint:depguard
 )
 
 // AWS accepted role name: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html
@@ -189,16 +189,16 @@ func GetAWSClientForUserRegion(reporter rprtr.Logger, logger *logrus.Logger,
 	awsRegionInUserConfig, err := GetRegion(arguments.GetRegion())
 	if err != nil {
 		reporter.Errorf("Error getting region: %v", err)
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo
 	}
 	if awsRegionInUserConfig == "" {
 		reporter.Errorf("AWS Region not set")
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo
 	}
 	if !helper.Contains(supportedRegions, awsRegionInUserConfig) {
 		reporter.Errorf("Unsupported region '%s', available regions: %s",
 			awsRegionInUserConfig, helper.SliceToSortedString(supportedRegions))
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo
 	}
 
 	// Create the AWS client:
@@ -209,7 +209,7 @@ func GetAWSClientForUserRegion(reporter rprtr.Logger, logger *logrus.Logger,
 		Build()
 	if err != nil {
 		reporter.Errorf("Error creating aws client for stack validation: %v", err)
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo
 	}
 	regionUsedForInit, err := client.GetClusterRegionTagForUser(AdminUserName)
 	if err != nil || regionUsedForInit == "" {
@@ -220,7 +220,7 @@ func GetAWSClientForUserRegion(reporter rprtr.Logger, logger *logrus.Logger,
 		if !helper.Contains(supportedRegions, regionUsedForInit) {
 			reporter.Errorf("Unsupported region '%s', available regions: %s",
 				regionUsedForInit, helper.SliceToSortedString(supportedRegions))
-			os.Exit(1)
+			os.Exit(1) //nolint:forbidigo
 		}
 		// Create the AWS client with the region used in the init
 		// So we can check for the stack in that region
@@ -231,7 +231,7 @@ func GetAWSClientForUserRegion(reporter rprtr.Logger, logger *logrus.Logger,
 			Build()
 		if err != nil {
 			reporter.Errorf("Error creating aws client for stack validation: %v", err)
-			os.Exit(1)
+			os.Exit(1) //nolint:forbidigo
 		}
 		return awsClient
 	}

--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -35,7 +35,7 @@ import (
 	client "github.com/openshift/rosa/pkg/aws/api_interface"
 	"github.com/openshift/rosa/pkg/aws/tags"
 	"github.com/openshift/rosa/pkg/helper"
-	"github.com/openshift/rosa/pkg/reporter"
+	"github.com/openshift/rosa/pkg/reporter" //nolint:depguard
 )
 
 const (
@@ -1129,11 +1129,11 @@ func (c *awsClient) DeleteOperatorRole(roleName string, managedPolicies bool,
 	err = c.detachOperatorRolePolicies(role)
 	if err != nil {
 		if awserr.IsNoSuchEntityException(err) {
-			fmt.Printf("Entity does not exist: %s", err)
+			fmt.Printf("Entity does not exist: %s", err) //nolint:forbidigo
 			err = nil
 		}
 		if awserr.IsDeleteConfictException(err) {
-			fmt.Printf("Unable to detach operator role policy: %s", err)
+			fmt.Printf("Unable to detach operator role policy: %s", err) //nolint:forbidigo
 			err = nil
 		}
 		if err != nil {
@@ -1239,11 +1239,11 @@ func (c *awsClient) DeleteAccountRole(roleName string, prefix string, managedPol
 	}
 	if err != nil {
 		if awserr.IsNoSuchEntityException(err) {
-			fmt.Printf("Entity does not exist: %s", err)
+			fmt.Printf("Entity does not exist: %s", err) //nolint:forbidigo
 			err = nil
 		}
 		if awserr.IsDeleteConfictException(err) {
-			fmt.Printf("Unable to detach account role policy: %s", err)
+			fmt.Printf("Unable to detach account role policy: %s", err) //nolint:forbidigo
 			err = nil
 		}
 		if err != nil {

--- a/pkg/aws/sts.go
+++ b/pkg/aws/sts.go
@@ -29,9 +29,9 @@ import (
 	common "github.com/openshift-online/ocm-common/pkg/aws/validations"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 
-	awscbRoles "github.com/openshift/rosa/pkg/aws/commandbuilder/helper/roles"
+	awscbRoles "github.com/openshift/rosa/pkg/aws/commandbuilder/helper/roles" //nolint:depguard
 	"github.com/openshift/rosa/pkg/aws/tags"
-	"github.com/openshift/rosa/pkg/reporter"
+	"github.com/openshift/rosa/pkg/reporter" //nolint:depguard
 )
 
 func (c *awsClient) DeleteUserRole(roleName string) error {

--- a/pkg/clusterregistryconfig/flags.go
+++ b/pkg/clusterregistryconfig/flags.go
@@ -6,12 +6,12 @@ import (
 	"strings"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
+	"github.com/spf13/cobra" //nolint:depguard
+	"github.com/spf13/pflag" //nolint:depguard
 
 	"github.com/openshift/rosa/pkg/helper"
 	"github.com/openshift/rosa/pkg/input"
-	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/interactive" //nolint:depguard
 	"github.com/openshift/rosa/pkg/ocm"
 )
 

--- a/pkg/helper/autonode/helpers.go
+++ b/pkg/helper/autonode/helpers.go
@@ -5,13 +5,13 @@ import (
 	"strings"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	"github.com/spf13/cobra"
+	"github.com/spf13/cobra" //nolint:depguard
 
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/fedramp"
-	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/interactive" //nolint:depguard
 	"github.com/openshift/rosa/pkg/ocm"
-	"github.com/openshift/rosa/pkg/rosa"
+	"github.com/openshift/rosa/pkg/rosa" //nolint:depguard
 )
 
 const (

--- a/pkg/helper/download/download.go
+++ b/pkg/helper/download/download.go
@@ -77,7 +77,7 @@ func Download(url string, filename string) error {
 	}
 
 	// The progress use the same line so print a new line once it's finished downloading
-	fmt.Print("\n")
+	fmt.Print("\n") //nolint:forbidigo
 
 	// Close the file without defer so it can happen before Rename()
 	out.Close()
@@ -158,11 +158,11 @@ func (wc *WriteCounter) Write(p []byte) (int, error) {
 func (wc WriteCounter) PrintProgress() {
 	// Clear the line by using a character return to go back to the start and remove
 	// the remaining characters by filling it with spaces
-	fmt.Printf("\r%s", strings.Repeat(" ", 35))
+	fmt.Printf("\r%s", strings.Repeat(" ", 35)) //nolint:forbidigo
 
 	// Return again and print current status of download
 	// We use the humanize package to print the bytes in a meaningful way (e.g. 10 MB)
-	fmt.Printf("\rDownloading... %s complete", readableBytes(wc.Total))
+	fmt.Printf("\rDownloading... %s complete", readableBytes(wc.Total)) //nolint:forbidigo
 }
 
 func readableBytes(b uint64) string {

--- a/pkg/helper/download/download.go
+++ b/pkg/helper/download/download.go
@@ -36,7 +36,7 @@ func Download(url string, filename string) error {
 	}
 
 	// Get the data
-	// nolint:gosec
+	//nolint:gosec
 	resp, err := http.Get(url)
 	if err != nil {
 		cleanupTempFile()
@@ -77,7 +77,7 @@ func Download(url string, filename string) error {
 	}
 
 	// The progress use the same line so print a new line once it's finished downloading
-	fmt.Print("\n")
+	fmt.Print("\n") //nolint:forbidigo
 
 	// Close the file without defer so it can happen before Rename()
 	out.Close()
@@ -158,11 +158,11 @@ func (wc *WriteCounter) Write(p []byte) (int, error) {
 func (wc WriteCounter) PrintProgress() {
 	// Clear the line by using a character return to go back to the start and remove
 	// the remaining characters by filling it with spaces
-	fmt.Printf("\r%s", strings.Repeat(" ", 35))
+	fmt.Printf("\r%s", strings.Repeat(" ", 35)) //nolint:forbidigo
 
 	// Return again and print current status of download
 	// We use the humanize package to print the bytes in a meaningful way (e.g. 10 MB)
-	fmt.Printf("\rDownloading... %s complete", readableBytes(wc.Total))
+	fmt.Printf("\rDownloading... %s complete", readableBytes(wc.Total)) //nolint:forbidigo
 }
 
 func readableBytes(b uint64) string {

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -14,7 +14,7 @@ import (
 	"github.com/briandowns/spinner"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 
-	"github.com/openshift/rosa/pkg/reporter"
+	"github.com/openshift/rosa/pkg/reporter" //nolint:depguard
 )
 
 var r *rand.Rand

--- a/pkg/helper/machinepools/helpers.go
+++ b/pkg/helper/machinepools/helpers.go
@@ -13,11 +13,11 @@ import (
 	v1 "github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1"
 	commonUtils "github.com/openshift-online/ocm-common/pkg/utils"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	"github.com/spf13/cobra"
+	"github.com/spf13/cobra" //nolint:depguard
 
 	"github.com/openshift/rosa/pkg/aws"
-	"github.com/openshift/rosa/pkg/interactive"
-	"github.com/openshift/rosa/pkg/rosa"
+	"github.com/openshift/rosa/pkg/interactive" //nolint:depguard
+	"github.com/openshift/rosa/pkg/rosa"        //nolint:depguard
 )
 
 // To clear existing labels in interactive mode, the user enters "" as an empty list value
@@ -102,13 +102,13 @@ func GetTaints(cmd *cobra.Command, r *rosa.Runtime, existingTaints []*cmv1.Taint
 		})
 		if err != nil {
 			r.Reporter.Errorf("Expected a valid comma-separated list of attributes: %s", err)
-			os.Exit(1)
+			os.Exit(1) //nolint:forbidigo
 		}
 	}
 	taintBuilders, err := ParseTaints(inputTaints)
 	if err != nil {
 		r.Reporter.Errorf("%s", err)
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo
 	}
 	return taintBuilders
 }
@@ -218,7 +218,7 @@ func GetAwsTags(cmd *cobra.Command, r *rosa.Runtime, inputTags []string) map[str
 		})
 		if err != nil {
 			r.Reporter.Errorf("Expected a valid set of tags: %s", err)
-			os.Exit(1)
+			os.Exit(1) //nolint:forbidigo
 		}
 		if len(tagsInput) > 0 {
 			tags = strings.Split(tagsInput, ",")
@@ -227,7 +227,7 @@ func GetAwsTags(cmd *cobra.Command, r *rosa.Runtime, inputTags []string) map[str
 	if len(tags) > 0 {
 		if err := aws.UserTagValidator(tags); err != nil {
 			r.Reporter.Errorf("%s", err)
-			os.Exit(1)
+			os.Exit(1) //nolint:forbidigo
 		}
 		delim := aws.GetTagsDelimiter(tags)
 		for _, tag := range tags {
@@ -260,13 +260,13 @@ func GetLabelMap(cmd *cobra.Command, r *rosa.Runtime, existingLabels map[string]
 		})
 		if err != nil {
 			r.Reporter.Errorf("Expected a valid comma-separated list of attributes: %s", err)
-			os.Exit(1)
+			os.Exit(1) //nolint:forbidigo
 		}
 	}
 	labelMap, err := ParseLabels(inputLabels)
 	if err != nil {
 		r.Reporter.Errorf("%s", err)
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo
 	}
 	return labelMap
 }

--- a/pkg/helper/versions/helpers.go
+++ b/pkg/helper/versions/helpers.go
@@ -8,7 +8,7 @@ import (
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 
 	"github.com/openshift/rosa/pkg/ocm"
-	"github.com/openshift/rosa/pkg/rosa"
+	"github.com/openshift/rosa/pkg/rosa" //nolint:depguard
 )
 
 const (

--- a/pkg/iamserviceaccount/helpers.go
+++ b/pkg/iamserviceaccount/helpers.go
@@ -147,7 +147,7 @@ func GenerateTrustPolicyMultiple(oidcProviderARN string, serviceAccounts []Servi
 			if i > 0 {
 				subjectsJSON.WriteString(", ")
 			}
-			fmt.Fprintf(&subjectsJSON, `"%s"`, subject)
+			fmt.Fprintf(&subjectsJSON, `"%s"`, subject) //nolint:forbidigo
 		}
 		subjectsJSON.WriteString(`]`)
 

--- a/pkg/input/input_validation.go
+++ b/pkg/input/input_validation.go
@@ -6,10 +6,10 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 
 	"github.com/openshift/rosa/pkg/ocm"
-	"github.com/openshift/rosa/pkg/rosa"
+	"github.com/openshift/rosa/pkg/rosa" //nolint:depguard
 )
 
-var exitFunc = os.Exit
+var exitFunc = os.Exit //nolint:forbidigo
 
 // CheckIfHypershiftClusterOrExit will exit if the input cluster is not an Hypershift cluster
 func CheckIfHypershiftClusterOrExit(r *rosa.Runtime, cluster *cmv1.Cluster) {

--- a/pkg/interactive/validation.go
+++ b/pkg/interactive/validation.go
@@ -70,7 +70,6 @@ func IsURL(val interface{}) error {
 // https://github.com/openshift/kubernetes/blob/91607f5d750ba4002f87d34a12ae1cfd45b45b81/openshift-kube-apiserver/admission/customresourcevalidation/oauth/helpers.go#L13
 // and denies any [*.]github.com hostnames
 // https://github.com/openshift/kubernetes/blob/258f1d5fb6491ba65fd8201c827e179432430627/openshift-kube-apiserver/admission/customresourcevalidation/oauth/validate_github.go#L49
-// nolint
 func IsValidHostname(val interface{}) error {
 	hostname := val.(string)
 	if hostname == "" {
@@ -79,6 +78,7 @@ func IsValidHostname(val interface{}) error {
 	if hostname == "github.com" || strings.HasSuffix(hostname, ".github.com") {
 		return fmt.Errorf("%s", fmt.Sprintf("'%s' hostname cannot be equal to [*.]github.com", hostname))
 	}
+	//nolint:staticcheck
 	if !(len(validation.IsDNS1123Subdomain(hostname)) == 0 || netutils.ParseIPSloppy(hostname) != nil) {
 		return fmt.Errorf("%s", fmt.Sprintf("'%s' hostname must be a valid DNS subdomain or IP address", hostname))
 	}

--- a/pkg/kubeletconfig/output.go
+++ b/pkg/kubeletconfig/output.go
@@ -13,7 +13,7 @@ func PrintKubeletConfigsForTabularOutput(configs []*cmv1.KubeletConfig) string {
 	var output strings.Builder
 	output.WriteString("ID\tNAME\tPOD PIDS LIMIT\n")
 	for _, config := range configs {
-		fmt.Fprintf(&output, "%s\t%s\t%d\n", config.ID(), getName(config), config.PodPidsLimit())
+		fmt.Fprintf(&output, "%s\t%s\t%d\n", config.ID(), getName(config), config.PodPidsLimit()) //nolint:forbidigo
 	}
 
 	return output.String()
@@ -32,7 +32,7 @@ func PrintKubeletConfigForHcp(config *cmv1.KubeletConfig, nodePools []*cmv1.Node
 	if len(nodePools) != 0 {
 		output.WriteString("MachinePools Using This KubeletConfig:\n")
 		for _, n := range nodePools {
-			fmt.Fprintf(&output, " - %s\n", n.ID())
+			fmt.Fprintf(&output, " - %s\n", n.ID()) //nolint:forbidigo
 		}
 	}
 

--- a/pkg/logforwarding/output.go
+++ b/pkg/logforwarding/output.go
@@ -37,7 +37,7 @@ func LogForwarderObjectAsString(logForwarder *cmv1.LogForwarder) string {
 			if i > 0 {
 				groupsStr.WriteString(" ")
 			}
-			fmt.Fprintf(&groupsStr, "(%s,v%s)", group.ID(), group.Version())
+			fmt.Fprintf(&groupsStr, "(%s,v%s)", group.ID(), group.Version()) //nolint:forbidigo
 		}
 		out += fmt.Sprintf("Groups:                              %s\n", groupsStr.String())
 	}

--- a/pkg/machinepool/helper.go
+++ b/pkg/machinepool/helper.go
@@ -10,17 +10,17 @@ import (
 	clustervalidations "github.com/openshift-online/ocm-common/pkg/cluster/validations"
 	commonUtils "github.com/openshift-online/ocm-common/pkg/utils"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	"github.com/spf13/cobra"
+	"github.com/spf13/cobra" //nolint:depguard
 
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/fedramp"
 	mpHelpers "github.com/openshift/rosa/pkg/helper/machinepools"
 	"github.com/openshift/rosa/pkg/helper/versions"
-	"github.com/openshift/rosa/pkg/interactive"
-	interactiveSgs "github.com/openshift/rosa/pkg/interactive/securitygroups"
+	"github.com/openshift/rosa/pkg/interactive"                               //nolint:depguard
+	interactiveSgs "github.com/openshift/rosa/pkg/interactive/securitygroups" //nolint:depguard
 	"github.com/openshift/rosa/pkg/ocm"
-	mpOpts "github.com/openshift/rosa/pkg/options/machinepool"
-	"github.com/openshift/rosa/pkg/rosa"
+	mpOpts "github.com/openshift/rosa/pkg/options/machinepool" //nolint:depguard
+	"github.com/openshift/rosa/pkg/rosa"                       //nolint:depguard
 )
 
 const (

--- a/pkg/machinepool/machinepool.go
+++ b/pkg/machinepool/machinepool.go
@@ -16,7 +16,7 @@ import (
 	diskValidator "github.com/openshift-online/ocm-common/pkg/machinepool/validations"
 	commonUtils "github.com/openshift-online/ocm-common/pkg/utils"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	"github.com/spf13/cobra"
+	"github.com/spf13/cobra" //nolint:depguard
 	errors "github.com/zgalor/weberr"
 
 	"github.com/openshift/rosa/pkg/fedramp"
@@ -24,15 +24,15 @@ import (
 	"github.com/openshift/rosa/pkg/helper/features"
 	mpHelpers "github.com/openshift/rosa/pkg/helper/machinepools"
 	"github.com/openshift/rosa/pkg/helper/versions"
-	"github.com/openshift/rosa/pkg/interactive"
-	"github.com/openshift/rosa/pkg/interactive/confirm"
-	"github.com/openshift/rosa/pkg/interactive/securitygroups"
+	"github.com/openshift/rosa/pkg/interactive"                //nolint:depguard
+	"github.com/openshift/rosa/pkg/interactive/confirm"        //nolint:depguard
+	"github.com/openshift/rosa/pkg/interactive/securitygroups" //nolint:depguard
 	"github.com/openshift/rosa/pkg/kubeletconfig"
 	"github.com/openshift/rosa/pkg/ocm"
-	ocmOutput "github.com/openshift/rosa/pkg/ocm/output"
-	mpOpts "github.com/openshift/rosa/pkg/options/machinepool"
-	"github.com/openshift/rosa/pkg/output"
-	"github.com/openshift/rosa/pkg/rosa"
+	ocmOutput "github.com/openshift/rosa/pkg/ocm/output"       //nolint:depguard
+	mpOpts "github.com/openshift/rosa/pkg/options/machinepool" //nolint:depguard
+	"github.com/openshift/rosa/pkg/output"                     //nolint:depguard
+	"github.com/openshift/rosa/pkg/rosa"                       //nolint:depguard
 )
 
 const (
@@ -1200,7 +1200,7 @@ func (m *machinePool) ListMachinePools(r *rosa.Runtime, clusterKey string, clust
 	if isHypershift {
 		finalStringToOutput = getNodePoolsString(nodePools)
 	}
-	fmt.Fprint(writer, finalStringToOutput)
+	fmt.Fprint(writer, finalStringToOutput) //nolint:forbidigo
 	writer.Flush()
 	return nil
 }
@@ -1225,7 +1225,7 @@ func (m *machinePool) DescribeMachinePool(r *rosa.Runtime, cluster *cmv1.Cluster
 		return output.Print(machinePool)
 	}
 
-	fmt.Print(machinePoolOutput(cluster.ID(), machinePool))
+	fmt.Print(machinePoolOutput(cluster.ID(), machinePool)) //nolint:forbidigo
 
 	return nil
 }
@@ -1256,7 +1256,7 @@ func (m *machinePool) describeNodePool(r *rosa.Runtime, cluster *cmv1.Cluster, c
 	}
 
 	// Attach and print scheduledUpgrades if they exist, otherwise, print output normally
-	fmt.Print(appendUpgradesIfExist(scheduledUpgrade, nodePoolOutput(cluster.ID(), nodePool)))
+	fmt.Print(appendUpgradesIfExist(scheduledUpgrade, nodePoolOutput(cluster.ID(), nodePool))) //nolint:forbidigo
 
 	return nil
 }
@@ -1964,7 +1964,7 @@ func editNodePool(cmd *cobra.Command, nodePoolID string,
 		err = ValidateKubeletConfig(inputKubeletConfig)
 		if err != nil {
 			r.Reporter.Errorf(err.Error())
-			os.Exit(1)
+			os.Exit(1) //nolint:forbidigo
 		}
 		npBuilder.KubeletConfigs(inputKubeletConfig...)
 		isKubeletConfigSet = true
@@ -2023,7 +2023,7 @@ func editNodePool(cmd *cobra.Command, nodePoolID string,
 			})
 			if err != nil {
 				r.Reporter.Errorf("expected a valid value for max surge: %s", err)
-				os.Exit(1)
+				os.Exit(1) //nolint:forbidigo
 			}
 
 			maxUnavailable, err = interactive.GetString(interactive.Input{
@@ -2037,7 +2037,7 @@ func editNodePool(cmd *cobra.Command, nodePoolID string,
 			})
 			if err != nil {
 				r.Reporter.Errorf("expected a valid value for max unavailable: %s", err)
-				os.Exit(1)
+				os.Exit(1) //nolint:forbidigo
 			}
 		}
 

--- a/pkg/machinepool/machinepool.go
+++ b/pkg/machinepool/machinepool.go
@@ -16,7 +16,7 @@ import (
 	diskValidator "github.com/openshift-online/ocm-common/pkg/machinepool/validations"
 	commonUtils "github.com/openshift-online/ocm-common/pkg/utils"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	"github.com/spf13/cobra"
+	"github.com/spf13/cobra" //nolint:depguard
 	errors "github.com/zgalor/weberr"
 
 	"github.com/openshift/rosa/pkg/fedramp"
@@ -24,15 +24,15 @@ import (
 	"github.com/openshift/rosa/pkg/helper/features"
 	mpHelpers "github.com/openshift/rosa/pkg/helper/machinepools"
 	"github.com/openshift/rosa/pkg/helper/versions"
-	"github.com/openshift/rosa/pkg/interactive"
-	"github.com/openshift/rosa/pkg/interactive/confirm"
-	"github.com/openshift/rosa/pkg/interactive/securitygroups"
+	"github.com/openshift/rosa/pkg/interactive"                //nolint:depguard
+	"github.com/openshift/rosa/pkg/interactive/confirm"        //nolint:depguard
+	"github.com/openshift/rosa/pkg/interactive/securitygroups" //nolint:depguard
 	"github.com/openshift/rosa/pkg/kubeletconfig"
 	"github.com/openshift/rosa/pkg/ocm"
-	ocmOutput "github.com/openshift/rosa/pkg/ocm/output"
-	mpOpts "github.com/openshift/rosa/pkg/options/machinepool"
-	"github.com/openshift/rosa/pkg/output"
-	"github.com/openshift/rosa/pkg/rosa"
+	ocmOutput "github.com/openshift/rosa/pkg/ocm/output"       //nolint:depguard
+	mpOpts "github.com/openshift/rosa/pkg/options/machinepool" //nolint:depguard
+	"github.com/openshift/rosa/pkg/output"                     //nolint:depguard
+	"github.com/openshift/rosa/pkg/rosa"                       //nolint:depguard
 )
 
 const (
@@ -1225,7 +1225,7 @@ func (m *machinePool) DescribeMachinePool(r *rosa.Runtime, cluster *cmv1.Cluster
 		return output.Print(machinePool)
 	}
 
-	fmt.Print(machinePoolOutput(cluster.ID(), machinePool))
+	fmt.Print(machinePoolOutput(cluster.ID(), machinePool)) //nolint:forbidigo
 
 	return nil
 }
@@ -1256,7 +1256,7 @@ func (m *machinePool) describeNodePool(r *rosa.Runtime, cluster *cmv1.Cluster, c
 	}
 
 	// Attach and print scheduledUpgrades if they exist, otherwise, print output normally
-	fmt.Print(appendUpgradesIfExist(scheduledUpgrade, nodePoolOutput(cluster.ID(), nodePool)))
+	fmt.Print(appendUpgradesIfExist(scheduledUpgrade, nodePoolOutput(cluster.ID(), nodePool))) //nolint:forbidigo
 
 	return nil
 }
@@ -1964,7 +1964,7 @@ func editNodePool(cmd *cobra.Command, nodePoolID string,
 		err = ValidateKubeletConfig(inputKubeletConfig)
 		if err != nil {
 			r.Reporter.Errorf(err.Error())
-			os.Exit(1)
+			os.Exit(1) //nolint:forbidigo
 		}
 		npBuilder.KubeletConfigs(inputKubeletConfig...)
 		isKubeletConfigSet = true
@@ -2023,7 +2023,7 @@ func editNodePool(cmd *cobra.Command, nodePoolID string,
 			})
 			if err != nil {
 				r.Reporter.Errorf("expected a valid value for max surge: %s", err)
-				os.Exit(1)
+				os.Exit(1) //nolint:forbidigo
 			}
 
 			maxUnavailable, err = interactive.GetString(interactive.Input{
@@ -2037,7 +2037,7 @@ func editNodePool(cmd *cobra.Command, nodePoolID string,
 			})
 			if err != nil {
 				r.Reporter.Errorf("expected a valid value for max unavailable: %s", err)
-				os.Exit(1)
+				os.Exit(1) //nolint:forbidigo
 			}
 		}
 

--- a/pkg/machinepool/output.go
+++ b/pkg/machinepool/output.go
@@ -5,8 +5,8 @@ import (
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 
-	ocmOutput "github.com/openshift/rosa/pkg/ocm/output"
-	"github.com/openshift/rosa/pkg/output"
+	ocmOutput "github.com/openshift/rosa/pkg/ocm/output" //nolint:depguard
+	"github.com/openshift/rosa/pkg/output"               //nolint:depguard
 )
 
 var nodePoolOutputString string = "\n" +

--- a/pkg/machinepool/validation.go
+++ b/pkg/machinepool/validation.go
@@ -3,7 +3,7 @@ package machinepool
 import (
 	"fmt"
 
-	"github.com/AlecAivazis/survey/v2/core"
+	"github.com/AlecAivazis/survey/v2/core" //nolint:depguard
 )
 
 func ValidateKubeletConfig(input interface{}) error {

--- a/pkg/network/helper.go
+++ b/pkg/network/helper.go
@@ -117,7 +117,7 @@ func formatParams(params map[string]string) string {
 	}
 	sort.Strings(keys)
 	for _, k := range keys {
-		fmt.Fprintf(&paramStr, "ParameterKey=%s,ParameterValue=%s ", k, params[k])
+		fmt.Fprintf(&paramStr, "ParameterKey=%s,ParameterValue=%s ", k, params[k]) //nolint:forbidigo
 	}
 	return paramStr.String()
 }
@@ -130,7 +130,7 @@ func formatTags(tags map[string]string) string {
 	}
 	sort.Strings(keys)
 	for _, k := range keys {
-		fmt.Fprintf(&tagStr, "Key=%s,Value=%s ", k, tags[k])
+		fmt.Fprintf(&tagStr, "Key=%s,Value=%s ", k, tags[k]) //nolint:forbidigo
 	}
 	return tagStr.String()
 }

--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -34,10 +34,10 @@ import (
 	"github.com/openshift/rosa/pkg/fedramp"
 	"github.com/openshift/rosa/pkg/helper"
 	"github.com/openshift/rosa/pkg/info"
-	"github.com/openshift/rosa/pkg/interactive/consts"
+	"github.com/openshift/rosa/pkg/interactive/consts" //nolint:depguard
 	"github.com/openshift/rosa/pkg/logforwarding"
 	"github.com/openshift/rosa/pkg/properties"
-	rprtr "github.com/openshift/rosa/pkg/reporter"
+	rprtr "github.com/openshift/rosa/pkg/reporter" //nolint:depguard
 )
 
 const (
@@ -817,12 +817,12 @@ func (c *Client) EnsureNoPendingClusters(awsCreator *aws.Creator) error {
 		pendingCluster, err := c.GetPendingClusterForARN(awsCreator)
 		if err != nil {
 			reporter.Errorf("Error getting cluster using ARN '%s'", awsCreator.ARN)
-			os.Exit(1)
+			os.Exit(1) //nolint:forbidigo
 		}
 		if time.Now().After(deadline) {
 			reporter.Errorf("Timeout waiting for the cluster '%s' installation. Try again in a few minutes",
 				pendingCluster.ID())
-			os.Exit(1)
+			os.Exit(1) //nolint:forbidigo
 		}
 		if pendingCluster == nil {
 			break

--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -43,8 +43,8 @@ import (
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/helper"
 	urlHelper "github.com/openshift/rosa/pkg/helper/url"
-	"github.com/openshift/rosa/pkg/output"
-	"github.com/openshift/rosa/pkg/reporter"
+	"github.com/openshift/rosa/pkg/output"   //nolint:depguard
+	"github.com/openshift/rosa/pkg/reporter" //nolint:depguard
 )
 
 const (
@@ -296,7 +296,6 @@ func isCompatible(relatedResource *amsv1.RelatedResource) bool {
 	cloudProvider := strings.ToLower(relatedResource.CloudProvider())
 	byoc := strings.ToLower(relatedResource.BYOC())
 
-	// nolint:goconst
 	return (product == ANY || product == "rosa" || product == "moa") &&
 		(cloudProvider == ANY || cloudProvider == "aws") &&
 		(byoc == ANY || byoc == "byoc")

--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -43,8 +43,8 @@ import (
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/helper"
 	urlHelper "github.com/openshift/rosa/pkg/helper/url"
-	"github.com/openshift/rosa/pkg/output"
-	"github.com/openshift/rosa/pkg/reporter"
+	"github.com/openshift/rosa/pkg/output"   //nolint:depguard
+	"github.com/openshift/rosa/pkg/reporter" //nolint:depguard
 )
 
 const (

--- a/pkg/roles/validation.go
+++ b/pkg/roles/validation.go
@@ -3,7 +3,7 @@ package roles
 import (
 	errors "github.com/zgalor/weberr"
 
-	"github.com/openshift/rosa/pkg/arguments"
+	"github.com/openshift/rosa/pkg/arguments" //nolint:depguard
 	"github.com/openshift/rosa/pkg/ocm"
 )
 

--- a/tests/e2e/test_rosacli_cluster.go
+++ b/tests/e2e/test_rosacli_cluster.go
@@ -306,7 +306,6 @@ var _ = Describe("Edit cluster",
 
 				clusterDetail, err := clusterService.ReflectClusterDescription(output)
 				Expect(err).ToNot(HaveOccurred())
-				// nolint
 				expectedUWMValue := UWMEnabled
 				recoverUWMStatus := false
 				if clusterConfig.DisableWorkloadMonitoring {
@@ -1295,7 +1294,6 @@ var _ = Describe("Classic cluster creation validation",
 				flags, err := clusterHandler.GenerateClusterCreateFlags()
 				Expect(err).To(BeNil())
 
-				// nolint
 				command = "rosa create cluster --cluster-name " + profile.ClusterConfig.Name + " " + strings.Join(flags, " ")
 				rosalCommand = config.GenerateCommand(command)
 
@@ -3084,7 +3082,7 @@ var _ = Describe("HCP cluster creation negative testing",
 					case "Support":
 						accountRoles[r.RoleName] = fmt.Sprintf("%s/ROSASRESupportPolicy",
 							arnPrefix)
-					case "Worker": // nolint:goconst
+					case "Worker":
 						accountRoles[r.RoleName] = fmt.Sprintf("%s/ROSAWorkerInstancePolicy",
 							arnPrefix)
 					}
@@ -3454,7 +3452,7 @@ var _ = Describe("Create cluster with availability zones testing",
 			func() {
 				profile := handler.LoadProfileYamlFileByENV()
 				mpID := "mp-52691"
-				machineType := "m5.2xlarge" // nolint:goconst
+				machineType := "m5.2xlarge"
 
 				if profile.ClusterConfig.BYOVPC || profile.ClusterConfig.Zones == "" {
 					SkipTestOnFeature("create rosa cluster with availability zones")

--- a/tests/e2e/test_rosacli_cluster_post.go
+++ b/tests/e2e/test_rosacli_cluster_post.go
@@ -417,7 +417,7 @@ var _ = Describe("Healthy check",
 					ingressPrivate := "false"
 					if clusterConfig.Private {
 						private = constants.Yes
-						ingressPrivate = "true" // nolint
+						ingressPrivate = "true"
 					}
 
 					By("Describe the cluster and check private field")

--- a/tests/e2e/test_rosacli_dns_domain.go
+++ b/tests/e2e/test_rosacli_dns_domain.go
@@ -1,9 +1,9 @@
 package e2e
 
 import (
-	// nolint:staticcheck
+	//nolint:staticcheck
 	. "github.com/onsi/ginkgo/v2"
-	// nolint:staticcheck
+	//nolint:staticcheck
 	. "github.com/onsi/gomega"
 
 	"github.com/openshift/rosa/tests/ci/labels"

--- a/tests/e2e/test_rosacli_kubelet_config.go
+++ b/tests/e2e/test_rosacli_kubelet_config.go
@@ -54,7 +54,6 @@ var _ = Describe("Kubeletconfig on Classic cluster",
 				output, _ := kubeletService.CreateKubeletConfig(clusterID,
 					"--pod-pids-limit", "12345")
 
-				// nolint:goconst
 				Expect(output.String()).To(ContainSubstring("Creating the KubeletConfig for cluster '%s' "+
 					"will cause all non-Control Plane nodes to reboot. "+
 					"This may cause outages to your applications. Do you wish to continue",

--- a/tests/e2e/test_rosacli_machine_pool.go
+++ b/tests/e2e/test_rosacli_machine_pool.go
@@ -282,7 +282,6 @@ var _ = Describe("Create machinepool",
 			labels.FedRAMP,
 			func() {
 				By("Create a spot machinepool on the cluster")
-				// nolint:goconst
 				machinePoolName := "spotmp"
 				output, err := machinePoolService.CreateMachinePool(
 					clusterID,
@@ -299,7 +298,6 @@ var _ = Describe("Create machinepool",
 						clusterID))
 
 				By("Create another machinepool without spot instances")
-				// nolint:goconst
 				machinePoolName = "nospotmp"
 				output, err = machinePoolService.CreateMachinePool(
 					clusterID,

--- a/tests/e2e/test_rosacli_node_pool.go
+++ b/tests/e2e/test_rosacli_node_pool.go
@@ -1360,28 +1360,28 @@ var _ = Describe("Edit nodepool",
 					{
 						"max surge":       "0",
 						"max unavailable": "0",
-						"errMsg": fmt.Sprintf("The value of only one attribute, %s", //nolint
+						"errMsg": fmt.Sprintf("The value of only one attribute, %s",
 							eitherMsg+
 								zeroMsg),
 					},
 					{
 						"max surge":       "0%",
 						"max unavailable": "0%",
-						"errMsg": fmt.Sprint("The value of only one attribute, " + //nolint
+						"errMsg": fmt.Sprint("The value of only one attribute, " +
 							eitherMsg +
 							zeroMsg),
 					},
 					{
 						"max surge":       "0",
 						"max unavailable": "1%",
-						"errMsg": fmt.Sprint("Attribute " + //nolint
+						"errMsg": fmt.Sprint("Attribute " +
 							bothMsg +
 							sameUnitMsg),
 					},
 					{
 						"max surge":       "1%",
 						"max unavailable": "0",
-						"errMsg": fmt.Sprint("Attribute " + //nolint
+						"errMsg": fmt.Sprint("Attribute " +
 							bothMsg +
 							sameUnitMsg),
 					},

--- a/tests/utils/handler/cluster_handler.go
+++ b/tests/utils/handler/cluster_handler.go
@@ -536,7 +536,7 @@ func (ch *clusterHandler) GenerateClusterCreateFlags() ([]string, error) {
 	}
 	if ch.profile.ClusterConfig.AutoscalerEnabled {
 		if !ch.profile.ClusterConfig.Autoscale {
-			return nil, errors.New("Autoscaler is enabled without having enabled the autoscale field") // nolint
+			return nil, errors.New("Autoscaler is enabled without having enabled the autoscale field") //nolint:staticcheck
 		}
 		autoscaler := &ClusterConfigure.Autoscaler{
 			AutoscalerBalanceSimilarNodeGroups:    true,


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
Supported ticket prefixes:
OCM-XXXXX, ROSAENG-XXXX
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For contributor workflow, see: ./CONTRIBUTING.md
For repo-local agent guidance, see: ./AGENTS.md
-->

## PR Summary
<!-- brief text of 1 or 2 lines with the most important changes and outcomes -->
Adds CI-enforced checks to prevent disallowed code patterns (e.g. calling os.Exit from `/pkg`), and prevent disallowed dependency directions (core layer -> CLI). Enforces architectural patterns that have been laid out in `guidelines/ARCHITECTURE.md` and `guidelines/refactor/pkg-architecture.md`


## Detailed Description of the Issue
- Add depguard deny list to prohibit imports defined in ARCHITECTURE.md (reporter, output, interactive, arguments, color, debug, commands, rosa, options, aws/profile, aws/region, aws/commandbuilder)
- Add nolint:depguard annotations to pre-existing internal import violations in files already within whole-files lint scope
- Add nolint:forbidigo annotations to pre-existing fmt.Print and os.Exit violations in files already within whole-files lint scope
- Added nolintlint to .golangci.yml with require-specific: true and allow-unused: false, and fixed existing violations

As files are touched, `//nolint:forbidgo` and `//nolint:depguard` will have to be added until files are refactored as part of this initiative.

## Related Issues and PRs
<!-- Link all tracking items and related code changes -->
- Jira: [ROSAENG-62490](https://redhat.atlassian.net/browse/ROSAENG-62490)
- Related design/docs: [ROSA+CLI+Refactor+CLI+to+enforce+layer+boundaries](https://redhat.atlassian.net/wiki/spaces/ROSACLITF/pages/432213369/ROSA+CLI+Refactor+CLI+to+enforce+layer+boundaries#Phase-1%3A-Define-and-Guard-the-Boundary)

## Type of Change
<!-- Check the primary type this PR represents -->
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [x] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [x] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
<!-- What users or systems experienced before this change -->
Bad dependency imports and disallowed code patterns were allowed

## Behavior After This Change
<!-- What changes now, including user-visible and non-user-visible behavior -->
Dependency imports as laid out in `ARCHITECTURE.md` and `refactor/pkg-architecture.md` are enforced. 

## How to Test (Step-by-Step)
<!-- Provide reproducible validation instructions -->
### Preconditions
<!-- Required setup, environment, credentials, flags, cluster state, etc. -->

### Test Steps
1. Add an incorrect dependency import (e.g. importing `/cmd` in `/pkg`) or incorrect code smell (e.g. `/pkg` calling `os.Exit` or writing to `stdout`)
2. Try to run the linter or push the code

### Expected Results
<!-- What should happen after running the steps above -->
Linter should catch the architectural violations

## Proof of the Fix
<!-- Attach evidence that demonstrates the changed behavior -->
- Screenshots:
- Videos:
- Logs/CLI output:
- Other artifacts:

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [x] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.


[ROSAENG-62490]: https://redhat.atlassian.net/browse/ROSAENG-62490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Strengthened static analysis rules to detect prohibited dependencies, direct console output, and process exits.
  * Standardized lint configuration and suppression formatting across command, AWS, cluster, machine pool, and helper components.
* **Refactor**
  * Updated retry-message handling and streamlined validation test messages.
  * Removed obsolete lint directives from application and end-to-end test code.
  * No user-facing functionality, public APIs, or runtime behavior changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->