### PR TITLE
ROSAENG-5657 | chore: add zip archives for Konflux GitHub releases

### DIFF
--- a/hack/build_cli.sh
+++ b/hack/build_cli.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -euo pipefail
+
 #This script invoked via a make target by the Dockerfile
 #which builds a cli wrapper container that contains all release images
 archs=(amd64 arm64)
@@ -16,9 +18,15 @@ do
         extension=".exe"
     fi
     tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' EXIT
     GOOS="${os}" GOARCH="${arch}" go build -ldflags="-X github.com/openshift/rosa/pkg/info.Build=$(git rev-parse --short HEAD)" -o "${tmpdir}/rosa${extension}" ./cmd/rosa
     tar -czf "releases/rosa_${os}_${arch}.tar.gz" -C "${tmpdir}" "rosa${extension}"
+    (
+      cd "${tmpdir}" && \
+      zip -r "${OLDPWD}/releases/rosa_${os}_${arch}.zip" "rosa${extension}"
+    )
     rm -rf "${tmpdir}"
+    trap - EXIT
   done
 done
 }


### PR DESCRIPTION
## What

Add `.zip` archives alongside the existing `.tar.gz` archives in `hack/build_cli.sh`.

## Why

The Konflux `create-github-release` task currently hardcodes `*.zip` in its `gh release create` glob. ROSA CLI only produced `.tar.gz`, which caused the GitHub release lane to fail with:

```
no match: /tmp/.../*.zip
```

By producing `.zip` archives as well, the existing Konflux task can upload the expected files without needing an upstream task change.

## Notes

- `.tar.gz` output is kept, so existing consumers are not broken
- this change is specifically to satisfy the GitHub release lane
- a matching KRD MR will update the CDN + GitHub RPAs to reference `.zip` consistently

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release builds now include ZIP archives alongside existing tarballs.

* **Bug Fixes**
  * Improved build reliability by detecting errors during the build process.
  * Temporary build files are now cleaned up automatically, including when archive creation encounters an issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->