### PR TITLE
ROSAENG-5657 | chore: generate SHA256SUMS file for Konflux GitHub releases

### DIFF
--- a/hack/build_cli.sh
+++ b/hack/build_cli.sh
@@ -32,3 +32,5 @@ done
 }
 
 build_release
+
+(cd releases && sha256sum -- *.tar.gz *.zip > rosa_SHA256SUMS)


### PR DESCRIPTION
## Summary
- Generates a `rosa_SHA256SUMS` file in the `releases/` directory after building all archives
- The `release-to-github` managed pipeline's `collect-gh-params` task expects a `*_SHA256SUMS` file to exist; without it the release fails with `StopIteration`

## Test plan
- [x] Pre-push checks pass
- [ ] Konflux build produces `releases/rosa_SHA256SUMS` in the container image
- [ ] `collect-gh-params` task finds the checksums file and proceeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SHA-256 checksum files for release archives, improving download verification.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->