### PR TITLE
ROSAENG-62605 | rosa-hcp-upgrade-y-stream-f3 | fix: align HCP y-stream upgrade tests with channel flow

### DIFF
--- a/tests/e2e/test_rosacli_upgrade.go
+++ b/tests/e2e/test_rosacli_upgrade.go
@@ -874,11 +874,15 @@ var _ = Describe("ROSA HCP cluster upgrade",
 			rosaClient     *rosacli.Client
 			clusterService rosacli.ClusterService
 			upgradeService rosacli.UpgradeService
+			profile        *handler.Profile
 			yStreamVersion string
 			zStreamVersion string
 		)
 
 		BeforeEach(func() {
+			yStreamVersion = ""
+			zStreamVersion = ""
+
 			By("Get the cluster")
 			clusterID = config.GetClusterID()
 			Expect(clusterID).ToNot(Equal(""), "ClusterID is required. Please export CLUSTER_ID")
@@ -887,6 +891,9 @@ var _ = Describe("ROSA HCP cluster upgrade",
 			rosaClient = rosacli.NewClient()
 			clusterService = rosaClient.Cluster
 			upgradeService = rosaClient.Upgrade
+
+			By("Load the profile")
+			profile = handler.LoadProfileYamlFileByENV()
 
 			By("Skip testing if the cluster is not a HCP cluster")
 			hostedCluster, err := clusterService.IsHostedCPCluster(clusterID)
@@ -900,6 +907,20 @@ var _ = Describe("ROSA HCP cluster upgrade",
 			Expect(err).ToNot(HaveOccurred())
 			clusterVersion := clusterVersionInfo.RawID
 
+			// Y-stream HCP lanes need the next-minor channel before available_upgrades
+			// populate (same flow as classic cases after ROSAENG-61412 / #3353).
+			if profile.Version == constants.YStreamPreviousVersion {
+				By("Prepare cluster for y-stream upgrade target discovery")
+				upgradingVersion, err := prepareYStreamUpgradeVersion(
+					clusterID,
+					profile.ChannelGroup,
+					clusterService,
+					upgradeService,
+				)
+				Expect(err).ToNot(HaveOccurred())
+				yStreamVersion = upgradingVersion
+			}
+
 			jsonData, err := clusterService.GetJSONClusterDescription(clusterID)
 			Expect(err).To(BeNil())
 
@@ -910,10 +931,10 @@ var _ = Describe("ROSA HCP cluster upgrade",
 				}
 			}
 
-			By("Get cluster z stream available version")
+			By("Get cluster available upgrade versions")
 			yStreamVersions, zStreamVersions, err := helper.FindUpgradeVersions(availableUpgrades, clusterVersion)
 			Expect(err).To(BeNil())
-			if len(yStreamVersions) != 0 {
+			if yStreamVersion == "" && len(yStreamVersions) != 0 {
 				yStreamVersion = yStreamVersions[len(yStreamVersions)-1]
 			}
 			if len(zStreamVersions) != 0 {
@@ -985,10 +1006,18 @@ var _ = Describe("ROSA HCP cluster upgrade",
 		})
 
 		It("manual upgrade for hcp upgrade  - [id:62929]", labels.Critical, labels.Runtime.Upgrade, func() {
-			targetVersion := zStreamVersion
-			if targetVersion == "" {
+			// On y-1 profiles use the prepared next-minor target; do not prefer a
+			// z-stream when both are advertised on the next-minor channel.
+			var targetVersion string
+			if profile.Version == constants.YStreamPreviousVersion {
 				targetVersion = yStreamVersion
+			} else {
+				targetVersion = zStreamVersion
+				if targetVersion == "" {
+					targetVersion = yStreamVersion
+				}
 			}
+			Expect(targetVersion).ToNot(BeEmpty())
 			By("Try to upgrade the cluster with manual mode and default time ")
 			output, err := upgradeService.Upgrade(
 				"-c", clusterID,
@@ -1107,10 +1136,18 @@ var _ = Describe("ROSA HCP cluster upgrade",
 
 				By("detach managed policies from account role and operator role and update cluster")
 				arbitraryPolicyService = rosaClient.Policy
-				upgradeVersion := zStreamVersion
-				if zStreamVersion == "" {
+				// On y-1 profiles use the prepared next-minor target; do not prefer a
+				// z-stream when both are advertised on the next-minor channel.
+				var upgradeVersion string
+				if profile.Version == constants.YStreamPreviousVersion {
 					upgradeVersion = yStreamVersion
+				} else {
+					upgradeVersion = zStreamVersion
+					if upgradeVersion == "" {
+						upgradeVersion = yStreamVersion
+					}
 				}
+				Expect(upgradeVersion).ToNot(BeEmpty())
 				for r, p := range rolePolicyMap {
 					_, err := arbitraryPolicyService.DetachPolicy(r, []string{p}, "--mode", "auto")
 					Expect(err).To(BeNil())


### PR DESCRIPTION
## PR Summary

Align HCP y-stream upgrade e2e with the classic channel-prep flow, and schedule the prepared next-minor target on `y-1` profiles so the lane validates y-stream upgrades (not a z-stream fallback).

## Detailed Description of the Issue

`periodic-ci-openshift-rosa-master-e2e-rosa-hcp-upgrade-y-stream-f3` started failing after staging began resolving `y-1` to tip versions such as `4.21.25` / `4.21.27`. On channel `stable-4.21`, HCP `available_upgrades` can be empty, so `OCP-62929` / `OCP-62161` fail with "There are no available upgrades". Classic y-stream cases already call `prepareYStreamUpgradeVersion` (#3353); the HCP suite still only snapshotted `available_upgrades` in `BeforeEach`. After channel prep, ROSA can advertise both patch and next-minor targets, so z-first selection can pass the lane without scheduling the intended y-stream upgrade.

## Related Issues and PRs
- Jira: [ROSAENG-62605](https://issues.redhat.com/browse/ROSAENG-62605)
- Fixes: N/A
- Related PR(s): #3353, #3412
- Related design/docs: N/A

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [x] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior

HCP upgrade `BeforeEach` read `version.available_upgrades` without moving the cluster to the next-minor channel. On tip `y-1` versions that list was often empty, so manual HCP upgrade cases failed immediately. When upgrades were present after channel changes elsewhere, manual/role-policy cases preferred a z-stream target when both z- and y-stream were advertised.

## Behavior After This Change

For profiles with `version: y-1`, the HCP suite loads the profile and calls existing `prepareYStreamUpgradeVersion` (edit to next-minor channel + wait) before refreshing upgrade targets. `OCP-62929` and `OCP-62161` use that prepared y-stream version directly on `y-1` profiles. Z-stream HCP profiles keep the previous z-first fallback. Channel is left mutated after tests (same as classic #3353); restore-on-cleanup is a follow-up across classic and HCP.

## Affected upgrade specs (`(upgrade)&&!Exclude`)

Primary scope: **64187 / 62929 / 62161**. Other specs only share the `upgrade` label used by the periodic filter.

| ID | `It` title | How this PR affects it |
|----|------------|------------------------|
| 64187 | automatic upgrade for HCP cluster | HCP `BeforeEach` runs `prepareYStreamUpgradeVersion` on `y-1` so next-minor channel/targets exist before the case runs. |
| 62929 | manual upgrade for hcp upgrade | Same channel prep; on `y-1` schedules the prepared **y-stream** target instead of preferring z-stream when both are advertised. |
| 62161 | to validate role's policy when upgrade hcp cluster | Same channel prep; on `y-1` uses the prepared **y-stream** version for the policy-validation upgrade attempt. |
| 67412 | can upgrade machinepool of hosted cluster | **Not changed.** May see a cluster whose channel was already moved if another prep case ran first (shared cluster). |
| 73731 | to upgrade roles/operator-roles and cluster | **Not changed.** Classic suite; already uses #3353 prep. |
| 57444 | to upgrade wide AMI roles with the managed policies in auto mode | **Not changed.** Classic/shared prep path already present. |
| 75445 | to upgrade wide AMI roles with the managed policies in manual mode | **Not changed.** Classic/shared prep path already present. |
| 57094 | to list/describe rosa upgrade via ROSA CLI | **Not changed.** Usually skips unless classic `y-1` STS profile matches. |
| 37499 | to upgrade NON-STS rosa cluster across Y stream | **Not changed.** Skips on HCP / non-matching profile. |
| 67168 | to upgrade shared VPC cluster across Y stream | **Not changed.** Skips unless shared-VPC `y-1` profile. |

## How to Test (Step-by-Step)
### Preconditions
- Staging env with `rosa-hcp-upgrade-y-stream` (`version: y-1`, `channel_group: stable`)
- Tip `y-1` HCP cluster whose current-minor channel has empty `available_upgrades`

### Test Steps
1. Run HCP upgrade e2e cases (`OCP-62929`, `OCP-62161`, `OCP-64187`) against that profile/cluster.
2. Confirm `BeforeEach` edits channel to next minor and waits for a y-stream target.
3. Confirm manual/role-policy cases schedule (or validate against) the prepared y-stream version, not a z-stream when both are listed.

### Expected Results
Y-stream HCP upgrade discovery no longer depends on non-empty create-time `available_upgrades` on the current-minor channel, and `y-1` cases schedule the next-minor target.

## Proof of the Fix
- Screenshots: N/A
- Videos: N/A
- Logs/CLI output: Local staging run with `TEST_PROFILE=rosa-hcp-upgrade-y-stream` and `--label-filter '(upgrade)&&!Exclude'` (IDs/hostnames redacted):

```text
# Before prep: tip y-1 HCP on current-minor channel, empty upgrades
OpenShift Version:          4.21.27
Channel:                    stable-4.21
"available_upgrades": []

STEP: Prepare cluster for y-stream upgrade target discovery
rosa edit cluster -c <cluster-id> --channel stable-4.22 -y

# After prep: next-minor channel + y-stream target
Channel:                    stable-4.22
"available_upgrades": [
  "4.22.8"
]
The available y stream latest [4.22.8] version:

# OCP-62929: schedules prepared y-stream (not a z-stream patch)
rosa upgrade cluster -c <cluster-id> --mode manual --version 4.22.8 -y
INFO: Upgrade successfully scheduled for cluster '<cluster-id>'

# OCP-62161: uses same y-stream target for expected policy validation errors
rosa upgrade cluster -c <cluster-id> --version 4.22.8 --mode manual -y
ERR: Failed while validating managed policies: role '<role>' is missing the attached managed policy 'arn:aws:iam::aws:policy/service-role/ROSAKMSProviderPolicy'

Ran 8 of 286 Specs in 1225.418 seconds
SUCCESS! -- 8 Passed | 0 Failed | 0 Pending | 278 Skipped
Test Suite Passed
```

- Other artifacts: `make fmt` / pre-push lint+unit tests; CodeRabbit on earlier revision

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan

N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [ ] `make test` passes.
- [x] `make lint` passes.
- [ ] `make rosa` passes.
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

[ROSAENG-62605]: https://redhat.atlassian.net/browse/ROSAENG-62605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ