### PR TITLE
ROSAENG-66016 | fix: derive channel group from --channel flag beforev ersion ID construction

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -1418,6 +1418,10 @@ func run(cmd *cobra.Command, _ []string) {
 	// OpenShift version:
 	version := args.version
 	channelGroup := args.channelGroup
+	channel := args.channel
+	if channel != "" {
+		channelGroup = ocm.ChannelGroupFromChannel(channel)
+	}
 	defaultVersion, versionList, err := versions.GetVersionList(r, channelGroup, isSTS, isHostedCP, isHostedCP, true)
 	if err != nil {
 		r.Reporter.Errorf("%s", err)
@@ -1444,14 +1448,6 @@ func run(cmd *cobra.Command, _ []string) {
 		r.Reporter.Errorf("Expected a valid OpenShift version: %s", err)
 		os.Exit(1)
 	}
-	if err := r.OCMClient.IsVersionCloseToEol(ocm.CloseToEolDays, version, channelGroup); err != nil {
-		r.Reporter.Warnf("%v", err)
-		if !confirm.Confirm("continue with version '%s'", ocm.GetRawVersionId(version)) {
-			os.Exit(0)
-		}
-	}
-
-	channel := args.channel
 	channels, err := r.OCMClient.GetAvailableChannels(version)
 	if err != nil {
 		r.Reporter.Errorf("Failed to retrieve available channels for version '%s': %s", version, err)
@@ -1468,6 +1464,17 @@ func run(cmd *cobra.Command, _ []string) {
 		if err != nil {
 			r.Reporter.Errorf("Expected a valid OpenShift Channel: %s", err)
 			os.Exit(1)
+		}
+	}
+	version, channelGroup, err = reconcileChannelGroupVersion(r, channel, channelGroup, version, isSTS, isHostedCP)
+	if err != nil {
+		r.Reporter.Errorf("%s", err)
+		os.Exit(1)
+	}
+	if err := r.OCMClient.IsVersionCloseToEol(ocm.CloseToEolDays, version, channelGroup); err != nil {
+		r.Reporter.Warnf("%v", err)
+		if !confirm.Confirm("continue with version '%s'", ocm.GetRawVersionId(version)) {
+			os.Exit(0)
 		}
 	}
 
@@ -4227,7 +4234,8 @@ func buildCommand(spec ocm.Spec, operatorRolesPrefix string,
 	}
 	if spec.Version != "" {
 		commandVersion := ocm.GetRawVersionId(spec.Version)
-		if spec.ChannelGroup != ocm.DefaultChannelGroup {
+		// --channel and --channel-group are mutually exclusive; prefer --channel when set.
+		if spec.Channel == "" && spec.ChannelGroup != ocm.DefaultChannelGroup {
 			command += fmt.Sprintf(" --channel-group %s", spec.ChannelGroup)
 		}
 		command += fmt.Sprintf(" --version %s", commandVersion)
@@ -4688,6 +4696,41 @@ func validateUniqueIamRoleArnsForStsCluster(accountRoles []string, operatorRoles
 	}
 
 	return nil
+}
+
+// reconcileChannelGroupVersion recomputes the channel group from the channel string and
+// re-validates the version against the new channel group's version list when they differ.
+// This handles the case where the channel was set via --channel flag or selected interactively
+// and the derived channel group differs from the one used during initial version resolution.
+// Note that this won't allow to choose a version that is present in the channel chosen in interactive mode
+// but not in the initial one. This is due to the fact that channel is available only after version
+// is known, not before.
+func reconcileChannelGroupVersion(
+	r *rosa.Runtime,
+	channel string,
+	channelGroup string,
+	version string,
+	isSTS bool,
+	isHostedCP bool,
+) (string, string, error) {
+	if channel == "" {
+		return version, channelGroup, nil
+	}
+	newChannelGroup := ocm.ChannelGroupFromChannel(channel)
+	if newChannelGroup == channelGroup {
+		return version, channelGroup, nil
+	}
+	channelGroup = newChannelGroup
+	_, versionList, err := versions.GetVersionList(r, channelGroup, isSTS, isHostedCP, isHostedCP, true)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to retrieve versions for channel group '%s': %w", channelGroup, err)
+	}
+	version, err = r.OCMClient.ValidateVersion(
+		ocm.GetRawVersionId(version), versionList, channelGroup, isSTS, isHostedCP)
+	if err != nil {
+		return "", "", fmt.Errorf("expected a valid OpenShift version for channel group '%s': %w", channelGroup, err)
+	}
+	return version, channelGroup, nil
 }
 
 func setSpotTerminationQueueURLForCreate(clusterConfig *ocm.Spec, isHostedCP bool, queueURL string) error {

--- a/pkg/ocm/versions.go
+++ b/pkg/ocm/versions.go
@@ -242,6 +242,21 @@ func GetNodePoolAvailableUpgrades(nodePool *cmv1.NodePool) []string {
 	return sortVersionsDesc(nodePool.Version().AvailableUpgrades())
 }
 
+// ChannelGroupFromChannel extracts the channel group prefix from a channel string.
+// For example, "candidate-4.22" returns "candidate", "eus-4.16" returns "eus",
+// "stable-4.20" returns "stable". Returns DefaultChannelGroup if the channel
+// string is empty or does not contain a hyphen separator.
+func ChannelGroupFromChannel(channel string) string {
+	if channel == "" {
+		return DefaultChannelGroup
+	}
+	idx := strings.Index(channel, "-")
+	if idx < 0 {
+		return DefaultChannelGroup
+	}
+	return channel[:idx]
+}
+
 func CreateVersionID(version string, channelGroup string) string {
 	versionID := fmt.Sprintf("%s%s", VersionPrefix, version)
 	if channelGroup != DefaultChannelGroup {

--- a/pkg/ocm/versions_test.go
+++ b/pkg/ocm/versions_test.go
@@ -237,6 +237,43 @@ var _ = Describe("Versions", Ordered, func() {
 		)
 	})
 
+	Context("when extracting channel group from channel", func() {
+		DescribeTable("Parse correctly channel group from channel string",
+			func(channel string, expected string) {
+				channelGroup := ChannelGroupFromChannel(channel)
+				Expect(channelGroup).To(Equal(expected))
+			},
+			Entry("candidate channel",
+				"candidate-4.22",
+				"candidate",
+			),
+			Entry("eus channel",
+				"eus-4.16",
+				"eus",
+			),
+			Entry("stable channel",
+				"stable-4.20",
+				"stable",
+			),
+			Entry("nightly channel",
+				"nightly-4.15",
+				"nightly",
+			),
+			Entry("fast channel",
+				"fast-4.18",
+				"fast",
+			),
+			Entry("empty channel defaults to stable",
+				"",
+				DefaultChannelGroup,
+			),
+			Entry("channel without hyphen defaults to stable",
+				"candidate",
+				DefaultChannelGroup,
+			),
+		)
+	})
+
 	Context("when upgrading a hosted control plane", func() {
 		DescribeTable("Should validate the requested version with the available upgrades",
 			func(userRequestedVersion string, supportedVersion string, clusterVersion string, expected bool) {

--- a/tests/e2e/test_rosacli_cluster.go
+++ b/tests/e2e/test_rosacli_cluster.go
@@ -3110,6 +3110,62 @@ var _ = Describe("HCP cluster creation negative testing",
 				}
 			})
 
+		It("to validate cluster creation with --channel flag resolves version correctly - [id:66016]",
+			labels.Medium, labels.Runtime.Day1Negative,
+			func() {
+				clusterName := helper.GenerateRandomName("ocp-66016", 2)
+				versionService := rosaClient.Version
+
+				By("Get a version available in the candidate channel group")
+				versionList, err := versionService.ListAndReflectJsonVersions(
+					rosacli.VersionChannelGroupCandidate, true)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(versionList).ToNot(BeEmpty())
+
+				candidateVersion := versionList[0].RAWID
+
+				By("Create HCP cluster with --channel and --version using dry-run")
+				replacingFlags := map[string]string{
+					"-c":              clusterName,
+					"--cluster-name":  clusterName,
+					"--domain-prefix": clusterName,
+					"--version":       candidateVersion,
+				}
+				rosalCommand.ReplaceFlagValue(replacingFlags)
+				if rosalCommand.CheckFlagExist("--channel-group") {
+					err = rosalCommand.DeleteFlag("--channel-group", true)
+					Expect(err).ToNot(HaveOccurred())
+				}
+				if rosalCommand.CheckFlagExist("--channel") {
+					err = rosalCommand.DeleteFlag("--channel", true)
+					Expect(err).ToNot(HaveOccurred())
+				}
+				rosalCommand.AddFlags(
+					"--channel", fmt.Sprintf("candidate-%s",
+						strings.Join(strings.Split(candidateVersion, ".")[:2], ".")),
+					"--dry-run", "-y")
+				out, err := rosaClient.Runner.RunCMD(strings.Split(rosalCommand.GetFullCommand(), " "))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(out.String()).To(ContainSubstring(
+					fmt.Sprintf("Creating cluster '%s' should succeed", clusterName)))
+			})
+
+		It("to validate --channel and --channel-group are mutually exclusive - [id:66016]",
+			labels.Medium, labels.Runtime.Day1Negative,
+			func() {
+				clusterName := helper.GenerateRandomName("ocp-66016-excl", 2)
+
+				By("Create cluster with both --channel and --channel-group")
+				_, err := clusterService.CreateDryRun(
+					clusterName,
+					"--channel", "candidate-4.22",
+					"--channel-group", "candidate",
+				)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(
+					"if any flags in the group [channel channel-group] are set none of the others can be"))
+			})
+
 		It("to validate hcp creation with registry config via rosacli - [id:76396]",
 			labels.Medium, labels.Runtime.Day1Negative,
 			func() {


### PR DESCRIPTION


<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when the option is not applicable to your case.

Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
Supported ticket prefixes:
OCM-XXXXX, ROSAENG-XXXX
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For contributor workflow, see: ./CONTRIBUTING.md
For repo-local agent guidance, see: ./AGENTS.md
-->

## PR Summary
Fix an issue when creating a cluster with a non-default channel that was behaving differently compared to the channel-group case.

## Detailed Description of the Issue
When creating a cluster with `--channel candidate-4.22 --version 4.22.8`, the version ID sent to the API was `openshift-v4.22.8` instead of `openshift-v4.22.8-candidate`. This happened because `--channel` and `--channel-group` are mutually exclusive, and `channelGroup` defaulted to `stable` when only `--channel` was provided. The channel group was never derived from the channel string before being used for version list fetching and version ID construction via `CreateVersionID()`.

Move the `channel` variable read before version resolution in `cmd/create/cluster/cmd.go` and, when set, derive the channel group from it using a new `ChannelGroupFromChannel()` helper in `pkg/ocm/versions.go`. This ensures `GetVersionList()` queries the correct channel group and `CreateVersionID()` appends the correct suffix.

Follow-up: [ROSAENG-66021](https://redhat.atlassian.net/browse/ROSAENG-66021) adds a `Channel` field to the E2E test `Profile` struct and a profile that exercises `--channel` on a live cluster.

## Related Issues and PRs
<!-- Link all tracking items and related code changes -->
- Jira: [ROSAENG-66016](https://issues.redhat.com/browse/ROSAENG-66016)
- Fixes: `#`
- Related PR(s):
- Related design/docs:

## Type of Change
<!-- Check the primary type this PR represents -->
- [ ] feat - adds a new user-facing capability.
- [X] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
<!-- What users or systems experienced before this change -->
When creating a cluster with a non-default channel, e.g.
`--channel candidate-4.22 --version 4.22.8`, the API output was
```
  "version": {
    "kind": "Version",
    "id": "openshift-v4.22.8",
    "channel_group": "candidate"
  }
```

## Behavior After This Change
<!-- What changes now, including user-visible and non-user-visible behavior -->
API output is now
```
  "version": {
    "kind": "Version",
    "id": "openshift-v4.22.8-candidate",
    "channel_group": "candidate"
  }
```

## How to Test (Step-by-Step)
<!-- Provide reproducible validation instructions -->
### Preconditions
<!-- Required setup, environment, credentials, flags, cluster state, etc. -->

### Test Steps
1. Create a cluster with a non default channel
2. Check that version.id is suffixed with the channel-group type
3.

### Expected Results
<!-- What should happen after running the steps above -->
It should be suffixed

## Proof of the Fix
<!-- Attach evidence that demonstrates the changed behavior -->
- Screenshots:
- Videos:
- Logs/CLI output:
- Other artifacts:
Debug output
```
time=2026-08-31T12:12:39+02:00 level=debug msg={
  "kind": "Cluster",
  "api": {
    "listening": "external"
  },
  "aws": {
    "sts": {
      "auto_mode": true,
      "instance_iam_roles": {
        "worker_role_arn": "arn:aws:iam::765374464689:role/adecorte-loc-HCP-ROSA-Worker-Role"
      },
      "oidc_config": {
        "id": "2mhlpkvc2etb4hqhns6kddh827eh2div"
      },
      "operator_iam_roles": [
        {
          "name": "control-plane-operator",
          "namespace": "kube-system",
          "role_arn": "arn:aws:iam::765374464689:role/ad-loc1-l0n8-kube-system-control-plane-operator"
        },
        {
          "name": "kms-provider",
          "namespace": "kube-system",
          "role_arn": "arn:aws:iam::765374464689:role/ad-loc1-l0n8-kube-system-kms-provider"
        },
        {
          "name": "kube-controller-manager",
          "namespace": "kube-system",
          "role_arn": "arn:aws:iam::765374464689:role/ad-loc1-l0n8-kube-system-k

        },
        {
          "name": "installer-cloud-credentials",
          "namespace": "openshift-image-registry",
          "role_arn": "arn:aws:iam::765374464689:role/ad-loc1-l0n8-openshift-image-registry-installer-cloud-credential"
        },
        {
          "name": "cloud-credentials",
          "namespace": "openshift-ingress-operator",
          "role_arn": "arn:aws:iam::765374464689:role/ad-loc1-l0n8-openshift-ingress-operator-cloud-credentials"
        },
        {
          "name": "ebs-cloud-credentials",
          "namespace": "openshift-cluster-csi-drivers",
          "role_arn": "arn:aws:iam::765374464689:role/ad-loc1-l0n8-openshift-cluster-csi-drivers-ebs-cloud-credentials"
        },
        {
          "name": "cloud-credentials",
          "namespace": "openshift-cloud-network-config-controller",
          "role_arn": "arn:aws:iam::765374464689:role/ad-loc1-l0n8-openshift-cloud-network-config-controller-cloud-cre"
        },
        {
          "name": "capa-controller-manager",
          "namespace": "kube-system",
          "role_arn": "arn:aws:iam::765374464689:role/ad-loc1-l0n8-kube-system-capa-controller-manager"
        }
      ],
      "role_arn": "arn:aws:iam::765374464689:role/adecorte-loc-HCP-ROSA-Installer-Role",
      "support_role_arn": "arn:aws:iam::765374464689:role/adecorte-loc-HCP-ROSA-Support-Role"
    },
    "account_id": "765374464689",
    "audit_log": {
      "role_arn": ""
    },
    "billing_account_id": "765374464689",
    "ec2_metadata_http_tokens": "optional",
    "private_link": false,
    "subnet_ids": [
      "subnet-06997ced6874ac324",
      "subnet-0e3a4046c1c2f1078"
    ]
  },
  "fips": false,
  "channel": "candidate-4.22",
  "etcd_encryption": false,
  "flavour": {
    "kind": "Flavour",
    "id": "osd-4"
  },
  "hypershift": {
    "enabled": true
  },
  "ingresses": {
    "items": [
      {
        "kind": "Ingress",
        "default": true,
        "listening": "external"
      }
    ]
  },
  "multi_az": true,
  "name": "ad-loc1",
  "network": {
    "host_prefix": 23,
    "machine_cidr": "10.0.0.0/16",
    "pod_cidr": "10.128.0.0/13",
    "service_cidr": "172.30.0.0/16"
  },
  "nodes": {
    "availability_zones": [
      "us-west-2a"
    ],
    "compute": 2,
    "compute_machine_type": {
      "kind": "MachineType",
      "id": "m5.xlarge"
    }
  },
  "product": {
    "kind": "Product",
    "id": "rosa"
  },
  "properties": {
    "rosa_cli_version": "1.2.64",
    "rosa_creator_arn": "arn:aws:iam::765374464689:user/adecorte"
  },
  "region": {
    "kind": "CloudRegion",
    "id": "us-west-2"
  },
  "version": {
    "kind": "Version",
    "id": "openshift-v4.22.8-candidate"
  }
}
```

Note: E2E tests will be followed up with [ROSAENG-66021](https://redhat.atlassian.net/browse/ROSAENG-66021) as they require new test profiles.

## Breaking Changes
- [X] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
<!-- Required only when breaking changes are introduced -->

## Developer Verification Checklist
- [X] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [X] PR description clearly explains both **what** changed and **why**.
- [X] Relevant Jira/GitHub issues and related PRs are linked.
- [X] `make install-hooks` has been run in this clone.
- [X] Tests were added/updated where appropriate.
- [X] I manually tested the change.
- [X] `make test` passes.
- [X] `make lint` passes.
- [X] `make rosa` passes.
- [X] Documentation or repo-local agent guidance was added/updated where appropriate.
- [X] Any risk, limitation, or follow-up work is documented.


[ROSAENG-66016]: https://redhat.atlassian.net/browse/ROSAENG-66016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ROSAENG-66021]: https://redhat.atlassian.net/browse/ROSAENG-66021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Added by amandahla -->
Reasoning:
The CLI must derive the channel group because the Version payload must contain a version ID and channel group that are consistent before cluster creation.
See https://github.com/openshift/rosa/pull/3493/changes#r3903829065

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cluster creation now automatically determines the appropriate channel group from the selected channel.
  * Version selection and validation remain aligned when channels are chosen through flags or interactive prompts.
  * Dry-run cluster creation resolves versions correctly for candidate channels.

* **Bug Fixes**
  * Prevented conflicting use of `--channel` and `--channel-group`.
  * Improved validation and end-of-life warnings when selected channels and versions require channel-group reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->