### PR TITLE
ROSAENG-6150 | fix: local zone and wavelength zone subnets no longer listed when creating machine pool

### DIFF
--- a/pkg/machinepool/helper.go
+++ b/pkg/machinepool/helper.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/fedramp"
+	"github.com/openshift/rosa/pkg/helper"
 	mpHelpers "github.com/openshift/rosa/pkg/helper/machinepools"
 	"github.com/openshift/rosa/pkg/helper/versions"
 	"github.com/openshift/rosa/pkg/interactive"                               //nolint:depguard
@@ -140,10 +141,59 @@ func getSubnetFromUser(cmd *cobra.Command, r *rosa.Runtime, isSubnetSet bool,
 	return subnet, nil
 }
 
+func filterOutNonStandardZoneSubnets(
+	r *rosa.Runtime, subnets []ec2types.Subnet,
+) ([]ec2types.Subnet, error) {
+	var filtered []ec2types.Subnet
+	var excludedSubnetIds []string
+	checkedZones := map[string]string{}
+
+	for _, subnet := range subnets {
+		az := awssdk.ToString(subnet.AvailabilityZone)
+		zoneType, seen := checkedZones[az]
+		if !seen {
+			var err error
+			zoneType, err = r.AWSClient.GetAvailabilityZoneType(az)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get availability zone type for '%s': %w", az, err)
+			}
+			checkedZones[az] = zoneType
+		}
+		if zoneType == aws.LocalZone || zoneType == aws.WavelengthZone {
+			excludedSubnetIds = append(excludedSubnetIds, awssdk.ToString(subnet.SubnetId))
+		} else {
+			filtered = append(filtered, subnet)
+		}
+	}
+
+	if len(excludedSubnetIds) > 0 {
+		r.Reporter.Warnf("The following subnets were excluded because they are on local zone"+
+			" or wavelength zone: %s", helper.SliceToSortedString(excludedSubnetIds))
+	}
+	return filtered, nil
+}
+
+func getFilteredPrivateSubnets(r *rosa.Runtime, cluster *cmv1.Cluster) ([]ec2types.Subnet, error) {
+	privateSubnets, err := r.AWSClient.GetVPCPrivateSubnets(cluster.AWS().SubnetIDs()[0])
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve private subnets: %w", err)
+	}
+	if cluster.Hypershift().Enabled() {
+		privateSubnets, err = filterOutNonStandardZoneSubnets(r, privateSubnets)
+		if err != nil {
+			return nil, err
+		}
+		if len(privateSubnets) == 0 {
+			return nil, fmt.Errorf("no private subnets available after excluding local zone" +
+				" and wavelength zone subnets")
+		}
+	}
+	return privateSubnets, nil
+}
+
 // getSubnetOptions gets one of the cluster subnets and returns a slice of formatted VPC's private subnets.
 func getSubnetOptions(r *rosa.Runtime, cluster *cmv1.Cluster) ([]string, error) {
-	// Fetch VPC's subnets
-	privateSubnets, err := r.AWSClient.GetVPCPrivateSubnets(cluster.AWS().SubnetIDs()[0])
+	privateSubnets, err := getFilteredPrivateSubnets(r, cluster)
 	if err != nil {
 		return nil, err
 	}
@@ -302,7 +352,7 @@ func spotMaxPriceValidator(val interface{}) error {
 func getSubnetFromAvailabilityZone(cmd *cobra.Command, r *rosa.Runtime, isAvailabilityZoneSet bool,
 	cluster *cmv1.Cluster, args *mpOpts.CreateMachinepoolUserOptions) (string, error) {
 
-	privateSubnets, err := r.AWSClient.GetVPCPrivateSubnets(cluster.AWS().SubnetIDs()[0])
+	privateSubnets, err := getFilteredPrivateSubnets(r, cluster)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/machinepool/helper_test.go
+++ b/pkg/machinepool/helper_test.go
@@ -2,6 +2,8 @@ package machinepool
 
 import (
 	"fmt"
+	"io"
+	"os"
 
 	"go.uber.org/mock/gomock"
 
@@ -245,7 +247,7 @@ var _ = Describe("getSubnetFromAvailabilityZone functionality", func() {
 
 	BeforeEach(func() {
 		mockClient = mock.NewMockClient(gomock.NewController(GinkgoT()))
-		r = &rosa.Runtime{AWSClient: mockClient}
+		r = &rosa.Runtime{AWSClient: mockClient, Reporter: reporter.CreateReporter()}
 		cmd = &cobra.Command{}
 		az = "us-east-1a"
 		subnetId1 = "subnet-123"
@@ -257,6 +259,7 @@ var _ = Describe("getSubnetFromAvailabilityZone functionality", func() {
 		BeforeEach(func() {
 			privateSubnets = []ec2types.Subnet{{AvailabilityZone: &az, SubnetId: &subnetId1}}
 			mockClient.EXPECT().GetVPCPrivateSubnets(gomock.Any()).Return(privateSubnets, nil)
+			mockClient.EXPECT().GetAvailabilityZoneType(az).Return("availability-zone", nil)
 			cluster = MockCluster(func(c *cmv1.ClusterBuilder) {
 				c.State(cmv1.ClusterStateReady)
 				b := cmv1.HypershiftBuilder{}
@@ -278,6 +281,7 @@ var _ = Describe("getSubnetFromAvailabilityZone functionality", func() {
 			args.AvailabilityZone = "us-west-1a"
 			privateSubnets = []ec2types.Subnet{{AvailabilityZone: &az, SubnetId: &subnetId1}}
 			mockClient.EXPECT().GetVPCPrivateSubnets(gomock.Any()).Return(privateSubnets, nil)
+			mockClient.EXPECT().GetAvailabilityZoneType(az).Return("availability-zone", nil)
 			cluster = MockCluster(func(c *cmv1.ClusterBuilder) {
 				c.State(cmv1.ClusterStateReady)
 				b := cmv1.HypershiftBuilder{}
@@ -293,34 +297,62 @@ var _ = Describe("getSubnetFromAvailabilityZone functionality", func() {
 			Expect(subnet).To(Equal(""))
 		})
 	})
+
+	When("VPC has local zone subnets for an HCP cluster", func() {
+		BeforeEach(func() {
+			localZoneAz := "us-east-1-atl-1a"
+			localSubnetId := "subnet-local"
+			privateSubnets = []ec2types.Subnet{
+				{AvailabilityZone: &az, SubnetId: &subnetId1},
+				{AvailabilityZone: &localZoneAz, SubnetId: &localSubnetId},
+			}
+			mockClient.EXPECT().GetVPCPrivateSubnets(gomock.Any()).Return(privateSubnets, nil)
+			mockClient.EXPECT().GetAvailabilityZoneType(az).Return("availability-zone", nil)
+			mockClient.EXPECT().GetAvailabilityZoneType(localZoneAz).Return("local-zone", nil)
+			cluster = MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateReady)
+				c.Hypershift(cmv1.NewHypershift().Enabled(true)).
+					Nodes(cmv1.NewClusterNodes().AvailabilityZones(az)).
+					AWS(cmv1.NewAWS().SubnetIDs(subnetId1))
+			})
+		})
+
+		It("excludes local zone subnets and returns only standard AZ subnets", func() {
+			subnet, err := getSubnetFromAvailabilityZone(cmd, r, false, cluster, args)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(subnet).To(Equal(subnetId1))
+		})
+	})
 })
 
 var _ = Describe("getSubnetOptions", func() {
 	var (
 		mockCtrl       *gomock.Controller
 		mockAWS        *mock.MockClient
-		runtime        *rosa.Runtime
+		r              *rosa.Runtime
 		cluster        *cmv1.Cluster
 		subnetIds      []string
+		azs            []string
 		privateSubnets []ec2types.Subnet
 	)
 
 	BeforeEach(func() {
 		mockCtrl = gomock.NewController(GinkgoT())
 		mockAWS = mock.NewMockClient(mockCtrl)
-		runtime = &rosa.Runtime{AWSClient: mockAWS}
+		r = &rosa.Runtime{AWSClient: mockAWS, Reporter: reporter.CreateReporter()}
 		subnetIds = []string{"subnet-123", "subnet-456"}
+		azs = []string{"us-east-1a", "us-east-1b"}
 		cluster = MockCluster(func(c *cmv1.ClusterBuilder) {
 			c.State(cmv1.ClusterStateReady)
 			b := cmv1.HypershiftBuilder{}
 			b.Enabled(true)
 			c.Hypershift(&b)
-			c.MultiAZ(true).Nodes(cmv1.NewClusterNodes().AvailabilityZones("us-east-1a", "us-east-1b")).
+			c.MultiAZ(true).Nodes(cmv1.NewClusterNodes().AvailabilityZones(azs...)).
 				AWS(cmv1.NewAWS().SubnetIDs(subnetIds...))
 		})
 		privateSubnets = []ec2types.Subnet{
-			{SubnetId: &subnetIds[0]},
-			{SubnetId: &subnetIds[1]},
+			{SubnetId: &subnetIds[0], AvailabilityZone: &azs[0]},
+			{SubnetId: &subnetIds[1], AvailabilityZone: &azs[1]},
 		}
 	})
 
@@ -331,10 +363,12 @@ var _ = Describe("getSubnetOptions", func() {
 	When("GetVPCPrivateSubnets returns subnets successfully", func() {
 		BeforeEach(func() {
 			mockAWS.EXPECT().GetVPCPrivateSubnets(subnetIds[0]).Return(privateSubnets, nil)
+			mockAWS.EXPECT().GetAvailabilityZoneType("us-east-1a").Return("availability-zone", nil)
+			mockAWS.EXPECT().GetAvailabilityZoneType("us-east-1b").Return("availability-zone", nil)
 		})
 
 		It("returns a slice of subnet options without error", func() {
-			subnetOptions, err := getSubnetOptions(runtime, cluster)
+			subnetOptions, err := getSubnetOptions(r, cluster)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(subnetOptions).To(HaveLen(2))
 		})
@@ -346,9 +380,97 @@ var _ = Describe("getSubnetOptions", func() {
 		})
 
 		It("returns an error and no subnet options", func() {
-			subnetOptions, err := getSubnetOptions(runtime, cluster)
+			subnetOptions, err := getSubnetOptions(r, cluster)
 			Expect(err).To(HaveOccurred())
 			Expect(subnetOptions).To(BeNil())
+		})
+	})
+
+	When("VPC has local zone and wavelength zone subnets for an HCP cluster", func() {
+		var localZoneAz, wavelengthAz string
+
+		BeforeEach(func() {
+			localZoneAz = "us-east-1-atl-1a"
+			wavelengthAz = "us-east-1-wl1-atl-wlz-1"
+			localSubnetId := "subnet-local"
+			wavelengthSubnetId := "subnet-wavelength"
+			allSubnets := make([]ec2types.Subnet, 0, len(privateSubnets)+2)
+			allSubnets = append(allSubnets, privateSubnets...)
+			allSubnets = append(allSubnets,
+				ec2types.Subnet{SubnetId: &localSubnetId, AvailabilityZone: &localZoneAz},
+				ec2types.Subnet{SubnetId: &wavelengthSubnetId, AvailabilityZone: &wavelengthAz},
+			)
+			mockAWS.EXPECT().GetVPCPrivateSubnets(subnetIds[0]).Return(allSubnets, nil)
+			mockAWS.EXPECT().GetAvailabilityZoneType("us-east-1a").Return("availability-zone", nil)
+			mockAWS.EXPECT().GetAvailabilityZoneType("us-east-1b").Return("availability-zone", nil)
+			mockAWS.EXPECT().GetAvailabilityZoneType(localZoneAz).Return("local-zone", nil)
+			mockAWS.EXPECT().GetAvailabilityZoneType(wavelengthAz).Return("wavelength-zone", nil)
+		})
+
+		It("excludes local zone and wavelength zone subnets and warns about it", func() {
+			var subnetOptions []string
+			var err error
+			stderr := captureStderr(func() {
+				subnetOptions, err = getSubnetOptions(r, cluster)
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(subnetOptions).To(HaveLen(2))
+			for _, opt := range subnetOptions {
+				Expect(opt).ToNot(ContainSubstring("subnet-local"))
+				Expect(opt).ToNot(ContainSubstring("subnet-wavelength"))
+			}
+			Expect(stderr).To(ContainSubstring("[subnet-local, subnet-wavelength]"))
+		})
+	})
+
+	When("all subnets are in non-standard zones for an HCP cluster", func() {
+		BeforeEach(func() {
+			localZoneAz := "us-east-1-atl-1a"
+			localSubnetId1 := "subnet-local1"
+			localSubnetId2 := "subnet-local2"
+			allLocalSubnets := []ec2types.Subnet{
+				{SubnetId: &localSubnetId1, AvailabilityZone: &localZoneAz},
+				{SubnetId: &localSubnetId2, AvailabilityZone: &localZoneAz},
+			}
+			mockAWS.EXPECT().GetVPCPrivateSubnets(subnetIds[0]).Return(allLocalSubnets, nil)
+			mockAWS.EXPECT().GetAvailabilityZoneType(localZoneAz).Return("local-zone", nil)
+		})
+
+		It("returns an error instead of panicking", func() {
+			subnetOptions, err := getSubnetOptions(r, cluster)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(
+				"no private subnets available after excluding local zone and wavelength zone subnets"))
+			Expect(subnetOptions).To(BeNil())
+		})
+	})
+
+	When("cluster is classic (not HCP)", func() {
+		BeforeEach(func() {
+			cluster = MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.State(cmv1.ClusterStateReady)
+				c.Hypershift(cmv1.NewHypershift().Enabled(false))
+				c.MultiAZ(false).
+					Nodes(cmv1.NewClusterNodes().AvailabilityZones("us-east-1a")).
+					AWS(cmv1.NewAWS().SubnetIDs(subnetIds...))
+			})
+			localZoneAz := "us-east-1-atl-1a"
+			wavelengthAz := "us-east-1-wl1-atl-wlz-1"
+			localSubnetId := "subnet-local"
+			wavelengthSubnetId := "subnet-wavelength"
+			allSubnets := make([]ec2types.Subnet, 0, len(privateSubnets)+2)
+			allSubnets = append(allSubnets, privateSubnets...)
+			allSubnets = append(allSubnets,
+				ec2types.Subnet{SubnetId: &localSubnetId, AvailabilityZone: &localZoneAz},
+				ec2types.Subnet{SubnetId: &wavelengthSubnetId, AvailabilityZone: &wavelengthAz},
+			)
+			mockAWS.EXPECT().GetVPCPrivateSubnets(subnetIds[0]).Return(allSubnets, nil)
+		})
+
+		It("does not filter any subnets", func() {
+			subnetOptions, err := getSubnetOptions(r, cluster)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(subnetOptions).To(HaveLen(4))
 		})
 	})
 })
@@ -1282,3 +1404,20 @@ var _ = Describe("ValidateImageType", func() {
 		Expect(err).To(HaveOccurred())
 	})
 })
+
+func captureStderr(function func()) string {
+	r, w, err := os.Pipe()
+	Expect(err).ToNot(HaveOccurred())
+	oldStderr := os.Stderr
+	os.Stderr = w
+	defer func() {
+		os.Stderr = oldStderr
+	}()
+
+	function()
+
+	Expect(w.Close()).To(Succeed())
+	stderr, err := io.ReadAll(r)
+	Expect(err).ToNot(HaveOccurred())
+	return string(stderr)
+}

--- a/pkg/machinepool/machinepool_test.go
+++ b/pkg/machinepool/machinepool_test.go
@@ -1581,6 +1581,7 @@ var _ = Describe("NodePools", func() {
 
 			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatVersionList([]*cmv1.Version{versionObj})))
 			mockClient.EXPECT().GetVPCPrivateSubnets(gomock.Any()).Return(privateSubnets, nil)
+			mockClient.EXPECT().GetAvailabilityZoneType(az).Return("availability-zone", nil)
 			err = machinePool.CreateNodePools(t.RosaRuntime, cmd, clusterKey, cluster, nil, &args)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("you must supply a valid instance type"))
@@ -1614,6 +1615,7 @@ var _ = Describe("NodePools", func() {
 
 			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatVersionList([]*cmv1.Version{versionObj})))
 			mockClient.EXPECT().GetVPCPrivateSubnets(gomock.Any()).Return(privateSubnets, nil)
+			mockClient.EXPECT().GetAvailabilityZoneType(day1AvailabilityZone).Return("availability-zone", nil)
 
 			err = machinePool.CreateNodePools(t.RosaRuntime, cmd, clusterKey, cluster, nil, &args)
 			Expect(err).To(HaveOccurred())
@@ -1650,6 +1652,7 @@ var _ = Describe("NodePools", func() {
 
 			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatVersionList([]*cmv1.Version{versionObj})))
 			mockClient.EXPECT().GetVPCPrivateSubnets(gomock.Any()).Return(privateSubnets, nil)
+			mockClient.EXPECT().GetAvailabilityZoneType(day1AvailabilityZone).Return("availability-zone", nil)
 			mockClient.EXPECT().GetSubnetAvailabilityZone(subnet).Return(az, nil)
 			mockClient.EXPECT().IsLocalAvailabilityZone(az).Return(true, nil)
 
@@ -1693,6 +1696,7 @@ var _ = Describe("NodePools", func() {
 			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatVersionList(
 				[]*cmv1.Version{versionObj})))
 			mockClient.EXPECT().GetVPCPrivateSubnets(gomock.Any()).Return(privateSubnets, nil)
+			mockClient.EXPECT().GetAvailabilityZoneType(az).Return("availability-zone", nil)
 			mockClient.EXPECT().GetSubnetAvailabilityZone(subnet).Return(az, nil)
 			mockClient.EXPECT().IsLocalAvailabilityZone(az).Return(false, nil)
 			mtBuilder := cmv1.NewMachineType().ID("t3.small").Name("t3.small")
@@ -1778,6 +1782,7 @@ var _ = Describe("NodePools", func() {
 
 			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatVersionList([]*cmv1.Version{versionObj})))
 			mockClient.EXPECT().GetVPCPrivateSubnets(gomock.Any()).Return(privateSubnets, nil)
+			mockClient.EXPECT().GetAvailabilityZoneType(az).Return("availability-zone", nil)
 			mockClient.EXPECT().GetSubnetAvailabilityZone(subnet).Return(az, nil)
 			mtBuilder := cmv1.NewMachineType().ID("t3.small").Name("t3.small")
 			machineType, err := mtBuilder.Build()
@@ -1832,6 +1837,7 @@ var _ = Describe("NodePools", func() {
 				[]*cmv1.Version{versionObj})))
 
 			mockClient.EXPECT().GetVPCPrivateSubnets(gomock.Any()).Return(privateSubnets, nil)
+			mockClient.EXPECT().GetAvailabilityZoneType(az).Return("availability-zone", nil)
 			mockClient.EXPECT().GetSubnetAvailabilityZone(subnet).Return(az, nil)
 
 			mtBuilder := cmv1.NewMachineType().ID("t3.small").Name("t3.small")
@@ -1911,6 +1917,7 @@ var _ = Describe("NodePools", func() {
 				[]*cmv1.Version{versionObj})))
 
 			mockClient.EXPECT().GetVPCPrivateSubnets(gomock.Any()).Return(privateSubnets, nil)
+			mockClient.EXPECT().GetAvailabilityZoneType(az).Return("availability-zone", nil)
 			mockClient.EXPECT().GetSubnetAvailabilityZone(subnet).Return(az, nil)
 
 			mtBuilder := cmv1.NewMachineType().ID("t3.small").Name("t3.small")
@@ -1995,6 +2002,7 @@ var _ = Describe("NodePools", func() {
 			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatVersionList(
 				[]*cmv1.Version{versionObj})))
 			mockClient.EXPECT().GetVPCPrivateSubnets(gomock.Any()).Return(privateSubnets, nil)
+			mockClient.EXPECT().GetAvailabilityZoneType(az).Return("availability-zone", nil)
 			mockClient.EXPECT().GetSubnetAvailabilityZone(subnet).Return(az, nil)
 			mtBuilder := cmv1.NewMachineType().ID("t3.small").Name("t3.small")
 			machineType, err := mtBuilder.Build()
@@ -2065,6 +2073,7 @@ var _ = Describe("NodePools", func() {
 			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatVersionList(
 				[]*cmv1.Version{versionObj})))
 			mockClient.EXPECT().GetVPCPrivateSubnets(gomock.Any()).Return(privateSubnets, nil)
+			mockClient.EXPECT().GetAvailabilityZoneType(az).Return("availability-zone", nil)
 			mockClient.EXPECT().GetSubnetAvailabilityZone(subnet).Return(az, nil)
 			mockClient.EXPECT().IsLocalAvailabilityZone(az).Return(false, nil)
 			mtBuilder := cmv1.NewMachineType().ID("t3.small").Name("t3.small")
@@ -2134,6 +2143,7 @@ var _ = Describe("NodePools", func() {
 			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatVersionList(
 				[]*cmv1.Version{versionObj})))
 			mockClient.EXPECT().GetVPCPrivateSubnets(gomock.Any()).Return(privateSubnets, nil)
+			mockClient.EXPECT().GetAvailabilityZoneType(az).Return("availability-zone", nil)
 			mockClient.EXPECT().GetSubnetAvailabilityZone(subnet).Return(az, nil)
 			mockClient.EXPECT().IsLocalAvailabilityZone(az).Return(false, nil)
 			mtBuilder := cmv1.NewMachineType().ID("t3.small").Name("t3.small")
@@ -2223,6 +2233,7 @@ var _ = Describe("NodePools", func() {
 			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatVersionList(
 				[]*cmv1.Version{versionObj})))
 			mockClient.EXPECT().GetVPCPrivateSubnets(gomock.Any()).Return(privateSubnets, nil)
+			mockClient.EXPECT().GetAvailabilityZoneType(az).Return("availability-zone", nil)
 			mockClient.EXPECT().GetSubnetAvailabilityZone(subnet).Return(az, nil)
 			mockClient.EXPECT().IsLocalAvailabilityZone(az).Return(false, nil)
 			mtBuilder := cmv1.NewMachineType().ID("t3.small").Name("t3.small")
@@ -2314,6 +2325,7 @@ var _ = Describe("NodePools", func() {
 			t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, test.FormatVersionList(
 				[]*cmv1.Version{versionObj})))
 			mockClient.EXPECT().GetVPCPrivateSubnets(gomock.Any()).Return(privateSubnets, nil)
+			mockClient.EXPECT().GetAvailabilityZoneType(az).Return("availability-zone", nil)
 			mockClient.EXPECT().GetSubnetAvailabilityZone(subnet).Return(az, nil)
 			mtBuilder := cmv1.NewMachineType().ID("t3.small").Name("t3.small")
 			machineType, err := mtBuilder.Build()


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
Supported ticket prefixes:
OCM-XXXXX, ROSAENG-XXXX
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For contributor workflow, see: ./CONTRIBUTING.md
For repo-local agent guidance, see: ./AGENTS.md
-->

## PR Summary
<!-- brief text of 1 or 2 lines with the most important changes and outcomes -->
Exclude local zone and wavelength zone subnets from HCP machinepool creation

## Detailed Description of the Issue
When creating a machinepool for a ROSA HCP cluster interactively, the subnet picker listed all private subnets in the VPC, including subnets in AWS Local Zones and Wavelength Zones. HCP clusters do not support nodepools in these zone types, so presenting them as options was misleading and could lead to failed machinepool creation.

The cluster creation path (cmd/create/cluster/cmd.go) already filtered these out using GetAvailabilityZoneType, but the machinepool creation path in pkg/machinepool/helper.go did not. This change adds the same filtering to both getSubnetOptions (interactive subnet list) and getSubnetFromAvailabilityZone (AZ-based subnet selection) for HCP clusters. Classic clusters are unaffected since they can legitimately have machinepools in local zones. Excluded subnets are reported to the user via a warning message, and an explicit error is returned if no subnets remain after filtering.

## Related Issues and PRs
<!-- Link all tracking items and related code changes -->
- Jira: [OCM-XXXXX](https://issues.redhat.com/browse/OCM-XXXXX) or [ROSAENG-XXXX](https://issues.redhat.com/browse/ROSAENG-XXXX)
- Fixes: `#`
- Related PR(s):
- Related design/docs:

## Type of Change
<!-- Check the primary type this PR represents -->
- [ ] feat - adds a new user-facing capability.
- [x] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
<!-- What users or systems experienced before this change -->
When creating a machine pool in an HCP cluster, all subnets were listed, including those in local zones and wavelength zones.

## Behavior After This Change
<!-- What changes now, including user-visible and non-user-visible behavior -->
Local zones and wavelength zones are now filtered out when creating machine pools in HCP clusters 

## How to Test (Step-by-Step)
<!-- Provide reproducible validation instructions -->
### Preconditions
- A ROSA HCP cluster in a VPC that has both standard-AZ private subnets and local zone or wavelength zone private subnets (e.g., us-east-1-atl-1a or us-east-1-wl1-atl-wlz-1)
  - AWS credentials configured with ec2:DescribeAvailabilityZones permission

### Test Steps
1. Run rosa create machinepool --cluster=<cluster-name> -i
2. When prompted "Select subnet for a hosted machine pool", answer Yes
3. Observe the subnet list

### Expected Results
- Local zone and wavelength zone subnets should NOT appear in the list
- A warning should be printed: WARN: The following subnets were excluded because they are on local zone or wavelength zone: <subnet-ids>
- Only standard availability zone subnets should be selectable


## Proof of the Fix
Old:
```
$ rosa create machinepool --cluster=mirish-lz-test -i
? Machine pool name: mirish-lz-test-mp
? Image Type (optional, choose 'Skip' to skip selection; ): Skip
? OpenShift version (default = '4.22.10'): 4.22.10
? Select subnet for a hosted machine pool: Yes
? Subnet ID (default = 'subnet-05d65c034cb18edda ('','vpc-0a03b5960423372ed','us-west-2-den-1a', Owner ID: '090777400063')'):  [Use arrows to move, type to filter, ? for more help]
> subnet-05d65c034cb18edda ('','vpc-0a03b5960423372ed','us-west-2-den-1a', Owner ID: '090777400063')
  subnet-04100f1e4b123d4db ('','vpc-0a03b5960423372ed','us-west-2-lax-1a', Owner ID: '090777400063')
  subnet-02403e8fc2d7c454e ('mirish-lz-test-Private-Subnet-1','vpc-0a03b5960423372ed','us-west-2a', Owner ID: '090777400063')
  ```

New
```
$ ./rosa create machinepool --cluster=mirish-lz-test -i
? Machine pool name: mirish-lz-test-mp
? Machine pool image type (optional, choose 'Skip' to skip selection; ): Skip
? OpenShift version (default = '4.22.10'): 4.22.10
? Select subnet for a hosted machine pool: Yes
W: The following subnets were excluded because they are on local zone or wavelength zone: [subnet-04100f1e4b123d4db, subnet-05d65c034cb18edda]
? Subnet ID (default = 'subnet-02403e8fc2d7c454e ('mirish-lz-test-Private-Subnet-1','vpc-0a03b5960423372ed','us-west-2a', Owner ID: '090777400063')'):  [Use arrows to move, type to filter, ? for more help]
> subnet-02403e8fc2d7c454e ('mirish-lz-test-Private-Subnet-1','vpc-0a03b5960423372ed','us-west-2a', Owner ID: '090777400063')
```

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
<!-- Required only when breaking changes are introduced -->

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [x] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hosted Control Plane clusters now exclude Local Zone and Wavelength Zone subnets when selecting private subnets.
  * Clear errors are shown when no eligible standard subnets remain.
  * Warnings identify subnets excluded from Hosted Control Plane selection.
  * Subnet selection and availability-zone resolution consistently use eligible subnets.
  * Classic clusters continue to support all available subnets.
  * Node pool creation now handles availability-zone details consistently during subnet selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->