### PR TITLE
ROSAENG-64571 | refactor: add Prompter DI for interactive account-roles tests

### DIFF
--- a/cmd/create/accountroles/cmd.go
+++ b/cmd/create/accountroles/cmd.go
@@ -308,7 +308,7 @@ func run(cmd *cobra.Command, argv []string) {
 
 	prefix := args.prefix
 	if interactive.Enabled() {
-		prefix, err = interactive.GetString(interactive.Input{
+		prefix, err = r.Prompter.GetString(interactive.Input{
 			Question: "Role prefix",
 			Help:     cmd.Flags().Lookup("prefix").Usage,
 			Default:  prefix,
@@ -338,7 +338,7 @@ func run(cmd *cobra.Command, argv []string) {
 
 	permissionsBoundary := args.permissionsBoundary
 	if interactive.Enabled() {
-		permissionsBoundary, err = interactive.GetString(interactive.Input{
+		permissionsBoundary, err = r.Prompter.GetString(interactive.Input{
 			Question: "Permissions boundary ARN",
 			Help:     cmd.Flags().Lookup("permissions-boundary").Usage,
 			Default:  permissionsBoundary,
@@ -362,7 +362,7 @@ func run(cmd *cobra.Command, argv []string) {
 
 	path := args.path
 	if interactive.Enabled() {
-		path, err = interactive.GetString(interactive.Input{
+		path, err = r.Prompter.GetString(interactive.Input{
 			Question: "Path",
 			Help:     cmd.Flags().Lookup("path").Usage,
 			Default:  path,
@@ -383,7 +383,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	if interactive.Enabled() && !cmd.Flags().Changed("external-id") {
-		args.externalID, err = interactive.GetString(interactive.Input{
+		args.externalID, err = r.Prompter.GetString(interactive.Input{
 			Question: "STS external ID",
 			Help:     cmd.Flags().Lookup("external-id").Usage,
 			Default:  args.externalID,
@@ -404,7 +404,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	if interactive.Enabled() {
-		mode, err = interactive.GetOptionMode(cmd, mode, "Role creation mode")
+		mode, err = r.Prompter.GetOptionMode(cmd, mode, "Role creation mode")
 		if err != nil {
 			r.Reporter.Errorf("Expected a valid role creation mode: %s", err)
 			os.Exit(1)
@@ -423,38 +423,26 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	createClassic := args.classic
-	if interactive.Enabled() && !isClassicValueSet && !isHostedCPValueSet {
-		createClassic, err = interactive.GetBool(interactive.Input{
-			Question: "Create Classic account roles",
-			Help:     cmd.Flags().Lookup("classic").Usage,
-			Default:  true,
-			Required: false,
-		})
-		if err != nil {
-			r.Reporter.Errorf("Expected a valid value: %s", err)
-			os.Exit(1)
-		}
-		isClassicValueSet = true
-	}
-
 	createHostedCP := args.hostedCP
 	defaultValue := args.route53RoleArn != "" && args.vpcEndpointRoleArn != ""
-	if interactive.Enabled() && !isHostedCPValueSet && !cmd.Flags().Changed("classic") {
-		createHostedCP, err = interactive.GetBool(interactive.Input{
-			Question: "Create Hosted CP account roles",
-			Help:     cmd.Flags().Lookup("hosted-cp").Usage,
-			Default:  defaultValue || !createClassic,
-			Required: false,
-		})
-		if err != nil {
-			r.Reporter.Errorf("Expected a valid value: %s", err)
-			os.Exit(1)
-		}
-		isHostedCPValueSet = true
+	createClassic, createHostedCP, isClassicValueSet, isHostedCPValueSet, err = promptClassicAndHostedCP(
+		r.Prompter,
+		cmd.Flags().Lookup("classic").Usage,
+		cmd.Flags().Lookup("hosted-cp").Usage,
+		createClassic,
+		createHostedCP,
+		isClassicValueSet,
+		isHostedCPValueSet,
+		cmd.Flags().Changed("classic"),
+		defaultValue,
+	)
+	if err != nil {
+		r.Reporter.Errorf("Expected a valid value: %s", err)
+		os.Exit(1)
 	}
 
 	if interactive.Enabled() && createHostedCP {
-		isHcpSharedVpc, err = interactive.GetBool(interactive.Input{
+		isHcpSharedVpc, err = r.Prompter.GetBool(interactive.Input{
 			Question: "Use account roles for Hosted CP shared VPC?",
 			Help: "Whether or not to set route53/VPC endpoint role ARNs to be used for Hosted CP shared VPC " +
 				"(cross-account VPC)",
@@ -473,7 +461,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	if interactive.Enabled() && isHcpSharedVpc && !r.Creator.IsGovcloud && createHostedCP {
-		args.vpcEndpointRoleArn, err = interactive.GetString(interactive.Input{
+		args.vpcEndpointRoleArn, err = r.Prompter.GetString(interactive.Input{
 			Question: "Set VPC endpoint role ARN",
 			Help:     cmd.Flags().Lookup(vpcEndpointRoleArnFlag).Usage,
 			Default:  args.vpcEndpointRoleArn,
@@ -488,7 +476,7 @@ func run(cmd *cobra.Command, argv []string) {
 		}
 	}
 	if interactive.Enabled() && isHcpSharedVpc && !r.Creator.IsGovcloud && createHostedCP {
-		args.route53RoleArn, err = interactive.GetString(interactive.Input{
+		args.route53RoleArn, err = r.Prompter.GetString(interactive.Input{
 			Question: "Set route53 role ARN",
 			Help:     cmd.Flags().Lookup(route53RoleArnFlag).Usage,
 			Default:  args.route53RoleArn,

--- a/cmd/create/accountroles/cmd_test.go
+++ b/cmd/create/accountroles/cmd_test.go
@@ -3,6 +3,8 @@ package accountroles
 import (
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
+
+	"github.com/openshift/rosa/pkg/interactive"
 )
 
 const cmdTestExternalID = "223B9588-36A5-ECA4-BE8D-7C673B77CEC1"
@@ -21,5 +23,91 @@ var _ = Describe("validateAccountRolesSTSExternalID", func() {
 	It("rejects an invalid external-id", func() {
 		err := validateAccountRolesSTSExternalID("x")
 		Expect(err).To(HaveOccurred(), "invalid external-id should fail validation")
+	})
+})
+
+// OCP-43071 interactive flow (Prompter).
+// Steps 6–7 already covered by cmd/verify/quota and cmd/verify/oc.
+// Step 5 (login/token) deferred — login path, not account-roles prompts.
+// Step 8 (invalid AWS credentials) deferred — fails in WithAWS()/client init
+// before interactive prompts; needs a larger harness than this pilot.
+var _ = Describe("OCP-43071 promptClassicAndHostedCP", func() {
+	BeforeEach(func() {
+		interactive.SetEnabled(true)
+	})
+
+	AfterEach(func() {
+		interactive.SetEnabled(false)
+	})
+
+	It("asks classic (default true) then hosted-cp when no flags are set", func() {
+		p := &recordingBoolPrompter{
+			answers: map[string]bool{
+				questionCreateClassic:  true,
+				questionCreateHostedCP: false,
+			},
+		}
+
+		createClassic, createHostedCP, _, _, err := promptClassicAndHostedCP(
+			p, "classic help", "hosted help",
+			false, false,
+			false, false,
+			false, false,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(p.asked).To(Equal([]string{questionCreateClassic, questionCreateHostedCP}))
+		Expect(p.defaults[0]).To(Equal(true), "classic default should be Y/true")
+		Expect(createClassic).To(BeTrue())
+		Expect(createHostedCP).To(BeFalse())
+	})
+
+	It("skips classic question when --hosted-cp is set", func() {
+		p := &recordingBoolPrompter{answers: map[string]bool{}}
+
+		createClassic, createHostedCP, _, _, err := promptClassicAndHostedCP(
+			p, "classic help", "hosted help",
+			false, true, // createHostedCP from --hosted-cp
+			false, true, // isHostedCPValueSet
+			false, false,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(p.asked).To(BeEmpty(), "no classic/hosted prompts when --hosted-cp already set")
+		Expect(createClassic).To(BeFalse())
+		Expect(createHostedCP).To(BeTrue())
+	})
+
+	It("skips hosted-cp question when --classic flag is set", func() {
+		p := &recordingBoolPrompter{answers: map[string]bool{}}
+
+		createClassic, createHostedCP, _, _, err := promptClassicAndHostedCP(
+			p, "classic help", "hosted help",
+			true, false, // createClassic from --classic
+			true, false, // isClassicValueSet
+			true, false, // classicFlagChanged
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(p.asked).To(BeEmpty(), "no classic/hosted prompts when --classic already set")
+		Expect(createClassic).To(BeTrue())
+		Expect(createHostedCP).To(BeFalse())
+	})
+
+	It("uses flag-driven hosted-cp default when still prompting for hosted-cp after classic=false", func() {
+		p := &recordingBoolPrompter{
+			answers: map[string]bool{
+				questionCreateClassic:  false,
+				questionCreateHostedCP: true,
+			},
+		}
+
+		_, createHostedCP, _, _, err := promptClassicAndHostedCP(
+			p, "classic help", "hosted help",
+			false, false,
+			false, false,
+			false, false,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(p.asked).To(Equal([]string{questionCreateClassic, questionCreateHostedCP}))
+		Expect(p.defaults[1]).To(Equal(true), "hosted-cp default should be true when classic is false")
+		Expect(createHostedCP).To(BeTrue())
 	})
 })

--- a/cmd/create/accountroles/interactive_prompts.go
+++ b/cmd/create/accountroles/interactive_prompts.go
@@ -1,0 +1,74 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package accountroles
+
+import (
+	"github.com/openshift/rosa/pkg/interactive"
+)
+
+const (
+	questionCreateClassic  = "Create Classic account roles"
+	questionCreateHostedCP = "Create Hosted CP account roles"
+)
+
+// promptClassicAndHostedCP applies interactive rules for classic vs hosted-cp
+// account-role creation (Polarion OCP-43071 steps 3–4).
+//
+//   - Classic is asked only when neither --classic nor --hosted-cp was set.
+//   - Hosted CP is asked only when --hosted-cp was not set and --classic was not
+//     changed on the command line.
+func promptClassicAndHostedCP(
+	p interactive.Prompter,
+	classicHelp string,
+	hostedCPHelp string,
+	createClassic bool,
+	createHostedCP bool,
+	isClassicValueSet bool,
+	isHostedCPValueSet bool,
+	classicFlagChanged bool,
+	sharedVpcRolesDefault bool,
+) (bool, bool, bool, bool, error) {
+	var err error
+
+	if interactive.Enabled() && !isClassicValueSet && !isHostedCPValueSet {
+		createClassic, err = p.GetBool(interactive.Input{
+			Question: questionCreateClassic,
+			Help:     classicHelp,
+			Default:  true,
+			Required: false,
+		})
+		if err != nil {
+			return createClassic, createHostedCP, isClassicValueSet, isHostedCPValueSet, err
+		}
+		isClassicValueSet = true
+	}
+
+	if interactive.Enabled() && !isHostedCPValueSet && !classicFlagChanged {
+		createHostedCP, err = p.GetBool(interactive.Input{
+			Question: questionCreateHostedCP,
+			Help:     hostedCPHelp,
+			Default:  sharedVpcRolesDefault || !createClassic,
+			Required: false,
+		})
+		if err != nil {
+			return createClassic, createHostedCP, isClassicValueSet, isHostedCPValueSet, err
+		}
+		isHostedCPValueSet = true
+	}
+
+	return createClassic, createHostedCP, isClassicValueSet, isHostedCPValueSet, nil
+}

--- a/cmd/create/accountroles/recording_prompter_test.go
+++ b/cmd/create/accountroles/recording_prompter_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package accountroles
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/interactive"
+)
+
+// recordingBoolPrompter records GetBool questions for OCP-43071 flow tests.
+// Other Prompter methods are unused in these tests.
+type recordingBoolPrompter struct {
+	asked    []string
+	defaults []any
+	answers  map[string]bool
+}
+
+func (p *recordingBoolPrompter) GetBool(input interactive.Input) (bool, error) {
+	p.asked = append(p.asked, input.Question)
+	p.defaults = append(p.defaults, input.Default)
+	if answer, ok := p.answers[input.Question]; ok {
+		return answer, nil
+	}
+	if dflt, ok := input.Default.(bool); ok {
+		return dflt, nil
+	}
+	return false, nil
+}
+
+func (p *recordingBoolPrompter) GetString(interactive.Input) (string, error) {
+	return "", fmt.Errorf("unexpected GetString in recordingBoolPrompter")
+}
+func (p *recordingBoolPrompter) GetInt(interactive.Input) (int, error) {
+	return 0, fmt.Errorf("unexpected GetInt in recordingBoolPrompter")
+}
+func (p *recordingBoolPrompter) GetFloat(interactive.Input) (float64, error) {
+	return 0, fmt.Errorf("unexpected GetFloat in recordingBoolPrompter")
+}
+func (p *recordingBoolPrompter) GetMultipleOptions(interactive.Input) ([]string, error) {
+	return nil, fmt.Errorf("unexpected GetMultipleOptions in recordingBoolPrompter")
+}
+func (p *recordingBoolPrompter) GetOption(interactive.Input) (string, error) {
+	return "", fmt.Errorf("unexpected GetOption in recordingBoolPrompter")
+}
+func (p *recordingBoolPrompter) GetIPNet(interactive.Input) (net.IPNet, error) {
+	return net.IPNet{}, fmt.Errorf("unexpected GetIPNet in recordingBoolPrompter")
+}
+func (p *recordingBoolPrompter) GetPassword(interactive.Input) (string, error) {
+	return "", fmt.Errorf("unexpected GetPassword in recordingBoolPrompter")
+}
+func (p *recordingBoolPrompter) GetCert(interactive.Input) (string, error) {
+	return "", fmt.Errorf("unexpected GetCert in recordingBoolPrompter")
+}
+func (p *recordingBoolPrompter) GetOptionMode(*cobra.Command, string, string) (string, error) {
+	return "", fmt.Errorf("unexpected GetOptionMode in recordingBoolPrompter")
+}

--- a/guidelines/ARCHITECTURE.md
+++ b/guidelines/ARCHITECTURE.md
@@ -207,6 +207,10 @@ The codebase does not yet follow this target architecture. Today:
   dependencies). In the target architecture, packages under `internal/` should
   be organized into `internal/core/` (private core implementation) or
   `internal/cli/` (shared CLI infrastructure).
+- Interactive prompting is still under `pkg/interactive` / `pkg/rosa.Runtime`.
+  Unit tests inject a `Prompter` on `Runtime` (same idea as `confirmFn` in
+  `cmd/dlt/cluster`). Production uses `SurveyPrompter`. This is the current
+  pattern, not the final `internal/cli/` move.
 
 The migration is incremental. See [`pkg-architecture.md`](refactor/pkg-architecture.md) for
 the per-package classification and split work required.

--- a/guidelines/refactor/pkg-architecture.md
+++ b/guidelines/refactor/pkg-architecture.md
@@ -78,7 +78,7 @@ Target location: `cmd/` (commands) or `internal/cli/` (shared CLI code). Each en
 | `internal/cli/commandbuilder/roles` (`pkg/aws/commandbuilder/helper/roles`) | Generates manual-mode AWS CLI commands for operator roles. |
 | `internal/cli/commands` (`pkg/commands`) | Single-function command registry wiring all subcommands onto root `cobra.Command`. |
 | `internal/cli/debug` (`pkg/debug`) | Adds the `--debug` pflag and tracks its boolean state. |
-| `internal/cli/interactive` (`pkg/interactive`) | `survey`-based `GetString`, `GetBool`, `GetInt`, `GetOption`, `GetPassword`, validation combinators, `--interactive` pflag. |
+| `internal/cli/interactive` (`pkg/interactive`) | `survey`-based `GetString`, `GetBool`, `GetInt`, `GetOption`, `GetPassword`, validation combinators, `--interactive` pflag. Interim: `Prompter` / `SurveyPrompter` for unit tests; package `Get*` stay as wrappers. Target path still `internal/cli/interactive`. |
 | `internal/cli/interactive/confirm` (`pkg/interactive/confirm`) | `--yes` flag and confirmation prompts using `survey`. |
 | `internal/cli/interactive/consts` (`pkg/interactive/consts`) | Single constant (`SkipSelectionOption`) used exclusively by the interactive layer. |
 | `internal/cli/interactive/logforwarding` (`pkg/interactive/logforwarding`) | Interactive prompts for CloudWatch/S3 log forwarding config. |
@@ -91,7 +91,7 @@ Target location: `cmd/` (commands) or `internal/cli/` (shared CLI code). Each en
 | `internal/cli/region` (`pkg/aws/region`) | Adds the `--region` pflag. |
 | `internal/cli/reporter` (`pkg/reporter`) | `Logger` interface and terminal-aware reporter printing colored messages to stdout/stderr. |
 | `internal/cli/roles` (`pkg/helper/roles`) | Needs split. CLI workflow orchestration: auto/manual mode branching, `confirm.Prompt`, `r.Reporter.*`, `fmt.Println`, `os.Exit`. Reusable logic (role name generation, ARN validation, managed policy validation, tag checks) moves to `pkg/operatorroles`. |
-| `internal/cli/runtime` (`pkg/rosa`) | Central `Runtime` struct bundling Reporter, Logger, OCMClient, AWSClient, plus `DefaultRunner`/`RuntimeVisitor` Cobra wrappers. The CLI lifecycle harness. |
+| `internal/cli/runtime` (`pkg/rosa`) | Central `Runtime` struct bundling Reporter, Logger, OCMClient, AWSClient, Prompter, plus `DefaultRunner`/`RuntimeVisitor` Cobra wrappers. The CLI lifecycle harness. Target path still `internal/cli/runtime`. |
 | `cmd/` (`pkg/options/iamserviceaccount`) | Builds full `cobra.Command` structs and wires flags for IAM service account create/delete/describe. |
 | `cmd/` (`pkg/options/machinepool`) | Builds `cobra.Command` and wires flags for machine pool creation. |
 | `cmd/` (`pkg/options/network`) | Builds `cobra.Command` and instantiates `reporter.CreateReporter()`. |

--- a/pkg/interactive/interactive.go
+++ b/pkg/interactive/interactive.go
@@ -42,8 +42,13 @@ type Input struct {
 	Validators     []Validator
 }
 
+// GetString gets string input from the command line using the default prompter.
+func GetString(input Input) (string, error) {
+	return defaultPrompter.GetString(input)
+}
+
 // Gets string input from the command line
-func GetString(input Input) (a string, err error) {
+func (s *SurveyPrompter) GetString(input Input) (a string, err error) {
 	transformer := survey.TransformString(helper.HandleEscapedEmptyString)
 	core.DisableColor = !color.UseColor()
 	dflt, ok := input.Default.(string)
@@ -67,8 +72,13 @@ func GetString(input Input) (a string, err error) {
 	return
 }
 
+// GetInt gets int input from the command line using the default prompter.
+func GetInt(input Input) (int, error) {
+	return defaultPrompter.GetInt(input)
+}
+
 // Gets int number input from the command line
-func GetInt(input Input) (a int, err error) {
+func (s *SurveyPrompter) GetInt(input Input) (a int, err error) {
 	core.DisableColor = !color.UseColor()
 	dflt, ok := input.Default.(int)
 	if !ok {
@@ -105,8 +115,13 @@ func parseInt(str string) (num int, err error) {
 	return strconv.Atoi(str)
 }
 
+// GetFloat gets float input from the command line using the default prompter.
+func GetFloat(input Input) (float64, error) {
+	return defaultPrompter.GetFloat(input)
+}
+
 // Gets float number input from the command line
-func GetFloat(input Input) (a float64, err error) {
+func (s *SurveyPrompter) GetFloat(input Input) (a float64, err error) {
 	core.DisableColor = !color.UseColor()
 	dflt, ok := input.Default.(float64)
 	if !ok {
@@ -145,8 +160,13 @@ func parseFloat(str string) (num float64, err error) {
 	return strconv.ParseFloat(str, commonUtils.MaxByteSize)
 }
 
-// Asks for multiple options selection
+// GetMultipleOptions asks for multiple options using the default prompter.
 func GetMultipleOptions(input Input) ([]string, error) {
+	return defaultPrompter.GetMultipleOptions(input)
+}
+
+// Asks for multiple options selection
+func (s *SurveyPrompter) GetMultipleOptions(input Input) ([]string, error) {
 	core.DisableColor = !color.UseColor()
 	var err error
 	res := make([]string, 0)
@@ -171,8 +191,13 @@ func GetMultipleOptions(input Input) ([]string, error) {
 	return res, err
 }
 
+// GetOption asks for option selection using the default prompter.
+func GetOption(input Input) (string, error) {
+	return defaultPrompter.GetOption(input)
+}
+
 // Asks for option selection in the command line
-func GetOption(input Input) (a string, err error) {
+func (s *SurveyPrompter) GetOption(input Input) (a string, err error) {
 	core.DisableColor = !color.UseColor()
 	dflt, ok := input.Default.(string)
 	if !ok {
@@ -235,8 +260,13 @@ func containsString(s []string, input string) bool {
 	return false
 }
 
+// GetBool asks for true/false using the default prompter.
+func GetBool(input Input) (bool, error) {
+	return defaultPrompter.GetBool(input)
+}
+
 // Asks for true/false value in the command line
-func GetBool(input Input) (a bool, err error) {
+func (s *SurveyPrompter) GetBool(input Input) (a bool, err error) {
 	core.DisableColor = !color.UseColor()
 	dflt, ok := input.Default.(bool)
 	if !ok {
@@ -254,8 +284,13 @@ func GetBool(input Input) (a bool, err error) {
 	return
 }
 
+// GetIPNet asks for a CIDR using the default prompter.
+func GetIPNet(input Input) (net.IPNet, error) {
+	return defaultPrompter.GetIPNet(input)
+}
+
 // Asks for CIDR value in the command line
-func GetIPNet(input Input) (a net.IPNet, err error) {
+func (s *SurveyPrompter) GetIPNet(input Input) (a net.IPNet, err error) {
 	core.DisableColor = !color.UseColor()
 	dflt, ok := input.Default.(net.IPNet)
 	if !ok {
@@ -295,8 +330,13 @@ func GetIPNet(input Input) (a net.IPNet, err error) {
 	return
 }
 
+// GetPassword gets password input using the default prompter.
+func GetPassword(input Input) (string, error) {
+	return defaultPrompter.GetPassword(input)
+}
+
 // Gets password input from the command line
-func GetPassword(input Input) (a string, err error) {
+func (s *SurveyPrompter) GetPassword(input Input) (a string, err error) {
 	core.DisableColor = !color.UseColor()
 	question := input.Question
 	if !input.Required {
@@ -313,8 +353,13 @@ func GetPassword(input Input) (a string, err error) {
 	return
 }
 
+// GetCert gets a certificate path using the default prompter.
+func GetCert(input Input) (string, error) {
+	return defaultPrompter.GetCert(input)
+}
+
 // Gets path to certificate file from the command line
-func GetCert(input Input) (a string, err error) {
+func (s *SurveyPrompter) GetCert(input Input) (a string, err error) {
 	core.DisableColor = !color.UseColor()
 	dflt, ok := input.Default.(string)
 	if !ok {

--- a/pkg/interactive/mode.go
+++ b/pkg/interactive/mode.go
@@ -56,7 +56,7 @@ func GetMode() (string, error) {
 		return "", nil
 	}
 	if !arguments.IsValidMode(Modes, mode) {
-		return "", fmt.Errorf("Invalid mode. Allowed values are %s", Modes)
+		return "", fmt.Errorf("invalid mode. Allowed values are %s", Modes)
 	}
 	return mode, nil
 }
@@ -66,7 +66,11 @@ func modeCompletion(cmd *cobra.Command, args []string, toComplete string) ([]str
 }
 
 func GetOptionMode(cmd *cobra.Command, mode string, question string) (string, error) {
-	mode, err := GetOption(Input{
+	return defaultPrompter.GetOptionMode(cmd, mode, question)
+}
+
+func (s *SurveyPrompter) GetOptionMode(cmd *cobra.Command, mode string, question string) (string, error) {
+	mode, err := s.GetOption(Input{
 		Question: question,
 		Help:     cmd.Flags().Lookup(Mode).Usage,
 		Default:  mode,

--- a/pkg/interactive/mode_test.go
+++ b/pkg/interactive/mode_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Mode Test", func() {
 			SetModeKey("invalid_mode")
 			_, err := GetMode()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("Invalid mode. Allowed values are %v", Modes)))
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("invalid mode. Allowed values are %v", Modes)))
 		})
 	})
 

--- a/pkg/interactive/prompter.go
+++ b/pkg/interactive/prompter.go
@@ -1,0 +1,44 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package interactive
+
+import (
+	"net"
+
+	"github.com/spf13/cobra"
+)
+
+// Prompter abstracts survey prompts so commands can be tested without a real
+// terminal. Same idea as confirmFn in cmd/dlt/cluster.
+type Prompter interface {
+	GetString(Input) (string, error)
+	GetInt(Input) (int, error)
+	GetFloat(Input) (float64, error)
+	GetMultipleOptions(Input) ([]string, error)
+	GetOption(Input) (string, error)
+	GetBool(Input) (bool, error)
+	GetIPNet(Input) (net.IPNet, error)
+	GetPassword(Input) (string, error)
+	GetCert(Input) (string, error)
+	GetOptionMode(cmd *cobra.Command, mode string, question string) (string, error)
+}
+
+// SurveyPrompter is the production Prompter that uses survey.AskOne.
+type SurveyPrompter struct{}
+
+// defaultPrompter backs the package-level Get* helpers.
+var defaultPrompter Prompter = &SurveyPrompter{}

--- a/pkg/rosa/runtime.go
+++ b/pkg/rosa/runtime.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/logging"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/output"
@@ -24,13 +25,19 @@ type Runtime struct {
 	ClusterKey string
 	Cluster    *cmv1.Cluster
 	Spinner    *spinner.Spinner
+	Prompter   interactive.Prompter
 }
 
 func NewRuntime() *Runtime {
 	r := reporter.CreateReporter()
 	logger := logging.NewLogger()
 	spinner := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-	return &Runtime{Reporter: output.NewStructuredReporter(r), Logger: logger, Spinner: spinner}
+	return &Runtime{
+		Reporter: output.NewStructuredReporter(r),
+		Logger:   logger,
+		Spinner:  spinner,
+		Prompter: &interactive.SurveyPrompter{},
+	}
 }
 
 // WithOCM Adds an OCM client to the runtime. Requires a deferred call to `.Cleanup()` to close connections.


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
Supported ticket prefixes:
OCM-XXXXX, ROSAENG-XXXX
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For contributor workflow, see: ./CONTRIBUTING.md
For repo-local agent guidance, see: ./AGENTS.md
-->

## PR Summary
Add a `Prompter` interface on `Runtime` so interactive account-roles flows (Polarion OCP-43071 steps 3–4) can be unit-tested without a real terminal. Production behavior unchanged via `SurveyPrompter`.

## Detailed Description of the Issue
Interactive ROSA CLI flows call package-level `interactive.Get*` helpers backed by `survey`, which blocks unit tests from asserting which questions run under which flags. [ROSAENG-64571](https://redhat.atlassian.net/browse/ROSAENG-64571) asks for a Prompter DI pilot on `create account-roles` so Polarion-style interactive flow checks can run in-process.

## Related Issues and PRs
- Jira: [ROSAENG-64571](https://issues.redhat.com/browse/ROSAENG-64571)
- Fixes: N/A
- Related PR(s): N/A
- Related design/docs: `guidelines/ARCHITECTURE.md`, `guidelines/refactor/pkg-architecture.md` (interim Prompter note; target remains `internal/cli/`)

## Type of Change
<!-- Check the primary type this PR represents -->
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [x] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
`create account-roles` interactive prompts used package `interactive.Get*` directly. Classic vs hosted-cp ask/skip rules lived inline in `run`. Those rules were not covered by unit tests.

## Behavior After This Change
- `Runtime` carries `Prompter` (default `SurveyPrompter`).
- Package `Get*` helpers delegate to `defaultPrompter`.
- `create account-roles` uses `r.Prompter`; classic/hosted-cp flow is in `promptClassicAndHostedCP`.
- Unit tests cover OCP-43071 steps 3–4 (which bool prompts run / defaults / skip on `--classic` / `--hosted-cp`).
- CLI flags and user-visible survey behavior are intended to be unchanged.
- Secondary commits: lowercase `GetMode` error string (staticcheck) + matching test assertion.

## How to Test (Step-by-Step)
### Preconditions
- Go toolchain matching `go.mod`
- No AWS/OCM credentials required for the unit tests below

### Test Steps
1. `go test ./pkg/interactive/ ./cmd/create/accountroles/ -count=1`
2. Optional manual smoke: `rosa create account-roles -i` and confirm classic (default Y) then hosted-cp (default N) still appear when no flags are set; `--hosted-cp` / `--classic` still skip the other question.

### Expected Results
1. Unit tests pass, including `OCP-43071 promptClassicAndHostedCP`.
2. Manual interactive flow matches previous ask/skip behavior.

## Proof of the Fix
- Screenshots: N/A
- Videos: N/A
- Logs/CLI output: Pre-push checks passed (fmt, build, lint, coverage, unit/integration tests). Local CodeRabbit uncommitted review reported 0 findings (untracked files later committed).
- Other artifacts: N/A

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [x] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

Made with [Cursor](https://cursor.com)

[ROSAENG-64571]: https://redhat.atlassian.net/browse/ROSAENG-64571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added interactive prompts for selecting Classic and Hosted control-plane account roles.
  - Prompts support configurable defaults and skip selections already provided through command options.
  - Interactive input can be supplied through a reusable runtime prompt interface.
  - Standardized interactive prompts for common input types while preserving validation and error handling.

- **Bug Fixes**
  - Improved consistency and validation when collecting role selections, including shared VPC and ARN checks.

- **Documentation**
  - Updated architecture guidance to document interactive prompting and testing patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->