### PR TITLE
ROSAENG-8272 | feat: add HCP spot CLI support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ fmt-check: $(GCI)
 
 .PHONY: lint
 lint: $(GOLANGCI_LINT)
-	$(GOLANGCI_LINT) run --timeout 5m0s $(LINT_OUTPUT_FLAGS) ./...
+	$(GOLANGCI_LINT) run --timeout 15m0s $(LINT_OUTPUT_FLAGS) ./...
 
 .PHONY: govulncheck
 govulncheck: $(GOVULNCHECK) rosa

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -54,6 +54,7 @@ import (
 	"github.com/openshift/rosa/pkg/helper"
 	mpHelpers "github.com/openshift/rosa/pkg/helper/machinepools"
 	"github.com/openshift/rosa/pkg/helper/roles"
+	urlHelper "github.com/openshift/rosa/pkg/helper/url"
 	"github.com/openshift/rosa/pkg/helper/versions"
 	"github.com/openshift/rosa/pkg/ingress"
 	"github.com/openshift/rosa/pkg/interactive"
@@ -214,6 +215,8 @@ var args struct {
 
 	// Audit Log Forwarding
 	AuditLogRoleARN string
+	// Spot termination handling
+	spotTerminationQueueUrl string
 
 	// Default Ingress Attributes
 	defaultIngressRouteSelectors            string
@@ -832,6 +835,12 @@ func initFlags(cmd *cobra.Command) {
 		"audit-log-arn",
 		"",
 		"The ARN of the role that is used to forward audit logs to AWS CloudWatch.",
+	)
+	flags.StringVar(
+		&args.spotTerminationQueueUrl,
+		"spot-termination-queue-url",
+		"",
+		"Optional SQS queue URL that enables graceful Spot interruption handling for Hosted Control Plane clusters.",
 	)
 
 	flags.StringVar(
@@ -3545,6 +3554,11 @@ func run(cmd *cobra.Command, _ []string) {
 		InfraMachineType:                       args.infraMachineType,
 	}
 
+	if err := setSpotTerminationQueueURLForCreate(&clusterConfig, isHostedCP, args.spotTerminationQueueUrl); err != nil {
+		r.Reporter.Errorf("%s", err)
+		os.Exit(1)
+	}
+
 	if !isHostedCP {
 		clusterConfig.DisableWorkloadMonitoring = &disableWorkloadMonitoring
 	}
@@ -4393,6 +4407,10 @@ func buildCommand(spec ocm.Spec, operatorRolesPrefix string,
 		command += fmt.Sprintf(" --billing-account %s", spec.BillingAccount)
 	}
 
+	if spec.TerminationHandlerQueueUrl != nil && *spec.TerminationHandlerQueueUrl != "" {
+		command += fmt.Sprintf(" --spot-termination-queue-url %s", *spec.TerminationHandlerQueueUrl)
+	}
+
 	if spec.NoCni {
 		command += " --no-cni"
 	}
@@ -4407,7 +4425,6 @@ func buildCommand(spec ocm.Spec, operatorRolesPrefix string,
 	}
 	return command
 }
-
 func buildTagsCommand(tags map[string]string) []string {
 	// set correct delim, if a key or value contains `:` the delim should be " "
 	delim := ":"
@@ -4670,5 +4687,20 @@ func validateUniqueIamRoleArnsForStsCluster(accountRoles []string, operatorRoles
 		return fmt.Errorf(duplicateIamRoleArnErrorMsg, duplicate)
 	}
 
+	return nil
+}
+
+func setSpotTerminationQueueURLForCreate(clusterConfig *ocm.Spec, isHostedCP bool, queueURL string) error {
+	if queueURL != "" && !isHostedCP {
+		return fmt.Errorf("the '--spot-termination-queue-url' flag is only supported for Hosted Control Plane clusters")
+	}
+	if queueURL == "" {
+		return nil
+	}
+	if err := urlHelper.ValidateHTTPSQueueURL(queueURL); err != nil {
+		return fmt.Errorf("invalid value for '--spot-termination-queue-url': %w", err)
+	}
+
+	clusterConfig.TerminationHandlerQueueUrl = &queueURL
 	return nil
 }

--- a/cmd/create/cluster/cmd_test.go
+++ b/cmd/create/cluster/cmd_test.go
@@ -15,6 +15,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/cmd/create/admin"
@@ -54,6 +55,29 @@ var _ = Describe("Validate build command", func() {
 				Expect(command).To(Equal(
 					"rosa create cluster --cluster-name cluster-name --domain-prefix dns-label" +
 						" --operator-roles-prefix prefix"))
+			})
+		})
+
+		When("spot termination queue URL is present", func() {
+			It("prints --spot-termination-queue-url", func() {
+				queueURL := "https://sqs.us-east-1.amazonaws.com/123456789012/rosa-spot-queue"
+				clusterConfig.TerminationHandlerQueueUrl = &queueURL
+				command := buildCommand(clusterConfig, operatorRolesPrefix,
+					expectedOperatorRolePath, userSelectedAvailabilityZones,
+					defaultMachinePoolLabels, argsDotProperties)
+				Expect(command).To(Equal(
+					"rosa create cluster --cluster-name cluster-name --operator-roles-prefix prefix" +
+						" --spot-termination-queue-url https://sqs.us-east-1.amazonaws.com/123456789012/rosa-spot-queue"))
+			})
+		})
+
+		When("spot termination queue URL pointer is nil", func() {
+			It("does not print --spot-termination-queue-url", func() {
+				clusterConfig.TerminationHandlerQueueUrl = nil
+				command := buildCommand(clusterConfig, operatorRolesPrefix,
+					expectedOperatorRolePath, userSelectedAvailabilityZones,
+					defaultMachinePoolLabels, argsDotProperties)
+				Expect(command).NotTo(ContainSubstring("spot-termination-queue-url"))
 			})
 		})
 
@@ -305,6 +329,88 @@ var _ = Describe("Validate build command", func() {
 				}
 			})
 		})
+	})
+})
+
+var _ = Describe("Create cluster command flags", func() {
+	It("exposes the spot-termination-queue-url flag", func() {
+		cmd := makeCmd()
+		initFlags(cmd)
+		Expect(cmd.Flags().Lookup("spot-termination-queue-url")).ToNot(BeNil())
+	})
+
+	It("spot-termination-queue-url guard rejects classic clusters", func() {
+		classicCluster, err := cmv1.NewCluster().
+			ID("classic-cluster").
+			Hypershift(cmv1.NewHypershift().Enabled(false)).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mock.IsHostedCP(classicCluster)).To(BeFalse(),
+			"classic cluster must not pass the spot-termination-queue-url HCP guard")
+	})
+
+	It("spot-termination-queue-url guard accepts HCP clusters", func() {
+		hcpCluster, err := cmv1.NewCluster().
+			ID("hcp-cluster").
+			Hypershift(cmv1.NewHypershift().Enabled(true)).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mock.IsHostedCP(hcpCluster)).To(BeTrue(),
+			"HCP cluster must pass the spot-termination-queue-url guard")
+	})
+})
+
+var _ = Describe("setSpotTerminationQueueURLForCreate", func() {
+	It("sets a valid queue URL for HCP clusters", func() {
+		clusterConfig := ocm.Spec{}
+		queueURL := "https://sqs.us-east-1.amazonaws.com/123456789012/rosa-spot-queue"
+
+		err := setSpotTerminationQueueURLForCreate(&clusterConfig, true, queueURL)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(clusterConfig.TerminationHandlerQueueUrl).ToNot(BeNil())
+		Expect(*clusterConfig.TerminationHandlerQueueUrl).To(Equal(queueURL))
+	})
+
+	It("rejects invalid queue URLs for HCP clusters", func() {
+		clusterConfig := ocm.Spec{}
+
+		err := setSpotTerminationQueueURLForCreate(
+			&clusterConfig,
+			true,
+			"http://sqs.us-east-1.amazonaws.com/123456789012/rosa-spot-queue",
+		)
+
+		Expect(err).To(MatchError(
+			"invalid value for '--spot-termination-queue-url': " +
+				"expect URL 'http://sqs.us-east-1.amazonaws.com/123456789012/rosa-spot-queue' to use an 'https://' scheme",
+		))
+		Expect(clusterConfig.TerminationHandlerQueueUrl).To(BeNil())
+	})
+
+	It("rejects non-empty queue URLs for classic clusters", func() {
+		clusterConfig := ocm.Spec{}
+		queueURL := "https://sqs.us-east-1.amazonaws.com/123456789012/rosa-spot-queue"
+
+		err := setSpotTerminationQueueURLForCreate(&clusterConfig, false, queueURL)
+
+		Expect(err).To(MatchError(
+			"the '--spot-termination-queue-url' flag is only supported for Hosted Control Plane clusters",
+		))
+		Expect(clusterConfig.TerminationHandlerQueueUrl).To(BeNil())
+	})
+
+	It("leaves an existing queue URL unchanged when the create input is empty", func() {
+		existingQueueURL := "https://sqs.us-east-1.amazonaws.com/123456789012/existing-queue"
+		clusterConfig := ocm.Spec{
+			TerminationHandlerQueueUrl: &existingQueueURL,
+		}
+
+		err := setSpotTerminationQueueURLForCreate(&clusterConfig, true, "")
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(clusterConfig.TerminationHandlerQueueUrl).ToNot(BeNil())
+		Expect(*clusterConfig.TerminationHandlerQueueUrl).To(Equal(existingQueueURL))
 	})
 })
 

--- a/cmd/create/cmd.go
+++ b/cmd/create/cmd.go
@@ -39,6 +39,7 @@ import (
 	"github.com/openshift/rosa/cmd/create/oidcprovider"
 	"github.com/openshift/rosa/cmd/create/operatorroles"
 	"github.com/openshift/rosa/cmd/create/service"
+	"github.com/openshift/rosa/cmd/create/spotterminationqueue"
 	"github.com/openshift/rosa/cmd/create/tuningconfigs"
 	"github.com/openshift/rosa/cmd/create/userrole"
 	"github.com/openshift/rosa/pkg/arguments"
@@ -82,6 +83,7 @@ func init() {
 	decisionCommand := decision.NewCreateDecisionCommand()
 	Cmd.AddCommand(decisionCommand)
 	Cmd.AddCommand(network.NewNetworkCommand())
+	Cmd.AddCommand(spotterminationqueue.NewCreateSpotTerminationQueueCommand())
 
 	flags := Cmd.PersistentFlags()
 	arguments.AddProfileFlag(flags)

--- a/cmd/create/cmd_test.go
+++ b/cmd/create/cmd_test.go
@@ -1,0 +1,15 @@
+package create
+
+import "testing"
+
+func TestCreateIncludesSpotTerminationQueueCommand(t *testing.T) {
+	t.Helper()
+
+	for _, command := range Cmd.Commands() {
+		if command.Name() == "spot-termination-queue" {
+			return
+		}
+	}
+
+	t.Fatalf("expected create root command to include spot-termination-queue subcommand")
+}

--- a/cmd/create/spotterminationqueue/cmd.go
+++ b/cmd/create/spotterminationqueue/cmd.go
@@ -1,0 +1,68 @@
+package spotterminationqueue
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	rosaaws "github.com/openshift/rosa/pkg/aws"
+	opts "github.com/openshift/rosa/pkg/options/spotterminationqueue"
+	"github.com/openshift/rosa/pkg/output"
+	"github.com/openshift/rosa/pkg/rosa"
+	queue "github.com/openshift/rosa/pkg/spotterminationqueue"
+)
+
+var newSpotTerminationQueueService = func(client rosaaws.Client) queue.Service {
+	return queue.NewService(client)
+}
+
+// NewCreateSpotTerminationQueueCommand returns the Cobra command for creating Spot termination queue resources.
+func NewCreateSpotTerminationQueueCommand() *cobra.Command {
+	cmd, options := opts.BuildCreateSpotTerminationQueueCommandWithOptions()
+	cmd.Run = rosa.DefaultRunner(rosa.RuntimeWithAWS(), CreateSpotTerminationQueueRunner(options))
+	return cmd
+}
+
+// CreateSpotTerminationQueueRunner returns a CommandRunner that validates inputs and delegates
+// to the spot termination queue service.
+func CreateSpotTerminationQueueRunner(userOptions *opts.CreateSpotTerminationQueueUserOptions) rosa.CommandRunner {
+	return func(ctx context.Context, r *rosa.Runtime, _ *cobra.Command, _ []string) error {
+		if userOptions.NodePoolManagementRoleArn == "" {
+			return fmt.Errorf("you must supply --nodepool-management-role-arn")
+		}
+		if !rosaaws.RoleArnRE.MatchString(userOptions.NodePoolManagementRoleArn) {
+			return fmt.Errorf("expected a valid value for nodepool-management-role-arn matching %s", rosaaws.RoleArnRE)
+		}
+
+		result, err := newSpotTerminationQueueService(r.AWSClient).CreateQueue(ctx, queue.CreateInput{
+			Name:                      userOptions.Name,
+			NodePoolManagementRoleArn: userOptions.NodePoolManagementRoleArn,
+			Mode:                      userOptions.Mode,
+			Region:                    r.AWSClient.GetRegion(),
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create spot termination queue: %w", err)
+		}
+
+		if output.HasFlag() {
+			if err := output.Print(result); err != nil {
+				return fmt.Errorf("failed to print spot termination queue result: %w", err)
+			}
+			return nil
+		}
+
+		r.Reporter.Infof("Created spot termination queue resources in region '%s'", result.Region)
+		r.Reporter.Infof("CloudFormation stack: %s", result.StackName)
+		r.Reporter.Infof("Queue name: %s", result.QueueName)
+		r.Reporter.Infof("EventBridge rule: %s", result.EventRuleName)
+		r.Reporter.Infof("Queue URL: %s", result.QueueURL)
+		r.Reporter.Infof(
+			"Use this queue URL with 'rosa create cluster --spot-termination-queue-url %s' "+
+				"or 'rosa edit cluster --spot-termination-queue-url %s --cluster <cluster>'",
+			result.QueueURL,
+			result.QueueURL,
+		)
+		return nil
+	}
+}

--- a/cmd/create/spotterminationqueue/cmd_test.go
+++ b/cmd/create/spotterminationqueue/cmd_test.go
@@ -1,0 +1,180 @@
+package spotterminationqueue
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	mock "github.com/openshift/rosa/pkg/aws"
+	opts "github.com/openshift/rosa/pkg/options/spotterminationqueue"
+	"github.com/openshift/rosa/pkg/output"
+	"github.com/openshift/rosa/pkg/rosa"
+	queue "github.com/openshift/rosa/pkg/spotterminationqueue"
+)
+
+func TestSpotTerminationQueueCommand(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Spot termination queue command suite")
+}
+
+type fakeQueueService struct {
+	input       queue.CreateInput
+	result      *queue.Result
+	err         error
+	invocations int
+}
+
+func (f *fakeQueueService) CreateQueue(_ context.Context, input queue.CreateInput) (*queue.Result, error) {
+	f.invocations++
+	f.input = input
+	return f.result, f.err
+}
+
+var _ = Describe("CreateSpotTerminationQueueRunner", func() {
+	var (
+		ctrl        *gomock.Controller
+		mockClient  *mock.MockClient
+		fakeService *fakeQueueService
+		runtime     *rosa.Runtime
+		oldFactory  func(mock.Client) queue.Service
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockClient = mock.NewMockClient(ctrl)
+		mockClient.EXPECT().GetRegion().Return("us-east-1").AnyTimes()
+
+		fakeService = &fakeQueueService{
+			result: &queue.Result{
+				QueueURL:      "https://sqs.us-east-1.amazonaws.com/123456789012/demo",
+				QueueName:     "demo-spot-termination-queue",
+				EventRuleName: "demo-spot-termination-events",
+				StackName:     "demo-spot-termination-stack",
+				Region:        "us-east-1",
+			},
+		}
+
+		oldFactory = newSpotTerminationQueueService
+		newSpotTerminationQueueService = func(client mock.Client) queue.Service {
+			return fakeService
+		}
+
+		runtime = rosa.NewRuntime()
+		runtime.AWSClient = mockClient
+	})
+
+	AfterEach(func() {
+		newSpotTerminationQueueService = oldFactory
+		ctrl.Finish()
+	})
+
+	Context("validation", func() {
+		It("rejects a missing nodepool-management-role-arn", func() {
+			options := &opts.CreateSpotTerminationQueueUserOptions{
+				Name: "demo",
+				Mode: "auto",
+			}
+
+			runner := CreateSpotTerminationQueueRunner(options)
+			err := runner(context.Background(), runtime, NewCreateSpotTerminationQueueCommand(), []string{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("--nodepool-management-role-arn"))
+			Expect(fakeService.invocations).To(Equal(0))
+		})
+
+		It("rejects an invalid nodepool-management-role-arn", func() {
+			options := &opts.CreateSpotTerminationQueueUserOptions{
+				Name:                      "demo",
+				NodePoolManagementRoleArn: "not-a-valid-arn",
+				Mode:                      "auto",
+			}
+
+			runner := CreateSpotTerminationQueueRunner(options)
+			err := runner(context.Background(), runtime, NewCreateSpotTerminationQueueCommand(), []string{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("valid value for nodepool-management-role-arn"))
+			Expect(fakeService.invocations).To(Equal(0))
+		})
+	})
+
+	Context("successful execution", func() {
+		It("passes options through to the service", func() {
+			options := &opts.CreateSpotTerminationQueueUserOptions{
+				Name:                      "demo",
+				NodePoolManagementRoleArn: "arn:aws:iam::123456789012:role/example-role",
+				Mode:                      "auto",
+			}
+
+			runner := CreateSpotTerminationQueueRunner(options)
+			err := runner(context.Background(), runtime, NewCreateSpotTerminationQueueCommand(), []string{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fakeService.invocations).To(Equal(1))
+			Expect(fakeService.input.Name).To(Equal("demo"))
+			Expect(fakeService.input.NodePoolManagementRoleArn).To(Equal("arn:aws:iam::123456789012:role/example-role"))
+			Expect(fakeService.input.Mode).To(Equal("auto"))
+			Expect(fakeService.input.Region).To(Equal("us-east-1"))
+		})
+
+		It("supports JSON output mode", func() {
+			options := &opts.CreateSpotTerminationQueueUserOptions{
+				Name:                      "demo",
+				NodePoolManagementRoleArn: "arn:aws:iam::123456789012:role/example-role",
+				Mode:                      "auto",
+			}
+
+			cmd := NewCreateSpotTerminationQueueCommand()
+			output.SetOutput("json")
+			defer output.SetOutput("")
+
+			stdoutState := os.Stdout
+			stdoutReader, stdoutWriter, err := os.Pipe()
+			Expect(err).ToNot(HaveOccurred())
+			os.Stdout = stdoutWriter
+			defer func() {
+				os.Stdout = stdoutState
+			}()
+
+			runner := CreateSpotTerminationQueueRunner(options)
+			err = runner(context.Background(), runtime, cmd, []string{})
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(stdoutWriter.Close()).To(Succeed())
+			stdout, err := io.ReadAll(stdoutReader)
+			Expect(err).ToNot(HaveOccurred())
+
+			var result queue.Result
+			Expect(json.Unmarshal(stdout, &result)).To(Succeed())
+			Expect(result.QueueURL).To(Equal(fakeService.result.QueueURL))
+			Expect(result.QueueName).To(Equal(fakeService.result.QueueName))
+			Expect(result.EventRuleName).To(Equal(fakeService.result.EventRuleName))
+			Expect(result.StackName).To(Equal(fakeService.result.StackName))
+			Expect(result.Region).To(Equal(fakeService.result.Region))
+		})
+	})
+
+	Context("error handling", func() {
+		It("wraps and returns service errors", func() {
+			fakeService.result = nil
+			fakeService.err = fmt.Errorf("stack creation failed")
+
+			options := &opts.CreateSpotTerminationQueueUserOptions{
+				Name:                      "demo",
+				NodePoolManagementRoleArn: "arn:aws:iam::123456789012:role/example-role",
+				Mode:                      "auto",
+			}
+
+			runner := CreateSpotTerminationQueueRunner(options)
+			err := runner(context.Background(), runtime, NewCreateSpotTerminationQueueCommand(), []string{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("failed to create spot termination queue: stack creation failed"))
+		})
+	})
+})

--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -549,6 +549,7 @@ func run(cmd *cobra.Command, argv []string) {
 			str = fmt.Sprintf("%s"+
 				"Audit Log Role ARN:         %s\n", str, cluster.AWS().AuditLog().RoleArn())
 		}
+		str = fmt.Sprintf("%s%s", str, getSpotTerminationHandling(cluster))
 		// Display AutoNode status
 		if cluster.AutoNode() != nil {
 			str = fmt.Sprintf("%s"+
@@ -1084,4 +1085,17 @@ func getLimitedSupportReasons(limitedSupportReasons []*cmv1.LimitedSupportReason
 			str, reason.Summary(), reason.Details())
 	}
 	return str
+}
+
+func getSpotTerminationHandling(cluster *cmv1.Cluster) string {
+	if cluster == nil || cluster.AWS() == nil || cluster.Hypershift() == nil || !cluster.Hypershift().Enabled() {
+		return ""
+	}
+
+	queueURL := cluster.AWS().TerminationHandlerQueueUrl()
+	if queueURL == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("Spot Termination Queue URL: %s\n", queueURL)
 }

--- a/cmd/describe/cluster/cmd_test.go
+++ b/cmd/describe/cluster/cmd_test.go
@@ -180,6 +180,38 @@ var _ = Describe("Cluster description", Ordered, func() {
 	})
 })
 
+var _ = Describe("Spot termination handling output", func() {
+	It("returns empty for non-hosted clusters", func() {
+		cluster, err := cmv1.NewCluster().
+			AWS(cmv1.NewAWS()).
+			Hypershift(cmv1.NewHypershift().Enabled(false)).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(getSpotTerminationHandling(cluster)).To(BeEmpty())
+	})
+
+	It("returns empty when no queue URL is configured", func() {
+		cluster, err := cmv1.NewCluster().
+			AWS(cmv1.NewAWS()).
+			Hypershift(cmv1.NewHypershift().Enabled(true)).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(getSpotTerminationHandling(cluster)).To(BeEmpty())
+	})
+
+	It("returns the queue URL when configured", func() {
+		queueURL := "https://sqs.us-east-1.amazonaws.com/123456789012/rosa-spot-queue"
+		cluster, err := cmv1.NewCluster().
+			AWS(cmv1.NewAWS().TerminationHandlerQueueUrl(queueURL)).
+			Hypershift(cmv1.NewHypershift().Enabled(true)).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(getSpotTerminationHandling(cluster)).To(Equal(
+			"Spot Termination Queue URL: https://sqs.us-east-1.amazonaws.com/123456789012/rosa-spot-queue\n",
+		))
+	})
+})
+
 var _ = Describe("getLimitedSupportReasons", func() {
 	It("Should return expected LimitedSupportReasons output", func() {
 		By("handle single limited support reason")

--- a/cmd/describe/machinepool/cmd_test.go
+++ b/cmd/describe/machinepool/cmd_test.go
@@ -33,6 +33,7 @@ Tags:
 Taints:                                
 Availability zone:                     us-east-1a
 Subnet:                                
+Spot instances:                        No
 Disk Size:                             300 GiB
 Version:                               4.12.24
 EC2 Metadata Http Tokens:              optional
@@ -61,6 +62,7 @@ Tags:
 Taints:                                
 Availability zone:                     us-east-1a
 Subnet:                                
+Spot instances:                        No
 Disk Size:                             300 GiB
 Version:                               4.12.24
 EC2 Metadata Http Tokens:              optional
@@ -91,6 +93,7 @@ Tags:
 Taints:                                
 Availability zone:                     us-east-1a
 Subnet:                                
+Spot instances:                        No
 Disk Size:                             300 GiB
 Version:                               4.12.24
 EC2 Metadata Http Tokens:              optional
@@ -120,6 +123,7 @@ Tags:
 Taints:                                
 Availability zone:                     us-east-1a
 Subnet:                                
+Spot instances:                        No
 Disk Size:                             300 GiB
 Version:                               4.12.24
 EC2 Metadata Http Tokens:              optional
@@ -149,6 +153,7 @@ Tags:                                  foo=bar
 Taints:                                
 Availability zone:                     us-east-1a
 Subnet:                                
+Spot instances:                        No
 Disk Size:                             300 GiB
 Version:                               4.12.24
 EC2 Metadata Http Tokens:              optional

--- a/cmd/edit/cluster/cmd.go
+++ b/cmd/edit/cluster/cmd.go
@@ -33,6 +33,7 @@ import (
 	"github.com/openshift/rosa/pkg/helper"
 	"github.com/openshift/rosa/pkg/helper/autonode"
 	"github.com/openshift/rosa/pkg/helper/roles"
+	urlHelper "github.com/openshift/rosa/pkg/helper/url"
 	"github.com/openshift/rosa/pkg/input"
 	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/interactive/confirm"
@@ -58,6 +59,8 @@ var args struct {
 
 	// Audit log forwarding
 	auditLogRoleARN string
+	// Spot termination handling
+	spotTerminationQueueUrl string
 
 	// AutoNode configuration
 	autonode        string
@@ -186,6 +189,12 @@ func initFlags(cmd *cobra.Command) {
 		"",
 		"The ARN of the role that is used to forward audit logs to AWS CloudWatch.",
 	)
+	flags.StringVar(
+		&args.spotTerminationQueueUrl,
+		"spot-termination-queue-url",
+		"",
+		"Optional SQS queue URL that enables graceful Spot interruption handling for Hosted Control Plane clusters.",
+	)
 
 	flags.StringVar(
 		&args.autonode,
@@ -282,7 +291,7 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 			"registry-config-allowed-registries", "registry-config-blocked-registries",
 			"registry-config-insecure-registries", "allowed-registries-for-import",
 			"registry-config-platform-allowlist", "registry-config-additional-trusted-ca", "billing-account",
-			"registry-config-allowed-registries-for-import", "enable-delete-protection",
+			"registry-config-allowed-registries-for-import", "enable-delete-protection", "spot-termination-queue-url",
 			"channel-group", "network-type", "channel"} {
 			if cmd.Flags().Changed(flag) {
 				changedFlags = true
@@ -760,6 +769,15 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 		clusterConfig.AdditionalAllowedPrincipals = additionalAllowedPrincipals
 	}
 
+	if err := setSpotTerminationQueueURLForEdit(
+		&clusterConfig,
+		isHostedCP,
+		cmd.Flags().Changed("spot-termination-queue-url"),
+		args.spotTerminationQueueUrl,
+	); err != nil {
+		return err
+	}
+
 	clusterRegistryConfigArgs, err = clusterregistryconfig.GetClusterRegistryConfigOptions(
 		cmd.Flags(), clusterRegistryConfigArgs, aws.IsHostedCP(cluster), cluster)
 	if err != nil {
@@ -1198,6 +1216,25 @@ func PromptUserToAcceptRegistryChange(r *rosa.Runtime) bool {
 		return false
 	}
 	return true
+}
+
+func setSpotTerminationQueueURLForEdit(
+	clusterConfig *ocm.Spec, isHostedCP bool, flagChanged bool, queueURL string,
+) error {
+	if flagChanged && !isHostedCP {
+		return fmt.Errorf("the '--spot-termination-queue-url' flag is only supported for Hosted Control Plane clusters")
+	}
+	if !flagChanged {
+		return nil
+	}
+	if queueURL != "" {
+		if err := urlHelper.ValidateHTTPSQueueURL(queueURL); err != nil {
+			return fmt.Errorf("invalid value for '--spot-termination-queue-url': %w", err)
+		}
+	}
+
+	clusterConfig.TerminationHandlerQueueUrl = &queueURL
+	return nil
 }
 
 func BuildClusterConfigWithRegistry(clusterConfig ocm.Spec, allowedRegistries []string,

--- a/cmd/edit/cluster/cmd_test.go
+++ b/cmd/edit/cluster/cmd_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/openshift-online/ocm-sdk-go/testing"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/ocm"
 	"github.com/openshift/rosa/pkg/test"
 )
@@ -54,6 +55,87 @@ var _ = Describe("Edit cluster", func() {
 				Expect(err.Error()).To(ContainSubstring(
 					"if any flags in the group [channel channel-group] are set none of the others can be"))
 			})
+		})
+		It("should expose the spot-termination-queue-url flag", func() {
+			Expect(cmd.Flags().Lookup("spot-termination-queue-url")).ToNot(BeNil())
+		})
+		It("should reject spot-termination-queue-url for classic clusters", func() {
+			classicCluster := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.Hypershift(cmv1.NewHypershift().Enabled(false))
+			})
+			Expect(aws.IsHostedCP(classicCluster)).To(BeFalse(),
+				"classic cluster must not satisfy IsHostedCP guard")
+		})
+		It("should accept spot-termination-queue-url for HCP clusters", func() {
+			hcpCluster := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.Hypershift(cmv1.NewHypershift().Enabled(true))
+			})
+			Expect(aws.IsHostedCP(hcpCluster)).To(BeTrue(),
+				"HCP cluster must satisfy IsHostedCP guard")
+		})
+	})
+	Context("setSpotTerminationQueueURLForEdit", func() {
+		It("sets a valid queue URL for HCP clusters", func() {
+			clusterConfig := ocm.Spec{}
+			queueURL := "https://sqs.us-east-1.amazonaws.com/123456789012/rosa-spot-queue"
+
+			err := setSpotTerminationQueueURLForEdit(&clusterConfig, true, true, queueURL)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(clusterConfig.TerminationHandlerQueueUrl).ToNot(BeNil())
+			Expect(*clusterConfig.TerminationHandlerQueueUrl).To(Equal(queueURL))
+		})
+
+		It("rejects invalid non-empty queue URLs", func() {
+			clusterConfig := ocm.Spec{}
+
+			err := setSpotTerminationQueueURLForEdit(
+				&clusterConfig,
+				true,
+				true,
+				"http://sqs.us-east-1.amazonaws.com/123456789012/rosa-spot-queue",
+			)
+
+			Expect(err).To(MatchError(
+				"invalid value for '--spot-termination-queue-url': " +
+					"expect URL 'http://sqs.us-east-1.amazonaws.com/123456789012/rosa-spot-queue' to use an 'https://' scheme",
+			))
+			Expect(clusterConfig.TerminationHandlerQueueUrl).To(BeNil())
+		})
+
+		It("allows clearing the queue URL", func() {
+			clusterConfig := ocm.Spec{}
+
+			err := setSpotTerminationQueueURLForEdit(&clusterConfig, true, true, "")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(clusterConfig.TerminationHandlerQueueUrl).ToNot(BeNil())
+			Expect(*clusterConfig.TerminationHandlerQueueUrl).To(BeEmpty())
+		})
+
+		It("rejects a changed non-empty queue URL for classic clusters", func() {
+			clusterConfig := ocm.Spec{}
+			queueURL := "https://sqs.us-east-1.amazonaws.com/123456789012/rosa-spot-queue"
+
+			err := setSpotTerminationQueueURLForEdit(&clusterConfig, false, true, queueURL)
+
+			Expect(err).To(MatchError(
+				"the '--spot-termination-queue-url' flag is only supported for Hosted Control Plane clusters",
+			))
+			Expect(clusterConfig.TerminationHandlerQueueUrl).To(BeNil())
+		})
+
+		It("leaves the queue URL unchanged when the edit flag was not changed", func() {
+			existingQueueURL := "https://sqs.us-east-1.amazonaws.com/123456789012/existing-queue"
+			clusterConfig := ocm.Spec{
+				TerminationHandlerQueueUrl: &existingQueueURL,
+			}
+
+			err := setSpotTerminationQueueURLForEdit(&clusterConfig, true, false, "https://ignored.example.com")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(clusterConfig.TerminationHandlerQueueUrl).ToNot(BeNil())
+			Expect(*clusterConfig.TerminationHandlerQueueUrl).To(Equal(existingQueueURL))
 		})
 	})
 	Context("warnUserForOAuthHCPVisibility", func() {

--- a/cmd/edit/machinepool/cmd.go
+++ b/cmd/edit/machinepool/cmd.go
@@ -112,6 +112,20 @@ func NewEditMachinePoolCommand() *cobra.Command {
 	)
 
 	flags.BoolVar(
+		&options.useSpotInstances,
+		"use-spot-instances",
+		false,
+		"Use spot instances for the hosted machine pool.",
+	)
+
+	flags.StringVar(
+		&options.spotMaxPrice,
+		"spot-max-price",
+		"on-demand",
+		"Max price for spot instances. Defaults to 'on-demand', which uses the on-demand price.",
+	)
+
+	flags.BoolVar(
 		&options.autorepair,
 		"autorepair",
 		true,

--- a/cmd/edit/machinepool/cmd_test.go
+++ b/cmd/edit/machinepool/cmd_test.go
@@ -1,6 +1,7 @@
 package machinepool
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 
@@ -69,6 +70,19 @@ var _ = Describe("Edit Machinepool", func() {
 		})
 
 		Describe("Machinepools", Ordered, func() {
+			It("Rejects spot flags on classic machine pools", func() {
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, mpResponse))
+				t.SetCluster(clusterId, mockClassicClusterReady)
+				args := NewEditMachinepoolUserOptions()
+				args.machinepool = nodePoolId
+				runner := EditMachinePoolRunner(args)
+				cmd := NewEditMachinePoolCommand()
+				Expect(cmd.Flag("cluster").Value.Set(clusterId)).To(Succeed())
+				Expect(cmd.Flags().Set("use-spot-instances", "true")).To(Succeed())
+				err := runner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).To(MatchError(
+					"spot instance configuration is only supported for Hosted Control Plane machine pools"))
+			})
 			It("Able to edit machinepool with no issues", func() {
 				// First get
 				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, mpResponse))
@@ -105,6 +119,11 @@ var _ = Describe("Edit Machinepool", func() {
 		})
 
 		Describe("Nodepools", func() {
+			It("exposes the spot edit flags", func() {
+				cmd := NewEditMachinePoolCommand()
+				Expect(cmd.Flags().Lookup("use-spot-instances")).ToNot(BeNil())
+				Expect(cmd.Flags().Lookup("spot-max-price")).ToNot(BeNil())
+			})
 			It("Able to edit nodepool with no issues", func() {
 				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
 				// First get
@@ -153,6 +172,57 @@ var _ = Describe("Edit Machinepool", func() {
 					"2", "--enable-autoscaling", "true", "--interactive", "false", "--max-replicas",
 					"10"})).To(Succeed())
 			})
+			It("Rejects modifying spot on an existing nodepool with guidance to recreate", func() {
+				spotNodePool, err := cmv1.NewNodePool().ID(nodePoolId).Version(version).
+					AWSNodePool(cmv1.NewAWSNodePool().InstanceType("m5.xlarge")).
+					AvailabilityZone("us-east-1a").Build()
+				Expect(err).ToNot(HaveOccurred())
+				spotNodePoolResponse := formatNodePoolResource(spotNodePool)
+
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, spotNodePoolResponse))
+				t.SetCluster(clusterId, mockClusterReady)
+				args := NewEditMachinepoolUserOptions()
+				args.machinepool = nodePoolId
+				runner := EditMachinePoolRunner(args)
+				cmd := NewEditMachinePoolCommand()
+				Expect(cmd.Flag("cluster").Value.Set(clusterId)).To(Succeed())
+				Expect(cmd.Flag("yes").Value.Set("true")).To(Succeed())
+				Expect(cmd.Flags().Set("use-spot-instances", "true")).To(Succeed())
+				Expect(cmd.Flags().Set("spot-max-price", "1.00")).To(Succeed())
+
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{nodePoolId})
+				Expect(err).To(MatchError(ContainSubstring(
+					"delete the machine pool and create a new one with the desired spot settings")))
+			})
+			It("Rejects disabling spot instances on nodepool edits for now", func() {
+				existingSpotNodePool, err := cmv1.NewNodePool().ID(nodePoolId).Version(version).
+					AWSNodePool(cmv1.NewAWSNodePool().InstanceType("m5.xlarge").
+						SpotMarketOptions(cmv1.NewAwsNodePoolSpotMarketOptions().MaxPrice("1.00"))).
+					AvailabilityZone("us-east-1a").Build()
+				Expect(err).ToNot(HaveOccurred())
+				existingSpotNodePoolResponse := formatNodePoolResource(existingSpotNodePool)
+
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, hypershiftClusterReady))
+				t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, existingSpotNodePoolResponse))
+				t.SetCluster(clusterId, mockClusterReady)
+				args := NewEditMachinepoolUserOptions()
+				args.machinepool = nodePoolId
+				runner := EditMachinePoolRunner(args)
+				cmd := NewEditMachinePoolCommand()
+				Expect(cmd.Flag("cluster").Value.Set(clusterId)).To(Succeed())
+				Expect(cmd.Flag("yes").Value.Set("true")).To(Succeed())
+				Expect(cmd.Flags().Set("use-spot-instances", "false")).To(Succeed())
+
+				err = runner(context.Background(), t.RosaRuntime, cmd, []string{nodePoolId})
+				Expect(err).To(MatchError("disabling spot instances on hosted machine pools is not supported yet"))
+			})
 		})
 	})
 })
+
+func formatNodePoolResource(nodePool *cmv1.NodePool) string {
+	var output bytes.Buffer
+	Expect(cmv1.MarshalNodePool(nodePool, &output)).To(Succeed())
+	return output.String()
+}

--- a/cmd/edit/machinepool/options.go
+++ b/cmd/edit/machinepool/options.go
@@ -21,6 +21,8 @@ type EditMachinepoolUserOptions struct {
 	nodeDrainGracePeriod string
 	maxSurge             string
 	maxUnavailable       string
+	useSpotInstances     bool
+	spotMaxPrice         string
 }
 
 type EditMachinepoolOptions struct {

--- a/cmd/list/machinepool/cmd_test.go
+++ b/cmd/list/machinepool/cmd_test.go
@@ -18,8 +18,8 @@ import (
 const (
 	nodePoolName         = "nodepool85"
 	clusterId            = "24vf9iitg3p6tlml88iml6j6mu095mh8"
-	singleNodePoolOutput = "ID          AUTOSCALING  REPLICAS  INSTANCE TYPE  LABELS    TAINTS    AVAILABILITY ZONE  SUBNET  DISK SIZE  VERSION  AUTOREPAIR  \n" +
-		"nodepool85  No           /0        m5.xlarge                          us-east-1a                 default    4.12.24  No          \n"
+	singleNodePoolOutput = "ID          AUTOSCALING  REPLICAS  INSTANCE TYPE  LABELS    TAINTS    AVAILABILITY ZONE  SUBNET  SPOT INSTANCES  DISK SIZE  VERSION  AUTOREPAIR  \n" +
+		"nodepool85  No           /0        m5.xlarge                          us-east-1a                 No              default    4.12.24  No          \n"
 
 	singleMachinePoolOutput = "ID          AUTOSCALING  REPLICAS  INSTANCE TYPE  AVAILABILITY ZONES                  SPOT INSTANCES  DISK SIZE\n" +
 		"nodepool85  No           0         m5.xlarge      us-east-1a, us-east-1b, us-east-1c  Yes (max $5)    default\n"
@@ -29,9 +29,9 @@ const (
 		"nodepool852  No           0         m5.xlarge      test=label               us-east-1a, us-east-1b, us-east-1c  Yes (max $5)    default\n" +
 		"nodepool853  Yes          1-100     m5.xlarge      test=label  test=taint:  us-east-1a, us-east-1b, us-east-1c  Yes (max $5)    default\n"
 
-	multipleNodePoolsOutput = "ID           AUTOSCALING  REPLICAS   INSTANCE TYPE  LABELS        TAINTS    AVAILABILITY ZONE  SUBNET  DISK SIZE  VERSION  AUTOREPAIR  \n" +
-		"nodepool85   No           /0         m5.xlarge                              us-east-1a                 default    4.12.24  No          \n" +
-		"nodepool852  Yes          /100-1000  m5.xlarge      test=label              us-east-1a                 default    4.12.24  No          \n"
+	multipleNodePoolsOutput = "ID           AUTOSCALING  REPLICAS   INSTANCE TYPE  LABELS        TAINTS    AVAILABILITY ZONE  SUBNET  SPOT INSTANCES  DISK SIZE  VERSION  AUTOREPAIR  \n" +
+		"nodepool85   No           /0         m5.xlarge                              us-east-1a                 No              default    4.12.24  No          \n" +
+		"nodepool852  Yes          /100-1000  m5.xlarge      test=label              us-east-1a                 No              default    4.12.24  No          \n"
 )
 
 var _ = Describe("List machine pool", func() {

--- a/cmd/rosa/structure_test/command_args/rosa/create/cluster/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/create/cluster/command_args.yml
@@ -29,6 +29,7 @@
 - name: no-proxy
 - name: additional-trust-bundle-file
 - name: additional-allowed-principals
+- name: spot-termination-queue-url
 - name: enable-customer-managed-key
 - name: kms-key-arn
 - name: etcd-encryption-kms-arn

--- a/cmd/rosa/structure_test/command_args/rosa/create/spot-termination-queue/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/create/spot-termination-queue/command_args.yml
@@ -1,0 +1,4 @@
+- name: mode
+- name: name
+- name: nodepool-management-role-arn
+- name: output

--- a/cmd/rosa/structure_test/command_args/rosa/edit/cluster/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/edit/cluster/command_args.yml
@@ -13,6 +13,7 @@
 - name: autonode
 - name: autonode-iam-role-arn
 - name: additional-allowed-principals
+- name: spot-termination-queue-url
 - name: registry-config-allowed-registries
 - name: registry-config-insecure-registries
 - name: registry-config-blocked-registries

--- a/cmd/rosa/structure_test/command_args/rosa/edit/machinepool/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/edit/machinepool/command_args.yml
@@ -14,6 +14,8 @@
 - name: profile
 - name: region
 - name: replicas
+- name: spot-max-price
 - name: taints
 - name: tuning-configs
+- name: use-spot-instances
 - name: "yes"

--- a/cmd/rosa/structure_test/command_structure.yml
+++ b/cmd/rosa/structure_test/command_structure.yml
@@ -35,6 +35,7 @@ children:
     - name: user-role
     - name: decision
     - name: network
+    - name: spot-termination-queue
 - name: delete
   children:
     - name: account-roles

--- a/pkg/helper/url/helpers.go
+++ b/pkg/helper/url/helpers.go
@@ -51,6 +51,32 @@ func ValidateURLCredentials(urlString string) error {
 	return checkForInvalidChars(password, "password")
 }
 
+// ValidateHTTPSQueueURL performs lightweight sanity checks for queue-style URLs
+// without mirroring backend-owned service semantics.
+func ValidateHTTPSQueueURL(urlString string) error {
+	if strings.Contains(urlString, "#") {
+		return fmt.Errorf("expect URL '%s' to not include a fragment", urlString)
+	}
+
+	parsedURL, err := ParseRequestURI(urlString)
+	if err != nil {
+		return err
+	}
+	if parsedURL.Scheme != "https" {
+		return fmt.Errorf("expect URL '%s' to use an 'https://' scheme", urlString)
+	}
+	if parsedURL.Host == "" {
+		return fmt.Errorf("expect URL '%s' to include a host", urlString)
+	}
+	if parsedURL.User != nil {
+		return fmt.Errorf("expect URL '%s' to not include user info", urlString)
+	}
+	if parsedURL.RawQuery != "" {
+		return fmt.Errorf("expect URL '%s' to not include a query string", urlString)
+	}
+	return nil
+}
+
 func checkForInvalidChars(value, field string) error {
 	invalidChars := "/:#?[]@!$&'()*+,;="
 

--- a/pkg/helper/url/helpers_test.go
+++ b/pkg/helper/url/helpers_test.go
@@ -107,6 +107,35 @@ var _ = Describe("ValidateURLCredentials", func() {
 })
 
 var _ = Describe("Parse helpers", func() {
+	Describe("ValidateHTTPSQueueURL", func() {
+		It("accepts a valid HTTPS queue URL", func() {
+			err := ValidateHTTPSQueueURL("https://sqs.us-east-1.amazonaws.com/123456789012/rosa-spot-queue")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("rejects malformed URLs", func() {
+			err := ValidateHTTPSQueueURL("not-a-url")
+			Expect(err).To(HaveOccurred())
+		})
+
+		DescribeTable("rejects invalid queue URL shapes",
+			func(queueURL string, expectedError string) {
+				err := ValidateHTTPSQueueURL(queueURL)
+				Expect(err).To(MatchError(expectedError))
+			},
+			Entry("non-https scheme", "http://sqs.us-east-1.amazonaws.com/123456789012/queue",
+				"expect URL 'http://sqs.us-east-1.amazonaws.com/123456789012/queue' to use an 'https://' scheme"),
+			Entry("missing host", "https:///123456789012/queue",
+				"expect URL 'https:///123456789012/queue' to include a host"),
+			Entry("userinfo", "https://user:pass@sqs.us-east-1.amazonaws.com/123456789012/queue",
+				"expect URL 'https://user:pass@sqs.us-east-1.amazonaws.com/123456789012/queue' to not include user info"),
+			Entry("query string", "https://sqs.us-east-1.amazonaws.com/123456789012/queue?debug=true",
+				"expect URL 'https://sqs.us-east-1.amazonaws.com/123456789012/queue?debug=true' to not include a query string"),
+			Entry("fragment", "https://sqs.us-east-1.amazonaws.com/123456789012/queue#anchor",
+				"expect URL 'https://sqs.us-east-1.amazonaws.com/123456789012/queue#anchor' to not include a fragment"),
+		)
+	})
+
 	Describe("Parse", func() {
 		It("accepts a valid IPv6 host literal", func() {
 			parsedURL, err := Parse("http://[::1]:8080")

--- a/pkg/machinepool/helper.go
+++ b/pkg/machinepool/helper.go
@@ -32,9 +32,12 @@ const (
 	zoneTypeStandard   = "Standard"
 	zoneTypeNA         = "N/A"
 
-	displayValueYes     = "Yes"
-	displayValueNo      = "No"
-	displayValueUnknown = "Unknown"
+	displayValueYes                              = "Yes"
+	displayValueNo                               = "No"
+	displayValueUnknown                          = "Unknown"
+	spotPriceOnDemand                            = "on-demand"
+	spotNodePoolWithoutTerminationHandlerWarning = "Spot NodePool created without termination handler configuration. " +
+		"Nodes will not be gracefully drained on interruptions."
 
 	imageTypeWindows = "windows"
 
@@ -282,7 +285,7 @@ func (r *ReplicaSizeValidation) MinReplicaValidator() interactive.Validator {
 
 func spotMaxPriceValidator(val interface{}) error {
 	spotMaxPrice := fmt.Sprintf("%v", val)
-	if spotMaxPrice == "on-demand" {
+	if spotMaxPrice == spotPriceOnDemand {
 		return nil
 	}
 	price, err := strconv.ParseFloat(spotMaxPrice, commonUtils.MaxByteSize)

--- a/pkg/machinepool/machinepool.go
+++ b/pkg/machinepool/machinepool.go
@@ -401,7 +401,7 @@ func (m *machinePool) CreateMachinePool(r *rosa.Runtime, cmd *cobra.Command, clu
 	if err != nil {
 		return err
 	}
-	if spotMaxPrice != "on-demand" {
+	if spotMaxPrice != spotPriceOnDemand {
 		price, _ := strconv.ParseFloat(spotMaxPrice, commonUtils.MaxByteSize)
 		maxPrice = &price
 	}
@@ -713,6 +713,18 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 		npBuilder.Subnet(subnet)
 	}
 
+	isSpotSet := cmd.Flags().Changed("use-spot-instances")
+	isSpotMaxPriceSet := cmd.Flags().Changed("spot-max-price")
+	useSpotInstances := args.UseSpotInstances
+	spotMaxPrice := args.SpotMaxPrice
+	if spotMaxPrice == "" {
+		spotMaxPrice = spotPriceOnDemand
+	}
+
+	if isSpotMaxPriceSet && (!isSpotSet || !useSpotInstances) {
+		return fmt.Errorf("can't set max price when not using spot instances")
+	}
+
 	// Machine pool instance type:
 	// NodePools don't support MultiAZ yet, so the availabilityZonesFilters is calculated from the cluster
 	instanceType := args.InstanceType
@@ -739,6 +751,18 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 			return fmt.Errorf("%s", err)
 		}
 		availabilityZonesFilter = []string{availabilityZone}
+	}
+
+	isLocalZone := false
+	if len(availabilityZonesFilter) == 1 &&
+		(useSpotInstances || (!isSpotSet && !isSpotMaxPriceSet && interactive.Enabled())) {
+		isLocalZone, err = r.AWSClient.IsLocalAvailabilityZone(availabilityZonesFilter[0])
+		if err != nil {
+			return err
+		}
+	}
+	if isLocalZone && useSpotInstances {
+		return fmt.Errorf("spot instances are not supported for local zones")
 	}
 
 	instanceTypeList, err := r.OCMClient.GetAvailableMachineTypesInRegion(cluster.Region().ID(),
@@ -943,6 +967,43 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 		return fmt.Errorf("expected a valid http tokens value : %v", err)
 	}
 
+	if !isSpotSet && !isSpotMaxPriceSet && !isLocalZone && interactive.Enabled() {
+		useSpotInstances, err = interactive.GetBool(interactive.Input{
+			Question: "Use spot instances",
+			Help:     cmd.Flags().Lookup("use-spot-instances").Usage,
+			Default:  useSpotInstances,
+			Required: false,
+		})
+		if err != nil {
+			return fmt.Errorf("expected a valid value for use spot instances: %s", err)
+		}
+	}
+
+	if useSpotInstances && (capacityReservationId != "" || capacityReservationPreference != "") {
+		return fmt.Errorf("can't use spot instances with capacity reservation")
+	}
+
+	if useSpotInstances {
+		if !isSpotMaxPriceSet && interactive.Enabled() {
+			spotMaxPrice, err = interactive.GetString(interactive.Input{
+				Question: "Spot instance max price",
+				Help:     cmd.Flags().Lookup("spot-max-price").Usage,
+				Required: false,
+				Default:  spotMaxPrice,
+				Validators: []interactive.Validator{
+					spotMaxPriceValidator,
+				},
+			})
+			if err != nil {
+				return fmt.Errorf("expected a valid value for spot max price: %s", err)
+			}
+		}
+		err = spotMaxPriceValidator(spotMaxPrice)
+		if err != nil {
+			return err
+		}
+	}
+
 	var rootDiskSize *int
 	_, _, _, _, defaultRootDiskSize, _ :=
 		r.OCMClient.GetDefaultClusterFlavors(cluster.Flavour().ID())
@@ -998,6 +1059,14 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 		awsTags,
 		rootDiskSize,
 	)
+
+	if useSpotInstances {
+		spotMarketOptions := cmv1.NewAwsNodePoolSpotMarketOptions()
+		if spotMaxPrice != spotPriceOnDemand {
+			spotMarketOptions = spotMarketOptions.MaxPrice(spotMaxPrice)
+		}
+		awsNodepoolBuilder = awsNodepoolBuilder.SpotMarketOptions(spotMarketOptions)
+	}
 
 	if !fedramp.Enabled() {
 		capacityReservation := cmv1.NewAWSCapacityReservation()
@@ -1146,9 +1215,19 @@ func (m *machinePool) CreateNodePools(r *rosa.Runtime, cmd *cobra.Command, clust
 		return fmt.Errorf("failed to create machine pool for hosted cluster '%s': %v", clusterKey, err)
 	}
 
-	createdNodePool, err := r.OCMClient.CreateNodePool(cluster.ID(), nodePool)
+	createResult, err := r.OCMClient.CreateNodePoolWithWarnings(cluster.ID(), nodePool)
 	if err != nil {
 		return fmt.Errorf("failed to add machine pool to hosted cluster '%s': %v", clusterKey, err)
+	}
+	createdNodePool := createResult.NodePool
+	for _, warning := range createResult.Warnings {
+		r.Reporter.Warnf("%s", warning)
+	}
+	if len(createResult.Warnings) == 0 &&
+		useSpotInstances &&
+		cluster.AWS() != nil &&
+		cluster.AWS().TerminationHandlerQueueUrl() == "" {
+		r.Reporter.Warnf("%s", spotNodePoolWithoutTerminationHandlerWarning)
 	}
 
 	if output.HasFlag() {
@@ -1476,9 +1555,9 @@ func getMachinePoolsString(
 
 func getNodePoolsString(nodePools []*cmv1.NodePool) string {
 	outputString := "ID\tAUTOSCALING\tREPLICAS\t" +
-		"INSTANCE TYPE\tLABELS\t\tTAINTS\t\tAVAILABILITY ZONE\tSUBNET\tDISK SIZE\tVERSION\tAUTOREPAIR\t\n"
+		"INSTANCE TYPE\tLABELS\t\tTAINTS\t\tAVAILABILITY ZONE\tSUBNET\tSPOT INSTANCES\tDISK SIZE\tVERSION\tAUTOREPAIR\t\n"
 	for _, nodePool := range nodePools {
-		outputString += fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t\t%s\t\t%s\t%s\t%s\t%s\t%s\t\n",
+		outputString += fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t\t%s\t\t%s\t%s\t%s\t%s\t%s\t%s\t\n",
 			nodePool.ID(),
 			ocmOutput.PrintNodePoolAutoscaling(nodePool.Autoscaling()),
 			ocmOutput.PrintNodePoolReplicasShort(
@@ -1490,6 +1569,7 @@ func getNodePoolsString(nodePools []*cmv1.NodePool) string {
 			ocmOutput.PrintTaints(nodePool.Taints()),
 			nodePool.AvailabilityZone(),
 			nodePool.Subnet(),
+			ocmOutput.PrintNodePoolSpot(nodePool.AWSNodePool()),
 			ocmOutput.PrintNodePoolDiskSize(nodePool.AWSNodePool()),
 			ocmOutput.PrintNodePoolVersion(nodePool.Version()),
 			ocmOutput.PrintNodePoolAutorepair(nodePool.AutoRepair()),
@@ -1707,6 +1787,10 @@ func editMachinePool(cmd *cobra.Command, machinePoolId string,
 	isLabelsSet := cmd.Flags().Changed("labels")
 	isTaintsSet := cmd.Flags().Changed("taints")
 
+	if cmd.Flags().Changed("use-spot-instances") || cmd.Flags().Changed("spot-max-price") {
+		return fmt.Errorf("spot instance configuration is only supported for Hosted Control Plane machine pools")
+	}
+
 	// if no value set enter interactive mode
 	//nolint:staticcheck
 	if !(isMinReplicasSet || isMaxReplicasSet || isReplicasSet || isAutoscalingSet || isLabelsSet || isTaintsSet) {
@@ -1802,10 +1886,22 @@ func editNodePool(cmd *cobra.Command, nodePoolID string,
 	isNodeDrainGracePeriodSet := cmd.Flags().Changed("node-drain-grace-period")
 	isUpgradeMaxSurgeSet := cmd.Flags().Changed("max-surge")
 	isUpgradeMaxUnavailableSet := cmd.Flags().Changed("max-unavailable")
+	isSpotSet := cmd.Flags().Changed("use-spot-instances")
+	isSpotMaxPriceSet := cmd.Flags().Changed("spot-max-price")
+	requestedUseSpotInstances := false
+	if isSpotSet {
+		requestedUseSpotInstances, err = strconv.ParseBool(cmd.Flags().Lookup("use-spot-instances").Value.String())
+		if err != nil {
+			return fmt.Errorf("failed to parse use-spot-instances flag: %s", err)
+		}
+		if !requestedUseSpotInstances {
+			return fmt.Errorf("disabling spot instances on hosted machine pools is not supported yet")
+		}
+	}
 
 	// isAnyAdditionalParameterSet is true if at least one parameter not related to replicas and autoscaling is set
 	isAnyAdditionalParameterSet := isLabelsSet || isTaintsSet || isAutorepairSet || isTuningsConfigSet ||
-		isKubeletConfigSet || isUpgradeMaxSurgeSet || isUpgradeMaxUnavailableSet
+		isKubeletConfigSet || isUpgradeMaxSurgeSet || isUpgradeMaxUnavailableSet || isSpotSet || isSpotMaxPriceSet
 	isAnyParameterSet := isMinReplicasSet || isMaxReplicasSet || isReplicasSet ||
 		isAutoscalingSet || isAnyAdditionalParameterSet
 
@@ -1834,6 +1930,21 @@ func editNodePool(cmd *cobra.Command, nodePoolID string,
 		isMinReplicasSet, isMaxReplicasSet)
 	if err != nil {
 		return err
+	}
+
+	existingSpotEnabled := nodePool.AWSNodePool() != nil && nodePool.AWSNodePool().SpotMarketOptions() != nil
+	targetUseSpotInstances := existingSpotEnabled
+	if isSpotSet {
+		targetUseSpotInstances = requestedUseSpotInstances
+	}
+
+	if isSpotMaxPriceSet && !isSpotSet && !existingSpotEnabled {
+		return fmt.Errorf("can't set max price when not using spot instances")
+	}
+
+	if isSpotMaxPriceSet || (isSpotSet && targetUseSpotInstances && !existingSpotEnabled) {
+		return fmt.Errorf("modifying spot configuration on an existing machine pool is not supported; " +
+			"delete the machine pool and create a new one with the desired spot settings")
 	}
 
 	labels := cmd.Flags().Lookup("labels").Value.String()

--- a/pkg/machinepool/machinepool_test.go
+++ b/pkg/machinepool/machinepool_test.go
@@ -24,6 +24,7 @@ import (
 
 	mock "github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/interactive/confirm"
 	"github.com/openshift/rosa/pkg/interactive/securitygroups"
 	"github.com/openshift/rosa/pkg/ocm"
 	ocmOutput "github.com/openshift/rosa/pkg/ocm/output"
@@ -303,8 +304,8 @@ var _ = Describe("Machinepool and nodepool", func() {
 			out := getNodePoolsString(cluster.NodePools().Slice())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(out).To(Equal(fmt.Sprintf("ID\tAUTOSCALING\tREPLICAS\t"+
-				"INSTANCE TYPE\tLABELS\t\tTAINTS\t\tAVAILABILITY ZONE\tSUBNET\tDISK SIZE\tVERSION\tAUTOREPAIR\t\n"+
-				"%s\t%s\t%s\t%s\t%s\t\t%s\t\t%s\t%s\t%s\t%s\t%s\t\n",
+				"INSTANCE TYPE\tLABELS\t\tTAINTS\t\tAVAILABILITY ZONE\tSUBNET\tSPOT INSTANCES\tDISK SIZE\tVERSION\tAUTOREPAIR\t\n"+
+				"%s\t%s\t%s\t%s\t%s\t\t%s\t\t%s\t%s\t%s\t%s\t%s\t%s\t\n",
 				cluster.NodePools().Get(0).ID(),
 				ocmOutput.PrintNodePoolAutoscaling(cluster.NodePools().Get(0).Autoscaling()),
 				ocmOutput.PrintNodePoolReplicasShort(
@@ -317,6 +318,39 @@ var _ = Describe("Machinepool and nodepool", func() {
 				ocmOutput.PrintTaints(cluster.NodePools().Get(0).Taints()),
 				cluster.NodePools().Get(0).AvailabilityZone(),
 				cluster.NodePools().Get(0).Subnet(),
+				ocmOutput.PrintNodePoolSpot(cluster.NodePools().Get(0).AWSNodePool()),
+				ocmOutput.PrintNodePoolDiskSize(cluster.NodePools().Get(0).AWSNodePool()),
+				ocmOutput.PrintNodePoolVersion(cluster.NodePools().Get(0).Version()),
+				ocmOutput.PrintNodePoolAutorepair(cluster.NodePools().Get(0).AutoRepair()))))
+		})
+		It("Test printNodePools with spot instances", func() {
+			clusterBuilder := cmv1.NewCluster().ID("test").State(cmv1.ClusterStateReady).
+				Hypershift(cmv1.NewHypershift().Enabled(true)).NodePools(cmv1.NewNodePoolList().
+				Items(cmv1.NewNodePool().ID("np").Replicas(8).AvailabilityZone("az").
+					AWSNodePool(cmv1.NewAWSNodePool().
+						RootVolume(cmv1.NewAWSVolume().Size(256)).
+						SpotMarketOptions(cmv1.NewAwsNodePoolSpotMarketOptions().MaxPrice("1.00"))).
+					Subnet("sn").Version(cmv1.NewVersion().ID("1")).AutoRepair(false)))
+			cluster, err := clusterBuilder.Build()
+			Expect(err).ToNot(HaveOccurred())
+			out := getNodePoolsString(cluster.NodePools().Slice())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(Equal(fmt.Sprintf("ID\tAUTOSCALING\tREPLICAS\t"+
+				"INSTANCE TYPE\tLABELS\t\tTAINTS\t\tAVAILABILITY ZONE\tSUBNET\tSPOT INSTANCES\tDISK SIZE\tVERSION\tAUTOREPAIR\t\n"+
+				"%s\t%s\t%s\t%s\t%s\t\t%s\t\t%s\t%s\t%s\t%s\t%s\t%s\t\n",
+				cluster.NodePools().Get(0).ID(),
+				ocmOutput.PrintNodePoolAutoscaling(cluster.NodePools().Get(0).Autoscaling()),
+				ocmOutput.PrintNodePoolReplicasShort(
+					ocmOutput.PrintNodePoolCurrentReplicas(cluster.NodePools().Get(0).Status()),
+					ocmOutput.PrintNodePoolReplicas(cluster.NodePools().Get(0).Autoscaling(),
+						cluster.NodePools().Get(0).Replicas()),
+				),
+				ocmOutput.PrintNodePoolInstanceType(cluster.NodePools().Get(0).AWSNodePool()),
+				ocmOutput.PrintLabels(cluster.NodePools().Get(0).Labels()),
+				ocmOutput.PrintTaints(cluster.NodePools().Get(0).Taints()),
+				cluster.NodePools().Get(0).AvailabilityZone(),
+				cluster.NodePools().Get(0).Subnet(),
+				"Yes (max $1.00)",
 				ocmOutput.PrintNodePoolDiskSize(cluster.NodePools().Get(0).AWSNodePool()),
 				ocmOutput.PrintNodePoolVersion(cluster.NodePools().Get(0).Version()),
 				ocmOutput.PrintNodePoolAutorepair(cluster.NodePools().Get(0).AutoRepair()))))
@@ -1551,6 +1585,148 @@ var _ = Describe("NodePools", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("you must supply a valid instance type"))
 		})
+		It("should error when spot-max-price is set without use-spot-instances for node pools", func() {
+			machinePool := &machinePool{}
+			version := "4.15.0"
+
+			cluster = returnMockCluster(version)
+			day1AvailabilityZone := "a1"
+			privateSubnets := []ec2types.Subnet{{AvailabilityZone: &day1AvailabilityZone, SubnetId: &subnet}}
+
+			cmd.Flags().StringVar(&args.Name, "name", "", "Name of the machine pool")
+			cmd.Flags().Set("name", "test")
+			cmd.Flags().StringVar(&args.Version, "version", "", "Version of the machine pool")
+			cmd.Flags().Set("version", version)
+			cmd.Flags().Int32("replicas", 3, "Replicas of the machine pool")
+			cmd.Flags().Set("replicas", "3")
+			cmd.Flags().StringVar(&args.SpotMaxPrice, "spot-max-price", "", "Spot max price")
+			cmd.Flags().Set("spot-max-price", "1.00")
+
+			args.Replicas = 3
+			args.InstanceType = "t3.small"
+			args.SpotMaxPrice = "1.00"
+
+			v := cmv1.VersionBuilder{}
+			v.ID(version).ChannelGroup("stable").RawID(version).Default(true).
+				Enabled(true).ROSAEnabled(true).HostedControlPlaneDefault(true)
+			versionObj, err := v.Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatVersionList([]*cmv1.Version{versionObj})))
+			mockClient.EXPECT().GetVPCPrivateSubnets(gomock.Any()).Return(privateSubnets, nil)
+
+			err = machinePool.CreateNodePools(t.RosaRuntime, cmd, clusterKey, cluster, nil, &args)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("can't set max price when not using spot instances"))
+		})
+
+		It("should reject spot instances for local zones on node pools", func() {
+			machinePool := &machinePool{}
+			version := "4.22.0"
+			az := "us-east-1-lz-1"
+
+			cluster = returnMockCluster(version)
+			day1AvailabilityZone := "a1"
+			privateSubnets := []ec2types.Subnet{{AvailabilityZone: &day1AvailabilityZone, SubnetId: &subnet}}
+
+			cmd.Flags().StringVar(&args.Name, "name", "", "Name of the machine pool")
+			cmd.Flags().Set("name", "test")
+			cmd.Flags().StringVar(&args.Version, "version", "", "Version of the machine pool")
+			cmd.Flags().Set("version", version)
+			cmd.Flags().Int32("replicas", 3, "Replicas of the machine pool")
+			cmd.Flags().Set("replicas", "3")
+			cmd.Flags().BoolVar(&args.UseSpotInstances, "use-spot-instances", false, "Use spot instances")
+			cmd.Flags().Set("use-spot-instances", "true")
+
+			args.Replicas = 3
+			args.InstanceType = "t3.small"
+			args.UseSpotInstances = true
+
+			v := cmv1.VersionBuilder{}
+			v.ID(version).ChannelGroup("stable").RawID(version).Default(true).
+				Enabled(true).ROSAEnabled(true).HostedControlPlaneDefault(true)
+			versionObj, err := v.Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatVersionList([]*cmv1.Version{versionObj})))
+			mockClient.EXPECT().GetVPCPrivateSubnets(gomock.Any()).Return(privateSubnets, nil)
+			mockClient.EXPECT().GetSubnetAvailabilityZone(subnet).Return(az, nil)
+			mockClient.EXPECT().IsLocalAvailabilityZone(az).Return(true, nil)
+
+			err = machinePool.CreateNodePools(t.RosaRuntime, cmd, clusterKey, cluster, nil, &args)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("spot instances are not supported for local zones"))
+		})
+		It("should error when spot instances and capacity reservation are both set for node pools", func() {
+			machinePool := &machinePool{}
+			version := "4.19.0"
+			az := "a1"
+
+			cluster = returnMockCluster(version)
+			privateSubnets := []ec2types.Subnet{
+				{AvailabilityZone: &az, SubnetId: &subnet},
+			}
+
+			cmd.Flags().StringVar(&args.Name, "name", "", "Name of the machine pool")
+			cmd.Flags().Set("name", "test")
+			cmd.Flags().StringVar(&args.Version, "version", "", "Version of the machine pool")
+			cmd.Flags().Set("version", version)
+			cmd.Flags().Int32("replicas", 3, "Replicas of the machine pool")
+			cmd.Flags().Set("replicas", "3")
+			cmd.Flags().BoolVar(&args.UseSpotInstances, "use-spot-instances", false, "Use spot instances")
+			cmd.Flags().Set("use-spot-instances", "true")
+			cmd.Flags().StringVar(&args.CapacityReservationId, "capacity-reservation-id",
+				"fake-capacity-reservation-id", "capacity-reservation-id")
+			cmd.Flags().Set("capacity-reservation-id", "fake-capacity-reservation-id")
+
+			args.Replicas = 3
+			args.InstanceType = "t3.small"
+			args.UseSpotInstances = true
+			args.CapacityReservationId = "fake-capacity-reservation-id"
+
+			v := cmv1.VersionBuilder{}
+			v.ID(version).ChannelGroup("stable").RawID(version).Default(true).
+				Enabled(true).ROSAEnabled(true).HostedControlPlaneDefault(true)
+			versionObj, err := v.Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatVersionList(
+				[]*cmv1.Version{versionObj})))
+			mockClient.EXPECT().GetVPCPrivateSubnets(gomock.Any()).Return(privateSubnets, nil)
+			mockClient.EXPECT().GetSubnetAvailabilityZone(subnet).Return(az, nil)
+			mockClient.EXPECT().IsLocalAvailabilityZone(az).Return(false, nil)
+			mtBuilder := cmv1.NewMachineType().ID("t3.small").Name("t3.small")
+			machineType, err := mtBuilder.Build()
+			Expect(err).ToNot(HaveOccurred())
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatMachineTypeList(
+				[]*cmv1.MachineType{machineType})))
+			acc, err := amsv1.NewAccount().ID("123456789012").Build()
+			Expect(err).ToNot(HaveOccurred())
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, FormatResources(acc)))
+			qc, err := amsv1.NewQuotaCost().QuotaID("test-quota").
+				OrganizationID("123456789012").Version("4.19.0").Build()
+			Expect(err).ToNot(HaveOccurred())
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatQuotaCostList([]*amsv1.QuotaCost{qc})))
+			flavour, err := cmv1.NewFlavour().AWS(cmv1.NewAWSFlavour().ComputeInstanceType("x-large").
+				WorkerVolume(cmv1.NewAWSVolume().Size(100))).
+				Network(cmv1.NewNetwork().MachineCIDR("").PodCIDR("").ServiceCIDR("").HostPrefix(1)).Build()
+			Expect(err).ToNot(HaveOccurred())
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, FormatResources(flavour)))
+
+			nodePoolObj, err := cmv1.NewNodePool().ID("np-1").Build()
+			Expect(err).ToNot(HaveOccurred())
+			nodePoolResponse := test.FormatNodePoolList([]*cmv1.NodePool{})
+			t.ApiServer.RouteToHandler(http.MethodGet,
+				fmt.Sprintf("/api/clusters_mgmt/v1/clusters/%s/node_pools", cluster.ID()),
+				RespondWithJSON(http.StatusOK, nodePoolResponse))
+			t.ApiServer.RouteToHandler(http.MethodPost,
+				fmt.Sprintf("/api/clusters_mgmt/v1/clusters/%s/node_pools", cluster.ID()),
+				RespondWithJSON(http.StatusOK, FormatResources(nodePoolObj)))
+
+			err = machinePool.CreateNodePools(t.RosaRuntime, cmd, clusterKey, cluster, nil, &args)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("can't use spot instances with capacity reservation"))
+		})
 		It("fails to add the node pool to the hosted cluster", func() {
 			machinePool := &machinePool{}
 			version := "4.15.0"
@@ -1853,6 +2029,248 @@ var _ = Describe("NodePools", func() {
 			err = machinePool.CreateNodePools(t.RosaRuntime, cmd, clusterKey, cluster, nil, &args)
 			Expect(err).To(Not(HaveOccurred()))
 		})
+		It("Successfully creates a spot node pool", func() {
+			machinePool := &machinePool{}
+			version := "4.22.0"
+			az := "a1"
+
+			cluster = returnMockCluster(version)
+			privateSubnets := []ec2types.Subnet{
+				{AvailabilityZone: &az, SubnetId: &subnet},
+			}
+
+			cmd.Flags().StringVar(&args.Name, "name", "", "Name of the machine pool")
+			cmd.Flags().Set("name", "spot-workers")
+
+			cmd.Flags().StringVar(&args.Version, "version", "", "Version of the machine pool")
+			cmd.Flags().Set("version", version)
+			cmd.Flags().Int32("replicas", 3, "Replicas of the machine pool")
+			cmd.Flags().Set("replicas", "3")
+			cmd.Flags().BoolVar(&args.UseSpotInstances, "use-spot-instances", false, "Use spot instances")
+			cmd.Flags().Set("use-spot-instances", "true")
+			cmd.Flags().StringVar(&args.SpotMaxPrice, "spot-max-price", "", "Spot max price")
+			cmd.Flags().Set("spot-max-price", "1.00")
+
+			args.Replicas = 3
+			args.InstanceType = "t3.small"
+			args.UseSpotInstances = true
+			args.SpotMaxPrice = "1.00"
+
+			v := cmv1.VersionBuilder{}
+			v.ID(version).ChannelGroup("stable").RawID(version).Default(true).
+				Enabled(true).ROSAEnabled(true).HostedControlPlaneDefault(true)
+			versionObj, err := v.Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatVersionList(
+				[]*cmv1.Version{versionObj})))
+			mockClient.EXPECT().GetVPCPrivateSubnets(gomock.Any()).Return(privateSubnets, nil)
+			mockClient.EXPECT().GetSubnetAvailabilityZone(subnet).Return(az, nil)
+			mockClient.EXPECT().IsLocalAvailabilityZone(az).Return(false, nil)
+			mtBuilder := cmv1.NewMachineType().ID("t3.small").Name("t3.small")
+			machineType, err := mtBuilder.Build()
+			Expect(err).ToNot(HaveOccurred())
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatMachineTypeList(
+				[]*cmv1.MachineType{machineType})))
+			acc, err := amsv1.NewAccount().ID("123456789012").Build()
+			Expect(err).ToNot(HaveOccurred())
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, FormatResources(acc)))
+			qc, err := amsv1.NewQuotaCost().QuotaID("test-quota").
+				OrganizationID("123456789012").Version(version).Build()
+			Expect(err).ToNot(HaveOccurred())
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatQuotaCostList([]*amsv1.QuotaCost{qc})))
+			flavour, err := cmv1.NewFlavour().AWS(cmv1.NewAWSFlavour().ComputeInstanceType("x-large").
+				WorkerVolume(cmv1.NewAWSVolume().Size(100))).
+				Network(cmv1.NewNetwork().MachineCIDR("").PodCIDR("").ServiceCIDR("").HostPrefix(1)).Build()
+			Expect(err).ToNot(HaveOccurred())
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, FormatResources(flavour)))
+
+			nodePoolObj, err := cmv1.NewNodePool().ID("np-1").Build()
+			Expect(err).ToNot(HaveOccurred())
+			nodePoolResponse := test.FormatNodePoolList([]*cmv1.NodePool{})
+			t.ApiServer.RouteToHandler(http.MethodGet,
+				fmt.Sprintf("/api/clusters_mgmt/v1/clusters/%s/node_pools", cluster.ID()),
+				RespondWithJSON(http.StatusOK, nodePoolResponse))
+			t.ApiServer.RouteToHandler(http.MethodPost,
+				fmt.Sprintf("/api/clusters_mgmt/v1/clusters/%s/node_pools", cluster.ID()),
+				ghttp.CombineHandlers(
+					RespondWithJSON(http.StatusOK, FormatResources(nodePoolObj)),
+					VerifyJQ(".aws_node_pool.spot_market_options.max_price", "1.00"),
+				))
+
+			err = machinePool.CreateNodePools(t.RosaRuntime, cmd, clusterKey, cluster, nil, &args)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("prints a warning when a spot node pool is created without termination handler configuration", func() {
+			machinePool := &machinePool{}
+			version := "4.22.0"
+			az := "a1"
+
+			cluster = returnMockCluster(version)
+			privateSubnets := []ec2types.Subnet{
+				{AvailabilityZone: &az, SubnetId: &subnet},
+			}
+
+			cmd.Flags().StringVar(&args.Name, "name", "", "Name of the machine pool")
+			cmd.Flags().Set("name", "spot-workers")
+
+			cmd.Flags().StringVar(&args.Version, "version", "", "Version of the machine pool")
+			cmd.Flags().Set("version", version)
+			cmd.Flags().Int32("replicas", 3, "Replicas of the machine pool")
+			cmd.Flags().Set("replicas", "3")
+			cmd.Flags().BoolVar(&args.UseSpotInstances, "use-spot-instances", false, "Use spot instances")
+			cmd.Flags().Set("use-spot-instances", "true")
+
+			args.Replicas = 3
+			args.InstanceType = "t3.small"
+			args.UseSpotInstances = true
+
+			v := cmv1.VersionBuilder{}
+			v.ID(version).ChannelGroup("stable").RawID(version).Default(true).
+				Enabled(true).ROSAEnabled(true).HostedControlPlaneDefault(true)
+			versionObj, err := v.Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatVersionList(
+				[]*cmv1.Version{versionObj})))
+			mockClient.EXPECT().GetVPCPrivateSubnets(gomock.Any()).Return(privateSubnets, nil)
+			mockClient.EXPECT().GetSubnetAvailabilityZone(subnet).Return(az, nil)
+			mockClient.EXPECT().IsLocalAvailabilityZone(az).Return(false, nil)
+			mtBuilder := cmv1.NewMachineType().ID("t3.small").Name("t3.small")
+			machineType, err := mtBuilder.Build()
+			Expect(err).ToNot(HaveOccurred())
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatMachineTypeList(
+				[]*cmv1.MachineType{machineType})))
+			acc, err := amsv1.NewAccount().ID("123456789012").Build()
+			Expect(err).ToNot(HaveOccurred())
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, FormatResources(acc)))
+			qc, err := amsv1.NewQuotaCost().QuotaID("test-quota").
+				OrganizationID("123456789012").Version(version).Build()
+			Expect(err).ToNot(HaveOccurred())
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatQuotaCostList([]*amsv1.QuotaCost{qc})))
+			flavour, err := cmv1.NewFlavour().AWS(cmv1.NewAWSFlavour().ComputeInstanceType("x-large").
+				WorkerVolume(cmv1.NewAWSVolume().Size(100))).
+				Network(cmv1.NewNetwork().MachineCIDR("").PodCIDR("").ServiceCIDR("").HostPrefix(1)).Build()
+			Expect(err).ToNot(HaveOccurred())
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, FormatResources(flavour)))
+
+			nodePoolObj, err := cmv1.NewNodePool().ID("np-1").Build()
+			Expect(err).ToNot(HaveOccurred())
+			nodePoolResponse := test.FormatNodePoolList([]*cmv1.NodePool{})
+			t.ApiServer.RouteToHandler(http.MethodGet,
+				fmt.Sprintf("/api/clusters_mgmt/v1/clusters/%s/node_pools", cluster.ID()),
+				RespondWithJSON(http.StatusOK, nodePoolResponse))
+			t.ApiServer.RouteToHandler(http.MethodPost,
+				fmt.Sprintf("/api/clusters_mgmt/v1/clusters/%s/node_pools", cluster.ID()),
+				ghttp.CombineHandlers(
+					func(w http.ResponseWriter, req *http.Request) {
+						w.Header().Add("Warning",
+							`199 - "Spot NodePool created without termination handler configuration. Nodes will not be gracefully drained on interruptions."`)
+					},
+					RespondWithJSON(http.StatusOK, FormatResources(nodePoolObj)),
+				))
+
+			stderrState := os.Stderr
+			stderrReader, stderrWriter, err := os.Pipe()
+			Expect(err).ToNot(HaveOccurred())
+			os.Stderr = stderrWriter
+			defer func() {
+				os.Stderr = stderrState
+			}()
+
+			err = machinePool.CreateNodePools(t.RosaRuntime, cmd, clusterKey, cluster, nil, &args)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = stderrWriter.Close()
+			Expect(err).ToNot(HaveOccurred())
+
+			stderrOutput, err := io.ReadAll(stderrReader)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(stderrOutput)).To(ContainSubstring(
+				"Spot NodePool created without termination handler configuration. Nodes will not be gracefully drained on interruptions.",
+			))
+		})
+		It("prints a fallback warning when the backend returns no warning header", func() {
+			machinePool := &machinePool{}
+			version := "4.22.0"
+			az := "a1"
+
+			cluster = returnMockCluster(version)
+			privateSubnets := []ec2types.Subnet{
+				{AvailabilityZone: &az, SubnetId: &subnet},
+			}
+
+			cmd.Flags().StringVar(&args.Name, "name", "", "Name of the machine pool")
+			cmd.Flags().Set("name", "spot-workers")
+
+			cmd.Flags().StringVar(&args.Version, "version", "", "Version of the machine pool")
+			cmd.Flags().Set("version", version)
+			cmd.Flags().Int32("replicas", 3, "Replicas of the machine pool")
+			cmd.Flags().Set("replicas", "3")
+			cmd.Flags().BoolVar(&args.UseSpotInstances, "use-spot-instances", false, "Use spot instances")
+			cmd.Flags().Set("use-spot-instances", "true")
+
+			args.Replicas = 3
+			args.InstanceType = "t3.small"
+			args.UseSpotInstances = true
+
+			v := cmv1.VersionBuilder{}
+			v.ID(version).ChannelGroup("stable").RawID(version).Default(true).
+				Enabled(true).ROSAEnabled(true).HostedControlPlaneDefault(true)
+			versionObj, err := v.Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatVersionList(
+				[]*cmv1.Version{versionObj})))
+			mockClient.EXPECT().GetVPCPrivateSubnets(gomock.Any()).Return(privateSubnets, nil)
+			mockClient.EXPECT().GetSubnetAvailabilityZone(subnet).Return(az, nil)
+			mockClient.EXPECT().IsLocalAvailabilityZone(az).Return(false, nil)
+			mtBuilder := cmv1.NewMachineType().ID("t3.small").Name("t3.small")
+			machineType, err := mtBuilder.Build()
+			Expect(err).ToNot(HaveOccurred())
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatMachineTypeList(
+				[]*cmv1.MachineType{machineType})))
+			acc, err := amsv1.NewAccount().ID("123456789012").Build()
+			Expect(err).ToNot(HaveOccurred())
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, FormatResources(acc)))
+			qc, err := amsv1.NewQuotaCost().QuotaID("test-quota").
+				OrganizationID("123456789012").Version(version).Build()
+			Expect(err).ToNot(HaveOccurred())
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatQuotaCostList([]*amsv1.QuotaCost{qc})))
+			flavour, err := cmv1.NewFlavour().AWS(cmv1.NewAWSFlavour().ComputeInstanceType("x-large").
+				WorkerVolume(cmv1.NewAWSVolume().Size(100))).
+				Network(cmv1.NewNetwork().MachineCIDR("").PodCIDR("").ServiceCIDR("").HostPrefix(1)).Build()
+			Expect(err).ToNot(HaveOccurred())
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, FormatResources(flavour)))
+
+			nodePoolObj, err := cmv1.NewNodePool().ID("np-1").Build()
+			Expect(err).ToNot(HaveOccurred())
+			nodePoolResponse := test.FormatNodePoolList([]*cmv1.NodePool{})
+			t.ApiServer.RouteToHandler(http.MethodGet,
+				fmt.Sprintf("/api/clusters_mgmt/v1/clusters/%s/node_pools", cluster.ID()),
+				RespondWithJSON(http.StatusOK, nodePoolResponse))
+			t.ApiServer.RouteToHandler(http.MethodPost,
+				fmt.Sprintf("/api/clusters_mgmt/v1/clusters/%s/node_pools", cluster.ID()),
+				RespondWithJSON(http.StatusOK, FormatResources(nodePoolObj)))
+
+			stderrState := os.Stderr
+			stderrReader, stderrWriter, err := os.Pipe()
+			Expect(err).ToNot(HaveOccurred())
+			os.Stderr = stderrWriter
+			defer func() {
+				os.Stderr = stderrState
+			}()
+
+			err = machinePool.CreateNodePools(t.RosaRuntime, cmd, clusterKey, cluster, nil, &args)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = stderrWriter.Close()
+			Expect(err).ToNot(HaveOccurred())
+
+			stderrOutput, err := io.ReadAll(stderrReader)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(stderrOutput)).To(ContainSubstring(spotNodePoolWithoutTerminationHandlerWarning))
+		})
 		It("should fail if disk size is invalid", func() {
 			machinePool := &machinePool{}
 			version := "4.15.0"
@@ -1929,6 +2347,127 @@ var _ = Describe("NodePools", func() {
 			Expect(err).To(HaveOccurred())
 
 			Expect(err.Error()).To(ContainSubstring("expected a valid node pool root disk size value"))
+		})
+	})
+
+	Context("EditNodePool spot behavior", func() {
+		const (
+			editNodePoolID     = "edit-nodepool"
+			editClusterKey     = "edit-cluster-key"
+			editClusterVersion = "4.22.0"
+		)
+
+		var (
+			t          *TestRuntime
+			mockClient *mock.MockClient
+			mockCtrl   *gomock.Controller
+			cmd        *cobra.Command
+			cluster    *cmv1.Cluster
+		)
+
+		BeforeEach(func() {
+			mockCtrl = gomock.NewController(GinkgoT())
+			mockClient = mock.NewMockClient(mockCtrl)
+			t = NewTestingRuntime(mockClient)
+			cmd = &cobra.Command{}
+			confirm.AddFlag(cmd.Flags())
+			Expect(cmd.Flags().Set("yes", "true")).To(Succeed())
+			Expect(cmd.Flags().Bool("use-spot-instances", false, "")).ToNot(BeNil())
+			Expect(cmd.Flags().String("spot-max-price", "on-demand", "")).ToNot(BeNil())
+			Expect(cmd.Flags().Int("replicas", 0, "")).ToNot(BeNil())
+			Expect(cmd.Flags().Bool("enable-autoscaling", false, "")).ToNot(BeNil())
+			Expect(cmd.Flags().Int("min-replicas", 0, "")).ToNot(BeNil())
+			Expect(cmd.Flags().Int("max-replicas", 0, "")).ToNot(BeNil())
+			Expect(cmd.Flags().String("labels", "", "")).ToNot(BeNil())
+			Expect(cmd.Flags().String("taints", "", "")).ToNot(BeNil())
+			Expect(cmd.Flags().Bool("autorepair", false, "")).ToNot(BeNil())
+			Expect(cmd.Flags().String("tuning-configs", "", "")).ToNot(BeNil())
+			Expect(cmd.Flags().String("kubelet-configs", "", "")).ToNot(BeNil())
+			Expect(cmd.Flags().String("node-drain-grace-period", "", "")).ToNot(BeNil())
+			Expect(cmd.Flags().String("max-surge", "", "")).ToNot(BeNil())
+			Expect(cmd.Flags().String("max-unavailable", "", "")).ToNot(BeNil())
+			cluster = returnMockCluster(editClusterVersion)
+		})
+
+		It("rejects enabling spot on an existing nodepool with guidance to recreate", func() {
+			existingNodePool, err := cmv1.NewNodePool().
+				ID(editNodePoolID).
+				Version(cmv1.NewVersion().ID("4.22.0").RawID("openshift-4.22.0")).
+				AWSNodePool(cmv1.NewAWSNodePool().InstanceType("m5.xlarge")).
+				AvailabilityZone("us-east-1a").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, FormatResources(existingNodePool)))
+
+			Expect(cmd.Flags().Set("use-spot-instances", "true")).To(Succeed())
+			Expect(cmd.Flags().Set("spot-max-price", "1.00")).To(Succeed())
+
+			err = editNodePool(cmd, editNodePoolID, editClusterKey, cluster, nil, t.RosaRuntime)
+			Expect(err).To(MatchError(ContainSubstring(
+				"delete the machine pool and create a new one with the desired spot settings")))
+		})
+
+		It("rejects modifying spot max price on an existing spot nodepool with guidance to recreate", func() {
+			existingNodePool, err := cmv1.NewNodePool().
+				ID(editNodePoolID).
+				Version(cmv1.NewVersion().ID("4.22.0").RawID("openshift-4.22.0")).
+				AWSNodePool(cmv1.NewAWSNodePool().
+					InstanceType("m5.xlarge").
+					SpotMarketOptions(cmv1.NewAwsNodePoolSpotMarketOptions().MaxPrice("0.50"))).
+				AvailabilityZone("us-east-1a").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, FormatResources(existingNodePool)))
+
+			Expect(cmd.Flags().Set("spot-max-price", "2.00")).To(Succeed())
+
+			err = editNodePool(cmd, editNodePoolID, editClusterKey, cluster, nil, t.RosaRuntime)
+			Expect(err).To(MatchError(ContainSubstring(
+				"delete the machine pool and create a new one with the desired spot settings")))
+		})
+
+		It("rejects disabling spot instances for now", func() {
+			Expect(cmd.Flags().Set("use-spot-instances", "false")).To(Succeed())
+
+			err := editNodePool(cmd, editNodePoolID, editClusterKey, cluster, nil, t.RosaRuntime)
+			Expect(err).To(MatchError("disabling spot instances on hosted machine pools is not supported yet"))
+		})
+
+		It("rejects spot max price when spot is not enabled", func() {
+			existingNodePool, err := cmv1.NewNodePool().
+				ID(editNodePoolID).
+				Version(cmv1.NewVersion().ID("4.22.0").RawID("openshift-4.22.0")).
+				AWSNodePool(cmv1.NewAWSNodePool().InstanceType("m5.xlarge")).
+				AvailabilityZone("us-east-1a").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, FormatResources(existingNodePool)))
+			Expect(cmd.Flags().Set("spot-max-price", "1.00")).To(Succeed())
+
+			err = editNodePool(cmd, editNodePoolID, editClusterKey, cluster, nil, t.RosaRuntime)
+			Expect(err).To(MatchError("can't set max price when not using spot instances"))
+		})
+
+		It("rejects enabling spot when the node pool has a capacity reservation", func() {
+			existingNodePool, err := cmv1.NewNodePool().
+				ID(editNodePoolID).
+				Version(cmv1.NewVersion().ID("4.22.0").RawID("openshift-4.22.0")).
+				AWSNodePool(cmv1.NewAWSNodePool().
+					InstanceType("m5.xlarge").
+					CapacityReservation(cmv1.NewAWSCapacityReservation().Id("cr-123"))).
+				AvailabilityZone("us-east-1a").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, FormatResources(existingNodePool)))
+			Expect(cmd.Flags().Set("use-spot-instances", "true")).To(Succeed())
+
+			err = editNodePool(cmd, editNodePoolID, editClusterKey, cluster, nil, t.RosaRuntime)
+			Expect(err).To(MatchError(ContainSubstring(
+				"delete the machine pool and create a new one with the desired spot settings")))
 		})
 	})
 })
@@ -2101,6 +2640,44 @@ var _ = Describe("Utility Functions", func() {
 		It("should not return error for positive price", func() {
 			err := spotMaxPriceValidator("0.01")
 			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("editMachinePool spot flag guard", func() {
+		It("rejects use-spot-instances on classic machine pools", func() {
+			cmd := &cobra.Command{}
+			var useSpot bool
+			cmd.Flags().BoolVar(&useSpot, "use-spot-instances", false, "")
+			Expect(cmd.Flags().Set("use-spot-instances", "true")).To(Succeed())
+
+			cluster, err := cmv1.NewCluster().ID("cls").
+				State(cmv1.ClusterStateReady).
+				Hypershift(cmv1.NewHypershift().Enabled(false)).Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			r := rosa.NewRuntime()
+
+			err = editMachinePool(cmd, "mp1", "cls", cluster, r)
+			Expect(err).To(MatchError(ContainSubstring(
+				"spot instance configuration is only supported for Hosted Control Plane machine pools")))
+		})
+
+		It("rejects spot-max-price on classic machine pools", func() {
+			cmd := &cobra.Command{}
+			var spotPrice string
+			cmd.Flags().StringVar(&spotPrice, "spot-max-price", "on-demand", "")
+			Expect(cmd.Flags().Set("spot-max-price", "1.00")).To(Succeed())
+
+			cluster, err := cmv1.NewCluster().ID("cls").
+				State(cmv1.ClusterStateReady).
+				Hypershift(cmv1.NewHypershift().Enabled(false)).Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			r := rosa.NewRuntime()
+
+			err = editMachinePool(cmd, "mp1", "cls", cluster, r)
+			Expect(err).To(MatchError(ContainSubstring(
+				"spot instance configuration is only supported for Hosted Control Plane machine pools")))
 		})
 	})
 })

--- a/pkg/machinepool/output.go
+++ b/pkg/machinepool/output.go
@@ -22,6 +22,7 @@ var nodePoolOutputString string = "\n" +
 	"Taints:                                %s\n" +
 	"Availability zone:                     %s\n" +
 	"Subnet:                                %s\n" +
+	"Spot instances:                        %s\n" +
 	"Disk Size:                             %s\n" +
 	"Version:                               %s\n" +
 	"EC2 Metadata Http Tokens:              %s\n" +
@@ -81,6 +82,7 @@ func nodePoolOutput(clusterId string, nodePool *cmv1.NodePool) string {
 		ocmOutput.PrintTaints(nodePool.Taints()),
 		nodePool.AvailabilityZone(),
 		nodePool.Subnet(),
+		ocmOutput.PrintNodePoolSpot(nodePool.AWSNodePool()),
 		ocmOutput.PrintNodePoolDiskSize(nodePool.AWSNodePool()),
 		ocmOutput.PrintNodePoolVersion(nodePool.Version()),
 		ocmOutput.PrintEC2MetadataHttpTokens(nodePool.AWSNodePool()),

--- a/pkg/machinepool/output_test.go
+++ b/pkg/machinepool/output_test.go
@@ -121,7 +121,7 @@ var _ = Describe("Output", Ordered, func() {
 
 			out := fmt.Sprintf(nodePoolOutputString,
 				"test-mp", "test-cluster", "Yes", replicasOutput, "", "", "", labelsOutput, "", taintsOutput,
-				"test-az", "test-subnets", "300 GiB", "1", "optional", "No", "test-tc", "test-kc", "", "", "",
+				"test-az", "test-subnets", ocmOutput.PrintNodePoolSpot(nodePool.AWSNodePool()), "300 GiB", "1", "optional", "No", "test-tc", "test-kc", "", "", "",
 				managementUpgradeOutput, "")
 
 			result := nodePoolOutput("test-cluster", nodePool)
@@ -141,7 +141,7 @@ var _ = Describe("Output", Ordered, func() {
 
 			out := fmt.Sprintf(nodePoolOutputString,
 				"test-mp", "test-cluster", "No", "4", "", "", "", labelsOutput, "", taintsOutput, "test-az",
-				"test-subnets", "300 GiB", "1", "optional", "No", "test-tc", "test-kc", "", "", "", "", "")
+				"test-subnets", ocmOutput.PrintNodePoolSpot(nodePool.AWSNodePool()), "300 GiB", "1", "optional", "No", "test-tc", "test-kc", "", "", "", "", "")
 
 			result := nodePoolOutput("test-cluster", nodePool)
 			Expect(out).To(Equal(result))
@@ -159,7 +159,7 @@ var _ = Describe("Output", Ordered, func() {
 
 			out := fmt.Sprintf(nodePoolOutputString,
 				"test-mp", "test-cluster", "No", "4", "", "", "", labelsOutput, "", taintsOutput, "test-az",
-				"test-subnets", "256 GiB", "1", "optional", "No", "test-tc", "test-kc", "", "", "", "", "")
+				"test-subnets", ocmOutput.PrintNodePoolSpot(nodePool.AWSNodePool()), "256 GiB", "1", "optional", "No", "test-tc", "test-kc", "", "", "", "", "")
 
 			result := nodePoolOutput("test-cluster", nodePool)
 			Expect(out).To(Equal(result))
@@ -180,9 +180,29 @@ var _ = Describe("Output", Ordered, func() {
 
 			out := fmt.Sprintf(nodePoolOutputString,
 				"test-mp", "test-cluster", "No", "4", "", "", "", labelsOutput, "", taintsOutput, "test-az",
-				"test-subnets", "256 GiB", "1", "optional", "No", "test-tc", "test-kc", "", "",
+				"test-subnets", ocmOutput.PrintNodePoolSpot(nodePool.AWSNodePool()), "256 GiB", "1", "optional", "No", "test-tc", "test-kc", "", "",
 				"\n - ID:                                 test-id\n - Type:                               OnDemand",
 				"", "")
+
+			result := nodePoolOutput("test-cluster", nodePool)
+			Expect(out).To(Equal(result))
+		})
+		It("nodepool output with spot instances", func() {
+			awsNodePoolBuilder := cmv1.NewAWSNodePool().RootVolume(cmv1.NewAWSVolume().Size(256)).
+				SpotMarketOptions(cmv1.NewAwsNodePoolSpotMarketOptions().MaxPrice("1.00"))
+
+			nodePoolBuilder := cmv1.NewNodePool().ID("test-mp").Replicas(4).AWSNodePool(awsNodePoolBuilder).
+				AvailabilityZone("test-az").Subnet("test-subnets").Version(cmv1.NewVersion().
+				ID("1")).AutoRepair(false).TuningConfigs("test-tc").
+				KubeletConfigs("test-kc").Labels(labels).Taints(taintsBuilder)
+			nodePool, err := nodePoolBuilder.Build()
+			Expect(err).ToNot(HaveOccurred())
+			labelsOutput := ocmOutput.PrintLabels(labels)
+			taintsOutput := ocmOutput.PrintTaints([]*cmv1.Taint{taint})
+
+			out := fmt.Sprintf(nodePoolOutputString,
+				"test-mp", "test-cluster", "No", "4", "", "", "", labelsOutput, "", taintsOutput, "test-az",
+				"test-subnets", "Yes (max $1.00)", "256 GiB", "1", "optional", "No", "test-tc", "test-kc", "", "", "", "", "")
 
 			result := nodePoolOutput("test-cluster", nodePool)
 			Expect(out).To(Equal(result))

--- a/pkg/ocm/clusters.go
+++ b/pkg/ocm/clusters.go
@@ -154,6 +154,8 @@ type Spec struct {
 
 	// Audit Log Forwarding
 	AuditLogRoleARN *string
+	// Spot termination handling
+	TerminationHandlerQueueUrl *string
 
 	// AutoNode configuration
 	AutoNodeMode    string
@@ -737,7 +739,7 @@ func (c *Client) UpdateCluster(clusterKey string, creator *aws.Creator, config S
 	}
 
 	if config.AuditLogRoleARN != nil || config.AdditionalAllowedPrincipals != nil || config.BillingAccount != "" ||
-		config.AutoNodeRoleARN != "" {
+		config.AutoNodeRoleARN != "" || config.TerminationHandlerQueueUrl != nil {
 		awsBuilder := cmv1.NewAWS()
 		if config.AdditionalAllowedPrincipals != nil {
 			awsBuilder = awsBuilder.AdditionalAllowedPrincipals(config.AdditionalAllowedPrincipals...)
@@ -754,6 +756,9 @@ func (c *Client) UpdateCluster(clusterKey string, creator *aws.Creator, config S
 		if config.AutoNodeRoleARN != "" {
 			autoNodeBuilder := cmv1.NewAwsAutoNode().RoleArn(config.AutoNodeRoleARN)
 			awsBuilder = awsBuilder.AutoNode(autoNodeBuilder)
+		}
+		if config.TerminationHandlerQueueUrl != nil {
+			awsBuilder = awsBuilder.TerminationHandlerQueueUrl(*config.TerminationHandlerQueueUrl)
 		}
 		clusterBuilder.AWS(awsBuilder)
 	}
@@ -1043,6 +1048,10 @@ func (c *Client) createClusterSpec(config Spec) (*cmv1.Cluster, error) {
 
 	if config.Ec2MetadataHttpTokens != "" {
 		awsBuilder = awsBuilder.Ec2MetadataHttpTokens(config.Ec2MetadataHttpTokens)
+	}
+
+	if config.TerminationHandlerQueueUrl != nil {
+		awsBuilder = awsBuilder.TerminationHandlerQueueUrl(*config.TerminationHandlerQueueUrl)
 	}
 
 	if config.RoleARN != "" {

--- a/pkg/ocm/clusters_test.go
+++ b/pkg/ocm/clusters_test.go
@@ -1,9 +1,17 @@
 package ocm
 
 import (
+	"bytes"
+	"net/http"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
 
 	"github.com/openshift/rosa/pkg/aws"
 )
@@ -244,5 +252,85 @@ var _ = Describe("Helper Functions", func() {
 			})
 
 		})
+	})
+})
+
+var _ = Describe("Spot termination queue URL wiring", func() {
+	It("createClusterSpec maps termination handler queue URL into the AWS builder", func() {
+		client := &Client{}
+		queueURL := "https://sqs.us-east-1.amazonaws.com/123456789012/rosa-spot-queue"
+
+		cluster, err := client.createClusterSpec(Spec{
+			Name:                       "test-cluster",
+			Region:                     "us-east-1",
+			Hypershift:                 Hypershift{Enabled: true},
+			RoleARN:                    "arn:aws:iam::123456789012:role/test-role",
+			AWSCreator:                 &aws.Creator{ARN: "arn:aws:iam::123456789012:role/test-role", AccountID: "123456789012"},
+			TerminationHandlerQueueUrl: &queueURL,
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cluster.AWS()).ToNot(BeNil())
+		Expect(cluster.AWS().TerminationHandlerQueueUrl()).To(Equal(queueURL))
+	})
+
+	It("createClusterSpec does NOT set termination handler queue URL when pointer is nil", func() {
+		client := &Client{}
+
+		cluster, err := client.createClusterSpec(Spec{
+			Name:       "test-cluster",
+			Region:     "us-east-1",
+			Hypershift: Hypershift{Enabled: true},
+			RoleARN:    "arn:aws:iam::123456789012:role/test-role",
+			AWSCreator: &aws.Creator{ARN: "arn:aws:iam::123456789012:role/test-role", AccountID: "123456789012"},
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cluster.AWS()).ToNot(BeNil())
+		Expect(cluster.AWS().TerminationHandlerQueueUrl()).To(BeEmpty())
+	})
+
+	It("UpdateCluster sends termination handler queue URL when it is the only AWS update", func() {
+		apiServer := MakeTCPServer()
+		DeferCleanup(apiServer.Close)
+
+		accessToken := MakeTokenString("Bearer", 15*time.Minute)
+		logger, err := logging.NewGoLoggerBuilder().
+			Debug(false).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		connection, err := sdk.NewConnectionBuilder().
+			Logger(logger).
+			Tokens(accessToken).
+			URL(apiServer.URL()).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		client := NewClientWithConnection(connection)
+		DeferCleanup(func() {
+			Expect(client.Close()).To(Succeed())
+		})
+
+		cluster, err := cmv1.NewCluster().
+			ID("test-cluster").
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		var clusterBody bytes.Buffer
+		err = cmv1.MarshalCluster(cluster, &clusterBody)
+		Expect(err).ToNot(HaveOccurred())
+		clusterListBody := []byte(`{"kind":"ClusterList","page":1,"size":1,"total":1,"items":[` + clusterBody.String() + `]}`)
+
+		queueURL := "https://sqs.us-east-1.amazonaws.com/123456789012/rosa-spot-queue"
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, string(clusterListBody)),
+			ghttp.CombineHandlers(
+				VerifyJQ(".aws.termination_handler_queue_url", queueURL),
+				RespondWithJSON(http.StatusOK, clusterBody.String()),
+			),
+		)
+
+		err = client.UpdateCluster("test-cluster", &aws.Creator{AccountID: "123456789012"}, Spec{
+			TerminationHandlerQueueUrl: &queueURL,
+		})
+		Expect(err).ToNot(HaveOccurred())
 	})
 })

--- a/pkg/ocm/nodepools.go
+++ b/pkg/ocm/nodepools.go
@@ -1,12 +1,29 @@
 package ocm
 
 import (
+	"net/http"
 	"slices"
+	"strings"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
+// CreateNodePoolResult bundles the created node pool with any server-side warnings.
+type CreateNodePoolResult struct {
+	NodePool *cmv1.NodePool
+	Warnings []string
+}
+
 func (c *Client) CreateNodePool(clusterID string, nodePool *cmv1.NodePool) (*cmv1.NodePool, error) {
+	result, err := c.CreateNodePoolWithWarnings(clusterID, nodePool)
+	if err != nil {
+		return nil, err
+	}
+	return result.NodePool, nil
+}
+
+// CreateNodePoolWithWarnings creates a node pool and returns any Warning headers from the response.
+func (c *Client) CreateNodePoolWithWarnings(clusterID string, nodePool *cmv1.NodePool) (*CreateNodePoolResult, error) {
 	response, err := c.ocm.ClustersMgmt().V1().
 		Clusters().Cluster(clusterID).
 		NodePools().
@@ -15,7 +32,39 @@ func (c *Client) CreateNodePool(clusterID string, nodePool *cmv1.NodePool) (*cmv
 	if err != nil {
 		return nil, handleErr(response.Error(), err)
 	}
-	return response.Body(), nil
+	return &CreateNodePoolResult{
+		NodePool: response.Body(),
+		Warnings: extractWarningHeaders(response.Header()),
+	}, nil
+}
+
+func extractWarningHeaders(headers http.Header) []string {
+	if headers == nil {
+		return nil
+	}
+
+	rawWarnings := headers.Values("Warning")
+	warnings := make([]string, 0, len(rawWarnings))
+	for _, raw := range rawWarnings {
+		warning := strings.TrimSpace(raw)
+		if warning == "" {
+			continue
+		}
+
+		firstQuote := strings.Index(warning, `"`)
+		lastQuote := strings.LastIndex(warning, `"`)
+		if firstQuote >= 0 && lastQuote > firstQuote {
+			warning = warning[firstQuote+1 : lastQuote]
+		} else if parts := strings.SplitN(warning, " - ", 2); len(parts) == 2 {
+			warning = strings.TrimSpace(parts[1])
+		}
+
+		if warning != "" {
+			warnings = append(warnings, warning)
+		}
+	}
+
+	return warnings
 }
 
 func (c *Client) FindNodePoolsUsingKubeletConfig(

--- a/pkg/ocm/nodepools_test.go
+++ b/pkg/ocm/nodepools_test.go
@@ -1,0 +1,111 @@
+package ocm
+
+import (
+	"bytes"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+)
+
+var _ = Describe("Node pool warnings", func() {
+	It("returns normalized warning headers from create node pool", func() {
+		apiServer := MakeTCPServer()
+		DeferCleanup(apiServer.Close)
+
+		accessToken := MakeTokenString("Bearer", 15*time.Minute)
+		logger, err := logging.NewGoLoggerBuilder().
+			Debug(false).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		connection, err := sdk.NewConnectionBuilder().
+			Logger(logger).
+			Tokens(accessToken).
+			URL(apiServer.URL()).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		client := NewClientWithConnection(connection)
+		DeferCleanup(func() {
+			Expect(client.Close()).To(Succeed())
+		})
+
+		nodePool, err := cmv1.NewNodePool().
+			ID("test-nodepool").
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		var nodePoolBody bytes.Buffer
+		err = cmv1.MarshalNodePool(nodePool, &nodePoolBody)
+		Expect(err).ToNot(HaveOccurred())
+
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				func(w http.ResponseWriter, req *http.Request) {
+					w.Header().Add("Warning",
+						`199 - "Spot NodePool created without termination handler configuration. Nodes will not be gracefully drained on interruptions."`)
+				},
+				RespondWithJSON(http.StatusCreated, nodePoolBody.String()),
+			),
+		)
+
+		result, err := client.CreateNodePoolWithWarnings("test-cluster", nodePool)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.NodePool).ToNot(BeNil())
+		Expect(result.NodePool.ID()).To(Equal("test-nodepool"))
+		Expect(result.Warnings).To(Equal([]string{
+			"Spot NodePool created without termination handler configuration. Nodes will not be gracefully drained on interruptions.",
+		}))
+	})
+
+	It("CreateNodePool preserves the existing body-only behavior", func() {
+		apiServer := MakeTCPServer()
+		DeferCleanup(apiServer.Close)
+
+		accessToken := MakeTokenString("Bearer", 15*time.Minute)
+		logger, err := logging.NewGoLoggerBuilder().
+			Debug(false).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		connection, err := sdk.NewConnectionBuilder().
+			Logger(logger).
+			Tokens(accessToken).
+			URL(apiServer.URL()).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		client := NewClientWithConnection(connection)
+		DeferCleanup(func() {
+			Expect(client.Close()).To(Succeed())
+		})
+
+		nodePool, err := cmv1.NewNodePool().
+			ID("test-nodepool").
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		var nodePoolBody bytes.Buffer
+		err = cmv1.MarshalNodePool(nodePool, &nodePoolBody)
+		Expect(err).ToNot(HaveOccurred())
+
+		apiServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				func(w http.ResponseWriter, req *http.Request) {
+					w.Header().Add("Warning", `199 - "warning that should be ignored by CreateNodePool"`)
+				},
+				RespondWithJSON(http.StatusCreated, nodePoolBody.String()),
+			),
+		)
+
+		createdNodePool, err := client.CreateNodePool("test-cluster", nodePool)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(createdNodePool).ToNot(BeNil())
+		Expect(createdNodePool.ID()).To(Equal("test-nodepool"))
+	})
+})

--- a/pkg/ocm/output/nodepools.go
+++ b/pkg/ocm/output/nodepools.go
@@ -73,6 +73,20 @@ func PrintNodePoolAdditionalSecurityGroups(aws *cmv1.AWSNodePool) string {
 	return output.PrintStringSlice(aws.AdditionalSecurityGroupIds())
 }
 
+// PrintNodePoolSpot returns a human-readable Spot instance status for a node pool.
+func PrintNodePoolSpot(aws *cmv1.AWSNodePool) string {
+	if aws != nil {
+		if spot := aws.SpotMarketOptions(); spot != nil {
+			price := "on-demand"
+			if maxPrice, ok := spot.GetMaxPrice(); ok && maxPrice != "" {
+				price = fmt.Sprintf("max $%s", maxPrice)
+			}
+			return fmt.Sprintf("Yes (%s)", price)
+		}
+	}
+	return output.No
+}
+
 func PrintEC2MetadataHttpTokens(aws *cmv1.AWSNodePool) cmv1.Ec2MetadataHttpTokens {
 	if aws == nil || aws.Ec2MetadataHttpTokens() == "" {
 		return cmv1.Ec2MetadataHttpTokensOptional

--- a/pkg/ocm/output/nodepools_test.go
+++ b/pkg/ocm/output/nodepools_test.go
@@ -31,6 +31,30 @@ var _ = Describe("Validate node drain grace period print output", func() {
 	)
 })
 
+var _ = Describe("PrintNodePoolSpot", func() {
+	It("returns No when spot is not configured", func() {
+		awsNodePool, err := cmv1.NewAWSNodePool().Build()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(PrintNodePoolSpot(awsNodePool)).To(Equal("No"))
+	})
+
+	It("returns on-demand when spot is configured without max price", func() {
+		awsNodePool, err := cmv1.NewAWSNodePool().
+			SpotMarketOptions(cmv1.NewAwsNodePoolSpotMarketOptions()).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(PrintNodePoolSpot(awsNodePool)).To(Equal("Yes (on-demand)"))
+	})
+
+	It("returns the max price when spot max price is configured", func() {
+		awsNodePool, err := cmv1.NewAWSNodePool().
+			SpotMarketOptions(cmv1.NewAwsNodePoolSpotMarketOptions().MaxPrice("1.00")).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(PrintNodePoolSpot(awsNodePool)).To(Equal("Yes (max $1.00)"))
+	})
+})
+
 var _ = Describe("PrintNodePoolReplicasInline", func() {
 	It("Should print the correct output if autoscaling exists", func() {
 		autoscaling := cmv1.NewNodePoolAutoscaling().MinReplica(2).MaxReplica(6)

--- a/pkg/options/spotterminationqueue/create.go
+++ b/pkg/options/spotterminationqueue/create.go
@@ -1,0 +1,72 @@
+package spotterminationqueue
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/output"
+)
+
+// CreateSpotTerminationQueueUserOptions holds user-supplied flag values for the
+// spot-termination-queue create command.
+type CreateSpotTerminationQueueUserOptions struct {
+	Name                      string
+	NodePoolManagementRoleArn string
+	Mode                      string
+}
+
+const (
+	use     = "spot-termination-queue"
+	short   = "Create Spot termination queue resources"
+	long    = "Create the SQS queue, queue policy, and EventBridge rule needed for ROSA HCP Spot interruption handling."
+	example = `  # Create the Spot termination queue resources using a custom resource-name prefix
+  rosa create spot-termination-queue --name my-cluster-prefix \
+    --nodepool-management-role-arn arn:aws:iam::123456789012:role/example-role
+
+  # Print the created queue metadata as JSON
+  rosa create spot-termination-queue --name my-cluster-prefix \
+    --nodepool-management-role-arn arn:aws:iam::123456789012:role/example-role -o json`
+)
+
+// NewCreateSpotTerminationQueueUserOptions returns options pre-populated with default values.
+func NewCreateSpotTerminationQueueUserOptions() *CreateSpotTerminationQueueUserOptions {
+	return &CreateSpotTerminationQueueUserOptions{
+		Mode: "auto",
+	}
+}
+
+// BuildCreateSpotTerminationQueueCommandWithOptions returns a Cobra command wired to
+// the returned user options struct for flag binding.
+func BuildCreateSpotTerminationQueueCommandWithOptions() (*cobra.Command, *CreateSpotTerminationQueueUserOptions) {
+	options := NewCreateSpotTerminationQueueUserOptions()
+	cmd := &cobra.Command{
+		Use:     use,
+		Short:   short,
+		Long:    long,
+		Example: example,
+		Args:    cobra.NoArgs,
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(
+		&options.Name,
+		"name",
+		"",
+		"Optional resource name prefix used to derive the queue, stack, and event rule names. "+
+			"When omitted, ROSA uses a default spot-termination prefix.",
+	)
+	flags.StringVar(
+		&options.NodePoolManagementRoleArn,
+		"nodepool-management-role-arn",
+		"",
+		"ARN of the Hosted Control Plane NodePoolManagement role that must be allowed to receive and delete SQS messages.",
+	)
+	flags.StringVar(
+		&options.Mode,
+		"mode",
+		"auto",
+		"Queue setup mode. Currently only 'auto' is supported.",
+	)
+	output.AddFlag(cmd)
+
+	return cmd, options
+}

--- a/pkg/options/spotterminationqueue/create_test.go
+++ b/pkg/options/spotterminationqueue/create_test.go
@@ -1,0 +1,17 @@
+package spotterminationqueue
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Spot termination queue command options", func() {
+	It("exposes the expected flags and defaults", func() {
+		cmd, options := BuildCreateSpotTerminationQueueCommandWithOptions()
+
+		Expect(cmd.Flags().Lookup("name")).ToNot(BeNil())
+		Expect(cmd.Flags().Lookup("nodepool-management-role-arn")).ToNot(BeNil())
+		Expect(cmd.Flags().Lookup("mode")).ToNot(BeNil())
+		Expect(options.Mode).To(Equal("auto"))
+	})
+})

--- a/pkg/options/spotterminationqueue/suite_test.go
+++ b/pkg/options/spotterminationqueue/suite_test.go
@@ -1,0 +1,13 @@
+package spotterminationqueue
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSpotTerminationQueueOptions(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Spot termination queue options suite")
+}

--- a/pkg/spotterminationqueue/service.go
+++ b/pkg/spotterminationqueue/service.go
@@ -1,0 +1,262 @@
+package spotterminationqueue
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	cloudformationtypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+)
+
+const defaultNamePrefix = "rosa-spot-termination"
+
+var namePrefixRE = regexp.MustCompile(`^[A-Za-z0-9-]+$`)
+
+// CreateInput holds the parameters for creating Spot termination queue resources.
+type CreateInput struct {
+	Name                      string
+	NodePoolManagementRoleArn string
+	Mode                      string
+	Region                    string
+}
+
+// Result describes the resources created by a Spot termination queue operation.
+type Result struct {
+	QueueURL      string `json:"queue_url"`
+	QueueName     string `json:"queue_name"`
+	EventRuleName string `json:"event_rule_name"`
+	StackName     string `json:"stack_name"`
+	Region        string `json:"region"`
+}
+
+type stackSpec struct {
+	NamePrefix    string
+	QueueName     string
+	EventRuleName string
+	StackName     string
+}
+
+type awsClient interface {
+	CreateStackWithParamsTags(ctx context.Context, cfTemplateBody, stackName string,
+		stackParams, stackTags map[string]string) (*string, error)
+	GetCFStack(ctx context.Context, stackName string) (*cloudformationtypes.Stack, error)
+	GetRoleByARN(roleARN string) (iamtypes.Role, error)
+	GetRegion() string
+}
+
+// Service manages the lifecycle of Spot termination queue AWS resources.
+type Service interface {
+	CreateQueue(ctx context.Context, input CreateInput) (*Result, error)
+}
+
+type service struct {
+	awsClient awsClient
+}
+
+// NewService returns a Service backed by the given AWS client.
+func NewService(awsClient awsClient) Service {
+	return &service{
+		awsClient: awsClient,
+	}
+}
+
+func validateMode(mode string) error {
+	if mode == "" || mode == "auto" {
+		return nil
+	}
+	return fmt.Errorf("only 'auto' is supported for --mode")
+}
+
+func validateNamePrefix(name string) error {
+	if name == "" {
+		return nil
+	}
+	const maxNamePrefixLength = 40
+	if len(name) > maxNamePrefixLength {
+		return fmt.Errorf("name must be at most %d characters (EventBridge rule name limit)", maxNamePrefixLength)
+	}
+	if !namePrefixRE.MatchString(name) {
+		return fmt.Errorf("name must contain only letters, numbers, and hyphens")
+	}
+	return nil
+}
+
+func buildStackSpec(name string) stackSpec {
+	if name == "" {
+		return stackSpec{
+			NamePrefix:    defaultNamePrefix,
+			QueueName:     defaultNamePrefix + "-queue",
+			EventRuleName: defaultNamePrefix + "-events",
+			StackName:     defaultNamePrefix + "-stack",
+		}
+	}
+
+	baseName := name + "-spot-termination"
+	return stackSpec{
+		NamePrefix:    name,
+		QueueName:     baseName + "-queue",
+		EventRuleName: baseName + "-events",
+		StackName:     baseName + "-stack",
+	}
+}
+
+func (s *service) CreateQueue(ctx context.Context, input CreateInput) (*Result, error) {
+	if err := validateMode(input.Mode); err != nil {
+		return nil, err
+	}
+	if err := validateNamePrefix(input.Name); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(input.NodePoolManagementRoleArn) == "" {
+		return nil, fmt.Errorf("nodepool-management-role-arn is required")
+	}
+	if s.awsClient == nil {
+		return nil, fmt.Errorf("aws client is required")
+	}
+	if _, err := s.awsClient.GetRoleByARN(input.NodePoolManagementRoleArn); err != nil {
+		return nil, fmt.Errorf("failed to validate nodepool-management-role-arn: %w", err)
+	}
+
+	spec := buildStackSpec(input.Name)
+
+	stackParams := map[string]string{
+		"QueueName":                 spec.QueueName,
+		"EventRuleName":             spec.EventRuleName,
+		"NodePoolManagementRoleArn": input.NodePoolManagementRoleArn,
+	}
+
+	_, err := s.awsClient.CreateStackWithParamsTags(
+		ctx,
+		cloudFormationTemplate,
+		spec.StackName,
+		stackParams,
+		map[string]string{},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create spot termination stack: %w", err)
+	}
+
+	err = waitForStackCreateComplete(ctx, s.awsClient, spec.StackName)
+	if err != nil {
+		return nil, fmt.Errorf("failed waiting for spot termination stack creation: %w", err)
+	}
+
+	describe, err := s.awsClient.GetCFStack(ctx, spec.StackName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe spot termination stack: %w", err)
+	}
+
+	queueURL := ""
+	for _, output := range describe.Outputs {
+		if output.OutputKey != nil && *output.OutputKey == "QueueUrl" && output.OutputValue != nil {
+			queueURL = *output.OutputValue
+			break
+		}
+	}
+	if queueURL == "" {
+		return nil, fmt.Errorf("spot termination stack did not return QueueUrl output")
+	}
+
+	return &Result{
+		QueueURL:      queueURL,
+		QueueName:     spec.QueueName,
+		EventRuleName: spec.EventRuleName,
+		StackName:     spec.StackName,
+		Region:        s.awsClient.GetRegion(),
+	}, nil
+}
+
+func waitForStackCreateComplete(ctx context.Context, awsClient awsClient, stackName string) error {
+	deadline := time.Now().Add(10 * time.Minute)
+	for {
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for CloudFormation stack %s", stackName)
+		}
+
+		stack, err := awsClient.GetCFStack(ctx, stackName)
+		if err != nil {
+			return err
+		}
+
+		switch stack.StackStatus {
+		case cloudformationtypes.StackStatusCreateComplete, cloudformationtypes.StackStatusUpdateComplete:
+			return nil
+		case cloudformationtypes.StackStatusCreateFailed, cloudformationtypes.StackStatusRollbackComplete,
+			cloudformationtypes.StackStatusRollbackFailed, cloudformationtypes.StackStatusDeleteComplete,
+			cloudformationtypes.StackStatusDeleteFailed:
+			return fmt.Errorf("stack %s ended in %s", stackName, stack.StackStatus)
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(5 * time.Second):
+		}
+	}
+}
+
+const cloudFormationTemplate = `AWSTemplateFormatVersion: '2010-09-09'
+Description: ROSA HCP Spot termination queue resources
+Parameters:
+  QueueName:
+    Type: String
+  EventRuleName:
+    Type: String
+  NodePoolManagementRoleArn:
+    Type: String
+Resources:
+  SpotTerminationQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Ref QueueName
+      Tags:
+        - Key: red-hat
+          Value: "true"
+  SpotTerminationQueuePolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      Queues:
+        - !Ref SpotTerminationQueue
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: AllowNodePoolManagementRole
+            Effect: Allow
+            Principal:
+              AWS: !Ref NodePoolManagementRoleArn
+            Action:
+              - sqs:DeleteMessage
+              - sqs:ReceiveMessage
+            Resource: !GetAtt SpotTerminationQueue.Arn
+          - Sid: AllowEventBridgeToSendMessages
+            Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action:
+              - sqs:SendMessage
+            Resource: !GetAtt SpotTerminationQueue.Arn
+            Condition:
+              ArnEquals:
+                aws:SourceArn: !GetAtt SpotTerminationEventRule.Arn
+  SpotTerminationEventRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: !Ref EventRuleName
+      EventPattern:
+        source:
+          - aws.ec2
+        detail-type:
+          - EC2 Spot Instance Interruption Warning
+          - EC2 Instance Rebalance Recommendation
+      Targets:
+        - Arn: !GetAtt SpotTerminationQueue.Arn
+          Id: spot-termination-queue
+Outputs:
+  QueueUrl:
+    Value: !Ref SpotTerminationQueue
+  QueueArn:
+    Value: !GetAtt SpotTerminationQueue.Arn
+`

--- a/pkg/spotterminationqueue/service_test.go
+++ b/pkg/spotterminationqueue/service_test.go
@@ -1,0 +1,226 @@
+package spotterminationqueue
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	cloudformationtypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type fakeAWSClient struct {
+	region           string
+	stacks           []*cloudformationtypes.Stack
+	createStackErr   error
+	getStackErr      error
+	getRoleErr       error
+	createCallCount  int
+	getCallCount     int
+	getRoleCallCount int
+	lastStackName    string
+	lastParams       map[string]string
+}
+
+func (f *fakeAWSClient) CreateStackWithParamsTags(_ context.Context, _ string, stackName string,
+	stackParams, _ map[string]string) (*string, error) {
+	f.createCallCount++
+	f.lastStackName = stackName
+	f.lastParams = stackParams
+	if f.createStackErr != nil {
+		return nil, f.createStackErr
+	}
+	return aws.String(stackName), nil
+}
+
+func (f *fakeAWSClient) GetCFStack(_ context.Context, _ string) (*cloudformationtypes.Stack, error) {
+	f.getCallCount++
+	if f.getStackErr != nil {
+		return nil, f.getStackErr
+	}
+	if len(f.stacks) == 0 {
+		return nil, fmt.Errorf("no fake stacks configured")
+	}
+	stack := f.stacks[0]
+	if len(f.stacks) > 1 {
+		f.stacks = f.stacks[1:]
+	}
+	return stack, nil
+}
+
+func (f *fakeAWSClient) GetRoleByARN(_ string) (iamtypes.Role, error) {
+	f.getRoleCallCount++
+	if f.getRoleErr != nil {
+		return iamtypes.Role{}, f.getRoleErr
+	}
+	return iamtypes.Role{}, nil
+}
+
+func (f *fakeAWSClient) GetRegion() string {
+	return f.region
+}
+
+var _ = Describe("stack spec helpers", func() {
+	It("builds deterministic resource names from a custom prefix", func() {
+		spec := buildStackSpec("demo")
+		Expect(spec.NamePrefix).To(Equal("demo"))
+		Expect(spec.QueueName).To(Equal("demo-spot-termination-queue"))
+		Expect(spec.EventRuleName).To(Equal("demo-spot-termination-events"))
+		Expect(spec.StackName).To(Equal("demo-spot-termination-stack"))
+	})
+
+	It("falls back to the default prefix when none is provided", func() {
+		spec := buildStackSpec("")
+		Expect(spec.NamePrefix).To(Equal(defaultNamePrefix))
+		Expect(spec.QueueName).To(Equal(defaultNamePrefix + "-queue"))
+		Expect(spec.EventRuleName).To(Equal(defaultNamePrefix + "-events"))
+		Expect(spec.StackName).To(Equal(defaultNamePrefix + "-stack"))
+	})
+
+	It("accepts a name prefix of exactly 40 characters", func() {
+		name := "abcdefghij-klmnopqrst-uvwxyz012345678901"
+		Expect(len(name)).To(Equal(40))
+		Expect(validateNamePrefix(name)).To(Succeed())
+	})
+
+	It("rejects a name prefix longer than 40 characters", func() {
+		name := "abcdefghij-klmnopqrst-uvwxyz0123456789-xy"
+		Expect(len(name)).To(Equal(41))
+		Expect(validateNamePrefix(name)).To(MatchError(ContainSubstring("at most 40 characters")))
+	})
+
+	It("rejects a name prefix with invalid characters", func() {
+		Expect(validateNamePrefix("has_underscore")).To(MatchError(ContainSubstring("letters, numbers, and hyphens")))
+		Expect(validateNamePrefix("has space")).To(MatchError(ContainSubstring("letters, numbers, and hyphens")))
+	})
+
+	It("accepts an empty name prefix (uses default)", func() {
+		Expect(validateNamePrefix("")).To(Succeed())
+	})
+
+	It("accepts only auto mode", func() {
+		Expect(validateMode("auto")).To(Succeed())
+		Expect(validateMode("manual")).To(MatchError(ContainSubstring("only 'auto' is supported")))
+	})
+
+	It("creates the queue stack through the injected AWS client", func() {
+		queueURL := "https://sqs.us-east-1.amazonaws.com/123456789012/rosa-spot-termination-queue"
+		stack := &cloudformationtypes.Stack{
+			StackStatus: cloudformationtypes.StackStatusCreateComplete,
+			Outputs: []cloudformationtypes.Output{
+				{
+					OutputKey:   aws.String("QueueUrl"),
+					OutputValue: aws.String(queueURL),
+				},
+			},
+		}
+		fakeClient := &fakeAWSClient{
+			region: "us-east-1",
+			stacks: []*cloudformationtypes.Stack{stack, stack},
+		}
+
+		result, err := NewService(fakeClient).CreateQueue(context.Background(), CreateInput{
+			Name:                      "demo",
+			NodePoolManagementRoleArn: "arn:aws:iam::123456789012:role/example-role",
+			Mode:                      "auto",
+			Region:                    "us-east-1",
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(fakeClient.createCallCount).To(Equal(1))
+		Expect(fakeClient.lastStackName).To(Equal("demo-spot-termination-stack"))
+		Expect(fakeClient.lastParams).To(HaveKeyWithValue("QueueName", "demo-spot-termination-queue"))
+		Expect(fakeClient.lastParams).To(HaveKeyWithValue("EventRuleName", "demo-spot-termination-events"))
+		Expect(fakeClient.lastParams).To(HaveKeyWithValue(
+			"NodePoolManagementRoleArn",
+			"arn:aws:iam::123456789012:role/example-role",
+		))
+		Expect(fakeClient.getRoleCallCount).To(Equal(1))
+		Expect(result.QueueURL).To(Equal(queueURL))
+		Expect(result.Region).To(Equal("us-east-1"))
+	})
+
+	It("fails when the completed stack has no QueueUrl output", func() {
+		stack := &cloudformationtypes.Stack{
+			StackStatus: cloudformationtypes.StackStatusCreateComplete,
+		}
+		fakeClient := &fakeAWSClient{
+			region: "us-east-1",
+			stacks: []*cloudformationtypes.Stack{stack, stack},
+		}
+
+		_, err := NewService(fakeClient).CreateQueue(context.Background(), CreateInput{
+			Name:                      "demo",
+			NodePoolManagementRoleArn: "arn:aws:iam::123456789012:role/example-role",
+			Mode:                      "auto",
+			Region:                    "us-east-1",
+		})
+		Expect(err).To(MatchError(ContainSubstring("did not return QueueUrl output")))
+	})
+
+	It("fails when the stack ends in a terminal error state", func() {
+		fakeClient := &fakeAWSClient{
+			region: "us-east-1",
+			stacks: []*cloudformationtypes.Stack{{
+				StackStatus: cloudformationtypes.StackStatusCreateFailed,
+			}},
+		}
+
+		_, err := NewService(fakeClient).CreateQueue(context.Background(), CreateInput{
+			Name:                      "demo",
+			NodePoolManagementRoleArn: "arn:aws:iam::123456789012:role/example-role",
+			Mode:                      "auto",
+			Region:                    "us-east-1",
+		})
+		Expect(err).To(MatchError(ContainSubstring("ended in CREATE_FAILED")))
+	})
+
+	It("fails when the nodepool management role cannot be validated", func() {
+		fakeClient := &fakeAWSClient{
+			region:     "us-east-1",
+			getRoleErr: fmt.Errorf("role not found"),
+		}
+
+		_, err := NewService(fakeClient).CreateQueue(context.Background(), CreateInput{
+			Name:                      "demo",
+			NodePoolManagementRoleArn: "arn:aws:iam::123456789012:role/example-role",
+			Mode:                      "auto",
+			Region:                    "us-east-1",
+		})
+		Expect(err).To(MatchError(ContainSubstring("failed to validate nodepool-management-role-arn")))
+		Expect(fakeClient.createCallCount).To(Equal(0))
+	})
+
+	It("fails when stack creation fails before polling", func() {
+		fakeClient := &fakeAWSClient{
+			region:         "us-east-1",
+			createStackErr: fmt.Errorf("create failed"),
+		}
+
+		_, err := NewService(fakeClient).CreateQueue(context.Background(), CreateInput{
+			Name:                      "demo",
+			NodePoolManagementRoleArn: "arn:aws:iam::123456789012:role/example-role",
+			Mode:                      "auto",
+			Region:                    "us-east-1",
+		})
+		Expect(err).To(MatchError(ContainSubstring("failed to create spot termination stack")))
+		Expect(fakeClient.getCallCount).To(Equal(0))
+	})
+
+	It("fails when describing the created stack returns an error", func() {
+		fakeClient := &fakeAWSClient{
+			region:      "us-east-1",
+			stacks:      []*cloudformationtypes.Stack{{StackStatus: cloudformationtypes.StackStatusCreateComplete}},
+			getStackErr: fmt.Errorf("describe failed"),
+		}
+
+		_, err := NewService(fakeClient).CreateQueue(context.Background(), CreateInput{
+			Name:                      "demo",
+			NodePoolManagementRoleArn: "arn:aws:iam::123456789012:role/example-role",
+			Mode:                      "auto",
+			Region:                    "us-east-1",
+		})
+		Expect(err).To(MatchError(ContainSubstring("failed waiting for spot termination stack creation")))
+	})
+})

--- a/pkg/spotterminationqueue/suite_test.go
+++ b/pkg/spotterminationqueue/suite_test.go
@@ -1,0 +1,13 @@
+package spotterminationqueue
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSpotTerminationQueue(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Spot termination queue suite")
+}

--- a/tests/e2e/hcp_cluster_test.go
+++ b/tests/e2e/hcp_cluster_test.go
@@ -942,4 +942,24 @@ var _ = Describe("hosted-cp cluster creation",
 				Expect(err).ToNot(HaveOccurred())
 				Expect(jsonData.DigBool("properties", "skip_inflight_tests")).To(BeTrue())
 			})
+
+		Describe("Spot termination queue URL lifecycle", func() {
+			It("should edit cluster with spot-termination-queue-url and verify enhanced mode [id:spot-hcp-cluster]",
+				labels.Medium, labels.Runtime.Day2,
+				func() {
+					By("Edit the cluster with a spot-termination-queue-url")
+					queueURL := "https://sqs.us-east-1.amazonaws.com/123456789012/rosa-spot-termination-queue"
+					out, err := clusterService.EditCluster(
+						clusterID,
+						"--spot-termination-queue-url", queueURL,
+					)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(out.String()).To(ContainSubstring("Updated cluster"))
+
+					By("Describe the cluster and verify the queue URL is set")
+					jsonData, err := clusterService.GetJSONClusterDescription(clusterID)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(jsonData.DigString("aws", "termination_handler_queue_url")).To(Equal(queueURL))
+				})
+		})
 	})

--- a/tests/e2e/hcp_machine_pool_test.go
+++ b/tests/e2e/hcp_machine_pool_test.go
@@ -986,4 +986,63 @@ var _ = Describe("HCP Machine Pool", labels.Feature.Machinepool, func() {
 			Expect(out.String()).To(ContainSubstring("should provide an integer number less than or equal to"))
 		})
 	})
+
+	Describe("Spot instance node pool lifecycle", func() {
+		It("should create, describe, edit, and delete a Spot node pool [id:spot-hcp-np]",
+			labels.Medium, labels.Runtime.Day2,
+			func() {
+				By("Create a node pool with spot instances enabled")
+				mpName := helper.GenerateRandomName("spot-np", 2)
+				_, err := rosaClient.MachinePool.CreateMachinePool(clusterID, mpName,
+					"--use-spot-instances",
+					"--spot-max-price", "0.05",
+					"--replicas", "1",
+					"-y",
+				)
+				Expect(err).ToNot(HaveOccurred())
+				defer rosaClient.MachinePool.DeleteMachinePool(clusterID, mpName)
+
+				if isNodePoolGlobalCheck {
+					err = rosaClient.MachinePool.WaitForNodePoolReplicasReady(
+						clusterID, mpName, false, constants.NodePoolCheckPoll, constants.NodePoolCheckTimeout)
+					Expect(err).ToNot(HaveOccurred())
+				}
+
+				By("Describe the node pool and verify spot info")
+				description, err := rosaClient.MachinePool.DescribeMachinePool(clusterID, mpName)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(description.String()).To(ContainSubstring("Yes (max $0.05)"))
+
+				By("Edit the node pool spot-max-price")
+				_, err = rosaClient.MachinePool.EditMachinePool(clusterID, mpName,
+					"--spot-max-price", "0.10",
+					"-y",
+				)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Verify the updated spot-max-price in describe")
+				description, err = rosaClient.MachinePool.DescribeMachinePool(clusterID, mpName)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(description.String()).To(ContainSubstring("Yes (max $0.10)"))
+			})
+
+		It("should create a Spot node pool with on-demand fallback (no max price) [id:spot-hcp-np-ondemand]",
+			labels.Medium, labels.Runtime.Day2,
+			func() {
+				By("Create a node pool with spot instances but no max price (on-demand price)")
+				mpName := helper.GenerateRandomName("spot-od", 2)
+				_, err := rosaClient.MachinePool.CreateMachinePool(clusterID, mpName,
+					"--use-spot-instances",
+					"--replicas", "1",
+					"-y",
+				)
+				Expect(err).ToNot(HaveOccurred())
+				defer rosaClient.MachinePool.DeleteMachinePool(clusterID, mpName)
+
+				By("Describe the node pool and verify spot info shows on-demand")
+				description, err := rosaClient.MachinePool.DescribeMachinePool(clusterID, mpName)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(description.String()).To(ContainSubstring("Yes (on-demand)"))
+			})
+	})
 })


### PR DESCRIPTION
## PR Summary
Add ROSA HCP Spot CLI support for both Simple and Enhanced modes. Spot node pools are created with `--use-spot-instances` and optionally `--spot-max-price` at machine pool creation time. Spot configuration is immutable after creation — users must delete and recreate the machine pool to change spot settings. A new `rosa create spot-termination-queue` helper provisions the AWS resources for graceful interruption handling. Cluster describe only shows the queue URL when configured, avoiding ambiguous mode display.

## Detailed Description of the Issue
ROSA HCP Spot support needs CLI changes across three user flows:
1. **Creating HCP node pools with spot market options** — `--use-spot-instances` and `--spot-max-price` flags on `rosa create machinepool`
2. **Configuring the cluster-level termination-handler queue URL** — `--spot-termination-queue-url` on `rosa create cluster` and `rosa edit cluster`
3. **Helping users create the AWS queue/rule/policy resources** — `rosa create spot-termination-queue` helper command

Prior to this change, the CLI exposed classic spot behavior but not the HCP node-pool API shape, could not set `aws.termination_handler_queue_url`, did not surface backend Simple-mode warnings, and had no supported helper for the AWS resource setup.

### Key behaviors:
- **Simple mode** (no queue URL): Spot node pools work immediately. CLI prints a warning when creating a Spot pool without a configured queue.
- **Enhanced mode** (with queue URL): Cluster has graceful interruption handling via AWS Node Termination Handler.
- **Spot is immutable**: Spot max price and enablement cannot be changed after node pool creation. Users must delete and recreate the machine pool.
- **Cluster describe**: Only shows `Spot Termination Queue URL: <url>` when configured. No output when no queue is set (avoids ambiguity between on-demand and Simple mode).
- **Queue URL validation**: Lightweight HTTPS URL sanity check client-side; backend owns format/region validation.
- **Queue helper role validation**: Validates the NodePoolManagement role exists before creating the CloudFormation stack.

## Related Issues and PRs
- Jira: [ROSAENG-8272](https://issues.redhat.com/browse/ROSAENG-8272)
- Fixes: N/A
- Related PR(s):
  - [openshift-online/ocm-api-model#1178](https://github.com/openshift-online/ocm-api-model/pull/1178) (SDK changes)
  - [uhc-clusters-service!11497](https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/11497) (Simple mode)
  - [uhc-clusters-service!11523](https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/11523) (Enhanced mode)
  - [openshift/rosa#3463](https://github.com/openshift/rosa/pull/3463) (SDK bump, merged)
- Related design/docs:
  - [Backend DDR](https://github.com/openshift-online/rosa-enhancements/pull/34)

## Type of Change
- [x] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
- No HCP Spot node pool support in ROSA CLI.
- No `--spot-termination-queue-url` flag on cluster create/edit.
- No queue helper command.
- No HCP-specific Spot output in describe/list.

## Behavior After This Change
- `rosa create machinepool --use-spot-instances [--spot-max-price <price>]` creates HCP Spot node pools.
- `rosa create cluster --spot-termination-queue-url <url>` and `rosa edit cluster --spot-termination-queue-url <url>` configure the cluster queue.
- `rosa create spot-termination-queue --name <prefix> --nodepool-management-role-arn <arn>` creates AWS resources and returns the queue URL.
- `rosa describe cluster` shows `Spot Termination Queue URL: <url>` only when configured.
- `rosa describe machinepool` / `rosa list machinepools` shows Spot status.
- Attempting to modify Spot settings on an existing machine pool returns a clear error guiding the user to delete and recreate.
- Simple-mode warning prints when creating a Spot pool on a cluster without a queue URL.

## How to Test (Step-by-Step)
### Preconditions
- Go toolchain compatible with the repo `go.mod` requirement.
- AWS/OCM credentials only required for live command checks.

### Test Steps
1. `make install-hooks`
2. `make fmt`
3. `make test`
4. `make pre-push-checks`
5. Optionally verify with `rosa create cluster --help`, `rosa edit cluster --help`, `rosa create machinepool --help`, `rosa create spot-termination-queue --help`

### Expected Results
- Local validation passes.
- New flags and commands are available.
- Spot machine pool create works with warning in Simple mode.
- Queue URL edit transitions cluster to Enhanced mode.
- Modifying spot on an existing pool returns guidance to delete and recreate.

## Proof of the Fix
- Logs/CLI output: `make pre-push-checks` passes
- Live validation runs performed in staging (see PR comments for raw outputs)

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [x] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

### Known Limitations
- **Spot configuration is immutable after node pool creation.** To change the spot max price or enable/disable spot, delete the machine pool and create a new one.
- **Day-2 Spot node pool edits**: The backend currently rejects updates to `aws_node_pool.spot_market_options` in staging. The CLI sends the request through without local guards, so the user sees the backend's actual error if the path becomes available in a future backend release.

[ROSAENG-8272]: https://redhat.atlassian.net/browse/ROSAENG-8272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ