### PR TITLE
ROSAENG-5657 | fix: include version in SHA256SUMS filename

### DIFF
--- a/hack/build_cli.sh
+++ b/hack/build_cli.sh
@@ -33,4 +33,12 @@ done
 
 build_release
 
-(cd releases && sha256sum -- *.tar.gz *.zip > rosa_SHA256SUMS)
+release_version=$(git describe --tags --exact-match 2>/dev/null || git rev-parse --short HEAD)
+release_version=${release_version#v}
+
+if [[ ! "$release_version" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+  echo "ERROR: unexpected release_version '${release_version}'" >&2
+  exit 1
+fi
+
+(cd releases && sha256sum -- *.tar.gz *.zip > "rosa_${release_version}_SHA256SUMS")


### PR DESCRIPTION
## Summary
- Include the version in the `SHA256SUMS` filename so `collect-gh-params` can parse it

## Why
The Konflux `collect-gh-params` task expects `rosa_<version>_SHA256SUMS` but the build was producing `rosa_SHA256SUMS`. This caused:

```
RuntimeError: Malformed SHA256SUMS filename: 'rosa_SHA256SUMS'.
Expected format: '<name>_<version>_SHA256SUMS'
```

## Change
Derive the version from `git describe --tags --exact-match` (falls back to short SHA) and embed it in the checksum filename, matching what the release pipeline expects.

## Test plan
- [x] Local `make rosa` builds successfully
- [x] Pre-push checks pass (fmt, lint, build, tests)
- [ ] Konflux build pipeline produces `rosa_<version>_SHA256SUMS`
- [ ] `collect-gh-params` parses the filename without error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Checksum files now use the exact release tag when available, or the short commit version otherwise.
  * Leading `v` characters are removed from version identifiers for consistent naming.
  * Checksum generation now validates the release version before creating output.
  * Checksum filenames now include the release version for easier identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->