### PR TITLE
ROSAENG-5657 | chore: add sast-snyk-check task to build pipeline

### DIFF
--- a/.tekton/rosa-github-release.yaml
+++ b/.tekton/rosa-github-release.yaml
@@ -426,6 +426,32 @@ spec:
         operator: in
         values:
         - "false"
+    - name: sast-snyk-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: TARGET_DIRS
+        value: $(params.sast-target-dirs)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-snyk-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.5@sha256:b78e9c05c5126613eddee53f2f3534a9b86bfca17d903599f2fa465b7938e241
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
     - name: sast-shell-check
       params:
       - name: image-digest

--- a/images/Dockerfile.konflux
+++ b/images/Dockerfile.konflux
@@ -3,7 +3,7 @@ WORKDIR /rosa
 USER root
 COPY . .
 
-RUN dnf install -y --setopt=install_weak_deps=False --nodocs wget tar python3-pip unzip && \
+RUN dnf install -y --setopt=install_weak_deps=False --nodocs wget tar python3-pip unzip zip && \
     pip3 install --target=/awscli awscli && \
     dnf clean all
 


### PR DESCRIPTION
## Summary
- Adds the `sast-snyk-check-oci-ta` task to the Konflux build pipeline (`.tekton/rosa-github-release.yaml`)
- The `github-standard` Enterprise Contract policy requires this task for releases
- The `snyk-secret` is already provisioned in `rh-rosa-cli-tenant`; the task definition was simply missing from the pipeline

## Test plan
- [x] Pre-push checks pass locally
- [ ] Konflux build triggered by tag push includes the snyk check
- [ ] EC verification passes with the task present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional security scan to the image build pipeline.
  - The scan runs automatically after image creation and can be skipped when needed.
  - Scan results are generated from the built image and associated source artifacts.

- **Improvements**
  - Updated the builder environment to support creating ZIP archives.
  - This enables workflows that package build outputs in ZIP format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->