### PR TITLE
ROSAENG-60033 | ci: add gitleaks to pre-commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist/
 # for VS Code debug sessions
 **/__debug_bin*
 **/ginkgo.report
+/bin/*

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,80 @@
+# Gitleaks — https://github.com/gitleaks/gitleaks/blob/master/README.md
+#
+# Purpose: Detect hardcoded secrets, credentials, and sensitive data in this
+# ROSA CLI repository.
+#
+# Integration:
+# - pre-commit hook (blocking; see .pre-commit-config.yaml)
+# - CodeRabbit when gitleaks is enabled (.coderabbit.yaml)
+#
+# Usage:
+#   pre-commit run gitleaks --all-files
+#   gitleaks detect --source . --config .gitleaks.toml --no-git --verbose
+#
+# Allowlist policy:
+# 1. Prefer fixing real or avoidable findings.
+# 2. Allowlist only justified mocks/fixtures with a short comment.
+# 3. Never disable gitleaks entirely.
+# 4. Keep the pre-commit gitleaks commit SHA (# frozen: <tag>) current in
+#    .pre-commit-config.yaml.
+
+title = "openshift/rosa"
+
+[extend]
+useDefault = true
+
+# =============================================================================
+# GLOBAL ALLOWLIST
+# =============================================================================
+
+[[allowlists]]
+description = "Exclude generated/vendor/tool directories that are not source inputs"
+condition = "AND"
+
+paths = [
+  # Local tool binaries and build artifacts (not source)
+  '''^bin/''',
+  '''^dist/''',
+  '''^\.bingo/''',
+  '''^vendor/''',
+]
+
+[[allowlists]]
+description = "AWS client unit test fixture uses a non-production Secrets Manager ARN"
+condition = "AND"
+paths = [
+  '''^pkg/aws/client_test\.go$''',
+]
+regexes = [
+  '''arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret-testexample''',
+]
+
+# =============================================================================
+# CUSTOM RULES (CLI / ROSA / OpenShift specific)
+# =============================================================================
+
+[[rules]]
+id = "ocm-rhcs-token"
+description = "OCM / RHCS offline or service token assignment"
+regex = '''(?i)(?:ocm|rhcs)[_-]?(?:offline[_-]?)?token\s*[:=]\s*['"]?[A-Za-z0-9._\-]{32,}'''
+tags = ["token", "ocm", "rhcs", "critical"]
+
+[[rules]]
+id = "openshift-pull-secret"
+description = "OpenShift pull secret auth blob"
+regex = '''(?i)pull[_-]?secret.*auth.*[A-Za-z0-9+/]{30,}={0,2}'''
+tags = ["secret", "openshift", "high"]
+
+[[rules]]
+id = "kubeconfig-embedded"
+description = "Embedded kubeconfig with certificate data"
+regex = '''client-certificate-data:\s*[A-Za-z0-9+/]{30,}={0,2}'''
+tags = ["kubeconfig", "certificate", "critical"]
+
+[[rules]]
+id = "private-key-pem"
+description = "PEM-encoded private key"
+regex = '''-----BEGIN\s+(?:RSA\s+|EC\s+|OPENSSH\s+)?PRIVATE KEY-----'''
+tags = ["private-key", "pem", "critical"]
+
+# AWS / GitHub / generic API keys: use gitleaks defaults via [extend] useDefault

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+# Copyright Red Hat
+# SPDX-License-Identifier: Apache-2.0
+
+repos:
+  # Secrets detection (blocking). Pin to the commit for release tag v8.30.1.
+  # Never SKIP=gitleaks or git commit --no-verify.
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: 83d9cd684c87d95d656c1458ef04895a7f1cbd8e  # frozen: v8.30.1
+    hooks:
+      - id: gitleaks
+        stages: [pre-commit]
+
+exclude: '^vendor/'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,8 @@ Use this file as the starting point for repository context. When this file point
   - Test style, generated-file boundaries, validation paths, and PR-readiness checklist use.
 - `guidelines/workflow-conventions.md`
   - Request and Result type naming, construction, optional-value handling, and the lifecycle for reusable workflow functions in `pkg/`.
+- `guidelines/security.md`
+  - Secret handling, gitleaks policy, and credential safety expectations.
 
 ## Codebase Map
 
@@ -121,7 +123,8 @@ When adding or changing a CLI command:
 ## Tests And Verification
 
 - Run `make install-hooks` once per clone before committing.
-- Do not bypass local hooks.
+- Do not bypass local hooks or verification gates (`git commit --no-verify`, `SKIP=gitleaks`).
+- Do not bypass gitleaks; it runs in the pre-commit hook via `.pre-commit-config.yaml`. Prefer fixing findings; allowlist only justified mocks in `.gitleaks.toml` (see `guidelines/security.md` and `CONTRIBUTING.md`).
 - Common checks:
   - `make fmt`
   - `make fmt-check`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,13 +39,17 @@ In this repository, the conventional-commit type still lives inside the required
 
 REQUIRED BEFORE YOUR FIRST COMMIT IN A CLONE:
 ```shell
+# Install pre-commit (required for the gitleaks hook). Examples:
+#   pip install pre-commit
+#   sudo dnf install pre-commit
+#   brew install pre-commit
 make install-hooks
 ```
 
 YOU MUST LET THE LOCAL HOOKS RUN ON EVERY COMMIT AND PUSH. DO NOT BYPASS LOCAL HOOKS.
 
 The hooks perform:
-- `pre-commit`: formats staged Go files (imports + gofmt) and blocks the commit if files were rewritten so you can review/stage updates
+- `pre-commit`: runs gitleaks (`.pre-commit-config.yaml`) and formats staged Go files (imports + gofmt); blocks the commit if files were rewritten so you can review/stage updates
 - `commit-msg`: validates the commit message format
 - `pre-push`: runs format-check, build, lint, changed-files coverage, and unit/integration tests
 - `pre-push` runs against committed content and blocks when staged/unstaged tracked changes are present

--- a/guidelines/security.md
+++ b/guidelines/security.md
@@ -1,0 +1,19 @@
+# Security
+
+Router: [`AGENTS.md`](../AGENTS.md). AWS and credential handling: [`aws-guidelines.md`](aws-guidelines.md).
+
+## Secrets
+
+When editing CLI code, tests, docs, examples, or logs:
+
+- MUST NOT: Hard code secrets, API keys, tokens, kubeconfigs, AWS credentials, or customer identifiers.
+- MUST NOT: Log or print credentials, tokens, or other secrets.
+- DEFAULT: Prefer placeholders and variables in examples and test fixtures.
+
+## Gitleaks (secret scanning)
+
+- MUST: Run the blocking pre-commit gitleaks hook (`.pre-commit-config.yaml` via `.githooks/pre-commit`).
+- MUST NOT: Bypass with `SKIP=gitleaks` or `git commit --no-verify`.
+- MUST: Prefer fixing findings. MAY allowlist only justified mocks/fixtures in `.gitleaks.toml` with a short comment — never disable the scan.
+- Config: `.gitleaks.toml`. Pre-commit pin: commit SHA with `# frozen: <tag>` in `.pre-commit-config.yaml`.
+- Commands and Renovate notes: [`CONTRIBUTING.md`](../CONTRIBUTING.md).

--- a/hack/pre-commit-hook.sh
+++ b/hack/pre-commit-hook.sh
@@ -9,6 +9,52 @@ if git diff --cached --quiet --exit-code; then
   exit 0
 fi
 
+if ! command -v pre-commit >/dev/null 2>&1; then
+  echo "Commit blocked: pre-commit is required for gitleaks (see CONTRIBUTING.md)"
+  exit 1
+fi
+
+# pre-commit honors SKIP; never allow inherited SKIP=gitleaks to bypass this scan.
+gitleaks_pre_commit_env=()
+if [ -n "${SKIP:-}" ]; then
+  cleaned_skip=""
+  IFS=',' read -r -a skip_hooks <<< "$SKIP"
+  for hook in "${skip_hooks[@]}"; do
+    hook="${hook#"${hook%%[![:space:]]*}"}"
+    hook="${hook%"${hook##*[![:space:]]}"}"
+    if [ "$hook" = "gitleaks" ]; then
+      continue
+    fi
+    if [ -n "$cleaned_skip" ]; then
+      cleaned_skip+=",$hook"
+    else
+      cleaned_skip="$hook"
+    fi
+  done
+  if [ -n "$cleaned_skip" ]; then
+    gitleaks_pre_commit_env=(env "SKIP=$cleaned_skip")
+  else
+    gitleaks_pre_commit_env=(env -u SKIP)
+  fi
+else
+  gitleaks_pre_commit_env=(env -u SKIP)
+fi
+
+set +e
+"${gitleaks_pre_commit_env[@]}" pre-commit run gitleaks --config .pre-commit-config.yaml
+gitleaks_exit_code=$?
+set -e
+
+if [ "$gitleaks_exit_code" -ne 0 ]; then
+  echo
+  if [ "$gitleaks_exit_code" -eq 130 ] || [ "$gitleaks_exit_code" -eq 143 ]; then
+    echo "Commit blocked: gitleaks pre-commit check interrupted"
+  else
+    echo "Commit blocked: gitleaks pre-commit check failed"
+  fi
+  exit 1
+fi
+
 set +e
 make --no-print-directory pre-commit-checks
 checks_exit_code=$?

--- a/pkg/aws/client_test.go
+++ b/pkg/aws/client_test.go
@@ -1173,7 +1173,7 @@ var _ = Describe("Client", func() {
 
 	Context("CreateSecretInSecretsManager", func() {
 		It("Returns ARN on success", func() {
-			expectedArn := "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret-abc123"
+			expectedArn := "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret-testexample"
 
 			mockSecretsManagerAPI.EXPECT().CreateSecret(gomock.Any(), gomock.Any(), gomock.Any()).
 				DoAndReturn(func(_ context.Context, input *secretsmanager.CreateSecretInput,
@@ -1202,7 +1202,7 @@ var _ = Describe("Client", func() {
 	})
 
 	Context("DeleteSecretInSecretsManager", func() {
-		secretArn := "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret-abc123"
+		secretArn := "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret-testexample"
 
 		It("Returns nil when secret is not found", func() {
 			mockSecretsManagerAPI.EXPECT().DescribeSecret(gomock.Any(), gomock.Any(), gomock.Any()).

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
   "enabledManagers": [
     "custom.regex",
     "gomod",
+    "pre-commit",
     "tekton",
     "dockerfile"
   ],
@@ -67,6 +68,9 @@
       "extractVersionTemplate": "{{extractVersion}}"
     }
   ],
+  "pre-commit": {
+    "enabled": true
+  },
   "packageRules": [
     {
       "description": "govulncheck jq bootstrap",
@@ -77,6 +81,18 @@
         "jqlang/jq"
       ],
       "groupName": "govulncheck-jq"
+    },
+    {
+      "description": "Bump pre-commit gitleaks SHA",
+      "matchManagers": [
+        "pre-commit"
+      ],
+      "matchDepNames": [
+        "gitleaks/gitleaks"
+      ],
+      "groupName": "gitleaks",
+      "groupSlug": "gitleaks",
+      "automerge": false
     },
     {
       "description": "Enable automerge Konflux .tekton task updates",


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
Supported ticket prefixes:
OCM-XXXXX, ROSAENG-XXXX
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For contributor workflow, see: ./CONTRIBUTING.md
For repo-local agent guidance, see: ./AGENTS.md
-->

## PR Summary

Add gitleaks (v8.30.1) as a blocking pre-commit secret scan for `openshift/rosa`, wired through `.pre-commit-config.yaml` and the existing `.githooks/pre-commit` hook.

## Detailed Description of the Issue

The ROSA CLI repository had no local blocking secret-scan gate. CodeRabbit can run gitleaks when enabled, but contributors could still commit without a repo-enforced scan. This PR adds a pre-commit-only gate modeled on [terraform-provider-rhcs#1283](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1283), adapted to ROSA's `.githooks` workflow (no Makefile gitleaks target and no `pre-push-checks` integration).

## Related Issues and PRs
- Jira: [ROSAENG-60033](https://issues.redhat.com/browse/ROSAENG-60033)
- Fixes: N/A
- Related PR(s): [terraform-provider-rhcs#1283](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1283)
- Related design/docs: N/A

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [x] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior

No blocking gitleaks scan ran during local commits. `.gitleaks.toml` did not exist, and the pre-commit hook only ran formatting checks.

## Behavior After This Change

- `.pre-commit-config.yaml` pins gitleaks v8.30.1 (`# frozen: v8.30.1`).
- `.githooks/pre-commit` runs `pre-commit run gitleaks` before existing `make pre-commit-checks` formatting.
- `.gitleaks.toml` extends upstream defaults with ROSA-specific rules and path-scoped `[[allowlists]]` entries (`condition = "AND"`).
- `AGENTS.md` and `guidelines/security.md` document gitleaks policy and bypass rules.
- Renovate bumps the pre-commit gitleaks SHA.
- Secrets Manager mock ARNs in `pkg/aws/client_test.go` were softened to avoid false positives.

## How to Test (Step-by-Step)
### Preconditions
- Install [pre-commit](https://pre-commit.com/).
- Run `make install-hooks` in this clone.

### Test Steps
1. `pre-commit run gitleaks --config .pre-commit-config.yaml --all-files`
2. Stage a change and run a commit to confirm `.githooks/pre-commit` runs gitleaks before formatting.
3. Confirm `make pre-push-checks` is unchanged (no gitleaks step).

### Expected Results
- Gitleaks exits 0 with no leaks on the current tree.
- Commits are blocked when gitleaks fails.
- `make run-checks -- pre-push --list-steps` does not list gitleaks.

## Proof of the Fix
- Screenshots: N/A
- Videos: N/A
- Logs/CLI output: `pre-commit run gitleaks --config .pre-commit-config.yaml --all-files` passed locally.
- Other artifacts: N/A

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [ ] `make test` passes.
- [ ] `make lint` passes.
- [ ] `make rosa` passes.
- [x] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

[ROSAENG-60033]: https://redhat.atlassian.net/browse/ROSAENG-60033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Added automated secret detection for commits, including checks for sensitive tokens, credentials, certificates, and private keys.
  - Commits are blocked when secret scanning fails or required tooling is unavailable, helping prevent accidental credential exposure.
  - Added safeguards to prevent bypassing mandatory secret scans.

- **Documentation**
  - Added guidance for handling secrets, running security checks, managing justified allowlists, and contributing securely.

- **Chores**
  - Added automated maintenance for security-scanning configuration and version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->