### PR TITLE
ROSAENG-64512 | rosa-ocm-resources-f3 | fix(test): pick y-1 base when candidate has no DEFAULT

### DIFF
--- a/tests/e2e/test_rosacli_account_roles.go
+++ b/tests/e2e/test_rosacli_account_roles.go
@@ -371,9 +371,7 @@ var _ = Describe("Edit account roles", labels.Feature.AccountRoles, func() {
 			versionService := rosaClient.Version
 			versionList, err := versionService.ListAndReflectVersions(rosacli.VersionChannelGroupStable, true)
 			Expect(err).To(BeNil())
-			defaultVersion := versionList.DefaultVersion()
-			Expect(defaultVersion).ToNot(BeNil())
-			version, err := versionList.FindNearestBackwardMinorVersion(defaultVersion.Version, 1, true)
+			_, version, err := versionList.FindBaseAndNearestBackwardMinorVersion(1, true)
 			Expect(err).To(BeNil())
 			Expect(version).NotTo(BeNil())
 			_, _, versionStable, err = version.MajorMinor()
@@ -381,11 +379,11 @@ var _ = Describe("Edit account roles", labels.Feature.AccountRoles, func() {
 
 			versionList, err = versionService.ListAndReflectVersions(rosacli.VersionChannelGroupCandidate, true)
 			Expect(err).To(BeNil())
-			defaultVersion = versionList.DefaultVersion()
-			Expect(defaultVersion).ToNot(BeNil())
-			version, err = versionList.FindNearestBackwardMinorVersion(defaultVersion.Version, 1, true)
+			_, version, err = versionList.FindBaseAndNearestBackwardMinorVersion(1, true)
 			Expect(err).To(BeNil())
-			Expect(version).NotTo(BeNil())
+			if version == nil {
+				Skip("No y-1 version pair available in candidate hosted-cp channel")
+			}
 			_, _, versionCandidate, err = version.MajorMinor()
 			Expect(err).To(BeNil())
 
@@ -592,9 +590,7 @@ var _ = Describe("Edit account roles", labels.Feature.AccountRoles, func() {
 			versionService := rosaClient.Version
 			versionList, err := versionService.ListAndReflectVersions(rosacli.VersionChannelGroupStable, true)
 			Expect(err).To(BeNil())
-			defaultVersion := versionList.DefaultVersion()
-			Expect(defaultVersion).ToNot(BeNil())
-			version, err := versionList.FindNearestBackwardMinorVersion(defaultVersion.Version, 1, true)
+			_, version, err := versionList.FindBaseAndNearestBackwardMinorVersion(1, true)
 			Expect(err).To(BeNil())
 			Expect(version).NotTo(BeNil())
 			_, _, roleVersion, err = version.MajorMinor()
@@ -1020,26 +1016,24 @@ var _ = Describe("Create account roles", labels.Feature.AccountRoles, func() {
 			// get stable channel version
 			versionListS, err := versionService.ListAndReflectVersions(rosacli.VersionChannelGroupStable, true)
 			Expect(err).To(BeNil())
-			defaultVersionS := versionListS.DefaultVersion()
-			Expect(defaultVersionS).ToNot(BeNil())
-			_, _, upgradeVersionS, err := defaultVersionS.MajorMinor()
-			Expect(err).To(BeNil())
-			versionS, err := versionListS.FindNearestBackwardMinorVersion(defaultVersionS.Version, 1, true)
+			baseVersionS, versionS, err := versionListS.FindBaseAndNearestBackwardMinorVersion(1, true)
 			Expect(err).To(BeNil())
 			Expect(versionS).NotTo(BeNil())
+			_, _, upgradeVersionS, err := baseVersionS.MajorMinor()
+			Expect(err).To(BeNil())
 			_, _, versionStable, err := versionS.MajorMinor()
 			Expect(err).To(BeNil())
 
 			// get candidate channel version
 			versionListC, err := versionService.ListAndReflectVersions(rosacli.VersionChannelGroupCandidate, true)
 			Expect(err).To(BeNil())
-			defaultVersionC := versionListC.DefaultVersion()
-			Expect(defaultVersionC).ToNot(BeNil())
-			_, _, upgradeVersionC, err := defaultVersionC.MajorMinor()
+			baseVersionC, versionC, err := versionListC.FindBaseAndNearestBackwardMinorVersion(1, true)
 			Expect(err).To(BeNil())
-			versionC, err := versionListC.FindNearestBackwardMinorVersion(defaultVersionC.Version, 1, true)
+			if versionC == nil {
+				Skip("No y-1 version pair available in candidate hosted-cp channel")
+			}
+			_, _, upgradeVersionC, err := baseVersionC.MajorMinor()
 			Expect(err).To(BeNil())
-			Expect(versionC).NotTo(BeNil())
 			_, _, versionCandidate, err := versionC.MajorMinor()
 			Expect(err).To(BeNil())
 

--- a/tests/utils/exec/rosacli/version_service.go
+++ b/tests/utils/exec/rosacli/version_service.go
@@ -309,6 +309,56 @@ func (vl *OpenShiftVersionTableList) DefaultVersion() (defaultVersion *OpenShift
 	return vl.OpenShiftVersions[0]
 }
 
+// FindBaseAndNearestBackwardMinorVersion picks a base version that has a same-list
+// nearest backward minor (e.g. y-1 when minorSub is 1). Prefer DEFAULT=yes when
+// that version has a pair; otherwise use the newest version that does.
+// minorSub selects Major.(minor-minorSub); strict limits matches to that exact minor
+// when true, or Minor() <= (minor-minorSub) when false.
+// When upgradable is true, the backward version must list the base in AvailableUpgrades.
+// Returns (nil, nil, nil) when no pair exists in the list.
+func (vl *OpenShiftVersionTableList) FindBaseAndNearestBackwardMinorVersion(
+	minorSub int64, strict bool, upgradable ...bool) (
+	base *OpenShiftVersionTableOutput, backward *OpenShiftVersionTableOutput, err error) {
+	if vl == nil || vl.Len() == 0 {
+		return nil, nil, nil
+	}
+
+	tryVersion := func(candidate *OpenShiftVersionTableOutput) (
+		*OpenShiftVersionTableOutput, *OpenShiftVersionTableOutput, error) {
+		found, findErr := vl.FindNearestBackwardMinorVersion(candidate.Version, minorSub, strict, upgradable...)
+		if findErr != nil {
+			return nil, nil, findErr
+		}
+		if found != nil {
+			return candidate, found, nil
+		}
+		return nil, nil, nil
+	}
+
+	for _, version := range vl.OpenShiftVersions {
+		if version.Default != "yes" {
+			continue
+		}
+		base, backward, err = tryVersion(version)
+		if err != nil || base != nil {
+			return base, backward, err
+		}
+		break
+	}
+
+	sorted, err := vl.Sort(true)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, version := range sorted.OpenShiftVersions {
+		base, backward, err = tryVersion(version)
+		if err != nil || base != nil {
+			return base, backward, err
+		}
+	}
+	return nil, nil, nil
+}
+
 func (vl *OpenShiftVersionTableOutput) MajorMinor() (major int64, minor int64, majorMinorVersion string, err error) {
 	var semverVersion *semver.Version
 	if semverVersion, err = semver.NewVersion(vl.Version); err != nil {

--- a/tests/utils/exec/rosacli/version_service_test.go
+++ b/tests/utils/exec/rosacli/version_service_test.go
@@ -1,0 +1,218 @@
+package rosacli
+
+import (
+	"github.com/Masterminds/semver"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("FindBaseAndNearestBackwardMinorVersion", func() {
+	It("prefers DEFAULT=yes when that version has a y-1 pair", func() {
+		vl := &OpenShiftVersionTableList{
+			OpenShiftVersions: []*OpenShiftVersionTableOutput{
+				{Version: "5.0.0-ec.5", Default: "no"},
+				{Version: "4.22.8", Default: "yes"},
+				{Version: "4.21.5", Default: "no"},
+			},
+		}
+
+		base, backward, err := vl.FindBaseAndNearestBackwardMinorVersion(1, true)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(base.Version).To(Equal("4.22.8"))
+		Expect(backward.Version).To(Equal("4.21.5"))
+	})
+
+	It("skips DEFAULT=yes without y-1 and picks the newest version that has a pair", func() {
+		vl := &OpenShiftVersionTableList{
+			OpenShiftVersions: []*OpenShiftVersionTableOutput{
+				{Version: "5.0.0-ec.5", Default: "yes"},
+				{Version: "4.22.8", Default: "no"},
+				{Version: "4.21.5", Default: "no"},
+			},
+		}
+
+		base, backward, err := vl.FindBaseAndNearestBackwardMinorVersion(1, true)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(base.Version).To(Equal("4.22.8"))
+		Expect(backward.Version).To(Equal("4.21.5"))
+	})
+
+	It("picks the newest version with a y-1 pair when no DEFAULT=yes exists", func() {
+		vl := &OpenShiftVersionTableList{
+			OpenShiftVersions: []*OpenShiftVersionTableOutput{
+				{Version: "5.0.0-ec.5", Default: "no"},
+				{Version: "4.22.8", Default: "no"},
+				{Version: "4.21.5", Default: "no"},
+			},
+		}
+
+		base, backward, err := vl.FindBaseAndNearestBackwardMinorVersion(1, true)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(base.Version).To(Equal("4.22.8"))
+		Expect(backward.Version).To(Equal("4.21.5"))
+	})
+
+	It("uses Sort fallback to pick newest pair from an ascending list", func() {
+		vl := &OpenShiftVersionTableList{
+			OpenShiftVersions: []*OpenShiftVersionTableOutput{
+				{Version: "4.20.3", Default: "no"},
+				{Version: "4.21.5", Default: "no"},
+				{Version: "4.22.8", Default: "no"},
+			},
+		}
+
+		base, backward, err := vl.FindBaseAndNearestBackwardMinorVersion(1, true)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(base.Version).To(Equal("4.22.8"))
+		Expect(backward.Version).To(Equal("4.21.5"))
+	})
+
+	It("returns nil when no y-1 pair exists", func() {
+		vl := &OpenShiftVersionTableList{
+			OpenShiftVersions: []*OpenShiftVersionTableOutput{
+				{Version: "5.0.0-ec.5", Default: "no"},
+				{Version: "5.0.0-ec.1", Default: "no"},
+			},
+		}
+
+		base, backward, err := vl.FindBaseAndNearestBackwardMinorVersion(1, true)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(base).To(BeNil())
+		Expect(backward).To(BeNil())
+	})
+
+	It("returns nil results for a nil list", func() {
+		var vl *OpenShiftVersionTableList
+
+		base, backward, err := vl.FindBaseAndNearestBackwardMinorVersion(1, true)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(base).To(BeNil())
+		Expect(backward).To(BeNil())
+	})
+
+	It("returns nil results for an empty list", func() {
+		vl := &OpenShiftVersionTableList{}
+
+		base, backward, err := vl.FindBaseAndNearestBackwardMinorVersion(1, true)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(base).To(BeNil())
+		Expect(backward).To(BeNil())
+	})
+
+	It("propagates ErrInvalidSemVer when DEFAULT version is malformed", func() {
+		vl := &OpenShiftVersionTableList{
+			OpenShiftVersions: []*OpenShiftVersionTableOutput{
+				{Version: "not-a-version", Default: "yes"},
+				{Version: "4.21.5", Default: "no"},
+			},
+		}
+
+		base, backward, err := vl.FindBaseAndNearestBackwardMinorVersion(1, true)
+
+		Expect(err).To(MatchError(semver.ErrInvalidSemVer))
+		Expect(base).To(BeNil())
+		Expect(backward).To(BeNil())
+	})
+
+	It("propagates ErrInvalidSemVer when DEFAULT is valid but a sibling version is malformed", func() {
+		vl := &OpenShiftVersionTableList{
+			OpenShiftVersions: []*OpenShiftVersionTableOutput{
+				{Version: "4.22.8", Default: "yes"},
+				{Version: "not-a-version", Default: "no"},
+				{Version: "4.21.5", Default: "no"},
+			},
+		}
+
+		base, backward, err := vl.FindBaseAndNearestBackwardMinorVersion(1, true)
+
+		Expect(err).To(MatchError(semver.ErrInvalidSemVer))
+		Expect(base).To(BeNil())
+		Expect(backward).To(BeNil())
+	})
+
+	It("propagates ErrInvalidSemVer from Sort during fallback", func() {
+		vl := &OpenShiftVersionTableList{
+			OpenShiftVersions: []*OpenShiftVersionTableOutput{
+				{Version: "not-a-version", Default: "no"},
+				{Version: "4.22.8", Default: "no"},
+				{Version: "4.21.5", Default: "no"},
+			},
+		}
+
+		base, backward, err := vl.FindBaseAndNearestBackwardMinorVersion(1, true)
+
+		Expect(err).To(MatchError(semver.ErrInvalidSemVer))
+		Expect(base).To(BeNil())
+		Expect(backward).To(BeNil())
+	})
+
+	It("finds the y-2 pair when minorSub is 2", func() {
+		vl := &OpenShiftVersionTableList{
+			OpenShiftVersions: []*OpenShiftVersionTableOutput{
+				{Version: "4.22.8", Default: "yes"},
+				{Version: "4.21.5", Default: "no"},
+				{Version: "4.20.3", Default: "no"},
+			},
+		}
+
+		base, backward, err := vl.FindBaseAndNearestBackwardMinorVersion(2, true)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(base.Version).To(Equal("4.22.8"))
+		Expect(backward.Version).To(Equal("4.20.3"))
+	})
+
+	It("finds a backward minor with strict=false when exact y-1 is missing", func() {
+		vl := &OpenShiftVersionTableList{
+			OpenShiftVersions: []*OpenShiftVersionTableOutput{
+				{Version: "4.22.8", Default: "yes"},
+				{Version: "4.20.3", Default: "no"},
+			},
+		}
+
+		base, backward, err := vl.FindBaseAndNearestBackwardMinorVersion(1, false)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(base.Version).To(Equal("4.22.8"))
+		Expect(backward.Version).To(Equal("4.20.3"))
+	})
+
+	It("requires an upgrade path when upgradable is true", func() {
+		vl := &OpenShiftVersionTableList{
+			OpenShiftVersions: []*OpenShiftVersionTableOutput{
+				{Version: "4.22.8", Default: "yes"},
+				{Version: "4.21.5", Default: "no"},
+				{Version: "4.20.3", Default: "no", AvailableUpgrades: "4.22.8"},
+			},
+		}
+
+		base, backward, err := vl.FindBaseAndNearestBackwardMinorVersion(1, false, true)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(base.Version).To(Equal("4.22.8"))
+		Expect(backward.Version).To(Equal("4.20.3"))
+	})
+
+	It("ignores upgrade path when upgradable is false", func() {
+		vl := &OpenShiftVersionTableList{
+			OpenShiftVersions: []*OpenShiftVersionTableOutput{
+				{Version: "4.22.8", Default: "yes"},
+				{Version: "4.21.5", Default: "no"},
+				{Version: "4.20.3", Default: "no", AvailableUpgrades: "4.22.8"},
+			},
+		}
+
+		base, backward, err := vl.FindBaseAndNearestBackwardMinorVersion(1, false)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(base.Version).To(Equal("4.22.8"))
+		Expect(backward.Version).To(Equal("4.21.5"))
+	})
+})


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
Supported ticket prefixes:
OCM-XXXXX, ROSAENG-XXXX
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For contributor workflow, see: ./CONTRIBUTING.md
For repo-local agent guidance, see: ./AGENTS.md
-->

## PR Summary
Fix OCP-54469/61322 candidate hosted-cp y-1 prep when the catalog leads with `5.0.0-ec.*` and has no `DEFAULT=yes`, so `rosa-ocm-resources-f3` no longer fails on nil y-1.

## Detailed Description of the Issue
`periodic-ci-openshift-rosa-master-e2e-rosa-ocm-resources-f3` was near-chronic. Sticky failures were OCP-54469 and OCP-61322 in the test phase: candidate `rosa list versions --hosted-cp` returned `5.0.0-ec.*` with all `DEFAULT no`, `DefaultVersion()` fell back to list head, and `FindNearestBackwardMinorVersion(..., 1, true)` returned nil (same-major y-1 does not exist for major 5). Spec intent is account-role create/upgrade with channel + a real y-1 pair, not “catalog head must always have y-1.” Stable prep in the same cases still finds `4.22` DEFAULT and y-1 correctly.

## Related Issues and PRs
- Jira: [ROSAENG-64512](https://redhat.atlassian.net/browse/ROSAENG-64512)
- Fixes: N/A
- Related PR(s): N/A
- Related design/docs: N/A
- Job history: https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/periodic-ci-openshift-rosa-master-e2e-rosa-ocm-resources-f3

## Type of Change
<!-- Check the primary type this PR represents -->
- [ ] feat - adds a new user-facing capability.
- [x] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
Candidate hosted-cp prep for OCP-54469 and OCP-61322 always used `DefaultVersion()` then `FindNearestBackwardMinorVersion`. With no DEFAULT and an EC 5.0 list head, y-1 was nil and both Its failed (`Expect(...).NotTo(BeNil())`).

## Behavior After This Change
`FindBaseAndNearestBackwardMinorVersion` prefers `DEFAULT=yes` when it has a same-list y-1; otherwise picks the newest version that has a y-1. Candidate prep in OCP-54469/61322 uses that helper; stable prep is unchanged. `Skip` only if no y-1 pair exists in the list. `DefaultVersion()` semantics are unchanged.

## How to Test (Step-by-Step)
### Preconditions
- Local Go toolchain for unit tests
- Optional: OCM staging credentials + AWS for `rosa-tests` with `(ocm-resources)&&!Exclude`

### Test Steps
1. `go test ./tests/utils/exec/rosacli/ -ginkgo.focus='FindBaseAndNearestBackwardMinorVersion' -count=1`
2. `make fmt && make lint`
3. Optional: run OCP-54469 and OCP-61322 against staging with a candidate hosted-cp list that includes `5.0.0-ec.*` without DEFAULT

### Expected Results
1. Helper unit tests pass (DEFAULT preference, skip DEFAULT without y-1, newest-with-pair, nil when no pair).
2. Format/lint clean.
3. Account-role create/upgrade still runs with a real candidate y-1 pair (e.g. 4.22→4.21); Skip only when no pair exists.

## Proof of the Fix
- Screenshots: N/A
- Videos: N/A
- Logs/CLI output: helper unit tests passed; `make fmt` / `make lint` (0 issues); pre-push format/build/lint/coverage/unit+integration passed
- Other artifacts: fail sample https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-rosa-master-e2e-rosa-ocm-resources-f3/2085084468149751808

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

Made with [Cursor](https://cursor.com)

[ROSAENG-64512]: https://redhat.atlassian.net/browse/ROSAENG-64512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version selection for upgrade testing, including default-version preference and fallback behavior.
  * Tests now gracefully skip when no suitable backward-minor version pair is available.
  * Upgrade scenarios derive candidate versions from the selected base version.

* **Tests**
  * Added coverage for version ordering, configurable minor offsets, upgrade filtering, invalid versions, non-strict matching, and missing version pairs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->