### PR TITLE
ROSAENG-6115 | fix: Add warning message to `verify network` when subnets are in different VPCs

### DIFF
--- a/cmd/verify/network/cmd.go
+++ b/cmd/verify/network/cmd.go
@@ -20,9 +20,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/briandowns/spinner"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
@@ -190,6 +192,11 @@ func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
 	}
 
 	r.Reporter.Debugf("Received the following subnetIDs: %v", args.subnetIDs)
+
+	if !cmd.Flags().Changed(statusOnlyFlag) {
+		warnIfSubnetsInDifferentVPCs(r, args.subnetIDs)
+	}
+
 	if r.Reporter.IsTerminal() {
 		if cmd.Flags().Changed(statusOnlyFlag) {
 			r.Reporter.Infof("Checking the status of the following subnet IDs: %v", args.subnetIDs)
@@ -324,6 +331,44 @@ func printStatus(r *rosa.Runtime, spin *spinner.Spinner, subnet string,
 
 	if spin != nil {
 		spin.Restart()
+	}
+}
+
+func warnIfSubnetsInDifferentVPCs(r *rosa.Runtime, subnetIDs []string) {
+	if len(subnetIDs) < 2 || r.AWSClient == nil {
+		return
+	}
+	subnets, err := r.AWSClient.ListSubnets(subnetIDs...)
+	if err != nil {
+		r.Reporter.Debugf("Unable to retrieve subnet details to check VPCs: %v", err)
+		return
+	}
+
+	vpcToSubnets := map[string][]string{}
+	for _, subnet := range subnets {
+		vpcID := awssdk.ToString(subnet.VpcId)
+		subnetID := awssdk.ToString(subnet.SubnetId)
+		vpcToSubnets[vpcID] = append(vpcToSubnets[vpcID], subnetID)
+	}
+
+	if len(vpcToSubnets) > 1 {
+		vpcIDs := make([]string, 0, len(vpcToSubnets))
+		for vpcID := range vpcToSubnets {
+			vpcIDs = append(vpcIDs, vpcID)
+		}
+		sort.Strings(vpcIDs)
+
+		var parts []string
+		for _, vpcID := range vpcIDs {
+			ids := vpcToSubnets[vpcID]
+			sort.Strings(ids)
+			if len(ids) == 1 {
+				parts = append(parts, fmt.Sprintf("Subnet %s is in VPC %s", ids[0], vpcID))
+			} else {
+				parts = append(parts, fmt.Sprintf("Subnets %s are in VPC %s", strings.Join(ids, ", "), vpcID))
+			}
+		}
+		r.Reporter.Warnf("Provided subnets are in different VPCs: %s", strings.Join(parts, "; "))
 	}
 }
 

--- a/cmd/verify/network/cmd_test.go
+++ b/cmd/verify/network/cmd_test.go
@@ -1,9 +1,14 @@
 package network
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
+	"go.uber.org/mock/gomock"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/ginkgo/v2/dsl/table"
 	. "github.com/onsi/gomega"
@@ -428,5 +433,112 @@ INFO: subnet-0f87f640e56934cbc, platform: aws, tags: {"t1":"v1"}: passed
 		Expect(err.Error()).To(
 			ContainSubstring(
 				"running the network verifier is only supported for BYO VPC clusters"))
+	})
+	It("Warns when subnets are in different VPCs", func() {
+		mockCtrl := gomock.NewController(GinkgoT())
+		mockClient := aws.NewMockClient(mockCtrl)
+		r.AWSClient = mockClient
+
+		mockClient.EXPECT().ListSubnets("subnet-0b761d44d3d9a4663", "subnet-0f87f640e56934cbc").
+			Return([]ec2types.Subnet{
+				{
+					SubnetId: awssdk.String("subnet-0b761d44d3d9a4663"),
+					VpcId:    awssdk.String("vpc-aaa"),
+				},
+				{
+					SubnetId: awssdk.String("subnet-0f87f640e56934cbc"),
+					VpcId:    awssdk.String("vpc-bbb"),
+				},
+			}, nil)
+
+		// POST /api/clusters_mgmt/v1/network_verifications
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, subnetsComplete),
+		)
+		// GET /api/clusters_mgmt/v1/network_verifications/subnetA
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, subnetPassedSuccess),
+		)
+		// GET /api/clusters_mgmt/v1/network_verifications/subnetB
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, subnetPassedSuccess),
+		)
+
+		cmd.Flags().Set(roleArnFlag, "arn:aws:iam::765374464689:role/tomckay-Installer-Role")
+		cmd.Flags().Set(subnetIDsFlag, "subnet-0b761d44d3d9a4663,subnet-0f87f640e56934cbc")
+		cmd.Flags().Set("region", "us-east-1")
+		stdout, stderr, err := test.RunWithOutputCapture(runWithRuntime, r, cmd)
+		Expect(err).To(BeNil())
+		Expect(stderr).To(Equal("WARN: Provided subnets are in different VPCs: " +
+			"Subnet subnet-0b761d44d3d9a4663 is in VPC vpc-aaa; " +
+			"Subnet subnet-0f87f640e56934cbc is in VPC vpc-bbb\n"))
+		Expect(stdout).To(Equal(successOutputComplete))
+	})
+	It("Does not warn when ListSubnets returns an error", func() {
+		mockCtrl := gomock.NewController(GinkgoT())
+		mockClient := aws.NewMockClient(mockCtrl)
+		r.AWSClient = mockClient
+
+		mockClient.EXPECT().ListSubnets("subnet-0b761d44d3d9a4663", "subnet-0f87f640e56934cbc").
+			Return(nil, fmt.Errorf("access denied"))
+
+		// POST /api/clusters_mgmt/v1/network_verifications
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, subnetsComplete),
+		)
+		// GET /api/clusters_mgmt/v1/network_verifications/subnetA
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, subnetPassedSuccess),
+		)
+		// GET /api/clusters_mgmt/v1/network_verifications/subnetB
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, subnetPassedSuccess),
+		)
+
+		cmd.Flags().Set(roleArnFlag, "arn:aws:iam::765374464689:role/tomckay-Installer-Role")
+		cmd.Flags().Set(subnetIDsFlag, "subnet-0b761d44d3d9a4663,subnet-0f87f640e56934cbc")
+		cmd.Flags().Set("region", "us-east-1")
+		stdout, stderr, err := test.RunWithOutputCapture(runWithRuntime, r, cmd)
+		Expect(err).To(BeNil())
+		Expect(stderr).To(Equal(""))
+		Expect(stdout).To(Equal(successOutputComplete))
+	})
+	It("Does not warn when subnets are in the same VPC", func() {
+		mockCtrl := gomock.NewController(GinkgoT())
+		mockClient := aws.NewMockClient(mockCtrl)
+		r.AWSClient = mockClient
+
+		mockClient.EXPECT().ListSubnets("subnet-0b761d44d3d9a4663", "subnet-0f87f640e56934cbc").
+			Return([]ec2types.Subnet{
+				{
+					SubnetId: awssdk.String("subnet-0b761d44d3d9a4663"),
+					VpcId:    awssdk.String("vpc-aaa"),
+				},
+				{
+					SubnetId: awssdk.String("subnet-0f87f640e56934cbc"),
+					VpcId:    awssdk.String("vpc-aaa"),
+				},
+			}, nil)
+
+		// POST /api/clusters_mgmt/v1/network_verifications
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, subnetsComplete),
+		)
+		// GET /api/clusters_mgmt/v1/network_verifications/subnetA
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, subnetPassedSuccess),
+		)
+		// GET /api/clusters_mgmt/v1/network_verifications/subnetB
+		apiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, subnetPassedSuccess),
+		)
+
+		cmd.Flags().Set(roleArnFlag, "arn:aws:iam::765374464689:role/tomckay-Installer-Role")
+		cmd.Flags().Set(subnetIDsFlag, "subnet-0b761d44d3d9a4663,subnet-0f87f640e56934cbc")
+		cmd.Flags().Set("region", "us-east-1")
+		stdout, stderr, err := test.RunWithOutputCapture(runWithRuntime, r, cmd)
+		Expect(err).To(BeNil())
+		Expect(stderr).To(Equal(""))
+		Expect(stdout).To(Equal(successOutputComplete))
 	})
 })


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
Supported ticket prefixes:
OCM-XXXXX, ROSAENG-XXXX
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For contributor workflow, see: ./CONTRIBUTING.md
For repo-local agent guidance, see: ./AGENTS.md
-->

## PR Summary
Warns users when subnets queried with `rosa verify network` are in different VPCs

## Detailed Description of the Issue
When rosa verify network is run with subnets from different VPCs, the command now emits a warning listing which subnets belong to which VPC. ROSA clusters require all subnets to be in the same VPC for internal node-to-node communication. The network verifier checks each subnet's egress independently and would report success even when the subnets are network-isolated from each other, giving the user false confidence before cluster creation. The check calls DescribeSubnets to look up VPC IDs, groups subnets by VPC, and warns via the reporter if more than one VPC is found. It does not block verific

## Related Issues and PRs
<!-- Link all tracking items and related code changes -->
- Jira: [ROSAENG-6155](https://redhat.atlassian.net/browse/ROSAENG-6115)
- Fixes: `#`
- Related PR(s):
- Related design/docs:

## Type of Change
<!-- Check the primary type this PR represents -->
- [ ] feat - adds a new user-facing capability.
- [x] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
<!-- What users or systems experienced before this change -->
When running `rosa verify network` and passing IDs for subnets on different VPCs, output would not warn:

```
I: Verifying the following subnet IDs are configured correctly: [subnet-123 subnet-456
I: subnet-123, platform: aws-classic, tags: {"Name":"network-verifier","network-verifier":"owned","red-hat-managed":"true"}: pending
I: subnet-456, platform: aws-classic, tags: {"Name":"network-verifier","network-verifier":"owned","red-hat-managed":"true"}: pending
I: Run the following command to wait for verification to all subnets to complete:
rosa verify network --watch --status-only --region us-east-1 --subnet-ids subnet-123,subnet-456
``` 

## Behavior After This Change
Now, when running `rosa verify network` and passing IDs for subnets on different VPCs, output warns about subnets being on different VPCs:

```
W: Provided subnets are in different VPCs: Subnet subnet-123 is in VPC vpc-abc; Subnet subnet-456 is in VPC vpc-def
I: Verifying the following subnet IDs are configured correctly: [subnet-123 subnet-456
I: subnet-123, platform: aws-classic, tags: {"Name":"network-verifier","network-verifier":"owned","red-hat-managed":"true"}: pending
I: subnet-456, platform: aws-classic, tags: {"Name":"network-verifier","network-verifier":"owned","red-hat-managed":"true"}: pending
I: Run the following command to wait for verification to all subnets to complete:
rosa verify network --watch --status-only --region us-east-1 --subnet-ids subnet-123,subnet-456
``` 

## How to Test (Step-by-Step)
<!-- Provide reproducible validation instructions -->
### Preconditions
<!-- Required setup, environment, credentials, flags, cluster state, etc. -->

### Test Steps
1. Get a list of subnets and their VPCs with `aws ec2 describe-subnets --region us-east-1 --query 'Subnets[*].[SubnetId,VpcId]' --output table`
2. Take two subnets in different VPCs and run `./rosa verify network --subnet-ids subnet1,subnet2 --region us-west-2 --role-arn arn:aws:iam::0000000000:role/Installer-Role`
3. See that a warning is now passed

### Expected Results
<!-- What should happen after running the steps above -->
The first output before the rest of the informational messages should be a warning

## Proof of the Fix
<!-- Attach evidence that demonstrates the changed behavior -->
```
$ ./rosa verify network --subnet-ids subnet-1,subnet-2 --region us-east-1 --role-arn arn:aws:iam::0000000:role/ROSA-Installer-Role
W: Provided subnets are in different VPCs: Subnet subnet-1 is in VPC vpc-1; Subnet subnet-2 is in VPC vpc-2
I: Verifying the following subnet IDs are configured correctly: [subnet-1 subnet-2]
I: subnet-1, platform: aws-classic, tags: {"Name":"osd-network-verifier","osd-network-verifier":"owned","red-hat-managed":"true"}: pending
I: subnet-2, platform: aws-classic, tags: {"Name":"osd-network-verifier","osd-network-verifier":"owned","red-hat-managed":"true"}: pending
I: Run the following command to wait for verification to all subnets to complete:
rosa verify network --watch --status-only --region us-east-1 --subnet-ids subnet-1,subnet-2
```

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
<!-- Required only when breaking changes are introduced -->

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.


[ROSAENG-6155]: https://redhat.atlassian.net/browse/ROSAENG-6155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pre-verification warning when supplied subnets span multiple VPCs.
  * Subnet checks now identify each subnet’s VPC before network verification.
  * Status-only operations continue without additional subnet validation.
  * Warnings list the affected VPCs and subnets to help diagnose configuration issues.

* **Bug Fixes**
  * Improved visibility into subnet lookup issues through debug-level logging.
  * Verification continues safely when subnet details cannot be retrieved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->