### PR TITLE
ROSAENG-61179 | fix(ci): align release image with v1.2.65 assets

### DIFF
--- a/images/Dockerfile.release
+++ b/images/Dockerfile.release
@@ -11,9 +11,9 @@ RUN curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscl
     ./aws/install && \
     rm -rf awscliv2.zip aws &&\
     aws --version
-RUN curl -sL $(curl -s https://api.github.com/repos/openshift/rosa/releases/latest | jq -r '.assets[] | select(.name == "rosa_Linux_x86_64.tar.gz") | .browser_download_url') --output /usr/bin/rosa.tar.gz && \
-    tar -xzvf /usr/bin/rosa.tar.gz -C /usr/bin && \
-    rm /usr/bin/rosa.tar.gz && \
+RUN curl -sL $(curl -s https://api.github.com/repos/openshift/rosa/releases/latest | jq -r '.assets[] | select(.name == "rosa_linux_amd64.zip") | .browser_download_url') --output /usr/bin/rosa.zip && \
+    unzip -oq /usr/bin/rosa.zip -d /usr/bin && \
+    rm /usr/bin/rosa.zip && \
     chmod +x /usr/bin/rosa
 RUN rosa verify openshift-client
 WORKDIR /rosa

--- a/images/Dockerfile.release
+++ b/images/Dockerfile.release
@@ -11,9 +11,14 @@ RUN curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscl
     ./aws/install && \
     rm -rf awscliv2.zip aws &&\
     aws --version
-RUN curl -sL $(curl -s https://api.github.com/repos/openshift/rosa/releases/latest | jq -r '.assets[] | select(.name == "rosa_linux_amd64.zip") | .browser_download_url') --output /usr/bin/rosa.zip && \
-    unzip -oq /usr/bin/rosa.zip -d /usr/bin && \
-    rm /usr/bin/rosa.zip && \
-    chmod +x /usr/bin/rosa
+RUN RELEASE_JSON=$(curl -fsSL https://api.github.com/repos/openshift/rosa/releases/latest) && \
+    RELEASE_TAG=$(echo "$RELEASE_JSON" | jq -r '.tag_name') && \
+    RELEASE_VERSION=${RELEASE_TAG#v} && \
+    curl -fsSL $(echo "$RELEASE_JSON" | jq -r '.assets[] | select(.name == "rosa_linux_amd64.zip") | .browser_download_url') --output /usr/bin/rosa_linux_amd64.zip && \
+    curl -fsSL "https://github.com/openshift/rosa/releases/download/${RELEASE_TAG}/rosa_${RELEASE_VERSION}_SHA256SUMS" --output /usr/bin/rosa_SHA256SUMS && \
+    cd /usr/bin && grep 'rosa_linux_amd64.zip' rosa_SHA256SUMS | sha256sum -c - && \
+    unzip -oq rosa_linux_amd64.zip && \
+    rm rosa_linux_amd64.zip rosa_SHA256SUMS && \
+    chmod +x rosa
 RUN rosa verify openshift-client
 WORKDIR /rosa


### PR DESCRIPTION
## PR Summary
Fixes `pull-ci-openshift-rosa-master-images-release-images` by updating `images/Dockerfile.release` to download the new `rosa_linux_amd64.zip` GitHub release asset introduced in v1.2.65.

## Detailed Description of the Issue
The v1.2.65 GitHub release changed asset naming and packaging (`rosa_linux_amd64.zip` instead of `rosa_Linux_x86_64.tar.gz`). `images/Dockerfile.release` still queried the old asset name from `releases/latest`, so `jq` returned an empty URL and the `rosa-aws-cli` image build failed with `curl: no URL specified!`. This blocked merge for PRs that only touch tests, including [#3445](https://github.com/openshift/rosa/pull/3445) and [#3444](https://github.com/openshift/rosa/pull/3444).

## Related Issues and PRs
- Jira: [ROSAENG-61179](https://issues.redhat.com/browse/ROSAENG-61179)
- Fixes: `N/A`
- Related PR(s):
  - [#3445](https://github.com/openshift/rosa/pull/3445) — blocked on `images-release-images`
  - [#3444](https://github.com/openshift/rosa/pull/3444) — blocked on `images-release-images`
  - [#3486](https://github.com/openshift/rosa/pull/3486) — Konflux release metadata / new asset naming
- Related design/docs: `N/A`

## Type of Change
- [ ] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [x] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
- `images/Dockerfile.release` downloaded `rosa_Linux_x86_64.tar.gz` from GitHub `releases/latest` and extracted it with `tar`.

## Behavior After This Change
- The release image Dockerfile downloads `rosa_linux_amd64.zip`, extracts the `rosa` binary with `unzip`, and continues the existing `rosa verify openshift-client` step.

## How to Test (Step-by-Step)
### Preconditions
- Network access to GitHub releases API and the v1.2.65 asset URL.

### Test Steps
1. Confirm the latest release exposes `rosa_linux_amd64.zip`:
   `curl -fsSL https://api.github.com/repos/openshift/rosa/releases/latest | jq -r '.assets[] | select(.name == "rosa_linux_amd64.zip") | .browser_download_url'`
2. Merge this PR and verify `pull-ci-openshift-rosa-master-images-release-images` succeeds on dependent PRs (for example #3445).

### Expected Results
- The `jq` query returns a non-empty download URL.
- The `images-release-images` Prow job builds `rosa-aws-cli` successfully.

## Proof of the Fix
- Screenshots: `N/A`
- Videos: `N/A`
- Logs/CLI output:
  - Failed job log showed `curl: no URL specified!` when querying `rosa_Linux_x86_64.tar.gz` after v1.2.65 publication.
  - Verified v1.2.65 zip layout contains a top-level `rosa` binary via `unzip -l`.
- Other artifacts: `N/A`

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
`N/A`

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [ ] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [x] `make test` passes (via pre-push).
- [x] `make lint` passes (via pre-push).
- [x] `make rosa` passes (via pre-push build).
- [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

[ROSAENG-61179]: https://redhat.atlassian.net/browse/ROSAENG-61179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated release packaging to use the latest ROSA Linux AMD64 release assets.
  - Added archive checksum verification to improve download integrity.
  - Improved extraction and cleanup of temporary download files during packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->