### PR TITLE
ROSAENG-66688 | ci: skip changelog generation for prerelease tags

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -11,14 +11,22 @@ permissions:
 jobs:
   tag-check:
     runs-on: ubuntu-latest
+    outputs:
+      is_stable: ${{ steps.check.outputs.is_stable }}
     steps:
-      - name: Validate stable release tag
+      - name: Check if tag is a stable release
+        id: check
         run: |
-          set -euo pipefail
-          [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] \
-            || { echo "❌  Tag '${GITHUB_REF_NAME}' is not a stable release tag"; exit 1; }
+          if [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "✅  Tag '${GITHUB_REF_NAME}' is a stable release tag"
+            echo "is_stable=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "⏭️  Tag '${GITHUB_REF_NAME}' is not a stable release tag — skipping changelog"
+            echo "is_stable=false" >> "$GITHUB_OUTPUT"
+          fi
   update-changelog:
     needs: tag-check
+    if: needs.tag-check.outputs.is_stable == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -42,11 +50,11 @@ jobs:
             | head -1)
           if [ -z "$PREV_TAG" ] || [ "$PREV_TAG" = "$CURRENT_TAG" ]; then
             echo "No previous stable tag found for ${CURRENT_TAG}"
-            echo "prev_tag=" >> $GITHUB_OUTPUT
+            echo "prev_tag=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           echo "Previous stable tag: $PREV_TAG"
-          echo "prev_tag=$PREV_TAG" >> $GITHUB_OUTPUT
+          echo "prev_tag=$PREV_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Check if there are commits between tags
         if: steps.prev-tag.outputs.prev_tag != ''


### PR DESCRIPTION
## Summary

Keep prerelease tags in the tag-triggered release flow without failing the workflow, and skip changelog PR generation for prerelease tags such as `vX.Y.Z-prerelease.N`.

## Related Issues and PRs

- Jira: [ROSAENG-66688](https://redhat.atlassian.net/browse/ROSAENG-66688)

## Why

ROSA prerelease tags are part of the supported release flow, but they should not generate historical changelog PRs. The changelog automation should only run for final release tags, while prerelease pushes should exit cleanly without breaking the release process.

## Test plan

- Retag `v1.2.65-prerelease.1` from the updated release branch and confirm the workflow completes successfully without opening a changelog PR
- Verify final stable tags still follow the existing changelog PR path

[ROSAENG-66688]: https://redhat.atlassian.net/browse/ROSAENG-66688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ