### PR TITLE
ROSAENG-64506 | rosa-day1-supplemental-f3 | test: fix OCP-45745 role upgrade via rosa upgrade roles

### DIFF
--- a/tests/e2e/test_rosacli_operator_roles.go
+++ b/tests/e2e/test_rosacli_operator_roles.go
@@ -1189,9 +1189,6 @@ var _ = Describe("Upgrade operator roles in auto mode",
 				Expect(err).ToNot(HaveOccurred())
 				Expect(upgradingVersion).ToNot(BeEmpty(), "Failed to find an upgrade target")
 
-				_, _, roleUpgradeVersion, err := helper.GetMajorMinorFromVersion(upgradingVersion)
-				Expect(err).To(BeNil())
-
 				By("Upgrade cluster to verify if there are any prompts to upgrade account roles firstly")
 				scheduledAt := time.Now().UTC().Add(10 * time.Minute)
 				scheduledDate := scheduledAt.Format("2006-01-02")
@@ -1206,46 +1203,21 @@ var _ = Describe("Upgrade operator roles in auto mode",
 				Expect(err).NotTo(BeNil())
 				Expect(output.String()).To(ContainSubstring("Account roles need to be upgraded to proceed"))
 
-				By("Upgrade account roles in auto mode")
-				accountRolePrefix := customProfile.ClusterConfig.Name
-				_, err = ocmResourceService.UpgradeAccountRole(
-					"--prefix", accountRolePrefix,
+				By("Upgrade account and operator roles in auto mode")
+				output, err = ocmResourceService.UpgradeRoles(
+					"-c", clusterID,
+					"--cluster-version", upgradingVersion,
 					"--mode", "auto",
-					"--version", roleUpgradeVersion,
-					"--channel-group", "candidate",
 					"-y",
 				)
 				Expect(err).To(BeNil())
+				Expect(output.String()).To(ContainSubstring("Ensuring account role/policies compatibility for " +
+					"upgrade"))
+				Expect(output.String()).To(ContainSubstring("Starting to upgrade the policies"))
+				Expect(output.String()).To(ContainSubstring("Ensuring operator role/policies compatibility for" +
+					" upgrade"))
 
-				By("Upgrade operator roles in auto mode")
-				output, err = ocmResourceService.UpgradeOperatorRoles(
-					"--cluster", clusterID,
-					"--version", upgradingVersion,
-					"--mode", "auto",
-					"-y",
-				)
-				Expect(err).To(BeNil())
-				Expect(output.String()).To(ContainSubstring("Starting to upgrade the operator IAM roles and " +
-					"policies"))
-				Expect(output.String()).To(ContainSubstring(
-					"policy/%s-openshift-image-registry-installer-cloud-credent' to version '%s'",
-					accountRolePrefix, roleUpgradeVersion))
-				Expect(output.String()).To(ContainSubstring(
-					"policy/%s-openshift-ingress-operator-cloud-credentials' to version '%s'",
-					accountRolePrefix, roleUpgradeVersion))
-				Expect(output.String()).To(ContainSubstring(
-					"policy/%s-openshift-cluster-csi-drivers-ebs-cloud-credenti' to version '%s'",
-					accountRolePrefix, roleUpgradeVersion))
-				Expect(output.String()).To(ContainSubstring(
-					"policy/%s-openshift-cloud-network-config-controller-cloud-' to version '%s'",
-					accountRolePrefix, roleUpgradeVersion))
-				Expect(output.String()).To(ContainSubstring(
-					"policy/%s-openshift-machine-api-aws-cloud-credentials' to version '%s'",
-					accountRolePrefix, roleUpgradeVersion))
-				Expect(output.String()).To(ContainSubstring(
-					"policy/%s-openshift-cloud-credential-operator-cloud-creden' to version '%s'",
-					accountRolePrefix, roleUpgradeVersion))
-				By("Update cluster with --dry-run")
+				By("Verify cluster upgrade no longer requires role upgrades")
 				output, _ = upgradeService.Upgrade(
 					"-c", clusterID,
 					"--version", upgradingVersion,


### PR DESCRIPTION
## PR Summary
Fix OCP-45745 by upgrading account and operator roles with `rosa upgrade roles --cluster-version`, aligned with [ROSAENG-62788](https://redhat.atlassian.net/browse/ROSAENG-62788).

## Detailed Description of the Issue
Periodic `rosa-day1-supplemental-f3` fails on OCP-45745 after a successful Y-stream target is found. The case called:

1. `rosa upgrade account-roles --prefix … --version 4.21 --channel-group candidate`
   → `Account roles … are already up-to-date.`
2. `rosa upgrade operator-roles --cluster … --version 4.21.24`
   → `Account roles … need to be upgraded before operator roles`

That pairing is inconsistent:

- `upgrade account-roles --version` is a **policy major.minor** and the test hard-coded **`candidate`**, while the cluster profile uses **`stable`**.
- Standalone `upgrade operator-roles` does **not** use `--version` for the account-role gate; it compares against **`GetLatestVersion(cluster.ChannelGroup())`** ([OCM-2731](https://redhat.atlassian.net/browse/OCM-2731)).
- So “already up-to-date” on `4.21`/`candidate` does not satisfy the operator-roles gate.

Recent product change [ROSAENG-62788 / #3431](https://github.com/openshift/rosa/pull/3431) makes `rosa upgrade roles` derive the policy version from `--cluster-version` (e.g. `4.21.24` → `4.21`) instead of always targeting latest. Other upgrade e2e cases already use that command. OCP-45745 still used the old split path from [OCM-21111](https://redhat.atlassian.net/browse/OCM-21111) (kept `candidate` when switching to `list upgrade` targets).

## Related Issues and PRs
- Jira: [ROSAENG-64506](https://issues.redhat.com/browse/ROSAENG-64506)
- Fixes: OCP-45745 on `periodic-ci-openshift-rosa-master-e2e-rosa-day1-supplemental-f3`
- Related PR(s): [#3431](https://github.com/openshift/rosa/pull/3431) ([ROSAENG-62788](https://redhat.atlassian.net/browse/ROSAENG-62788)), [#3428](https://github.com/openshift/rosa/pull/3428) (Y-stream discovery only)
- Related design/docs: N/A
- Example failure: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-rosa-master-e2e-rosa-day1-supplemental-f3/2081881313475825664

## Type of Change
- [x] test - adds or updates tests only.

## Previous Behavior
After `upgrade cluster` correctly required account-role upgrades first, the test upgraded account roles with `--version <major.minor> --channel-group candidate`, then `upgrade operator-roles` with the full Y target, which still reported that account roles needed upgrading.

## Behavior After This Change
The test upgrades roles with a single `rosa upgrade roles -c <id> --cluster-version <Y-target> --mode auto`, matching the CLI path fixed in [ROSAENG-62788](https://redhat.atlassian.net/browse/ROSAENG-62788) and other upgrade e2e. Assertions follow that command’s output, then verify `upgrade cluster` no longer requires role upgrades.

## How to Test (Step-by-Step)
### Preconditions
- Stage/token AWS + OCM; `NAME_PREFIX` set; region `us-west-2` (case profile).

### Test Steps
1. `ginkgo run --focus '45745' tests/e2e --timeout 2h -v` with `TEST_PROFILE=null` and `NAME_PREFIX=<alias>`.
2. Or replay: after a y-1 classic STS cluster is ready and a Y upgrade target exists, run:
   `rosa upgrade roles -c <cluster> --cluster-version <target> --mode auto -y`
   then confirm `rosa upgrade cluster -c <cluster> --version <target> --mode auto -y` reports roles already up-to-date (without scheduling if still blocked only by schedule flags as in the case).

### Expected Results
- No `Account roles … need to be upgraded before operator roles` after `upgrade roles`.
- OCP-45745 passes when install/`Preparing account` infra is healthy.

## Proof of the Fix
- Screenshots: N/A
- Videos: N/A
- Logs/CLI output: N/A (full e2e not re-run in this session; unit/lint/fmt verified)
- Other artifacts: CI periodic after merge

## Breaking Changes
- [x] No breaking changes

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [ ] `make rosa` passes.
- [x] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

### Risk / follow-up
- Case still needs a ready y-1 cluster (~1h); unrelated `pending (Preparing account)` failures are out of scope.

Made with [Cursor](https://cursor.com)

[ROSAENG-64506]: https://redhat.atlassian.net/browse/ROSAENG-64506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ROSAENG-62788]: https://redhat.atlassian.net/browse/ROSAENG-62788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated upgrade validation to confirm account and operator role compatibility during cluster upgrades.
  * Simplified upgrade verification to ensure no additional role-upgrade prompts appear after compatibility checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->