### PR TITLE
OCM-00000 | fix: update .govulncheck-ignore.yaml GO-2026-5932 reason and add new ignored vulnerabilities

### DIFF
--- a/.govulncheck-ignore.yaml
+++ b/.govulncheck-ignore.yaml
@@ -12,4 +12,34 @@
 ignored_vulnerabilities:
   - id: GO-2026-5932
     module: golang.org/x/crypto
-    reason: "Transitive dependency on deprecated openpgp package. No fix available — package is unmaintained by design. Not directly imported by ROSA."
+    reason: "Known binary-mode false positive: advisory only affects golang.org/x/crypto/openpgp, which is not imported (source scan is clean). hack/govulncheck-wrapper.sh guards this: the ignore only applies while golang.org/x/crypto/openpgp is absent from the import graph, so a future change that starts using openpgp will surface this finding instead of masking it."
+  - id: GO-2026-5026
+    module: stdlib
+    reason: "Fixed in Go 1.26.6, but registry.access.redhat.com/ubi9/go-toolset does not yet have a 1.26.6 image available. Remove once the toolchain image is bumped."
+  - id: GO-2026-5942
+    module: stdlib
+    reason: "Fixed in Go 1.26.6, but registry.access.redhat.com/ubi9/go-toolset does not yet have a 1.26.6 image available. Remove once the toolchain image is bumped."
+  - id: GO-2026-5972
+    module: stdlib
+    reason: "Fixed in Go 1.26.6, but registry.access.redhat.com/ubi9/go-toolset does not yet have a 1.26.6 image available. Remove once the toolchain image is bumped."
+  - id: GO-2026-6088
+    module: stdlib
+    reason: "Fixed in Go 1.26.6, but registry.access.redhat.com/ubi9/go-toolset does not yet have a 1.26.6 image available. Remove once the toolchain image is bumped."
+  - id: GO-2026-6089
+    module: stdlib
+    reason: "Fixed in Go 1.26.6, but registry.access.redhat.com/ubi9/go-toolset does not yet have a 1.26.6 image available. Remove once the toolchain image is bumped."
+  - id: GO-2026-6090
+    module: stdlib
+    reason: "Fixed in Go 1.26.6, but registry.access.redhat.com/ubi9/go-toolset does not yet have a 1.26.6 image available. Remove once the toolchain image is bumped."
+  - id: GO-2026-6091
+    module: stdlib
+    reason: "Fixed in Go 1.26.6, but registry.access.redhat.com/ubi9/go-toolset does not yet have a 1.26.6 image available. Remove once the toolchain image is bumped."
+  - id: GO-2026-6218
+    module: stdlib
+    reason: "Fixed in Go 1.26.6, but registry.access.redhat.com/ubi9/go-toolset does not yet have a 1.26.6 image available. Remove once the toolchain image is bumped."
+  - id: GO-2026-6170
+    module: github.com/lib/pq
+    reason: "No fix available (fixed version: N/A)."
+  - id: GO-2026-6172
+    module: github.com/lib/pq
+    reason: "No fix available (fixed version: N/A)."


### PR DESCRIPTION
## PR Summary
Update the reason in .govulncheck-ignore for skipping GO-2026-5932. Also add new ignored vulnerabilities.

## Detailed Description of the Issue
- [Started a review here](https://github.com/openshift/rosa/pull/3464), but forgot to hit submit. Just needs to indicate the issue is observability at the binary level, and that it is a known issue.
- Add additional skipped vulnerabilities:
  - `stdlib` (no registry image available for 1.26.6 yet): GO-2026-5026, GO-2026-5942, GO-2026-5972, GO-2026-6088, GO-2026-6089, GO-2026-6090, GO-2026-6091,GO-2026-6218
  - `github.com/lib/pq` (no fixed version yet): GO-2026-6170, GO-2026-6172

## Related Issues and PRs
<!-- Link all tracking items and related code changes -->
- Jira: [OCM-XXXXX](https://issues.redhat.com/browse/OCM-XXXXX) or [ROSAENG-XXXX](https://issues.redhat.com/browse/ROSAENG-XXXX)
- Fixes: `#` N/A
- Related PR(s): https://github.com/openshift/rosa/pull/3464
- Related design/docs:

## Type of Change
<!-- Check the primary type this PR represents -->
- [ ] feat - adds a new user-facing capability.
- [x] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
Skip reason reads:
>"Transitive dependency on deprecated openpgp package. No fix available — package is unmaintained by design. Not directly imported by ROSA."

## Behavior After This Change
Reason now reads:
>"Known binary-mode false positive: advisory only affects golang.org/x/crypto/openpgp, which is not imported (source scan is clean). govulncheck's binary-mode can't inspect at the sub-package level, and flags the entire module. See golang/go#80347."

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [x] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated vulnerability ignore documentation to clarify a known false positive.
  * Added temporary ignores for standard library vulnerabilities pending Go 1.26.6 availability.
  * Added ignores for two PostgreSQL driver vulnerabilities that currently have no available fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->