### PR TITLE
ROSAENG-5657 | fix: fetch tags in Konflux clone task for release versioning

### DIFF
--- a/.tekton/rosa-github-release.yaml
+++ b/.tekton/rosa-github-release.yaml
@@ -144,6 +144,8 @@ spec:
         value: $(params.git-url)
       - name: revision
         value: $(params.revision)
+      - name: fetchTags
+        value: "true"
       - name: ociStorage
         value: $(params.output-image).git
       - name: ociArtifactExpiresAfter


### PR DESCRIPTION
## Summary
Add `fetchTags: "true"` to the `clone-repository` task in `.tekton/rosa-github-release.yaml`.

## Why
Without fetching tags, `git describe --tags --exact-match` fails during the Konflux build, and `hack/build_cli.sh` falls back to the short commit SHA for versioning. This causes:
- SHA256SUMS filename: `rosa_74506ba_SHA256SUMS` instead of `rosa_1.2.65-prerelease.1_SHA256SUMS`
- Metadata JSON: `rosa_74506ba_metadata.json` instead of `rosa_1.2.65-prerelease.1_metadata.json`
- GitHub release title: "Release 74506ba" instead of "Release 1.2.65-prerelease.1"

## Test plan
- [x] Pre-push checks pass
- [ ] Konflux build from a tag produces version-named artifacts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release workflows now fetch repository tags during cloning, improving tag-based release handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->