### PR TITLE
ROSAENG-5657 | feat: generate release metadata JSON for Konflux

### DIFF
--- a/hack/build_cli.sh
+++ b/hack/build_cli.sh
@@ -41,4 +41,18 @@ if [[ ! "$release_version" =~ ^[a-zA-Z0-9._-]+$ ]]; then
   exit 1
 fi
 
-(cd releases && sha256sum -- *.tar.gz *.zip > "rosa_${release_version}_SHA256SUMS")
+cat > "releases/rosa_${release_version}_metadata.json" <<METADATA
+{
+  "product": "Red Hat OpenShift Service on AWS (ROSA) CLI",
+  "version": "${release_version}",
+  "commit": "$(git rev-parse HEAD)",
+  "platforms": [
+    "linux/amd64", "linux/arm64",
+    "darwin/amd64", "darwin/arm64",
+    "windows/amd64", "windows/arm64"
+  ],
+  "formats": ["tar.gz", "zip"]
+}
+METADATA
+
+(cd releases && sha256sum -- *.tar.gz *.zip *.json > "rosa_${release_version}_SHA256SUMS")


### PR DESCRIPTION
## Summary
Generate a `rosa_<version>_metadata.json` file during the release build containing product name, version, commit SHA, and supported platforms.

## Why
The Konflux `create-github-release` task globs for `*.json` in the binaries directory. Without a JSON file, the task fails with `no match: *.json` due to `failglob`. This was originally written for Terraform provider releases which include a registry manifest JSON.

## What it produces
```json
{
  "product": "Red Hat OpenShift Service on AWS (ROSA) CLI",
  "version": "1.2.65-prerelease.1",
  "commit": "<full-sha>",
  "platforms": [
    "linux/amd64", "linux/arm64",
    "darwin/amd64", "darwin/arm64",
    "windows/amd64", "windows/arm64"
  ],
  "formats": ["tar.gz", "zip"]
}
```

The JSON is also included in the SHA256SUMS checksum manifest.

## Test plan
- [x] Pre-push checks pass (fmt, lint, build, tests)
- [ ] Konflux build produces the JSON in `releases/`
- [ ] `create-github-release` task picks up the JSON without error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release packages now include a metadata file with product version, commit information, supported platforms, and archive formats.
* **Chores**
  * SHA256 checksum files now verify the release metadata file alongside the TAR.GZ and ZIP archives, making package integrity checks more complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->