### PR TITLE
ROSAENG-63262 | refactor: separate validation concerns and classify workflow errors for the CLI boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,8 @@ Use this file as the starting point for repository context. When this file point
   - Request and Result type naming, construction, optional-value handling, and the lifecycle for reusable workflow functions in `pkg/`.
 - `guidelines/security.md`
   - Secret handling, gitleaks policy, and credential safety expectations.
+- `guidelines/error-conventions.md`
+  - Error handling at the CLI/core boundary: wrapping, typed errors, CLI translation, exit codes, and diagnostic context.
 
 ## Codebase Map
 

--- a/cmd/create/iamserviceaccount/cmd.go
+++ b/cmd/create/iamserviceaccount/cmd.go
@@ -16,14 +16,17 @@ package iamserviceaccount
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
 
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
-	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/aws/rolebridge"
+	rosaerrors "github.com/openshift/rosa/pkg/errors"
 	"github.com/openshift/rosa/pkg/iamserviceaccount"
 	iamServiceAccountOpts "github.com/openshift/rosa/pkg/options/iamserviceaccount"
 	"github.com/openshift/rosa/pkg/rosa"
@@ -40,7 +43,7 @@ var Cmd = NewCreateIamServiceAccountCommand()
 func CreateIamServiceAccountRunner(
 	userOptions *iamServiceAccountOpts.CreateIamServiceAccountUserOptions,
 ) rosa.CommandRunner {
-	return func(ctx context.Context, r *rosa.Runtime, cmd *cobra.Command, argv []string) error {
+	return func(ctx context.Context, r *rosa.Runtime, cmd *cobra.Command, argv []string) (err error) {
 		cluster := r.FetchCluster()
 
 		// Validate cluster has STS enabled
@@ -48,40 +51,89 @@ func CreateIamServiceAccountRunner(
 			return fmt.Errorf("cluster '%s' is not an STS cluster", cluster.Name())
 		}
 
+		// Early feedback before any AWS API call (GetCreator, the OIDC
+		// provider lookup); see "Intentional duplication" in
+		// guidelines/workflow-conventions.md. CreateIAMServiceAccountRequest.
+		// Validate() checks all of this again: pkg/iamserviceaccount may
+		// eventually be called by something other than this CLI, so it must
+		// not assume these checks already ran.
+		//
+		// Usage is shown only for the checks below where a required flag was
+		// not supplied at all: that's the one case where reminding the
+		// caller of the command's flags actually helps. A value that was
+		// supplied but is malformed (an invalid ARN, an empty inline policy)
+		// is explained by its own error message; showing the full flag list
+		// alongside it reads as "your flags are wrong" when they aren't.
+		if len(userOptions.ServiceAccountNames) == 0 {
+			_ = cmd.Usage()
+			return &rosaerrors.ValidationError{
+				Field: "ServiceAccounts", Message: "at least one service account name is required",
+			}
+		}
+		if len(userOptions.PolicyArns) == 0 && userOptions.InlinePolicy == "" {
+			_ = cmd.Usage()
+			return &rosaerrors.ValidationError{Message: "at least one policy ARN or inline policy must be specified"}
+		}
+		for i, policyARN := range userOptions.PolicyArns {
+			if policyARN == "" {
+				return &rosaerrors.ValidationError{
+					Field:   "PolicyARNs",
+					Message: fmt.Sprintf("policy ARN at index %d is empty", i),
+				}
+			}
+			parsed, err := arn.Parse(policyARN)
+			if err != nil {
+				return &rosaerrors.ValidationError{
+					Field:   "PolicyARNs",
+					Message: fmt.Sprintf("policy ARN at index %d is invalid", i),
+					Err:     err,
+				}
+			}
+			if parsed.Service != "iam" || !strings.HasPrefix(parsed.Resource, "policy/") ||
+				strings.HasSuffix(parsed.Resource, "/") {
+				return &rosaerrors.ValidationError{
+					Field:   "PolicyARNs",
+					Message: fmt.Sprintf("policy ARN at index %d is not an IAM policy ARN", i),
+				}
+			}
+		}
+		if userOptions.RoleName == "" && len(userOptions.ServiceAccountNames) > 1 {
+			_ = cmd.Usage()
+			return &rosaerrors.ValidationError{
+				Field:   "RoleName",
+				Message: "role name is required when specifying multiple service accounts",
+			}
+		}
+
+		// nil means "no inline policy requested," which must be decided by
+		// whether the flag was provided, not by what it resolves to: a
+		// file:// reference that resolves to empty content is a request for
+		// an (invalid) empty inline policy, not the absence of one. Checked
+		// here, before any AWS call, as well as in domain validation; see
+		// "Intentional duplication" in guidelines/workflow-conventions.md.
+		var inlinePolicy *string
+		if userOptions.InlinePolicy != "" {
+			resolved, err := resolveInlinePolicy(userOptions.InlinePolicy)
+			if err != nil {
+				return err
+			}
+			if resolved == "" {
+				return &rosaerrors.ValidationError{
+					Field: "InlinePolicy", Message: "inline policy must not be empty when provided",
+				}
+			}
+			if !json.Valid([]byte(resolved)) {
+				return &rosaerrors.ValidationError{
+					Field: "InlinePolicy", Message: "inline policy must be valid JSON",
+				}
+			}
+			inlinePolicy = &resolved
+		}
+
 		// Get AWS creator information to determine partition for FedRAMP
 		creator, err := r.AWSClient.GetCreator()
 		if err != nil {
-			return fmt.Errorf("failed to get AWS creator information: %s", err)
-		}
-
-		// Validate service account names
-		if len(userOptions.ServiceAccountNames) == 0 {
-			return fmt.Errorf("at least one service account name is required")
-		}
-
-		// Validate that at least one policy is specified
-		if len(userOptions.PolicyArns) == 0 && userOptions.InlinePolicy == "" {
-			return fmt.Errorf("at least one policy ARN or inline policy must be specified")
-		}
-
-		// Validate policy ARNs
-		for _, arn := range userOptions.PolicyArns {
-			if err := aws.ARNValidator(arn); err != nil {
-				return fmt.Errorf("invalid policy ARN '%s': %s", arn, err)
-			}
-		}
-
-		// Generate role name if not provided
-		roleName := userOptions.RoleName
-		if roleName == "" {
-			if len(userOptions.ServiceAccountNames) > 1 {
-				return fmt.Errorf("role name is required when specifying multiple service accounts")
-			}
-			roleName = iamserviceaccount.GenerateRoleName(
-				cluster.Name(),
-				userOptions.Namespace,
-				userOptions.ServiceAccountNames[0],
-			)
+			return fmt.Errorf("failed to get AWS creator information: %w", err)
 		}
 
 		serviceAccounts := make([]iamserviceaccount.ServiceAccountIdentifier, len(userOptions.ServiceAccountNames))
@@ -94,71 +146,62 @@ func CreateIamServiceAccountRunner(
 
 		oidcProviderARN, err := getOIDCProviderARN(r, cluster)
 		if err != nil {
-			return fmt.Errorf("failed to get OIDC provider ARN: %s", err)
+			return fmt.Errorf("failed to get OIDC provider ARN: %w", err)
 		}
 
-		trustPolicy := iamserviceaccount.GenerateTrustPolicyMultiple(oidcProviderARN, serviceAccounts)
-		tags := iamserviceaccount.GenerateDefaultTags(
-			cluster.Name(),
-			userOptions.Namespace,
-			userOptions.ServiceAccountNames[0],
-		)
+		req := iamserviceaccount.CreateIAMServiceAccountRequest{
+			ClusterName:         cluster.Name(),
+			OIDCProviderARN:     oidcProviderARN,
+			ServiceAccounts:     serviceAccounts,
+			RoleName:            nilIfEmpty(userOptions.RoleName),
+			PolicyARNs:          userOptions.PolicyArns,
+			InlinePolicy:        inlinePolicy,
+			PermissionsBoundary: nilIfEmpty(userOptions.PermissionsBoundary),
+			Path:                nilIfEmpty(userOptions.Path),
+			AccountID:           creator.AccountID,
+			Partition:           creator.Partition,
+			IsGovcloud:          creator.IsGovcloud,
+		}
 
-		managedPolicies := false
-		roleARN, err := r.AWSClient.EnsureRole(
-			r.Reporter,
-			roleName,
-			trustPolicy,
-			userOptions.PermissionsBoundary,
-			"",
-			tags,
-			userOptions.Path,
-			managedPolicies,
-		)
+		adapter := rolebridge.New(r.AWSClient, r.Reporter)
+		service := &iamserviceaccount.Service{}
+		result, err := service.CreateIAMServiceAccount(ctx, adapter, req)
 		if err != nil {
-			return fmt.Errorf("failed to create role: %s", err)
+			return err
 		}
 
-		// For FedRAMP environments, update the role ARN to use the correct partition
-		if creator.IsGovcloud {
-			roleARN = iamserviceaccount.GetRoleARN(creator.AccountID, roleName, userOptions.Path, creator.Partition)
-		}
-
-		r.Reporter.Infof("Created IAM role '%s' with ARN '%s' using OIDC '%s'", roleName, roleARN, oidcProviderARN)
-
-		// Attach managed policies
-		for _, policyARN := range userOptions.PolicyArns {
-			err = r.AWSClient.AttachRolePolicy(r.Reporter, roleName, policyARN)
-			if err != nil {
-				return fmt.Errorf("failed to attach policy '%s' to role '%s': %s", policyARN, roleName, err)
-			}
-		}
-
-		// Handle inline policy
-		if userOptions.InlinePolicy != "" {
-			inlinePolicy := userOptions.InlinePolicy
-
-			// Process inline policy if it's a file reference
-			if after, ok := strings.CutPrefix(inlinePolicy, "file://"); ok {
-				policyPath := after
-				policyBytes, err := os.ReadFile(policyPath)
-				if err != nil {
-					return fmt.Errorf("failed to read policy file '%s': %s", policyPath, err)
-				}
-				inlinePolicy = string(policyBytes)
-			}
-
-			// Generate inline policy name
-			policyName := fmt.Sprintf("%s-inline-policy", roleName)
-			err = r.AWSClient.PutRolePolicy(roleName, policyName, inlinePolicy)
-			if err != nil {
-				return fmt.Errorf("failed to attach inline policy to role '%s': %s", roleName, err)
-			}
-			r.Reporter.Infof("Attached inline policy '%s' to role '%s'", policyName, roleName)
+		r.Reporter.Infof("Created IAM role '%s' with ARN '%s' using OIDC '%s'",
+			result.RoleName, result.RoleARN, oidcProviderARN)
+		if result.InlinePolicyName != "" {
+			r.Reporter.Infof("Attached inline policy '%s' to role '%s'", result.InlinePolicyName, result.RoleName)
 		}
 
 		return nil
 	}
+}
+
+// resolveInlinePolicy returns the inline policy document, reading it from
+// disk when raw is a file:// reference. raw must be non-empty.
+func resolveInlinePolicy(raw string) (string, error) {
+	policyPath, ok := strings.CutPrefix(raw, "file://")
+	if !ok {
+		return raw, nil
+	}
+	policyBytes, err := os.ReadFile(policyPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read policy file '%s': %w", policyPath, err)
+	}
+	return string(policyBytes), nil
+}
+
+// nilIfEmpty converts a CLI option's zero-value string into a nil pointer,
+// matching CreateIAMServiceAccountRequest's "not provided" representation
+// for optional fields.
+func nilIfEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
 }
 
 func getOIDCProviderARN(r *rosa.Runtime, cluster *cmv1.Cluster) (string, error) {
@@ -168,8 +211,10 @@ func getOIDCProviderARN(r *rosa.Runtime, cluster *cmv1.Cluster) (string, error) 
 	}
 
 	providerArn, err := r.AWSClient.GetOpenIDConnectProviderByOidcEndpointUrl(oidcConfigEndpointUrl)
-
-	if err != nil || providerArn == "" {
+	if err != nil {
+		return "", fmt.Errorf("failed to get OIDC provider for cluster with ID '%s': %w", cluster.ID(), err)
+	}
+	if providerArn == "" {
 		return "", fmt.Errorf("no OIDC provider found for cluster with ID '%s'", cluster.ID())
 	}
 

--- a/cmd/create/iamserviceaccount/cmd_test.go
+++ b/cmd/create/iamserviceaccount/cmd_test.go
@@ -15,7 +15,11 @@ limitations under the License.
 package iamserviceaccount
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"os"
+	"path/filepath"
 
 	"go.uber.org/mock/gomock"
 
@@ -25,6 +29,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/rosa/pkg/aws"
+	rosaerrors "github.com/openshift/rosa/pkg/errors"
 	iamServiceAccountOpts "github.com/openshift/rosa/pkg/options/iamserviceaccount"
 	"github.com/openshift/rosa/pkg/test"
 )
@@ -139,7 +144,294 @@ var _ = Describe("Create IAM Service Account", func() {
 
 				t.SetCluster(cluster.ID(), cluster)
 
-				// Mock GetCreator to return standard AWS creator
+				// No GetCreator mock: the missing policies must be caught by
+				// the CLI's fail-fast check before that (AWS API) call ever
+				// happens.
+
+				options := &iamServiceAccountOpts.CreateIamServiceAccountUserOptions{
+					ServiceAccountNames: []string{"test-sa"},
+					Namespace:           "default",
+					// No policies provided
+				}
+				testRunner := CreateIamServiceAccountRunner(options)
+
+				var out bytes.Buffer
+				cmd.SetOut(&out)
+				cmd.SetErr(&out)
+
+				err := testRunner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("at least one policy ARN or inline policy must be specified"))
+
+				var validationErr *rosaerrors.ValidationError
+				Expect(errors.As(err, &validationErr)).To(BeTrue())
+				Expect(out.String()).To(ContainSubstring("Usage:"))
+			})
+
+			It("should fail when no service account names are provided", func() {
+				cluster := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+					c.ID("test-cluster-id")
+					c.Name("test-cluster")
+					c.AWS(cmv1.NewAWS().
+						STS(cmv1.NewSTS().
+							RoleARN("arn:aws:iam::123456789012:role/test-role")))
+				})
+
+				t.SetCluster(cluster.ID(), cluster)
+
+				// No GetCreator mock: the missing service account names must
+				// be caught by the CLI's fail-fast check before that (AWS
+				// API) call ever happens.
+
+				options := &iamServiceAccountOpts.CreateIamServiceAccountUserOptions{
+					Namespace:  "default",
+					PolicyArns: []string{"arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"},
+					// No service account names provided
+				}
+				testRunner := CreateIamServiceAccountRunner(options)
+
+				var out bytes.Buffer
+				cmd.SetOut(&out)
+				cmd.SetErr(&out)
+
+				err := testRunner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("at least one service account name is required"))
+
+				var validationErr *rosaerrors.ValidationError
+				Expect(errors.As(err, &validationErr)).To(BeTrue())
+				Expect(out.String()).To(ContainSubstring("Usage:"))
+			})
+
+			It("should classify a malformed policy ARN as a validation error without showing usage", func() {
+				cluster := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+					c.ID("test-cluster-id")
+					c.Name("test-cluster")
+					c.AWS(cmv1.NewAWS().
+						STS(cmv1.NewSTS().
+							RoleARN("arn:aws:iam::123456789012:role/test-role").
+							OidcConfig(cmv1.NewOidcConfig().
+								ID("test-oidc-id").
+								IssuerUrl("https://test.example.com")).
+							OIDCEndpointURL("https://test.example.com")))
+				})
+
+				t.SetCluster(cluster.ID(), cluster)
+
+				// No GetCreator or GetOpenIDConnectProviderByOidcEndpointUrl
+				// mock: the malformed ARN must be caught by the CLI's
+				// fail-fast check before either (AWS API) call ever happens.
+
+				options := &iamServiceAccountOpts.CreateIamServiceAccountUserOptions{
+					ServiceAccountNames: []string{"test-sa"},
+					Namespace:           "default",
+					PolicyArns:          []string{"not-a-valid-arn"},
+				}
+				testRunner := CreateIamServiceAccountRunner(options)
+
+				var out bytes.Buffer
+				cmd.SetOut(&out)
+				cmd.SetErr(&out)
+
+				err := testRunner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("policy ARN at index 0 is invalid"))
+
+				var validationErr *rosaerrors.ValidationError
+				Expect(errors.As(err, &validationErr)).To(BeTrue())
+			})
+
+			It("should classify a non-IAM-policy ARN as a validation error", func() {
+				cluster := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+					c.ID("test-cluster-id")
+					c.Name("test-cluster")
+					c.AWS(cmv1.NewAWS().
+						STS(cmv1.NewSTS().
+							RoleARN("arn:aws:iam::123456789012:role/test-role").
+							OidcConfig(cmv1.NewOidcConfig().
+								ID("test-oidc-id").
+								IssuerUrl("https://test.example.com")).
+							OIDCEndpointURL("https://test.example.com")))
+				})
+
+				t.SetCluster(cluster.ID(), cluster)
+
+				// No GetCreator or GetOpenIDConnectProviderByOidcEndpointUrl
+				// mock: the non-IAM-policy ARN must be caught by the CLI's
+				// fail-fast check before either (AWS API) call ever happens.
+
+				options := &iamServiceAccountOpts.CreateIamServiceAccountUserOptions{
+					ServiceAccountNames: []string{"test-sa"},
+					Namespace:           "default",
+					PolicyArns:          []string{"arn:aws:s3:::my-bucket"},
+				}
+				testRunner := CreateIamServiceAccountRunner(options)
+
+				err := testRunner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("policy ARN at index 0 is not an IAM policy ARN"))
+
+				var validationErr *rosaerrors.ValidationError
+				Expect(errors.As(err, &validationErr)).To(BeTrue())
+			})
+
+			It("should classify a policy ARN with no policy name as a validation error", func() {
+				cluster := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+					c.ID("test-cluster-id")
+					c.Name("test-cluster")
+					c.AWS(cmv1.NewAWS().
+						STS(cmv1.NewSTS().
+							RoleARN("arn:aws:iam::123456789012:role/test-role").
+							OidcConfig(cmv1.NewOidcConfig().
+								ID("test-oidc-id").
+								IssuerUrl("https://test.example.com")).
+							OIDCEndpointURL("https://test.example.com")))
+				})
+
+				t.SetCluster(cluster.ID(), cluster)
+
+				// No GetCreator or GetOpenIDConnectProviderByOidcEndpointUrl
+				// mock: the malformed ARN must be caught by the CLI's
+				// fail-fast check before either (AWS API) call ever happens.
+
+				options := &iamServiceAccountOpts.CreateIamServiceAccountUserOptions{
+					ServiceAccountNames: []string{"test-sa"},
+					Namespace:           "default",
+					PolicyArns:          []string{"arn:aws:iam::123456789012:policy/"},
+				}
+				testRunner := CreateIamServiceAccountRunner(options)
+
+				err := testRunner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("policy ARN at index 0 is not an IAM policy ARN"))
+
+				var validationErr *rosaerrors.ValidationError
+				Expect(errors.As(err, &validationErr)).To(BeTrue())
+			})
+
+			It("should classify a policy ARN with a trailing slash as a validation error", func() {
+				cluster := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+					c.ID("test-cluster-id")
+					c.Name("test-cluster")
+					c.AWS(cmv1.NewAWS().
+						STS(cmv1.NewSTS().
+							RoleARN("arn:aws:iam::123456789012:role/test-role").
+							OidcConfig(cmv1.NewOidcConfig().
+								ID("test-oidc-id").
+								IssuerUrl("https://test.example.com")).
+							OIDCEndpointURL("https://test.example.com")))
+				})
+
+				t.SetCluster(cluster.ID(), cluster)
+
+				// No GetCreator or GetOpenIDConnectProviderByOidcEndpointUrl
+				// mock: the malformed ARN must be caught by the CLI's
+				// fail-fast check before either (AWS API) call ever happens.
+
+				options := &iamServiceAccountOpts.CreateIamServiceAccountUserOptions{
+					ServiceAccountNames: []string{"test-sa"},
+					Namespace:           "default",
+					PolicyArns:          []string{"arn:aws:iam::123456789012:policy/MyPolicy/"},
+				}
+				testRunner := CreateIamServiceAccountRunner(options)
+
+				err := testRunner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("policy ARN at index 0 is not an IAM policy ARN"))
+
+				var validationErr *rosaerrors.ValidationError
+				Expect(errors.As(err, &validationErr)).To(BeTrue())
+			})
+
+			It("should classify malformed inline policy JSON as a validation error without making AWS calls", func() {
+				cluster := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+					c.ID("test-cluster-id")
+					c.Name("test-cluster")
+					c.AWS(cmv1.NewAWS().
+						STS(cmv1.NewSTS().
+							RoleARN("arn:aws:iam::123456789012:role/test-role").
+							OidcConfig(cmv1.NewOidcConfig().
+								ID("test-oidc-id").
+								IssuerUrl("https://test.example.com")).
+							OIDCEndpointURL("https://test.example.com")))
+				})
+
+				t.SetCluster(cluster.ID(), cluster)
+
+				// No GetCreator or GetOpenIDConnectProviderByOidcEndpointUrl
+				// mock: the malformed inline policy must be caught by the
+				// CLI's fail-fast check before either (AWS API) call ever
+				// happens.
+
+				options := &iamServiceAccountOpts.CreateIamServiceAccountUserOptions{
+					ServiceAccountNames: []string{"test-sa"},
+					Namespace:           "default",
+					InlinePolicy:        `{"Version": "2012-10-17", "Statement": [`,
+				}
+				testRunner := CreateIamServiceAccountRunner(options)
+
+				err := testRunner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("inline policy must be valid JSON"))
+
+				var validationErr *rosaerrors.ValidationError
+				Expect(errors.As(err, &validationErr)).To(BeTrue())
+			})
+
+			It("should fail fast on multiple service accounts without a role name, before the OIDC lookup", func() {
+				cluster := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+					c.ID("test-cluster-id")
+					c.Name("test-cluster")
+					c.AWS(cmv1.NewAWS().
+						STS(cmv1.NewSTS().
+							RoleARN("arn:aws:iam::123456789012:role/test-role").
+							OidcConfig(cmv1.NewOidcConfig().
+								ID("test-oidc-id").
+								IssuerUrl("https://test.example.com")).
+							OIDCEndpointURL("https://test.example.com")))
+				})
+
+				t.SetCluster(cluster.ID(), cluster)
+
+				// No GetCreator or GetOpenIDConnectProviderByOidcEndpointUrl
+				// mock: the missing role name must be caught by the CLI's
+				// fail-fast check before either (AWS API) call ever happens.
+
+				options := &iamServiceAccountOpts.CreateIamServiceAccountUserOptions{
+					ServiceAccountNames: []string{"app-one", "app-two"},
+					Namespace:           "default",
+					PolicyArns:          []string{"arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"},
+				}
+				testRunner := CreateIamServiceAccountRunner(options)
+
+				var out bytes.Buffer
+				cmd.SetOut(&out)
+				cmd.SetErr(&out)
+
+				err := testRunner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("role name is required when specifying multiple service accounts"))
+
+				var validationErr *rosaerrors.ValidationError
+				Expect(errors.As(err, &validationErr)).To(BeTrue())
+				Expect(out.String()).To(ContainSubstring("Usage:"))
+			})
+
+			It("should not classify an EnsureRole failure as a validation error or show usage", func() {
+				cluster := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+					c.ID("test-cluster-id")
+					c.Name("test-cluster")
+					c.AWS(cmv1.NewAWS().
+						STS(cmv1.NewSTS().
+							RoleARN("arn:aws:iam::123456789012:role/test-role").
+							OidcConfig(cmv1.NewOidcConfig().
+								ID("test-oidc-id").
+								IssuerUrl("https://test.example.com")).
+							OIDCEndpointURL("https://test.example.com")))
+				})
+
+				t.SetCluster(cluster.ID(), cluster)
+
 				mockAWS.EXPECT().
 					GetCreator().
 					Return(&aws.Creator{
@@ -150,16 +442,38 @@ var _ = Describe("Create IAM Service Account", func() {
 						Partition:  "aws",
 					}, nil)
 
+				providers := []aws.OidcProviderOutput{
+					{
+						Arn: "arn:aws:iam::123456789012:oidc-provider/test.example.com",
+					},
+				}
+
+				mockAWS.EXPECT().
+					GetOpenIDConnectProviderByOidcEndpointUrl("https://test.example.com").
+					Return(providers[0].Arn, nil)
+
+				mockAWS.EXPECT().
+					EnsureRole(gomock.Any(), gomock.Any(), gomock.Any(), "", "", gomock.Any(), gomock.Any(), false).
+					Return("", errors.New("access denied"))
+
 				options := &iamServiceAccountOpts.CreateIamServiceAccountUserOptions{
 					ServiceAccountNames: []string{"test-sa"},
 					Namespace:           "default",
-					// No policies provided
+					PolicyArns:          []string{"arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"},
 				}
 				testRunner := CreateIamServiceAccountRunner(options)
 
+				var out bytes.Buffer
+				cmd.SetOut(&out)
+				cmd.SetErr(&out)
+
 				err := testRunner(context.Background(), t.RosaRuntime, cmd, []string{})
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("at least one policy ARN or inline policy must be specified"))
+				Expect(err.Error()).To(ContainSubstring("failed to create role"))
+
+				var validationErr *rosaerrors.ValidationError
+				Expect(errors.As(err, &validationErr)).To(BeFalse())
+				Expect(out.String()).To(BeEmpty())
 			})
 
 			It("should create a service account role with inline policy", func() {
@@ -215,6 +529,47 @@ var _ = Describe("Create IAM Service Account", func() {
 
 				err := testRunner(context.Background(), t.RosaRuntime, cmd, []string{})
 				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should reject a file:// inline policy that resolves to empty content instead of silently dropping it", func() {
+				cluster := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+					c.ID("test-cluster-id")
+					c.Name("test-cluster")
+					c.AWS(cmv1.NewAWS().
+						STS(cmv1.NewSTS().
+							RoleARN("arn:aws:iam::123456789012:role/test-role").
+							OidcConfig(cmv1.NewOidcConfig().
+								ID("test-oidc-id").
+								IssuerUrl("https://test.example.com")).
+							OIDCEndpointURL("https://test.example.com")))
+				})
+
+				t.SetCluster(cluster.ID(), cluster)
+
+				// No GetCreator or GetOpenIDConnectProviderByOidcEndpointUrl
+				// mock: the empty resolved inline policy must be caught by
+				// the CLI's fail-fast check before either (AWS API) call
+				// ever happens.
+
+				emptyPolicyPath := filepath.Join(GinkgoT().TempDir(), "empty-policy.json")
+				Expect(os.WriteFile(emptyPolicyPath, []byte{}, 0o600)).To(Succeed())
+
+				options := &iamServiceAccountOpts.CreateIamServiceAccountUserOptions{
+					ServiceAccountNames: []string{"test-sa"},
+					Namespace:           "default",
+					InlinePolicy:        "file://" + emptyPolicyPath,
+				}
+				testRunner := CreateIamServiceAccountRunner(options)
+
+				err := testRunner(context.Background(), t.RosaRuntime, cmd, []string{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("inline policy must not be empty when provided"))
+
+				var validationErr *rosaerrors.ValidationError
+				Expect(errors.As(err, &validationErr)).To(BeTrue())
+
+				// No EnsureRole/PutRolePolicy mock was set up above; gomock
+				// fails the test if either was called with an invalid request.
 			})
 
 			It("should handle FedRAMP environment correctly", func() {
@@ -322,6 +677,29 @@ var _ = Describe("Create IAM Service Account", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("no OIDC provider found for cluster with ID " +
 				"'test-cluster-id'"))
+		})
+
+		It("should preserve the underlying AWS error when the provider lookup call fails", func() {
+			cluster := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.ID("test-cluster-id")
+				c.Name("test-cluster")
+				c.AWS(cmv1.NewAWS().
+					STS(cmv1.NewSTS().
+						OidcConfig(cmv1.NewOidcConfig().
+							ID("test-oidc-id").
+							IssuerUrl("https://test.example.com")).
+						OIDCEndpointURL("https://test123.example.com")))
+			})
+
+			mockAWS.EXPECT().
+				GetOpenIDConnectProviderByOidcEndpointUrl("https://test123.example.com").
+				Return("", errors.New("access denied"))
+
+			_, err := getOIDCProviderARN(t.RosaRuntime, cluster)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to get OIDC provider for cluster with ID " +
+				"'test-cluster-id'"))
+			Expect(errors.Unwrap(err)).To(MatchError("access denied"))
 		})
 	})
 })

--- a/guidelines/ARCHITECTURE.md
+++ b/guidelines/ARCHITECTURE.md
@@ -189,6 +189,7 @@ around them.
 | Business logic (create pool, validate labels, build OCM request) | `pkg/` | `machinepool.CreateMachinePool(...)` |
 | Request/Result types (workflow boundary contract) | `pkg/` | `machinepool.CreateMachinePoolRequest`, `CreateMachinePoolResult` |
 | Domain types and validation | `pkg/` | `machinepool.MachinePool`, `ValidateLabels` |
+| Shared error types (CLI/core boundary) | `pkg/` | `errors.ValidationError` |
 | Constants (tag keys, property keys, env var names) | `pkg/` | `aws/tags`, `properties`, `constants` |
 | AWS SDK operations | `internal/core/` | `aws.Client.CreateRole(...)` |
 | OCM API operations | `internal/core/` | `ocm.Client.CreateCluster(...)` |

--- a/guidelines/error-conventions.md
+++ b/guidelines/error-conventions.md
@@ -1,0 +1,336 @@
+# Error Conventions
+
+## Scope
+
+Use this file when writing or modifying code that produces, propagates, or
+translates errors across the CLI/core boundary described in
+[ARCHITECTURE.md](ARCHITECTURE.md). For Request/Result lifecycle conventions,
+see [workflow-conventions.md](workflow-conventions.md).
+
+## Principle
+
+Core layer code (`pkg/`) returns errors. CLI layer code (`cmd/`) decides how
+to present them to the user and whether to exit the process. The core layer
+never controls the user experience of a failure.
+
+## Core Layer Error Rules
+
+### Error string formatting
+
+Error strings must start with a lowercase letter and must not end with
+punctuation, per Go convention (enforced by `staticcheck`'s ST1005). They
+are often wrapped into a larger sentence by a caller:
+
+```go
+// Good
+return fmt.Errorf("failed to create role: %w", err)
+
+// Bad: capitalized and punctuated as if it were a standalone sentence.
+return fmt.Errorf("Failed to create role: %w.", err)
+```
+
+### Return errors, never exit
+
+Core layer functions must return errors to their caller. They must not:
+
+- Call `os.Exit`.
+- Call `reporter.Errorf` or any reporter method.
+- Call `log.Fatal` or any function that terminates the process.
+- Depend on Cobra usage-error behavior (e.g., `cmd.Usage()`).
+
+```go
+// Good: return the error for the caller to handle.
+func (s *Service) CreateIAMServiceAccount(ctx context.Context, client CreateIAMServiceAccountClient,
+    req CreateIAMServiceAccountRequest) (*CreateIAMServiceAccountResult, error) {
+    if err := req.Validate(); err != nil {
+        return nil, &rosaerrors.ValidationError{Err: fmt.Errorf("invalid request: %w", err)}
+    }
+    // ...
+}
+
+// Bad: core code should not exit or log to the user.
+func CreateRole(reporter reporter.Logger, roleName string) {
+    // ...
+    reporter.Errorf("Failed to create role: %s", err)
+    os.Exit(1)
+}
+```
+
+Functions in `pkg/rosa/runtime.go` currently call `os.Exit` in methods like
+`FetchCluster` and `WithAWS`. This is a known legacy pattern. New code must
+not follow it.
+
+### Wrap with context using %w
+
+When a function catches an error from a lower layer, wrap it with
+`fmt.Errorf` and the `%w` verb so the original error remains available for
+matching with `errors.Is` and `errors.As`:
+
+```go
+roleARN, err := client.EnsureRole(ctx, roleName, trustPolicy, ...)
+if err != nil {
+    return nil, fmt.Errorf("failed to create role: %w", err)
+}
+```
+
+The wrapping message should describe what the current function was trying to
+do, not repeat the underlying error's message. The result reads as a chain:
+
+```
+failed to create role: AccessDenied: User is not authorized to perform iam:CreateRole
+```
+
+### Do not wrap with static messages that lose the cause
+
+Wrapping without `%w` discards the error chain:
+
+```go
+// Bad: the original error is converted to a string and cannot be matched.
+return fmt.Errorf("failed to create role: %s", err)
+
+// Good: the original error is preserved in the chain.
+return fmt.Errorf("failed to create role: %w", err)
+```
+
+## Error Types
+
+### When to use each form
+
+| Form | When to use | How the caller matches |
+|------|-------------|----------------------|
+| `fmt.Errorf("...: %w", err)` | Default. Wrapping an error from a lower layer. | `errors.Is(err, target)` or `errors.As(err, &target)` on the wrapped cause |
+| Typed error (struct) | The caller needs to inspect structured fields or branch on the error category. | `errors.As(err, &typedErr)` |
+| Sentinel (`var ErrX = errors.New(...)`) | The caller needs to branch on one specific, fixed condition. | `errors.Is(err, ErrX)` |
+
+Don't create a typed error or sentinel speculatively for every failure path.
+Most errors are adequately served by `fmt.Errorf` with `%w` wrapping; add a
+type or sentinel only where a caller genuinely needs to branch on it.
+
+### `rosaerrors.ValidationError`: the one shared classification every workflow uses
+
+`pkg/errors.ValidationError` marks the one error condition every workflow
+that follows the [Request/Validate() pattern](workflow-conventions.md#validation)
+needs its caller to distinguish: "the request was invalid, no side effects
+occurred" versus "an operational step further into the workflow failed."
+See [Classifying validation errors](workflow-conventions.md#classifying-validation-errors)
+for the full pattern and rationale.
+
+`pkg/errors` shares its name with the standard library `errors` package
+(the package almost every caller also needs, for `errors.Is`/`errors.As`),
+so it is imported under an alias:
+
+```go
+// pkg/iamserviceaccount/create.go
+import rosaerrors "github.com/openshift/rosa/pkg/errors"
+```
+
+Individual validator functions return it directly, with `Field` set when
+the check maps to exactly one request field:
+
+```go
+func validateClusterName(r *CreateIAMServiceAccountRequest) []error {
+    if r.ClusterName == "" {
+        return []error{&rosaerrors.ValidationError{Field: "ClusterName", Message: "cluster name is required"}}
+    }
+    return nil
+}
+```
+
+`Field` is structured metadata only — `Error()` never renders it, so adding
+`Field` to a check never changes its user-facing text. It exists for a
+consumer that wants to branch or report on *which* field failed without
+parsing the message (a future `--output json` mode, a REST API, a TUI). When
+a check wraps a lower-level error, set `Err` too so the cause survives for
+`errors.Is`/`errors.As` instead of being flattened into the message string.
+
+The workflow function then wraps `Validate()`'s aggregate result the same
+way, this time with only `Err` set:
+
+```go
+func (s *Service) CreateIAMServiceAccount(ctx context.Context, client CreateIAMServiceAccountClient,
+    req CreateIAMServiceAccountRequest) (*CreateIAMServiceAccountResult, error) {
+    if err := req.Validate(); err != nil {
+        return nil, &rosaerrors.ValidationError{Err: fmt.Errorf("invalid request: %w", err)}
+    }
+    // ... EnsureRole/AttachRolePolicy/PutRolePolicy failures stay plain
+    // wrapped errors; they correctly do not match *rosaerrors.ValidationError.
+}
+```
+
+This aggregate wrap guarantees classification holds regardless of what any
+individual check returns, rather than relying on every check remembering to
+use the typed error.
+
+The CLI layer matches it via `errors.As` whenever it needs to know whether
+the request was invalid, independent of what it does with that information:
+
+```go
+result, err := service.CreateIAMServiceAccount(ctx, adapter, req)
+if err != nil {
+    return err
+}
+```
+
+`errors.As` recurses through the aggregate wrapper and the `errors.Join`
+tree of individual checks automatically, so one call finds a match
+regardless of which check failed, without the CLI layer needing to walk the
+tree itself.
+
+`rosaerrors.ValidationError` is shared by every workflow — do not define a
+per-workflow type such as `CreateIAMServiceAccountValidationError`. Callers
+only ever need to know "was this input invalid," never which workflow
+produced it.
+
+### Showing command usage
+
+Show `cmd.Usage()` only when a required flag was not supplied at all, not
+for every `rosaerrors.ValidationError`. A malformed value (an invalid ARN,
+an empty inline policy) already has its own error message; printing the
+full flag list next to it reads as "your flags are wrong" when the value
+was the problem.
+
+`cmd/create/iamserviceaccount/cmd.go` calls `cmd.Usage()` inline, only at
+the specific invocation checks that catch an entirely missing required
+value, before returning the `rosaerrors.ValidationError`:
+
+```go
+if len(userOptions.ServiceAccountNames) == 0 {
+    cmd.Usage()
+    return &rosaerrors.ValidationError{
+        Field: "ServiceAccounts", Message: "at least one service account name is required",
+    }
+}
+```
+
+It does not call `cmd.Usage()` for a malformed-value check (an invalid ARN
+format), nor for the aggregate `rosaerrors.ValidationError` that
+`service.CreateIAMServiceAccount` can return from domain validation: those
+failures are explained well enough by their own message.
+
+### Other error categories: typed errors and sentinels
+
+For an operational condition that needs its own distinct CLI handling — not
+"was input invalid," but something workflow-specific like "this role already
+exists in a different profile" — use a sentinel or a small typed error
+carrying data, scoped to that one condition, following existing repo
+precedent: `cmd/whoami/cmd.go`'s `errNotLoggedIn`, `cmd/create/ocmrole`'s
+`ErrRoleExistsWrongProfile`, `cmd/initialize/cmd.go`'s `errInitExitZero`.
+
+## CLI Layer Translation
+
+### The DefaultRunner pattern
+
+`rosa.DefaultRunner` is the standard error exit point for newer commands.
+A `CommandRunner` function returns an error; `DefaultRunner` prints it via
+`reporter.Errorf` and calls `os.Exit(1)`:
+
+```go
+// pkg/rosa/runner.go
+func DefaultRunner(visitor RuntimeVisitor, runner CommandRunner) func(command *cobra.Command, args []string) {
+    return func(command *cobra.Command, args []string) {
+        ctx := context.Background()
+        r := NewRuntime()
+        defer r.Cleanup()
+
+        if visitor != nil {
+            visitor(ctx, r, command, args)
+        }
+
+        if err := runner(ctx, r, command, args); err != nil {
+            r.Reporter.Errorf("%s", err)
+            os.Exit(1)
+        }
+    }
+}
+```
+
+Commands using `DefaultRunner` should return errors, not call `os.Exit`
+or `reporter.Errorf` for terminal failures.
+
+### Adding remediation guidance
+
+When the CLI layer can identify the error category, it can add guidance
+that would be inappropriate in the core layer (because the core layer does
+not know it is running inside a CLI). `cmd/create/iamserviceaccount/cmd.go`
+does this today by showing command usage for a missing-required-flag error
+(see [Showing command usage](#showing-command-usage) above). A command could
+go further and add remediation text for an operational failure the same way:
+
+```go
+result, err := service.CreateIAMServiceAccount(ctx, adapter, req)
+if err != nil {
+    var validationErr *rosaerrors.ValidationError
+    if errors.As(err, &validationErr) {
+        return err
+    }
+    // Illustrative: operational errors could get remediation context the
+    // core layer can't add. Not yet done for this command.
+    return fmt.Errorf("%w\n\nVerify that your AWS credentials are valid and "+
+        "that your IAM user has permission to create roles", err)
+}
+```
+
+Remediation strings are CLI concerns. The core layer should never embed
+guidance like "run `aws iam ...`" or "check your credentials" in its errors.
+
+### Exit codes
+
+The CLI layer decides the exit code. The core layer never returns or
+suggests an exit code. Currently, ROSA uses `0` for success and `1` for
+all failures. [ARCHITECTURE.md](ARCHITECTURE.md#backward-compatibility)
+prohibits introducing new exit codes during the migration to the target
+architecture. When that constraint is relaxed, the CLI layer would map
+error types to codes — the typed error infrastructure (`rosaerrors.ValidationError`
+and future categories) supports this, but it is not in use today.
+
+Since every failure exits `1` today, ordering matters more than the code
+itself: cheap checks that are likely to fail should run before expensive
+ones, so a doomed command exits on the cheapest possible check instead of
+paying for a network call first. See
+[Ordering within invocation validation](workflow-conventions.md#ordering-within-invocation-validation)
+for the phase breakdown.
+
+## Diagnostic Context
+
+### What to include in wrapped errors
+
+Include context that helps identify which operation failed and on what
+input. Include identifiers (role name, cluster ID, policy ARN) but not
+large payloads (full policy documents, API response bodies) or sensitive
+values (credentials, tokens, secrets), even when they would fit inline:
+
+```go
+// Good: identifies the operation and the resource.
+return fmt.Errorf("failed to attach policy '%s' to role '%s': %w", policyARN, roleName, err)
+
+// Bad: includes the entire policy document.
+return fmt.Errorf("failed to put inline policy %s on role %s: %w", policyDocument, roleName, err)
+
+// Bad: leaks a credential into logs, terminal history, and bug reports.
+return fmt.Errorf("failed to authenticate with token %s: %w", token, err)
+```
+
+### Reporter for non-fatal messages
+
+Use `reporter.Infof` and `reporter.Debugf` in the CLI layer for progress
+messages, warnings, and diagnostic output that are not errors:
+
+```go
+r.Reporter.Infof("Created IAM role '%s' with ARN '%s'", result.RoleName, result.RoleARN)
+r.Reporter.Debugf("Trust policy attached for OIDC provider '%s'", req.OIDCProviderARN)
+```
+
+The core layer must not call reporter methods. If the core layer needs to
+surface non-fatal warnings, return them as structured data in the Result
+type (see [workflow-conventions.md](workflow-conventions.md#what-a-result-contains)).
+
+## Review Prompts
+
+- Does the core layer return all errors without calling `os.Exit` or
+  reporter methods?
+- Are errors wrapped with `%w` so the cause chain is preserved?
+- Does the wrapping message describe what the current function was doing?
+- Can the CLI layer distinguish error categories when it needs to show
+  different messages or remediation guidance?
+- Are exit codes decided by the CLI layer, not the core layer?
+- Is remediation guidance in the CLI layer, not embedded in core errors?

--- a/guidelines/refactor/pkg-architecture.md
+++ b/guidelines/refactor/pkg-architecture.md
@@ -29,7 +29,7 @@ Target location: `pkg/` (stable, exported). Each entry shows **target name** wit
 | `pkg/clusterregistryconfig` | Needs split | Registry config spec building for hosted clusters and validation rules. |
 | `pkg/constants` | Needs split | Environment variable names (`ROSA_TOKEN`, `AWS_PROFILE`, `OCM_CONFIG`, etc.). OIDC flag-name and help-message constants in `oidc_constants.go` are CLI-specific and should be separated. |
 | `pkg/externalauthprovider` | Needs split | External auth provider creation via OCM, URL validation, and claim mapping logic. |
-| `pkg/fedramp` | Needs split | FedRAMP/GovCloud environment configuration: URL and token endpoint mappings per environment. |
+| `pkg/fedramp` | Needs split | FedRAMP/GovCloud environment configuration: URL and token endpoint mappings per environment, and GovCloud account-field validation. |
 | `pkg/utils` (`pkg/helper`) | Needs split | General-purpose utilities: random labels, string/slice operations, shell quoting, file saving, `IsBYOVPC` check. |
 | `pkg/utils/urlutil` (`pkg/helper/url`) | Clean | URL validation utilities: credential character checks, IPv6 literal host detection. |
 | `pkg/utils/fileutil` (`pkg/input`) | Needs split | YAML/JSON file unmarshalling and input helpers. |
@@ -47,6 +47,7 @@ Target location: `pkg/` (stable, exported). Each entry shows **target name** wit
 | `pkg/machinepool` | Needs split | Machine pool and node pool CRUD via OCM, replica/autoscaling validation, spot instance logic, root disk sizing, version compatibility checks. Most entangled package. |
 | `pkg/properties` | Clean | OCM cluster property key constants (`rosa_cli_version`, `fake_cluster`, etc.). |
 | `pkg/version` | Needs split | Version retrieval from mirror.openshift.com, comparison logic, cache-backed version list. Reusable API for TUIs, automation, and other non-CLI consumers. Cobra-accepting functions (`ShouldRunCheck`) and `output.HasFlag()` checks move to `internal/cli/`. |
+| `pkg/errors` | Clean | Shared `ValidationError` type (`Field`, `Message`, `Err`) distinguishing invalid input from operational failures across `Request.Validate()`-based workflows. No dependencies of its own; imported under the `rosaerrors` alias since it shares its name with the standard library `errors` package. |
 
 ## Private Core Implementation
 
@@ -77,6 +78,7 @@ Target location: `cmd/` (commands) or `internal/cli/` (shared CLI code). Each en
 | `internal/cli/commandbuilder` (`pkg/aws/commandbuilder`) | Builds human-readable AWS CLI command strings (e.g., `aws iam create-role ...`) for "manual mode" output. |
 | `internal/cli/commandbuilder/roles` (`pkg/aws/commandbuilder/helper/roles`) | Generates manual-mode AWS CLI commands for operator roles. |
 | `internal/cli/commands` (`pkg/commands`) | Single-function command registry wiring all subcommands onto root `cobra.Command`. |
+| `internal/cli/rolebridge` (`pkg/aws/rolebridge`) | Adapts `aws.Client`'s reporter.Logger-based `EnsureRole`/`AttachRolePolicy` (and context-free `PutRolePolicy`) to `context.Context`-based signatures, so workflow packages can declare `context.Context`-based client interfaces without depending on `pkg/reporter`. Temporary: delete once those `aws.Client` methods stop taking a `reporter.Logger`. |
 | `internal/cli/debug` (`pkg/debug`) | Adds the `--debug` pflag and tracks its boolean state. |
 | `internal/cli/interactive` (`pkg/interactive`) | `survey`-based `GetString`, `GetBool`, `GetInt`, `GetOption`, `GetPassword`, validation combinators, `--interactive` pflag. |
 | `internal/cli/interactive/confirm` (`pkg/interactive/confirm`) | `--yes` flag and confirmation prompts using `survey`. |
@@ -142,7 +144,7 @@ rule; this section lists only what must move.
 
 | Target | Extract to CLI Layer |
 |--------|----------------------|
-| `internal/core/aws` (`pkg/aws`) | `os.Exit` (7 sites via `CreateNewClientOrExit` and `helpers.go`), `fedramp.Enabled()` (3 sites), `fmt.Printf` error output (4 sites). |
+| `internal/core/aws` (`pkg/aws`) | `os.Exit` (7 sites via `CreateNewClientOrExit` and `helpers.go`), `fedramp.Enabled()` (3 sites), `fmt.Printf` error output (4 sites). `EnsureRole`/`AttachRolePolicy` take a `reporter.Logger` parameter and call it directly; move to returning structured progress data and let the CLI layer report it, once callers no longer depend on the current signature (`pkg/aws/rolebridge` bridges this in the meantime). |
 | `internal/core/ocm` (`pkg/ocm`) | Cobra `--cluster` flag with shell completion, `reporter.IsTerminal()`, `output.HasFlag()`, `os.Exit(1)` (2 sites), `CreateNewClientOrExit`. |
 | `internal/core/policy` (`pkg/policy`) | `reporter.Logger` parameter on `AutoAttachArbitraryPolicy`. `ManualAttachArbitraryPolicy` and `ManualDetachArbitraryPolicy` generate `aws iam ...` command strings for terminal display; move to `internal/cli/`. `AutoDetachArbitraryPolicy` returns human-readable status messages; return structured results instead. |
 | `internal/core/sharedvpcroles` (`pkg/roles`) | `rosa.Runtime` and `arguments` (CLI flag package) dependencies. |

--- a/guidelines/workflow-conventions.md
+++ b/guidelines/workflow-conventions.md
@@ -5,7 +5,9 @@
 Use this file when designing or modifying reusable workflow functions in the
 core layer (`pkg/`). It defines the type conventions for data that crosses
 the boundary between the CLI layer and core layer, as described in
-[ARCHITECTURE.md](ARCHITECTURE.md#boundary-rules).
+[ARCHITECTURE.md](ARCHITECTURE.md#boundary-rules). For error handling,
+wrapping, and CLI translation conventions, see
+[error-conventions.md](error-conventions.md).
 
 ## Lifecycle
 
@@ -174,34 +176,336 @@ codebase.
 
 ### Validation
 
-The core layer validates the Request before performing any operation. Return
-a descriptive error for invalid input rather than silently correcting it or
-exiting the process.
+Validation is split between the CLI layer and the core layer. Each layer owns
+a distinct set of concerns.
 
-Validation belongs in the same package as the Request type, either as a method
-on the Request or as a standalone function:
+#### Invocation validation (CLI layer)
+
+Invocation validation catches problems that only make sense in the context of
+a CLI command. It runs in the `cmd/` runner before the Request is built.
+
+Invocation validation is responsible for:
+
+- **Flag and argument syntax**: required flags are present, mutually exclusive
+  flags are not combined, positional arguments are well-formed.
+- **Type coercion and parsing**: Cobra handles basic type validation for typed
+  flags (e.g., `IntVar` rejects `"three"`). For string flags with format
+  constraints -- CIDR ranges, version strings, comma-separated key=value
+  pairs -- the CLI layer parses and validates the raw input before building
+  the Request. By the time the Request is constructed, all values should be
+  correctly typed and parsed.
+- **Interactive prompts**: prompting for missing values when interactive mode
+  is enabled.
+- **Environment prerequisites**: the cluster exists, STS is enabled, the
+  caller has the right AWS identity.
+- **Input resolution**: resolving `file://` references to file contents,
+  looking up a cluster name to get an OIDC provider ARN, calling `GetCreator`
+  to determine the AWS partition.
+- **Format-specific checks**: validating that a policy ARN matches the ARN
+  format, so a typo is rejected before the OIDC-provider lookup (an AWS API
+  call) or a `file://` read runs.
 
 ```go
-func (r *CreateMachinePoolRequest) Validate() error {
-    if r.ClusterID == "" {
-        return fmt.Errorf("cluster ID is required")
+// cmd/create/iamserviceaccount/cmd.go (invocation validation)
+
+// Verify the cluster supports this operation. This is an environment
+// prerequisite, not a request-invalid check, so it stays a plain wrapped
+// error rather than a rosaerrors.ValidationError; see "Classifying
+// validation errors" below.
+if cluster.AWS().STS().RoleARN() == "" {
+    return fmt.Errorf("cluster '%s' is not an STS cluster", cluster.Name())
+}
+
+// Validate flag values before building the Request. These checks are
+// duplicated in CreateIAMServiceAccountRequest.Validate() too: pkg/ may
+// eventually be called by something other than this CLI, so the core
+// layer must not assume these checks already ran.
+if len(userOptions.PolicyArns) == 0 && userOptions.InlinePolicy == "" {
+    return &rosaerrors.ValidationError{Message: "at least one policy ARN or inline policy must be specified"}
+}
+for i, policyARN := range userOptions.PolicyArns {
+    if _, err := arn.Parse(policyARN); err != nil {
+        return &rosaerrors.ValidationError{
+            Field:   "PolicyARNs",
+            Message: fmt.Sprintf("policy ARN at index %d is invalid", i),
+            Err:     err,
+        }
     }
-    if r.Name == "" {
-        return fmt.Errorf("machine pool name is required")
+}
+
+// Resolve file:// references before passing to the core layer
+if after, ok := strings.CutPrefix(inlinePolicy, "file://"); ok {
+    policyBytes, err := os.ReadFile(after)
+    // ...
+    inlinePolicy = string(policyBytes)
+}
+```
+
+Note that the ARN check returns `&rosaerrors.ValidationError{...}` rather
+than a plain `fmt.Errorf`, using the same type and wording as the domain
+check it duplicates (see [Classifying validation errors](#classifying-validation-errors)).
+An invocation check that fails fast still needs to be classified as an
+invalid-input error like any other, so the CLI layer can react the same way
+regardless of which layer caught it.
+
+By contrast, the STS check above and a `GetCreator` lookup failure are not
+request-invalid conditions. The request may be perfectly well-formed, and
+the environment or AWS call itself is what failed. Those stay plain wrapped
+errors (`fmt.Errorf("...: %w", err)`), not `rosaerrors.ValidationError`.
+`rosaerrors.ValidationError` is reserved for "the input the caller gave was
+invalid," never for "an external prerequisite or lookup failed."
+
+Invocation validation may overlap with domain validation for usability.
+Catching "no policies specified" at the flag level gives the user immediate
+feedback before expensive lookups (OIDC provider, AWS identity) run. The
+domain layer will catch the same condition independently.
+
+##### Ordering within invocation validation
+
+Within the CLI layer, order checks from cheapest to most expensive, so a
+caller gets feedback from the earliest phase capable of producing it, not
+from whichever phase happens to run first. The boundary that matters is
+whether a check makes a new network call, not merely whether it depends on
+some prior state:
+
+1. **No new network call**: flag-value checks (required fields present, ARN
+   format, mutually exclusive combinations) and checks against state already
+   fetched earlier in the same command (e.g., testing a field on the
+   `cluster` object `FetchCluster()` already returned). Cheapest, so these
+   run first.
+2. **Local resolution**: reading local state that needs no network call
+   either, such as resolving a `file://` reference, together with any
+   validation of what that resolves to (e.g., rejecting empty content).
+3. **New AWS API calls**: lookups that hit AWS (`GetCreator`, the OIDC
+   provider lookup). Run only after phases 1 and 2 have passed, since there
+   is no point paying for an API call the request was already going to fail
+   before reaching.
+4. **Domain validation (`Request.Validate()`)**: runs inside the workflow
+   function after the Request is built from the results of phases 1 to 3, and
+   re-checks invariants independently of the CLI layer (see
+   [Domain validation](#domain-validation-core-layer) below).
+
+`cmd/create/iamserviceaccount/cmd.go` follows this ordering: the STS check
+(phase 1, since `cluster` was already fetched) and the pure input checks
+(also phase 1) run first, then inline-policy resolution (phase 2), then
+`GetCreator` and the OIDC provider lookup (phase 3), then the Request is
+built and passed to a workflow function that calls `Validate()` (phase 4). A
+new command should follow the same ordering rather than interleaving cheap
+and expensive checks based on the order fields happen to appear in the flag
+definitions.
+
+#### Domain validation (core layer)
+
+Domain validation protects business invariants that must hold regardless of
+how the workflow is called -- CLI, TUI, test, or automation. It runs inside
+the workflow function via `Validate()` on the Request, before any side
+effects.
+
+Domain validation is responsible for:
+
+- **Required fields**: all fields the workflow needs are present and non-empty.
+- **Domain naming rules**: Kubernetes service account and namespace names
+  follow RFC 1123 / DNS subdomain conventions.
+- **Cross-field constraints**: a role name is required when multiple service
+  accounts share a single role.
+- **Conditional requirements**: GovCloud environments require an account ID
+  and partition.
+- **Value integrity**: optional pointer fields are not empty strings when
+  provided (e.g., `InlinePolicy` is `*string`; `nil` means absent, but a
+  pointer to `""` is invalid).
+
+```go
+// pkg/iamserviceaccount/create.go (domain validation)
+
+func (r *CreateIAMServiceAccountRequest) Validate() error {
+    if r.ClusterName == "" {
+        return fmt.Errorf("cluster name is required")
     }
-    if r.MinReplicas != nil && r.MaxReplicas == nil {
-        return fmt.Errorf("max replicas is required when min replicas is set")
+    for _, sa := range r.ServiceAccounts {
+        if err := ValidateServiceAccountName(sa.Name); err != nil {
+            return fmt.Errorf("invalid service account name %q: %w", sa.Name, err)
+        }
     }
-    if r.MaxReplicas != nil && r.MinReplicas == nil {
-        return fmt.Errorf("min replicas is required when max replicas is set")
+    if r.RoleName == nil && len(r.ServiceAccounts) > 1 {
+        return fmt.Errorf("role name is required when specifying multiple service accounts")
+    }
+    // ...
+}
+```
+
+Domain validation belongs in the same package as the Request type, either as
+a method on the Request or as a standalone function. The workflow function
+calls `Validate()` before performing any operation and must not assume the
+CLI layer validated first.
+
+#### Validator lists
+
+A single linear if-chain works for a handful of invariants, but it gets hard
+to read and to test in isolation as invariants accumulate: an early `return`
+hides every check that comes after it, so a caller only ever sees the first
+violation, and there is no way to exercise one invariant without exercising
+all of the ones before it.
+
+Prefer a list of small, independently testable validator functions once a
+Request has more than a few invariants. Each validator checks exactly one
+concern and returns its own violations as a `[]error` (nil if none), rather
+than pre-joining them with `errors.Join` itself. `Validate()` collects every
+validator's slice into one flat list and calls `errors.Join` exactly once,
+so a caller sees every violation in a single response instead of fixing
+them one at a time, and no validator ends up joining a join:
+
+```go
+// pkg/iamserviceaccount/create.go (domain validation)
+
+var createValidators = []func(*CreateIAMServiceAccountRequest) []error{
+    validateClusterName,
+    validateOIDCProviderARN,
+    validateServiceAccountsPresent,
+    validateServiceAccountIdentifiers,
+    validatePolicies,
+    validateRoleName,
+    validateGovcloud,
+}
+
+func (r *CreateIAMServiceAccountRequest) Validate() error {
+    var errs []error
+    for _, validate := range createValidators {
+        errs = append(errs, validate(r)...)
+    }
+    return errors.Join(errs...)
+}
+
+func validateClusterName(r *CreateIAMServiceAccountRequest) []error {
+    if r.ClusterName == "" {
+        return []error{&rosaerrors.ValidationError{Field: "ClusterName", Message: "cluster name is required"}}
     }
     return nil
 }
 ```
 
-The CLI layer may also validate early (e.g., checking that a required flag is
-present before prompting for additional values), but the core layer must not
-assume the caller validated first.
+A validator that checks more than one thing (e.g. `validateGovcloud`) builds
+its own local `[]error` with plain `append` and returns it directly --
+it never calls `errors.Join` itself. Only `Validate()` calls `errors.Join`,
+over the fully flattened list. Each validator returns
+`&rosaerrors.ValidationError{...}` rather than a plain `fmt.Errorf`; see
+[Classifying validation errors](#classifying-validation-errors) below for
+why and for the full pattern.
+
+`pkg/iamserviceaccount/create.go` implements the full validator list for
+`CreateIAMServiceAccountRequest`. New Request types with more than a few
+invariants should follow the same shape rather than growing a single
+`Validate()` method.
+
+#### Classifying validation errors
+
+A workflow function (e.g. `CreateIAMServiceAccount`) calls `Validate()`
+internally, before performing any side effects. Its caller never calls
+`Validate()` directly, so a plain `error` returned from the workflow function
+does not tell the caller whether the request was invalid (nothing happened)
+or whether a later, operational step failed (e.g. a role was created but
+attaching a policy to it failed). Callers that need to react differently to
+those two cases must be able to tell them apart with `errors.As`, not by
+inspecting message text.
+
+Have individual validator functions return `&rosaerrors.ValidationError{Field,
+Message}` (`pkg/errors`, imported as `rosaerrors` since it shares its name
+with the standard library `errors` package) instead of a plain `fmt.Errorf`:
+
+```go
+func validateClusterName(r *CreateIAMServiceAccountRequest) []error {
+    if r.ClusterName == "" {
+        return []error{&rosaerrors.ValidationError{Field: "ClusterName", Message: "cluster name is required"}}
+    }
+    return nil
+}
+```
+
+`Field` is the request field the check applies to, when it maps to exactly
+one field; leave it empty for a check that spans more than one (see
+`validatePolicies`'s "at least one policy ARN or inline policy is required"
+for an example). `Error()` never renders `Field` — it exists purely as
+structured metadata for a consumer that wants to branch or report on
+*which* field failed (a future `--output json` mode, a REST API, a TUI)
+without parsing the message. Introducing `Field` therefore never changes
+existing user-facing text.
+
+When a check wraps a lower-level error (`ValidateServiceAccountName`,
+`arn.Parse`), set `Err` instead of interpolating the error into `Message`,
+so the cause survives for `errors.Is`/`errors.As`:
+
+```go
+if err := ValidateServiceAccountName(sa.Name); err != nil {
+    errs = append(errs, &rosaerrors.ValidationError{
+        Field:   "ServiceAccounts",
+        Message: fmt.Sprintf("invalid service account name %q", sa.Name),
+        Err:     err,
+    })
+}
+```
+
+Then, at the point a workflow function calls `Validate()` internally, wrap
+its aggregate result the same way — this time with only `Err` set:
+
+```go
+if err := req.Validate(); err != nil {
+    return nil, &rosaerrors.ValidationError{Err: fmt.Errorf("invalid request: %w", err)}
+}
+```
+
+This aggregate wrap guarantees every `Validate()` failure is classified as
+a validation error regardless of what individual checks return, without
+relying on every check remembering to use the typed error. A caller can
+then do:
+
+```go
+var validationErr *rosaerrors.ValidationError
+if errors.As(err, &validationErr) {
+    // invalid input: no side effects occurred
+}
+```
+
+`errors.As` recurses through both the aggregate wrapper and the
+`errors.Join` tree of individual checks automatically, so this one call
+finds a match regardless of which check (or how many) failed.
+
+**`rosaerrors.ValidationError` is shared by every workflow.** Do not define
+a per-workflow type such as `CreateIAMServiceAccountValidationError` or
+`DeleteIAMServiceAccountValidationError` — callers only ever need to know
+"was this input invalid," never which workflow produced it. Only the
+`Validate()` failure path (and the individual checks it runs) return this
+type; a workflow's other failure paths (AWS/OCM calls, network errors) stay
+plain wrapped errors and correctly do not match `*rosaerrors.ValidationError`.
+
+`rosaerrors.ValidationError` is for exactly one condition: "the request was
+invalid." When a caller needs to distinguish some other specific condition —
+not "was input invalid," but something like "this role already exists in a
+different profile" — use a sentinel (`var ErrX = errors.New(...)`) or a small
+typed error carrying data, scoped to that one condition, matching existing
+precedent: `cmd/whoami/cmd.go`'s `errNotLoggedIn`, `cmd/create/ocmrole`'s
+`ErrRoleExistsWrongProfile`, `cmd/initialize/cmd.go`'s `errInitExitZero`.
+Don't create a sentinel or type speculatively for every validator or every
+failure path — only where a caller genuinely needs to branch on it.
+
+#### Intentional duplication
+
+Some checks appear in both layers. This is acceptable when:
+
+- The CLI check provides **early feedback** before expensive operations (API
+  calls, file I/O, interactive prompts).
+- The domain check ensures the **invariant holds for all callers**, not just
+  the CLI.
+
+Do not remove a domain validation just because the CLI also checks the same
+condition. Do not add domain validation solely to catch CLI-specific concerns
+(e.g., flag syntax, interactive mode state).
+
+#### What does not belong in domain validation
+
+- Cobra flag registration errors (handled by Cobra itself).
+- Interactive prompt flow control (`interactive.Enabled()`).
+- Output format selection (`--output json`).
+- File system operations (`file://` resolution, config file reads).
+- AWS or OCM client construction and authentication.
 
 ## Result Types
 
@@ -401,6 +705,21 @@ minimizing method count. Two workflows may need identically-named methods
 each still declares its own interface. Go's structural typing lets one
 concrete client type satisfy every one of these interfaces without them
 referencing each other or the client needing to know they exist.
+
+This is why the *interface declaration* is scoped per workflow, but the
+*concrete client implementation* that satisfies it does not have to be
+written once per workflow. When several workflows need the same
+underlying operations and the only obstacle is a signature mismatch (e.g.
+`pkg/aws.Client.EnsureRole` takes a `reporter.Logger` where a workflow's
+interface expects `context.Context`), write that translation once as a
+small shared type, not as a hand-rolled adapter struct copied into each
+CLI command. `pkg/aws/rolebridge.Client` is this in practice: it adapts
+`aws.Client`'s `EnsureRole`/`AttachRolePolicy`/`PutRolePolicy` to
+`context.Context`-based signatures, and any workflow's
+`<Verb><Resource>Client` interface that needs those same three methods is
+satisfied by it directly, with no per-workflow adapter file. Delete a
+bridge like this once the underlying signature mismatch it exists to paper
+over is fixed at the source.
 
 Do not collapse a workflow's multiple client calls behind one higher-level
 method (e.g., a single `Create(...)` that internally calls `EnsureRole`,

--- a/pkg/aws/rolebridge/rolebridge.go
+++ b/pkg/aws/rolebridge/rolebridge.go
@@ -1,0 +1,74 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package rolebridge adapts pkg/aws.Client's IAM role and policy methods to
+// the context.Context-based signatures that core workflow packages declare
+// in their own <Verb><Resource>Client interfaces (see "Client Interfaces
+// Are Scoped Per Workflow, Not Per Package" in
+// guidelines/workflow-conventions.md).
+//
+// aws.Client's EnsureRole and AttachRolePolicy take a reporter.Logger
+// instead of a context.Context, and PutRolePolicy takes neither, because
+// aws.Client predates the Request/Result/Service workflow pattern. This
+// package exists only to bridge that mismatch, in one place, for every
+// workflow that needs these operations, instead of each workflow's CLI
+// command hand-rolling its own copy of the same translation. Go's
+// structural typing lets this single concrete type satisfy any number of
+// distinct workflow client interfaces without them referencing each other.
+//
+// Delete this package once EnsureRole and AttachRolePolicy stop taking a
+// reporter.Logger (see the "Needs split" entry for pkg/aws in
+// guidelines/refactor/pkg-architecture.md) -- at that point workflows can
+// depend on aws.Client directly.
+//
+// The context.Context each method accepts is currently discarded: none of
+// the underlying aws.Client methods take one, so cancellation and deadlines
+// set by a caller do not propagate to the AWS calls this package makes.
+package rolebridge
+
+import (
+	"context"
+
+	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/reporter" //nolint:depguard
+)
+
+// Client wraps an aws.Client and a reporter.Logger to present the IAM role
+// and policy operations with context.Context-based signatures.
+type Client struct {
+	client   aws.Client
+	reporter reporter.Logger
+}
+
+// New returns a Client that forwards to client, using reporter for the
+// aws.Client methods that require one.
+func New(client aws.Client, reporter reporter.Logger) *Client {
+	return &Client{client: client, reporter: reporter}
+}
+
+// EnsureRole creates or updates an IAM role with the given trust policy and tags.
+func (c *Client) EnsureRole(_ context.Context, name, policy, permissionsBoundary,
+	version string, tagList map[string]string, path string, managedPolicies bool) (string, error) {
+	return c.client.EnsureRole(c.reporter, name, policy, permissionsBoundary, version, tagList, path, managedPolicies)
+}
+
+// AttachRolePolicy attaches a managed policy to a role.
+func (c *Client) AttachRolePolicy(_ context.Context, roleName, policyARN string) error {
+	return c.client.AttachRolePolicy(c.reporter, roleName, policyARN)
+}
+
+// PutRolePolicy creates or updates an inline policy on a role.
+func (c *Client) PutRolePolicy(_ context.Context, roleName, policyName, policy string) error {
+	return c.client.PutRolePolicy(roleName, policyName, policy)
+}

--- a/pkg/aws/rolebridge/rolebridge_test.go
+++ b/pkg/aws/rolebridge/rolebridge_test.go
@@ -1,0 +1,96 @@
+package rolebridge
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/reporter"
+)
+
+func TestRolebridge(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "rolebridge testing")
+}
+
+var _ = Describe("Client", func() {
+	var (
+		ctrl         *gomock.Controller
+		mockAWS      *aws.MockClient
+		testReporter reporter.Logger
+		testClient   *Client
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockAWS = aws.NewMockClient(ctrl)
+		testReporter = reporter.CreateReporter()
+		testClient = New(mockAWS, testReporter)
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	It("forwards EnsureRole to aws.Client with the held reporter, ignoring ctx", func() {
+		mockAWS.EXPECT().
+			EnsureRole(testReporter, "my-role", "trust-policy", "boundary", "v1", map[string]string{"k": "v"}, "/path/", true).
+			Return("arn:aws:iam::123456789012:role/my-role", nil)
+
+		roleARN, err := testClient.EnsureRole(context.Background(), "my-role", "trust-policy", "boundary",
+			"v1", map[string]string{"k": "v"}, "/path/", true)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(roleARN).To(Equal("arn:aws:iam::123456789012:role/my-role"))
+	})
+
+	It("propagates EnsureRole errors", func() {
+		mockAWS.EXPECT().
+			EnsureRole(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return("", errors.New("access denied"))
+
+		_, err := testClient.EnsureRole(context.Background(), "my-role", "", "", "", nil, "", false)
+		Expect(err).To(MatchError("access denied"))
+	})
+
+	It("forwards AttachRolePolicy to aws.Client with the held reporter, ignoring ctx", func() {
+		mockAWS.EXPECT().
+			AttachRolePolicy(testReporter, "my-role", "arn:aws:iam::aws:policy/Foo").
+			Return(nil)
+
+		err := testClient.AttachRolePolicy(context.Background(), "my-role", "arn:aws:iam::aws:policy/Foo")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("propagates AttachRolePolicy errors", func() {
+		mockAWS.EXPECT().
+			AttachRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(errors.New("access denied"))
+
+		err := testClient.AttachRolePolicy(context.Background(), "my-role", "arn:aws:iam::aws:policy/Foo")
+		Expect(err).To(MatchError("access denied"))
+	})
+
+	It("forwards PutRolePolicy to aws.Client, ignoring ctx", func() {
+		mockAWS.EXPECT().
+			PutRolePolicy("my-role", "my-policy", "{}").
+			Return(nil)
+
+		err := testClient.PutRolePolicy(context.Background(), "my-role", "my-policy", "{}")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("propagates PutRolePolicy errors", func() {
+		mockAWS.EXPECT().
+			PutRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(errors.New("access denied"))
+
+		err := testClient.PutRolePolicy(context.Background(), "my-role", "my-policy", "{}")
+		Expect(err).To(MatchError("access denied"))
+	})
+})

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,85 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package errors holds shared error types for the CLI/core boundary
+// described in guidelines/error-conventions.md. It has no dependencies of
+// its own, so any core workflow package can import it without pulling in
+// CLI or presentation concerns.
+//
+// Because it shares its name with the standard library "errors" package,
+// callers that also use errors.Is/errors.As import this package under an
+// alias, e.g. rosaerrors "github.com/openshift/rosa/pkg/errors".
+package errors
+
+import "fmt"
+
+// ValidationError marks a failure that occurred during domain validation.
+// It serves two roles that share the same type so callers only ever need
+// one import and one errors.As target:
+//
+//   - A leaf-level error from a single check, e.g.
+//     &ValidationError{Field: "ClusterName", Message: "cluster name is required"}.
+//     Field is the struct field the check applies to, when the check maps
+//     to exactly one field; it is metadata for structured consumers (a
+//     future --output json mode, a REST API, a TUI) and is never rendered
+//     by Error() itself, so introducing Field never changes existing
+//     user-facing text.
+//   - The aggregate wrapper a workflow function places around its
+//     Request's Validate() call, e.g.
+//     &ValidationError{Err: fmt.Errorf("invalid request: %w", err)}.
+//     This guarantees every Validate() failure is classified as a
+//     validation error regardless of what individual checks return,
+//     without relying on every check remembering to use this type.
+//
+// Callers use errors.As to distinguish invalid input (no side effects
+// occurred) from operational failures encountered later in a workflow,
+// without parsing error text. This type is shared by every
+// Request/Validate() workflow; workflows do not define their own
+// <Verb><Resource>ValidationError. See "Classifying validation errors" in
+// guidelines/workflow-conventions.md.
+type ValidationError struct {
+	// Field is the request field that failed validation, when the failure
+	// maps to exactly one field. Empty for checks that span more than one
+	// field, and for the aggregate wrapper case.
+	Field string
+
+	// Message describes the violation. Empty for the aggregate wrapper
+	// case, where Error() delegates to Err instead.
+	Message string
+
+	// Err is the underlying cause, when there is one: either a wrapped
+	// error from a lower-level check, or the aggregate error a workflow
+	// function wraps at its Validate() call site. Preserved for
+	// errors.Is/errors.As via Unwrap().
+	Err error
+}
+
+func (e *ValidationError) Error() string {
+	switch {
+	case e.Message != "" && e.Err != nil:
+		return fmt.Sprintf("%s: %s", e.Message, e.Err)
+	case e.Message != "":
+		return e.Message
+	case e.Err != nil:
+		return e.Err.Error()
+	case e.Field != "":
+		return fmt.Sprintf("validation failed: %s", e.Field)
+	default:
+		return "validation failed"
+	}
+}
+
+func (e *ValidationError) Unwrap() error {
+	return e.Err
+}

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -1,0 +1,107 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestErrors(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "errors testing")
+}
+
+var _ = Describe("ValidationError", func() {
+	Context("as an aggregate wrapper (Err only)", func() {
+		It("preserves the wrapped error's text verbatim", func() {
+			inner := fmt.Errorf("cluster name is required")
+			validationErr := &ValidationError{Err: inner}
+
+			Expect(validationErr.Error()).To(Equal("cluster name is required"))
+		})
+
+		It("unwraps to the wrapped error", func() {
+			inner := fmt.Errorf("cluster name is required")
+			validationErr := &ValidationError{Err: inner}
+
+			Expect(errors.Unwrap(validationErr)).To(Equal(inner))
+		})
+
+		It("is detectable with errors.As through an outer wrap", func() {
+			inner := fmt.Errorf("invalid request: %s", "cluster name is required")
+			wrapped := fmt.Errorf("create failed: %w", &ValidationError{Err: inner})
+
+			var validationErr *ValidationError
+			Expect(errors.As(wrapped, &validationErr)).To(BeTrue())
+			Expect(validationErr.Error()).To(Equal(inner.Error()))
+		})
+
+		It("does not match a plain error via errors.As", func() {
+			plain := fmt.Errorf("failed to create role: network error")
+
+			var validationErr *ValidationError
+			Expect(errors.As(plain, &validationErr)).To(BeFalse())
+		})
+
+		It("preserves errors.Is against a sentinel wrapped further down the chain", func() {
+			sentinel := errors.New("boom")
+			wrapped := fmt.Errorf("invalid request: %w", sentinel)
+			validationErr := &ValidationError{Err: wrapped}
+
+			Expect(errors.Is(validationErr, sentinel)).To(BeTrue())
+		})
+	})
+
+	Context("as a leaf-level, field-carrying error", func() {
+		It("renders only the message, never the field, so introducing Field never changes user-facing text", func() {
+			validationErr := &ValidationError{Field: "ClusterName", Message: "cluster name is required"}
+
+			Expect(validationErr.Error()).To(Equal("cluster name is required"))
+		})
+
+		It("exposes Field for structured consumers without needing to parse the message", func() {
+			validationErr := &ValidationError{Field: "RoleName", Message: "role name must not be blank when provided"}
+
+			Expect(validationErr.Field).To(Equal("RoleName"))
+		})
+
+		It("appends a wrapped cause to the message and preserves it for errors.Is", func() {
+			cause := errors.New("must be a valid DNS-1123 label")
+			validationErr := &ValidationError{
+				Field:   "ServiceAccounts",
+				Message: `invalid service account name "BAD"`,
+				Err:     cause,
+			}
+
+			Expect(validationErr.Error()).To(Equal(`invalid service account name "BAD": must be a valid DNS-1123 label`))
+			Expect(errors.Is(validationErr, cause)).To(BeTrue())
+		})
+
+		It("is found by errors.As even nested inside an errors.Join tree with no outer wrapper", func() {
+			leaf := &ValidationError{Field: "ClusterName", Message: "cluster name is required"}
+			joined := errors.Join(fmt.Errorf("some other failure"), leaf)
+			wrapped := fmt.Errorf("invalid request: %w", joined)
+
+			var found *ValidationError
+			Expect(errors.As(wrapped, &found)).To(BeTrue())
+			Expect(found.Field).To(Equal("ClusterName"))
+		})
+	})
+
+	Context("when constructed without a Message or Err", func() {
+		It("falls back to a non-empty message instead of an empty string", func() {
+			validationErr := &ValidationError{}
+
+			Expect(validationErr.Error()).To(Equal("validation failed"))
+		})
+
+		It("includes the field in the fallback message when Field is set", func() {
+			validationErr := &ValidationError{Field: "ClusterName"}
+
+			Expect(validationErr.Error()).To(Equal("validation failed: ClusterName"))
+		})
+	})
+})

--- a/pkg/fedramp/validate.go
+++ b/pkg/fedramp/validate.go
@@ -1,0 +1,42 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fedramp
+
+import (
+	rosaerrors "github.com/openshift/rosa/pkg/errors"
+)
+
+// ValidateGovCloudFields checks that accountID and partition are present
+// when isGovcloud is true. It takes plain values, resolved by a caller from
+// aws.Creator (via GetCreator) or an equivalent source, rather than a
+// workflow-specific Request type, so any workflow that operates on a
+// GovCloud-capable AWS account can validate the same invariant.
+func ValidateGovCloudFields(isGovcloud bool, accountID, partition string) []error {
+	if !isGovcloud {
+		return nil
+	}
+	var errs []error
+	if accountID == "" {
+		errs = append(errs, &rosaerrors.ValidationError{
+			Field: "AccountID", Message: "account ID is required for GovCloud environments",
+		})
+	}
+	if partition == "" {
+		errs = append(errs, &rosaerrors.ValidationError{
+			Field: "Partition", Message: "partition is required for GovCloud environments",
+		})
+	}
+	return errs
+}

--- a/pkg/fedramp/validate_test.go
+++ b/pkg/fedramp/validate_test.go
@@ -1,0 +1,54 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fedramp
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	rosaerrors "github.com/openshift/rosa/pkg/errors"
+)
+
+var _ = Describe("ValidateGovCloudFields", func() {
+	It("returns no errors when isGovcloud is false, regardless of the other fields", func() {
+		Expect(ValidateGovCloudFields(false, "", "")).To(BeEmpty())
+	})
+
+	It("returns no errors when isGovcloud is true and both fields are present", func() {
+		Expect(ValidateGovCloudFields(true, "111222333444", "aws-us-gov")).To(BeEmpty())
+	})
+
+	It("reports a missing account ID", func() {
+		errs := ValidateGovCloudFields(true, "", "aws-us-gov")
+		Expect(errs).To(HaveLen(1))
+		var validationErr *rosaerrors.ValidationError
+		Expect(errors.As(errs[0], &validationErr)).To(BeTrue())
+		Expect(validationErr.Field).To(Equal("AccountID"))
+	})
+
+	It("reports a missing partition", func() {
+		errs := ValidateGovCloudFields(true, "111222333444", "")
+		Expect(errs).To(HaveLen(1))
+		var validationErr *rosaerrors.ValidationError
+		Expect(errors.As(errs[0], &validationErr)).To(BeTrue())
+		Expect(validationErr.Field).To(Equal("Partition"))
+	})
+
+	It("reports both violations when account ID and partition are empty", func() {
+		Expect(ValidateGovCloudFields(true, "", "")).To(HaveLen(2))
+	})
+})

--- a/pkg/iamserviceaccount/client.go
+++ b/pkg/iamserviceaccount/client.go
@@ -27,12 +27,11 @@ import (
 // it calls, not a method added here. See "Client Interfaces Are Scoped Per
 // Workflow, Not Per Package" in guidelines/workflow-conventions.md.
 //
-// TODO: It is not yet implemented or wired up anywhere; the CLI command in
-// cmd/create/iamserviceaccount still calls aws.Client directly. When that
-// command is migrated to call IAMServiceAccountService, the CLI layer will
-// provide an adapter around aws.Client (which passes reporter.Logger
-// through to EnsureRole and AttachRolePolicy) so that the core workflows
-// stay free of reporter and CLI dependencies.
+// cmd/create/iamserviceaccount wires this up with pkg/aws/rolebridge.Client,
+// which adapts aws.Client's reporter.Logger-based EnsureRole/AttachRolePolicy
+// to this context.Context-based interface so this core workflow package
+// stays free of reporter and CLI dependencies. rolebridge is shared by any
+// workflow needing these same IAM operations -- see its package doc.
 type CreateIAMServiceAccountClient interface {
 	// EnsureRole creates or updates an IAM role with the given trust policy and tags.
 	EnsureRole(ctx context.Context, name string, policy string, permissionsBoundary string,

--- a/pkg/iamserviceaccount/create.go
+++ b/pkg/iamserviceaccount/create.go
@@ -17,10 +17,14 @@ package iamserviceaccount
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
+
+	rosaerrors "github.com/openshift/rosa/pkg/errors"
+	"github.com/openshift/rosa/pkg/fedramp"
 )
 
 // CreateIAMServiceAccountRequest contains the resolved inputs for creating
@@ -50,58 +54,142 @@ type CreateIAMServiceAccountRequest struct {
 	IsGovcloud bool
 }
 
+// createValidators enforces each domain invariant for
+// CreateIAMServiceAccountRequest independently. Keeping each check as a
+// small, separately testable function makes it easy to see which invariants
+// exist and to add or remove one without touching the others. Each
+// validator returns its own violations directly (nil if none), rather than
+// pre-joining them, so Validate() can build one flat list and call
+// errors.Join exactly once instead of nesting a join inside a join.
+var createValidators = []func(*CreateIAMServiceAccountRequest) []error{
+	validateClusterName,
+	validateOIDCProviderARN,
+	validateServiceAccountsPresent,
+	validateServiceAccountIdentifiers,
+	validatePolicies,
+	validateRoleName,
+	validateGovcloud,
+}
+
 // Validate checks that the request contains all required fields and that
-// service account names and namespaces are syntactically valid.
+// service account names and namespaces are syntactically valid. It runs
+// every validator in createValidators and joins their errors, so a caller
+// sees every violation at once instead of fixing them one at a time.
 func (r *CreateIAMServiceAccountRequest) Validate() error {
+	var errs []error
+	for _, validate := range createValidators {
+		errs = append(errs, validate(r)...)
+	}
+	return errors.Join(errs...)
+}
+
+func validateClusterName(r *CreateIAMServiceAccountRequest) []error {
 	if r.ClusterName == "" {
-		return fmt.Errorf("cluster name is required")
+		return []error{&rosaerrors.ValidationError{Field: "ClusterName", Message: "cluster name is required"}}
 	}
+	return nil
+}
+
+func validateOIDCProviderARN(r *CreateIAMServiceAccountRequest) []error {
 	if r.OIDCProviderARN == "" {
-		return fmt.Errorf("OIDC provider ARN is required")
+		return []error{&rosaerrors.ValidationError{Field: "OIDCProviderARN", Message: "OIDC provider ARN is required"}}
 	}
+	return nil
+}
+
+func validateServiceAccountsPresent(r *CreateIAMServiceAccountRequest) []error {
 	if len(r.ServiceAccounts) == 0 {
-		return fmt.Errorf("at least one service account is required")
-	}
-	for _, sa := range r.ServiceAccounts {
-		if err := ValidateServiceAccountName(sa.Name); err != nil {
-			return fmt.Errorf("invalid service account name %q: %w", sa.Name, err)
-		}
-		if err := ValidateNamespaceName(sa.Namespace); err != nil {
-			return fmt.Errorf("invalid namespace %q for service account %q: %w", sa.Namespace, sa.Name, err)
-		}
-	}
-	if len(r.PolicyARNs) == 0 && r.InlinePolicy == nil {
-		return fmt.Errorf("at least one policy ARN or inline policy is required")
-	}
-	if r.InlinePolicy != nil && *r.InlinePolicy == "" {
-		return fmt.Errorf("inline policy must not be empty when provided")
-	}
-	if r.InlinePolicy != nil && !json.Valid([]byte(*r.InlinePolicy)) {
-		return fmt.Errorf("inline policy must be valid JSON")
-	}
-	for i, policyARN := range r.PolicyARNs {
-		if policyARN == "" {
-			return fmt.Errorf("policy ARN at index %d is empty", i)
-		}
-		if _, err := arn.Parse(policyARN); err != nil {
-			return fmt.Errorf("policy ARN at index %d is invalid: %w", i, err)
-		}
-	}
-	if r.RoleName != nil && strings.TrimSpace(*r.RoleName) == "" {
-		return fmt.Errorf("role name must not be blank when provided")
-	}
-	if r.RoleName == nil && len(r.ServiceAccounts) > 1 {
-		return fmt.Errorf("role name is required when specifying multiple service accounts")
-	}
-	if r.IsGovcloud {
-		if r.AccountID == "" {
-			return fmt.Errorf("account ID is required for GovCloud environments")
-		}
-		if r.Partition == "" {
-			return fmt.Errorf("partition is required for GovCloud environments")
+		return []error{
+			&rosaerrors.ValidationError{Field: "ServiceAccounts", Message: "at least one service account is required"},
 		}
 	}
 	return nil
+}
+
+func validateServiceAccountIdentifiers(r *CreateIAMServiceAccountRequest) []error {
+	var errs []error
+	for _, sa := range r.ServiceAccounts {
+		if err := ValidateServiceAccountName(sa.Name); err != nil {
+			errs = append(errs, &rosaerrors.ValidationError{
+				Field:   "ServiceAccounts",
+				Message: fmt.Sprintf("invalid service account name %q", sa.Name),
+				Err:     err,
+			})
+		}
+		if err := ValidateNamespaceName(sa.Namespace); err != nil {
+			errs = append(errs, &rosaerrors.ValidationError{
+				Field:   "ServiceAccounts",
+				Message: fmt.Sprintf("invalid namespace %q for service account %q", sa.Namespace, sa.Name),
+				Err:     err,
+			})
+		}
+	}
+	return errs
+}
+
+func validatePolicies(r *CreateIAMServiceAccountRequest) []error {
+	var errs []error
+	if len(r.PolicyARNs) == 0 && r.InlinePolicy == nil {
+		errs = append(errs, &rosaerrors.ValidationError{
+			Message: "at least one policy ARN or inline policy is required",
+		})
+	}
+	if r.InlinePolicy != nil {
+		if *r.InlinePolicy == "" {
+			errs = append(errs, &rosaerrors.ValidationError{
+				Field: "InlinePolicy", Message: "inline policy must not be empty when provided",
+			})
+		} else if !json.Valid([]byte(*r.InlinePolicy)) {
+			errs = append(errs, &rosaerrors.ValidationError{
+				Field: "InlinePolicy", Message: "inline policy must be valid JSON",
+			})
+		}
+	}
+	for i, policyARN := range r.PolicyARNs {
+		if policyARN == "" {
+			errs = append(errs, &rosaerrors.ValidationError{
+				Field:   "PolicyARNs",
+				Message: fmt.Sprintf("policy ARN at index %d is empty", i),
+			})
+			continue
+		}
+		parsed, err := arn.Parse(policyARN)
+		if err != nil {
+			errs = append(errs, &rosaerrors.ValidationError{
+				Field:   "PolicyARNs",
+				Message: fmt.Sprintf("policy ARN at index %d is invalid", i),
+				Err:     err,
+			})
+			continue
+		}
+		if parsed.Service != "iam" || !strings.HasPrefix(parsed.Resource, "policy/") ||
+			strings.HasSuffix(parsed.Resource, "/") {
+			errs = append(errs, &rosaerrors.ValidationError{
+				Field:   "PolicyARNs",
+				Message: fmt.Sprintf("policy ARN at index %d is not an IAM policy ARN", i),
+			})
+		}
+	}
+	return errs
+}
+
+func validateRoleName(r *CreateIAMServiceAccountRequest) []error {
+	var errs []error
+	if r.RoleName != nil && strings.TrimSpace(*r.RoleName) == "" {
+		errs = append(errs, &rosaerrors.ValidationError{
+			Field: "RoleName", Message: "role name must not be blank when provided",
+		})
+	}
+	if r.RoleName == nil && len(r.ServiceAccounts) > 1 {
+		errs = append(errs, &rosaerrors.ValidationError{
+			Field: "RoleName", Message: "role name is required when specifying multiple service accounts",
+		})
+	}
+	return errs
+}
+
+func validateGovcloud(r *CreateIAMServiceAccountRequest) []error {
+	return fedramp.ValidateGovCloudFields(r.IsGovcloud, r.AccountID, r.Partition)
 }
 
 // CreateIAMServiceAccountResult contains the structured outcome of creating
@@ -134,7 +222,7 @@ func (s *Service) CreateIAMServiceAccount(
 ) (*CreateIAMServiceAccountResult, error) {
 	// Validate the request
 	if err := req.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid request: %w", err)
+		return nil, &rosaerrors.ValidationError{Err: fmt.Errorf("invalid request: %w", err)}
 	}
 
 	// Generate role name if not provided

--- a/pkg/iamserviceaccount/create_test.go
+++ b/pkg/iamserviceaccount/create_test.go
@@ -21,6 +21,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	rosaerrors "github.com/openshift/rosa/pkg/errors"
 )
 
 // mockCreateIAMServiceAccountClient is a test double for CreateIAMServiceAccountClient
@@ -96,6 +98,47 @@ func expectNoClientCalls(client *mockCreateIAMServiceAccountClient) {
 	Expect(client.ensureRoleCalls).To(BeEmpty())
 	Expect(client.attachRolePolicyCalls).To(BeEmpty())
 	Expect(client.putRolePolicyCalls).To(BeEmpty())
+}
+
+// flattenLeafErrors returns the individual violations inside err, peeling
+// through the single-cause wrapping layers a workflow function adds around
+// Validate()'s result (the aggregate *rosaerrors.ValidationError, then its
+// fmt.Errorf "invalid request: %w" wrap) to reach the errors.Join underneath.
+// Validate() builds that join from one flat list (see createValidators in
+// create.go), so there is exactly one Unwrap() []error to expand -- never a
+// join nested inside another join -- and no recursion is needed.
+func flattenLeafErrors(err error) []error {
+	for err != nil {
+		if joined, ok := err.(interface{ Unwrap() []error }); ok {
+			return joined.Unwrap()
+		}
+		wrapped, ok := err.(interface{ Unwrap() error })
+		if !ok {
+			break
+		}
+		// A type can implement Unwrap() error yet have nothing to unwrap
+		// (e.g. a *rosaerrors.ValidationError leaf with no cause set) --
+		// that err is itself the leaf, not an empty branch.
+		inner := wrapped.Unwrap()
+		if inner == nil {
+			break
+		}
+		err = inner
+	}
+	if err == nil {
+		return nil
+	}
+	return []error{err}
+}
+
+// soleValidationError returns the single *rosaerrors.ValidationError leaf
+// expected in err, for tests that assert on Field.
+func soleValidationError(err error) *rosaerrors.ValidationError {
+	leaves := flattenLeafErrors(err)
+	ExpectWithOffset(1, leaves).To(HaveLen(1))
+	validationErr, ok := leaves[0].(*rosaerrors.ValidationError)
+	ExpectWithOffset(1, ok).To(BeTrue(), "expected a *rosaerrors.ValidationError leaf, got: %T", leaves[0])
+	return validationErr
 }
 
 var _ = Describe("CreateIAMServiceAccount", func() {
@@ -265,6 +308,7 @@ var _ = Describe("CreateIAMServiceAccount", func() {
 			_, err := service.CreateIAMServiceAccount(context.Background(), client, req)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("cluster name is required"))
+			Expect(soleValidationError(err).Field).To(Equal("ClusterName"))
 			expectNoClientCalls(client)
 		})
 
@@ -273,6 +317,7 @@ var _ = Describe("CreateIAMServiceAccount", func() {
 			_, err := service.CreateIAMServiceAccount(context.Background(), client, req)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("OIDC provider ARN is required"))
+			Expect(soleValidationError(err).Field).To(Equal("OIDCProviderARN"))
 			expectNoClientCalls(client)
 		})
 
@@ -281,6 +326,7 @@ var _ = Describe("CreateIAMServiceAccount", func() {
 			_, err := service.CreateIAMServiceAccount(context.Background(), client, req)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("at least one service account is required"))
+			Expect(soleValidationError(err).Field).To(Equal("ServiceAccounts"))
 			expectNoClientCalls(client)
 		})
 
@@ -290,6 +336,25 @@ var _ = Describe("CreateIAMServiceAccount", func() {
 			_, err := service.CreateIAMServiceAccount(context.Background(), client, req)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("at least one policy ARN or inline policy is required"))
+			// This check spans two fields (PolicyARNs, InlinePolicy), so it
+			// intentionally carries no single Field.
+			Expect(soleValidationError(err).Field).To(BeEmpty())
+			expectNoClientCalls(client)
+		})
+
+		It("should report every violation when multiple invariants are broken", func() {
+			req.ClusterName = ""
+			req.OIDCProviderARN = ""
+			req.PolicyARNs = nil
+			req.InlinePolicy = nil
+			_, err := service.CreateIAMServiceAccount(context.Background(), client, req)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cluster name is required"))
+			Expect(err.Error()).To(ContainSubstring("OIDC provider ARN is required"))
+			Expect(err.Error()).To(ContainSubstring("at least one policy ARN or inline policy is required"))
+
+			leaves := flattenLeafErrors(err)
+			Expect(leaves).To(HaveLen(3), "expected exactly the three broken invariants, got: %v", leaves)
 			expectNoClientCalls(client)
 		})
 
@@ -298,6 +363,7 @@ var _ = Describe("CreateIAMServiceAccount", func() {
 			_, err := service.CreateIAMServiceAccount(context.Background(), client, req)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("policy ARN at index 1 is empty"))
+			Expect(soleValidationError(err).Field).To(Equal("PolicyARNs"))
 			expectNoClientCalls(client)
 		})
 
@@ -307,6 +373,7 @@ var _ = Describe("CreateIAMServiceAccount", func() {
 			_, err := service.CreateIAMServiceAccount(context.Background(), client, req)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("inline policy must not be empty when provided"))
+			Expect(soleValidationError(err).Field).To(Equal("InlinePolicy"))
 			expectNoClientCalls(client)
 		})
 
@@ -315,7 +382,43 @@ var _ = Describe("CreateIAMServiceAccount", func() {
 			_, err := service.CreateIAMServiceAccount(context.Background(), client, req)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("policy ARN at index 0 is invalid"))
+			validationErr := soleValidationError(err)
+			Expect(validationErr.Field).To(Equal("PolicyARNs"))
+			Expect(validationErr.Err).To(HaveOccurred(), "the arn.Parse cause must be preserved, not flattened into the message")
 			expectNoClientCalls(client)
+		})
+
+		It("should reject request with a non-IAM-policy ARN", func() {
+			req.PolicyARNs = []string{"arn:aws:s3:::my-bucket"}
+			_, err := service.CreateIAMServiceAccount(context.Background(), client, req)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("policy ARN at index 0 is not an IAM policy ARN"))
+			Expect(soleValidationError(err).Field).To(Equal("PolicyARNs"))
+			expectNoClientCalls(client)
+		})
+
+		It("should reject a policy ARN with no policy name after 'policy/'", func() {
+			req.PolicyARNs = []string{"arn:aws:iam::123456789012:policy/"}
+			_, err := service.CreateIAMServiceAccount(context.Background(), client, req)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("policy ARN at index 0 is not an IAM policy ARN"))
+			Expect(soleValidationError(err).Field).To(Equal("PolicyARNs"))
+			expectNoClientCalls(client)
+		})
+
+		It("should reject a policy ARN with a trailing slash", func() {
+			req.PolicyARNs = []string{"arn:aws:iam::123456789012:policy/MyPolicy/"}
+			_, err := service.CreateIAMServiceAccount(context.Background(), client, req)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("policy ARN at index 0 is not an IAM policy ARN"))
+			Expect(soleValidationError(err).Field).To(Equal("PolicyARNs"))
+			expectNoClientCalls(client)
+		})
+
+		It("should accept a policy ARN with a path-scoped policy name", func() {
+			req.PolicyARNs = []string{"arn:aws:iam::123456789012:policy/team/MyPolicy"}
+			_, err := service.CreateIAMServiceAccount(context.Background(), client, req)
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should reject request with invalid JSON inline policy", func() {
@@ -324,6 +427,7 @@ var _ = Describe("CreateIAMServiceAccount", func() {
 			_, err := service.CreateIAMServiceAccount(context.Background(), client, req)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("inline policy must be valid JSON"))
+			Expect(soleValidationError(err).Field).To(Equal("InlinePolicy"))
 			expectNoClientCalls(client)
 		})
 
@@ -334,6 +438,7 @@ var _ = Describe("CreateIAMServiceAccount", func() {
 			_, err := service.CreateIAMServiceAccount(context.Background(), client, req)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("invalid service account name"))
+			Expect(soleValidationError(err).Field).To(Equal("ServiceAccounts"))
 			expectNoClientCalls(client)
 		})
 
@@ -344,6 +449,7 @@ var _ = Describe("CreateIAMServiceAccount", func() {
 			_, err := service.CreateIAMServiceAccount(context.Background(), client, req)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("invalid namespace"))
+			Expect(soleValidationError(err).Field).To(Equal("ServiceAccounts"))
 			expectNoClientCalls(client)
 		})
 
@@ -354,6 +460,7 @@ var _ = Describe("CreateIAMServiceAccount", func() {
 			_, err := service.CreateIAMServiceAccount(context.Background(), client, req)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("account ID is required for GovCloud"))
+			Expect(soleValidationError(err).Field).To(Equal("AccountID"))
 			expectNoClientCalls(client)
 		})
 
@@ -364,6 +471,21 @@ var _ = Describe("CreateIAMServiceAccount", func() {
 			_, err := service.CreateIAMServiceAccount(context.Background(), client, req)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("partition is required for GovCloud"))
+			Expect(soleValidationError(err).Field).To(Equal("Partition"))
+			expectNoClientCalls(client)
+		})
+
+		It("should report both GovCloud violations when account ID and partition are empty", func() {
+			req.IsGovcloud = true
+			req.AccountID = ""
+			req.Partition = ""
+			_, err := service.CreateIAMServiceAccount(context.Background(), client, req)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("account ID is required for GovCloud"))
+			Expect(err.Error()).To(ContainSubstring("partition is required for GovCloud"))
+
+			leaves := flattenLeafErrors(err)
+			Expect(leaves).To(HaveLen(2), "expected both GovCloud violations, got: %v", leaves)
 			expectNoClientCalls(client)
 		})
 
@@ -376,6 +498,7 @@ var _ = Describe("CreateIAMServiceAccount", func() {
 			_, err := service.CreateIAMServiceAccount(context.Background(), client, req)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("role name is required when specifying multiple service accounts"))
+			Expect(soleValidationError(err).Field).To(Equal("RoleName"))
 			expectNoClientCalls(client)
 		})
 
@@ -385,6 +508,7 @@ var _ = Describe("CreateIAMServiceAccount", func() {
 			_, err := service.CreateIAMServiceAccount(context.Background(), client, req)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("role name must not be blank when provided"))
+			Expect(soleValidationError(err).Field).To(Equal("RoleName"))
 			expectNoClientCalls(client)
 		})
 
@@ -397,6 +521,17 @@ var _ = Describe("CreateIAMServiceAccount", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.InlinePolicyName).ToNot(BeEmpty())
 			Expect(client.attachRolePolicyCalls).To(BeEmpty())
+		})
+
+		It("should classify a Validate() failure as a rosaerrors.ValidationError", func() {
+			req.ClusterName = ""
+
+			_, err := service.CreateIAMServiceAccount(context.Background(), client, req)
+			Expect(err).To(HaveOccurred())
+
+			var validationErr *rosaerrors.ValidationError
+			Expect(errors.As(err, &validationErr)).To(BeTrue())
+			expectNoClientCalls(client)
 		})
 	})
 
@@ -411,6 +546,11 @@ var _ = Describe("CreateIAMServiceAccount", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(errors.Is(err, errEnsureRole)).To(BeTrue())
 			Expect(err.Error()).To(ContainSubstring("failed to create role"))
+
+			// An operational AWS failure must not be mistaken for an invalid
+			// request: it happens only after Validate() already succeeded.
+			var validationErr *rosaerrors.ValidationError
+			Expect(errors.As(err, &validationErr)).To(BeFalse())
 
 			// Should not attempt to attach policies after role creation fails
 			Expect(client.attachRolePolicyCalls).To(BeEmpty())


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
Supported ticket prefixes:
OCM-XXXXX, ROSAENG-XXXX
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For contributor workflow, see: ./CONTRIBUTING.md
For repo-local agent guidance, see: ./AGENTS.md
-->

## PR Summary
Establishes a layered validation and error-classification pattern for reusable workflows: Request.Validate() aggregates every domain violation via a flat validator list, and a shared `pkg/errors.ValidationError` type lets callers distinguish invalid input from operational failures with errors.As. Codifies error translation at the CLI boundary and demonstrates the full pattern end-to-end in the iamserviceaccount create workflow.

## Detailed Description of the Issue
As part of the refactor project, the following stories need to be addressed:

- [**[ROSAENG-63262](https://redhat.atlassian.net/browse/ROSAENG-63262)**:  Separate invocation validation from domain validation](https://redhat.atlassian.net/browse/ROSAENG-63262)
- [**[ROSAENG-63263](https://redhat.atlassian.net/browse/ROSAENG-63263)**: Introduce distinguishable workflow errors](https://redhat.atlassian.net/browse/ROSAENG-63263)
- [**[ROSAENG-63264](https://redhat.atlassian.net/browse/ROSAENG-63264)**: Define error translation at the CLI boundary](https://redhat.atlassian.net/browse/ROSAENG-63264)

This PR accomplishes the following:
- **[ROSAENG-63262](https://redhat.atlassian.net/browse/ROSAENG-63262)**: Refactor C`reateIAMServiceAccountRequest.Validate()` into independently-testable validator functions joined once via errors.Join, so every violation is reported instead of only the first
- **[ROSAENG-63262](https://redhat.atlassian.net/browse/ROSAENG-63262)**: Document the CLI-layer/domain-layer validation split and the validator-list pattern in `guidelines/workflow-conventions.md`
- **[ROSAENG-63263](https://redhat.atlassian.net/browse/ROSAENG-63263)**: Add shared `pkg/errors.ValidationError{Field, Message, Err}` so callers can distinguish invalid-input failures from operational failures via `errors.As`, without parsing error text
- **[ROSAENG-63263](https://redhat.atlassian.net/browse/ROSAENG-63263)**: Document criteria for typed errors vs. sentinels, and the "Classifying validation errors" pattern, in `guidelines/workflow-conventions.md`
- **[ROSAENG-63263](https://redhat.atlassian.net/browse/ROSAENG-63263)**: Add domain and CLI tests proving validation failures are distinguishable from operational (AWS) failures via `errors.As`, using `pkg/iamserviceaccount` as the representative workflow
- **[ROSAENG-63264](https://redhat.atlassian.net/browse/ROSAENG-63264)**: Document core/CLI error-translation responsibilities (wrapping, typed errors, exit codes, remediation, diagnostics) in new `guidelines/error-conventions.md`
- **[ROSAENG-63264](https://redhat.atlassian.net/browse/ROSAENG-63264)**: Wire `cmd/create/iamserviceaccount` to call `pkg/iamserviceaccount.Service.CreateIAMServiceAccount` instead of calling `aws.Client` inline, showing command usage when the error is a validation failure

## Related Issues and PRs
<!-- Link all tracking items and related code changes -->
- Jira: [ROSAENG-63262](https://issues.redhat.com/browse/ROSAENG-63262), [ROSAENG-63263](https://issues.redhat.com/browse/ROSAENG-63263), [ROSAENG-63264](https://issues.redhat.com/browse/ROSAENG-63264)
- Fixes: `#`
- Related PR(s):
- Related design/docs:

## Type of Change
<!-- Check the primary type this PR represents -->
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [x] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
- rosa create iamserviceaccount validated inline in cmd.go, calling aws.Client directly: cluster/STS check, "at least one service account name," "at least one policy or inline policy," ARN format via `aws.ARNValidator` (message included the literal ARN string), and "role name required for multiple service accounts." Each check returned on the first failure.
- No validation existed for: Kubernetes service account/namespace name format (RFC 1123), inline policy JSON validity, GovCloud account ID/partition presence, or a blank (whitespace-only) explicit role name. These functions existed in `pkg/iamserviceaccount` but were never called by the CLI.
- Any error (bad input or an AWS API failure) was reported identically: printed via the reporter and the process exited 1. No usage/help text was ever shown.
- On success, "Created IAM role..." was printed immediately after role creation, before policy attachment ran.


## Behavior After This Change
- The command now delegates to pkg/iamserviceaccount.Service.CreateIAMServiceAccount, which runs the full domain Validate() in addition to the cheap CLI-side pre-checks (kept for fail-fast feedback before the OIDC/AWS lookup).
- New validations are now enforced that previously would have been silently accepted or failed later with a confusing AWS-side error: service account name/namespace format, inline policy JSON validity, GovCloud account ID/partition, and blank explicit role names.
- Domain-level violations are now aggregated and reported together in one response instead of one-at-a-time (e.g., a malformed service account name and a GovCloud misconfiguration both show up in the same error).
- The policy-ARN-format error message changed wording: it now reports the ARN's index (policy ARN at index 0 is invalid: ...) instead of embedding the literal ARN string.
- Errors are now classified: an invalid-input failure (*rosaerrors.ValidationError) additionally prints command usage/help before exiting; an operational failure (e.g., role created but policy attach failed) does not.
- The "Created IAM role..." confirmation now prints only after the entire operation succeeds, rather than before policy attachment — though aws.Client's own internal progress messages during role/policy creation are unaffected.

## How to Test (Step-by-Step)
<!-- Provide reproducible validation instructions -->
### Preconditions
<!-- Required setup, environment, credentials, flags, cluster state, etc. -->

### Test Steps
1. <TODO:>

### Expected Results
<TODO>

## Proof of the Fix
<!-- Attach evidence that demonstrates the changed behavior -->
- Screenshots:
- Videos:
- Logs/CLI output:
- Other artifacts:

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
Nothing breaking, but important things to consider:
1. Stricter validation could reject previously-"succeeding" calls. If anyone's automation was passing a service account name that doesn't meet Kubernetes naming rules, or a slightly-malformed inline policy JSON, IAM itself doesn't care about k8s naming conventions, so that call may have silently succeeded before (creating a role bound to a technically-invalid service account reference) and will now be rejected at the CLI.
2. The ARN-format error message text changed (index-based instead of embedding the literal ARN string). Anything scripting against that exact string breaks. Error text isn't a documented/stable interface for this CLI, but it's worth naming since it's a concrete, easy-to-hit case.


## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] `make rosa` passes.
- [x] Documentation or repo-local agent guidance was added/updated where appropriate.
- [] Any risk, limitation, or follow-up work is documented.


[ROSAENG-63262]: https://redhat.atlassian.net/browse/ROSAENG-63262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * IAM service-account creation supports inline policies provided through file references.
  * Successful IAM operations now report results more consistently.

* **Bug Fixes**
  * Added validation for malformed inputs, policy files, identifiers, role names, policy JSON, and GovCloud account details.
  * Multiple validation issues can be reported together.
  * Invalid requests fail before AWS lookups, while usage is shown for validation failures.
  * Underlying AWS and OIDC errors are preserved for clearer diagnostics.

* **Documentation**
  * Added guidance on error handling, validation, diagnostics, and exit-code conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->