### PR TITLE
ROSAENG-64850 | rosa-day1-negative-f7 | fix(e2e): align registry asserts and retry AWS region flakes

### DIFF
--- a/tests/e2e/test_rosacli_cluster.go
+++ b/tests/e2e/test_rosacli_cluster.go
@@ -982,7 +982,7 @@ var _ = Describe("Edit cluster validation should", labels.Feature.Cluster, func(
 			if !hostedCluster {
 				_, err = clusterService.EditCluster(clusterID,
 					"--registry-config-blocked-registries", "test.blocked.com")
-				helper.ExpectErrorWithMessage(err, "Setting the registry config is only supported for hosted clusters")
+				helper.ExpectErrorWithMessage(err, "setting the registry config is only supported for hosted clusters")
 				return
 			}
 
@@ -995,7 +995,7 @@ var _ = Describe("Edit cluster validation should", labels.Feature.Cluster, func(
 			By("patch hcp with invalid value for --registry-config-allowed-registries-for-import flag")
 			_, err = clusterService.EditCluster(clusterID,
 				"--registry-config-allowed-registries-for-import", "test.com:stringType")
-			helper.ExpectErrorWithMessage(err, "Expected valid allowed registries for import values")
+			helper.ExpectErrorWithMessage(err, "expected valid allowed registries for import values")
 		})
 	It("can validate autonode edit - [id:84982]", labels.Medium, labels.Runtime.Day2,
 		labels.FedRAMP, func() {
@@ -3127,12 +3127,9 @@ var _ = Describe("HCP cluster creation negative testing",
 					if rosalCommand.CheckFlagExist(flag) {
 						rosalCommand.DeleteFlag(flag, true)
 					}
-					output, err := clusterService.CreateDryRun(clusterName, flag, "dummy-value")
-					Expect(err).To(HaveOccurred())
-					Expect(output.String()).
-						To(
-							ContainSubstring(
-								"ERR: Setting the registry config is only supported for hosted clusters"))
+					_, err := clusterService.CreateDryRun(clusterName, flag, "dummy-value")
+					helper.ExpectErrorWithMessage(err,
+						"setting the registry config is only supported for hosted clusters")
 				}
 
 				By("create hcp with invalid value for --registry-config-allowed-registries-for-import flag")
@@ -3146,19 +3143,17 @@ var _ = Describe("HCP cluster creation negative testing",
 				log.Logger.Debug(strings.Split(rosalCommand.GetFullCommand(), " "))
 
 				rosalCommand.AddFlags("--registry-config-allowed-registries-for-import", "test.com:invalid")
-				output, err := rosaClient.Runner.RunCMD(strings.Split(rosalCommand.GetFullCommand(), " "))
+				_, err := rosaClient.Runner.RunCMD(strings.Split(rosalCommand.GetFullCommand(), " "))
 				log.Logger.Info(strings.Split(rosalCommand.GetFullCommand(), " "))
-				Expect(err).To(HaveOccurred())
-				Expect(output.String()).To(ContainSubstring("ERR: Expected valid allowed registries for import values"))
+				helper.ExpectErrorWithMessage(err, "expected valid allowed registries for import values")
 
 				By("create hcp with --registry-config-blocked-registries and --registry-config-allowed-registries at same time")
 				rosalCommand.DeleteFlag("--registry-config-allowed-registries-for-import", true)
 				rosalCommand.AddFlags("--registry-config-allowed-registries", "test.com",
 					"--registry-config-blocked-registries", "test.blocked.com")
-				output, err = rosaClient.Runner.RunCMD(strings.Split(rosalCommand.GetFullCommand(), " "))
-				Expect(err).To(HaveOccurred())
-				Expect(output.String()).To(ContainSubstring(
-					"ERR: Allowed registries and blocked registries are mutually exclusive fields"))
+				_, err = rosaClient.Runner.RunCMD(strings.Split(rosalCommand.GetFullCommand(), " "))
+				helper.ExpectErrorWithMessage(err,
+					"allowed registries and blocked registries are mutually exclusive fields")
 			})
 	})
 

--- a/tests/utils/config/aws_retry.go
+++ b/tests/utils/config/aws_retry.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"bytes"
+	"strings"
+	"time"
+
+	"github.com/openshift/rosa/tests/utils/log"
+)
+
+// isAWSRegionsCredentialTransient reports whether out/err indicate a transient
+// failure retrieving AWS regions (credentials not yet valid for OCM/AWS).
+// rosa create cluster calls GetRegionList early; this can flake before the
+// intended validation error is reached.
+func isAWSRegionsCredentialTransient(out bytes.Buffer, err error) bool {
+	combined := out.String()
+	if err != nil {
+		combined += "\n" + err.Error()
+	}
+	return strings.Contains(combined, "Failed to retrieve AWS regions") ||
+		strings.Contains(combined, "AWS was not able to validate the provided access credentials")
+}
+
+// RetryOnAWSRegionsCredentialError retries fn when the result indicates a
+// transient AWS regions / credentials failure (for example CLUSTERS-MGMT-400
+// while listing regions). Modeled on RetryOnIAMPropagationError.
+func RetryOnAWSRegionsCredentialError(
+	fn func() (bytes.Buffer, error),
+	maxRetries int,
+	delay time.Duration,
+) (bytes.Buffer, error) {
+	var out bytes.Buffer
+	var err error
+	for i := 0; i <= maxRetries; i++ {
+		out, err = fn()
+		if !isAWSRegionsCredentialTransient(out, err) {
+			return out, err
+		}
+		if i < maxRetries {
+			log.Logger.Infof(
+				"AWS regions/credentials not yet available (attempt %d/%d), retrying in %s...",
+				i+1, maxRetries+1, delay,
+			)
+			time.Sleep(delay)
+		}
+	}
+	return out, err
+}

--- a/tests/utils/config/aws_retry_test.go
+++ b/tests/utils/config/aws_retry_test.go
@@ -1,0 +1,113 @@
+package config
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func awsRetryBuffer(content string) bytes.Buffer {
+	var out bytes.Buffer
+	out.WriteString(content)
+	return out
+}
+
+var _ = Describe("isAWSRegionsCredentialTransient", func() {
+	DescribeTable("classifies AWS regions and credential flakes",
+		func(outContent string, err error, expected bool) {
+			Expect(isAWSRegionsCredentialTransient(awsRetryBuffer(outContent), err)).To(Equal(expected))
+		},
+		Entry("empty output and no error", "", nil, false),
+		Entry("regions failure in output", "Failed to retrieve AWS regions", nil, true),
+		Entry("regions failure in error", "", errors.New("Failed to retrieve AWS regions"), true),
+		Entry("credential validation failure in output",
+			"AWS was not able to validate the provided access credentials", nil, true),
+		Entry("credential validation failure in error", "",
+			errors.New("AWS was not able to validate the provided access credentials"), true),
+		Entry("validation error unrelated to regions or credentials",
+			"ERR: expected valid allowed registries for import values",
+			errors.New("expected valid allowed registries for import values"), false),
+		Entry("generic CLI failure", "command failed", errors.New("exit status 1"), false),
+	)
+})
+
+var _ = Describe("RetryOnAWSRegionsCredentialError", func() {
+	const retryDelay = time.Millisecond
+
+	It("returns immediately when fn succeeds", func() {
+		calls := 0
+		expected := awsRetryBuffer("ok")
+
+		out, err := RetryOnAWSRegionsCredentialError(func() (bytes.Buffer, error) {
+			calls++
+			return expected, nil
+		}, 3, retryDelay)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out.String()).To(Equal("ok"))
+		Expect(calls).To(Equal(1))
+	})
+
+	It("returns immediately when fn returns a non-transient error", func() {
+		calls := 0
+		expectedErr := errors.New("ERR: invalid subnet")
+
+		out, err := RetryOnAWSRegionsCredentialError(func() (bytes.Buffer, error) {
+			calls++
+			return awsRetryBuffer("validation failed"), expectedErr
+		}, 3, retryDelay)
+
+		Expect(err).To(MatchError(expectedErr))
+		Expect(out.String()).To(Equal("validation failed"))
+		Expect(calls).To(Equal(1))
+	})
+
+	It("retries transient failures until fn succeeds", func() {
+		calls := 0
+		transientErr := errors.New("Failed to retrieve AWS regions")
+
+		out, err := RetryOnAWSRegionsCredentialError(func() (bytes.Buffer, error) {
+			calls++
+			if calls < 3 {
+				return awsRetryBuffer("transient"), transientErr
+			}
+			return awsRetryBuffer("expected validation error"), errors.New("expected validation error")
+		}, 3, retryDelay)
+
+		Expect(err).To(MatchError(errors.New("expected validation error")))
+		Expect(out.String()).To(Equal("expected validation error"))
+		Expect(calls).To(Equal(3))
+	})
+
+	It("stops after maxRetries and returns the last transient result", func() {
+		calls := 0
+		transientErr := errors.New("AWS was not able to validate the provided access credentials")
+
+		out, err := RetryOnAWSRegionsCredentialError(func() (bytes.Buffer, error) {
+			calls++
+			return awsRetryBuffer(fmt.Sprintf("attempt-%d", calls)), transientErr
+		}, 2, retryDelay)
+
+		Expect(err).To(MatchError(transientErr))
+		Expect(out.String()).To(Equal("attempt-3"))
+		Expect(calls).To(Equal(3))
+	})
+
+	It("does not retry when maxRetries is zero", func() {
+		calls := 0
+		transientErr := errors.New("Failed to retrieve AWS regions")
+
+		out, err := RetryOnAWSRegionsCredentialError(func() (bytes.Buffer, error) {
+			calls++
+			return awsRetryBuffer("only-once"), transientErr
+		}, 0, retryDelay)
+
+		Expect(err).To(MatchError(transientErr))
+		Expect(out.String()).To(Equal("only-once"))
+		Expect(calls).To(Equal(1))
+	})
+})

--- a/tests/utils/config/config_suite_test.go
+++ b/tests/utils/config/config_suite_test.go
@@ -1,0 +1,13 @@
+package config
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Config Suite")
+}

--- a/tests/utils/exec/rosacli/cluster_service.go
+++ b/tests/utils/exec/rosacli/cluster_service.go
@@ -260,10 +260,12 @@ func (c *clusterService) List() (bytes.Buffer, error) {
 
 func (c *clusterService) CreateDryRun(clusterName string, flags ...string) (bytes.Buffer, error) {
 	combflags := append([]string{"-c", clusterName, "--dry-run", "--mode=auto", "--yes"}, flags...)
-	createDryRun := c.client.Runner.
-		Cmd("create", "cluster").
-		CmdFlags(combflags...)
-	return createDryRun.Run()
+	return config.RetryOnAWSRegionsCredentialError(func() (bytes.Buffer, error) {
+		createDryRun := c.client.Runner.
+			Cmd("create", "cluster").
+			CmdFlags(combflags...)
+		return createDryRun.Run()
+	}, 3, 10*time.Second)
 }
 
 func (c *clusterService) Create(clusterName string, flags ...string) (bytes.Buffer, string, error) {


### PR DESCRIPTION
## PR Summary

Align registry-config error assertions with lowercased CLI output (#3419), migrate OCP-76396 checks to `helper.ExpectErrorWithMessage`, and retry transient AWS regions/credentials failures in `CreateDryRun` so day1-negative specs reach their intended validation errors.

## Detailed Description of the Issue

Two E2E stability issues in `rosa-day1-negative-f7`:

1. **Registry config error casing** — PR #3419 lowercased registry-config validation messages in the CLI, but OCP-76396 / OCP-77149 assertions still expected title-case strings.
2. **AWS region/credential flakes** — `CreateDryRun` calls `GetRegionList` early; transient `Failed to retrieve AWS regions` / credential validation errors can fail negative specs before they reach the validation error under test (e.g. OCP-66761).

## Related Issues and PRs

- Jira: [ROSAENG-64850](https://issues.redhat.com/browse/ROSAENG-64850), [OCP-76396](https://issues.redhat.com/browse/OCP-76396)
- Related PR(s): #3419 (lowercased registry-config errors)

## Type of Change

- [x] fix - resolves incorrect behavior or test flakes.
- [ ] feat - adds a new user-facing capability.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior

- OCP-76396 / OCP-77149 failed on registry-config assertion casing mismatches.
- OCP-76396 used raw `ContainSubstring` on command output for error checks.
- `CreateDryRun` returned immediately on transient AWS regions/credentials failures.

## Behavior After This Change

- Registry error expectations use lowercase strings; OCP-76396 uses `helper.ExpectErrorWithMessage` (case-insensitive) for all checks in that test case.
- `CreateDryRun` retries up to 3 times (10s delay) on transient AWS regions/credentials errors via `RetryOnAWSRegionsCredentialError`.
- Unit tests cover the transient classifier and retry boundary.

## How to Test (Step-by-Step)

### Preconditions

- AWS credentials and OCM token configured
- `TEST_PROFILE` set for e2e (see repo test docs)

### Test Steps

1. `go test ./tests/utils/config/ -count=1`
2. `make fmt-check && make lint && make test`
3. Run OCP-76396 / day1-negative filter locally or via periodic job `rosa-day1-negative-f7`

### Expected Results

- Config unit tests pass (classifier + retry boundary).
- OCP-76396 passes with lowercased registry validation messages.
- Day1-negative specs tolerate transient AWS setup flakes on `CreateDryRun`.

## Proof of the Fix

- `go test ./tests/utils/config/` — classifier and retry unit tests pass.
- `go build ./tests/e2e/...` — compiles.
- Local `day1-negative` run (`day1-negative-ginkgo-2.log`): **29 passed | 3 failed** (~2h24m)
  - **OCP-76396 passed** (registry casing + `ExpectErrorWithMessage`)
  - **OCP-66761 passed** (retry path exercised)
  - Remaining failures: OCP-68971 (`SHARED_VPC_*`), OCP-45509 (proxy/subnet message), OCP-71329 (AWS creds masking label) — out of scope

## Breaking Changes

- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

## Developer Verification Checklist

- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [ ] I manually tested the change. (E2E requires OCM/AWS env; local day1-negative run cited above.)
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cluster creation reliability by automatically retrying transient AWS region and credential errors.
  - Updated registry configuration validation expectations for consistent lowercase error messages.

- **Tests**
  - Added coverage for AWS error detection, retry behavior, successful recovery, exhausted retries, and zero-retry scenarios.
  - Added configuration test-suite registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[ROSAENG-64850]: https://redhat.atlassian.net/browse/ROSAENG-64850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ