### PR TITLE
rosa-day1-negative-f7 | fix(day1-negative): OCP-73725 OCP-73755 OCP-38857

### DIFF
--- a/tests/e2e/test_rosacli_cluster.go
+++ b/tests/e2e/test_rosacli_cluster.go
@@ -2124,7 +2124,7 @@ var _ = Describe("Create cluster with invalid options will",
 					"--pod-cidr":     "10111.0.0.0/16",
 				}
 				for flag, invalidValue := range illegalCIDRMap {
-					output, _, err := clusterService.Create(clusterName,
+					output, err := clusterService.CreateDryRun(clusterName,
 						flag, invalidValue,
 					)
 					Expect(err).To(HaveOccurred())
@@ -2133,7 +2133,7 @@ var _ = Describe("Create cluster with invalid options will",
 							invalidValue, flag, invalidValue))
 				}
 				By("Check the overlapped CIDR block validation")
-				output, _, err := clusterService.Create(clusterName,
+				output, err := clusterService.CreateDryRun(clusterName,
 					"--service-cidr", "1.0.0.0/16",
 					"--pod-cidr", "1.0.0.0/16",
 				)
@@ -2148,7 +2148,7 @@ var _ = Describe("Create cluster with invalid options will",
 					"--pod-cidr":     "1.0.0.0/28",
 				}
 				for flag, invalidValue := range invalidCIDRMap {
-					output, _, err := clusterService.Create(clusterName,
+					output, err := clusterService.CreateDryRun(clusterName,
 						flag, invalidValue,
 					)
 					Expect(err).To(HaveOccurred())
@@ -2167,7 +2167,7 @@ var _ = Describe("Create cluster with invalid options will",
 
 				}
 				By("Check the invalid machine CIDR for multi az")
-				output, _, err = clusterService.Create(clusterName,
+				output, err = clusterService.CreateDryRun(clusterName,
 					"--machine-cidr", "2.0.0.0/25",
 					"--multi-az",
 				)
@@ -2176,7 +2176,7 @@ var _ = Describe("Create cluster with invalid options will",
 					ContainSubstring("The allowed block size must be between a /16 netmask and /24"))
 
 				By("Check illegal host prefix")
-				output, _, err = clusterService.Create(clusterName,
+				output, err = clusterService.CreateDryRun(clusterName,
 					"--machine-cidr", "2.0.0.0/25",
 					"--host-prefix", "28",
 				)
@@ -2185,7 +2185,7 @@ var _ = Describe("Create cluster with invalid options will",
 					ContainSubstring("Subnet length should be between 23 and 26"))
 
 				By("Check invalid host prefix")
-				output, _, err = clusterService.Create(clusterName,
+				output, err = clusterService.CreateDryRun(clusterName,
 					"--machine-cidr", "2.0.0.0/25",
 					"--host-prefix", "invalid",
 				)
@@ -2706,7 +2706,7 @@ var _ = Describe("HCP cluster creation negative testing",
 		It("create HCP cluster with network type validation can work well via rosa cli - [id:73725]",
 			labels.Medium, labels.Runtime.Day1Negative,
 			func() {
-				clusterName := helper.GenerateRandomName("cluster-73725", 2)
+				clusterName := helper.GenerateRandomName("ocp-73725", 2)
 				By("Create HCP cluster with --no-cni and \"--network-type={OVNKubernetes, OpenshiftSDN}\" at the same time")
 				replacingFlags := map[string]string{
 					"-c":              clusterName,
@@ -2895,9 +2895,10 @@ var _ = Describe("HCP cluster creation negative testing",
 					"--cluster-name":  clusterName,
 					"--domain-prefix": clusterName,
 					"--version":       foundVersion,
-					"--channel-group": cg,
 				}
 				rosalCommand.ReplaceFlagValue(replacingFlags)
+				err = rosalCommand.DeleteFlag("--channel-group", true)
+				Expect(err).ToNot(HaveOccurred())
 				if !rosalCommand.CheckFlagExist("--external-auth-providers-enabled") {
 					rosalCommand.AddFlags("--external-auth-providers-enabled")
 				}


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
Supported ticket prefixes:
OCM-XXXXX, ROSAENG-XXXX
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For contributor workflow, see: ./CONTRIBUTING.md
For repo-local agent guidance, see: ./AGENTS.md
-->

## PR Summary
Align three `day1-negative` e2e specs (OCP-73725, OCP-73755, OCP-38857) with current ROSA CLI validation so periodic `rosa-day1-negative-f7` reaches the intended negative assertions.

## Detailed Description of the Issue
Periodic `periodic-ci-openshift-rosa-master-e2e-rosa-day1-negative-f7` (`(day1-negative)&&!Exclude`, profile `null`) has been chronically red. Prow artifacts showed these specs failing before their target validation:

- **OCP-73725**: Generated HCP cluster names exceeded the 15-character shared-VPC limit, so the CLI failed on name length instead of network-type validation.
- **OCP-73755**: Pinning OpenShift 4.14.x with `--channel-group=stable` made OCM reject the create before the external-auth version-gate message could be asserted.
- **OCP-38857**: `rosa create cluster` without `--dry-run` did not surface flag/CIDR errors on the path the spec expects.

## Related Issues and PRs
- Jira: [ROSAENG-62387](https://issues.redhat.com/browse/ROSAENG-62387)
- Fixes: N/A
- Related PR(s): #3429 (OCP-45509), #3460 (OCP-76396 registry asserts)
- Related design/docs: N/A

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [x] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
- OCP-73725 failed on shared-VPC cluster name length.
- OCP-73755 failed on channel/version mismatch (`stable-4.21` vs pinned 4.14.x).
- OCP-38857 failed when `Create()` did not return errors or overlap checks hit live AWS paths.

## Behavior After This Change
- OCP-73725 uses a cluster name trimmed to ≤15 characters.
- OCP-73755 drops `--channel-group` and sets `--channel=eus-4.16` for the 4.14 negative path.
- OCP-38857 passes `--dry-run` on all `Create()` calls in the invalid-CIDR `It`.

No ROSA CLI product behavior changes.

## How to Test (Step-by-Step)
### Preconditions
- OCM and AWS credentials for e2e (or rely on periodic `rosa-day1-negative-f7`).
- Label filter: `(day1-negative)&&!Exclude`.

### Test Steps
1. Run e2e with focus on OCP-73725, OCP-73755, and OCP-38857 (or the full day1-negative filter).
2. Confirm each `It` fails the CLI on the intended validation, not setup/channel/name-length errors.
3. Watch periodic `periodic-ci-openshift-rosa-master-e2e-rosa-day1-negative-f7` after merge.

### Expected Results
- OCP-73725 asserts network-type / `--no-cni` errors.
- OCP-73755 asserts external-auth version gate on 4.14.x.
- OCP-38857 asserts invalid/overlap CIDR messages via dry-run.

## Proof of the Fix
- Screenshots: N/A
- Videos: N/A
- Logs/CLI output: Prow job-history for `rosa-day1-negative-f7` (pre-fix failure signatures for these IDs).
- Other artifacts: N/A

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.


[ROSAENG-62387]: https://redhat.atlassian.net/browse/ROSAENG-62387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated cluster creation validation coverage to use dry-run checks.
  * Refined HCP network validation test naming.
  * Improved external authentication validation coverage for older OpenShift versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->