### PR TITLE
ROSAENG-65904 | test: drain HyperFleet ingress ELBs before VPC teardown

### DIFF
--- a/tests/utils/handler/resources_handler.go
+++ b/tests/utils/handler/resources_handler.go
@@ -269,7 +269,13 @@ func (rh *resourcesHandler) DestroyResources() (errors []error) {
 	// delete vpc chain
 	if resources.VpcID != "" {
 		log.Logger.Infof("Find prepared vpc id: %s", resources.VpcID)
-		err = rh.DeleteVPCChain(resources.FromSharedAWSAccount != nil && resources.FromSharedAWSAccount.VPC)
+		sharedVPC := resources.FromSharedAWSAccount != nil && resources.FromSharedAWSAccount.VPC
+		if usesRegionalPlatformAPI() {
+			if preErr := rh.drainVPCLoadBalancers(resources.VpcID, sharedVPC); preErr != nil {
+				log.Logger.Warnf("drain VPC load balancers: %v", preErr)
+			}
+		}
+		err = rh.DeleteVPCChain(sharedVPC)
 		success := destroyLog(err, "vpc chain")
 		if success {
 			rh.registerVpcID("", false)

--- a/tests/utils/handler/resources_handler_clean.go
+++ b/tests/utils/handler/resources_handler_clean.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -11,6 +12,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	elbclassic "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing"
+	elbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
 	r53 "github.com/aws/aws-sdk-go-v2/service/route53"
 	r53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
 	"github.com/openshift-online/ocm-common/pkg/aws/aws_client"
@@ -436,4 +439,112 @@ func isAWSAuthorizationError(err error) bool {
 // internal communication zone (suffix: hypershift.local) vs an ingress zone.
 func hostedZoneIsHCPInternal(hostedZoneName string) bool {
 	return strings.HasSuffix(hostedZoneName, hcpInternalHostedZoneSuffix)
+}
+
+// drainVPCLoadBalancers deletes ingress LBs in the VPC and waits for their ENIs
+// to release so DeleteVPCChain can finish. OCM destroy does not call this.
+func (rh *resourcesHandler) drainVPCLoadBalancers(vpcID string, withSharedAccount bool) error {
+	awsClient, err := rh.GetAWSClient(withSharedAccount)
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	classic := elbclassic.NewFromConfig(*awsClient.AWSConfig)
+	err = wait.PollUntilContextTimeout(ctx, 10*time.Second, 10*time.Minute, true, func(ctx context.Context) (bool, error) {
+		remaining, err := drainLBs(ctx, classic, awsClient.ElbClient, vpcID)
+		if err != nil || remaining > 0 {
+			return false, err
+		}
+		inUse, err := elbENIsInUse(ctx, awsClient.Ec2Client, vpcID)
+		return !inUse, err
+	})
+	if err != nil {
+		return fmt.Errorf("drain ingress LBs in VPC %s: %w", vpcID, err)
+	}
+	return deleteAvailableENIs(ctx, awsClient.Ec2Client, vpcID)
+}
+
+func drainLBs(ctx context.Context, classic *elbclassic.Client, v2 *elbv2.Client, vpcID string) (int, error) {
+	classicCount, classicErr := drainClassicELBs(ctx, classic, vpcID)
+	v2Count, v2Err := drainV2ELBs(ctx, v2, vpcID)
+	return classicCount + v2Count, errors.Join(classicErr, v2Err)
+}
+
+func elbENIsInUse(ctx context.Context, ec2c aws_client.EC2ClientAPI, vpcID string) (bool, error) {
+	out, err := ec2c.DescribeNetworkInterfaces(ctx, &ec2.DescribeNetworkInterfacesInput{
+		Filters: eniFilters(vpcID, "in-use"),
+	})
+	if err != nil {
+		return false, err
+	}
+	for _, eni := range out.NetworkInterfaces {
+		if strings.HasPrefix(aws.ToString(eni.Description), "ELB ") {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func deleteAvailableENIs(ctx context.Context, ec2c aws_client.EC2ClientAPI, vpcID string) error {
+	out, err := ec2c.DescribeNetworkInterfaces(ctx, &ec2.DescribeNetworkInterfacesInput{
+		Filters: eniFilters(vpcID, "available"),
+	})
+	if err != nil {
+		return err
+	}
+	for _, eni := range out.NetworkInterfaces {
+		_, _ = ec2c.DeleteNetworkInterface(ctx, &ec2.DeleteNetworkInterfaceInput{
+			NetworkInterfaceId: eni.NetworkInterfaceId,
+		})
+	}
+	return nil
+}
+
+func eniFilters(vpcID, status string) []types.Filter {
+	return []types.Filter{
+		{Name: aws.String("vpc-id"), Values: []string{vpcID}},
+		{Name: aws.String("status"), Values: []string{status}},
+	}
+}
+
+func drainClassicELBs(ctx context.Context, classic *elbclassic.Client, vpcID string) (int, error) {
+	remaining := 0
+	var marker *string
+	for {
+		out, err := classic.DescribeLoadBalancers(ctx, &elbclassic.DescribeLoadBalancersInput{Marker: marker})
+		if err != nil {
+			return 0, err
+		}
+		for _, lb := range out.LoadBalancerDescriptions {
+			if aws.ToString(lb.VPCId) != vpcID {
+				continue
+			}
+			remaining++
+			_, _ = classic.DeleteLoadBalancer(ctx, &elbclassic.DeleteLoadBalancerInput{LoadBalancerName: lb.LoadBalancerName})
+		}
+		if marker = out.NextMarker; marker == nil {
+			return remaining, nil
+		}
+	}
+}
+
+func drainV2ELBs(ctx context.Context, v2 *elbv2.Client, vpcID string) (int, error) {
+	remaining := 0
+	var marker *string
+	for {
+		out, err := v2.DescribeLoadBalancers(ctx, &elbv2.DescribeLoadBalancersInput{Marker: marker})
+		if err != nil {
+			return 0, err
+		}
+		for _, lb := range out.LoadBalancers {
+			if aws.ToString(lb.VpcId) != vpcID {
+				continue
+			}
+			remaining++
+			_, _ = v2.DeleteLoadBalancer(ctx, &elbv2.DeleteLoadBalancerInput{LoadBalancerArn: lb.LoadBalancerArn})
+		}
+		if marker = out.NextMarker; marker == nil {
+			return remaining, nil
+		}
+	}
 }


### PR DESCRIPTION
## PR Summary
HyperFleet E2E cleanup now deletes ingress load balancers and waits for their ENIs before tearing down the VPC. OCM destroy is unchanged.

## Detailed Description of the Issue
HyperFleet destroy left classic ELBs in the BYO VPC. VPC cleanup then failed on security groups and ELB ENIs.

## Related Issues and PRs
- Jira: [ROSAENG-65904](https://issues.redhat.com/browse/ROSAENG-65904)
- Fixes: N/A
- Related PR(s): N/A
- Related design/docs: N/A

## Type of Change
- [ ] feat
- [ ] fix
- [ ] docs
- [ ] style
- [ ] refactor
- [x] test
- [ ] chore
- [ ] build
- [ ] ci
- [ ] perf

## Previous Behavior
Cleanup called `DeleteVPCChain` while ingress ELBs and ENIs were still in the VPC.

## Behavior After This Change
For HyperFleet runs only: delete classic and v2 LBs, wait for ENIs, then run `DeleteVPCChain`.

## How to Test (Step-by-Step)
### Preconditions
HyperFleet config, AWS creds, BYO VPC cluster.

### Test Steps

1)
```
unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
export AWS_PROFILE=rrp-hcp-dev
export AWS_DEFAULT_REGION=us-east-1
export HYPERFLEET_URL=<api_url>
export TEST_PROFILE=rosa-hyperfleet-basic
export NAME_PREFIX=<cluster_name>
export REGION=<region>
export WAIT_SETUP_CLUSTER_READY=false
export SHARED_DIR=$PWD/tests/output/rosa-hyperfleet-basic

rosa login --hyperfleet-url "$HYPERFLEET_URL"
rosa whoami -o json        
rosa list clusters                
```
2)
```
ginkgo run --label-filter 'day1||day1-readiness' --timeout 90m -v ./tests/e2e/
```
3)
```
ginkgo run --label-filter destroy --timeout 30m -v ./tests/e2e/
```

### Expected Results
No ELBs or ENIs left. VPC cleanup succeeds.

## Proof of the Fix
- Screenshots: N/A
- Videos: N/A
- Logs/CLI output: E2E cleanup completes without VPC/ENI errors.
- Other artifacts: N/A

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [ ] `make test` passes.
- [ ] `make lint` passes.
- [ ] `make rosa` passes.
- [x] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.


[ROSAENG-65904]: https://redhat.atlassian.net/browse/ROSAENG-65904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ