### PR TITLE
ROSAENG-65546 | feat: add dispatch routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,23 @@ When adding or changing a CLI command:
 - Prefer placing business logic in `pkg/` and keeping Cobra command files thin.
 - Review similar commands in the same area before adding new flags, validation, or flow control.
 
+## Hyperfleet Dispatch Pattern
+
+Each command that supports the Platform API (hyperfleet) path uses a `dispatch` function
+as the Cobra `Run:` entrypoint. The dispatch checks `hyperfleet.Enabled()` and routes to
+either the v2 runner (once implemented) or the original v1 `run()` function. Until a v2
+runner exists, the enabled path reports an unsupported-command error and exits.
+
+When adding hyperfleet support to a command:
+
+- Implement the v2 logic in a separate `run_v2.go` file inside the command package.
+  Use the name `runV2` for the entrypoint function. Avoid using product names like
+  "hyperfleet" in file or function names under `cmd/` — use `v2` instead.
+- Replace the stub error in `dispatch.go` with a call to `runV2`.
+- Do not modify the original `run()` function or add hyperfleet conditionals inside it.
+- Keep the v2 runner self-contained: it should build its own runtime
+  (e.g., `NewRuntime().WithHyperFleet()`) without affecting the v1 path.
+
 ## Tests And Verification
 
 - Run `make install-hooks` once per clone before committing.

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -290,7 +290,7 @@ func makeCmd() *cobra.Command {
 
   # Create a cluster in the us-east-2 region
   rosa create cluster --cluster-name=mycluster --region=us-east-2`,
-		Run:  run,
+		Run:  dispatch,
 		Args: cobra.NoArgs,
 	}
 }

--- a/cmd/create/cluster/dispatch.go
+++ b/cmd/create/cluster/dispatch.go
@@ -1,0 +1,26 @@
+package cluster
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/hyperfleet"
+	"github.com/openshift/rosa/pkg/reporter"
+)
+
+var (
+	hyperfleetEnabled = hyperfleet.Enabled
+	runV1             = run
+	exitWithError     = func() { os.Exit(1) }
+)
+
+func dispatch(cmd *cobra.Command, args []string) {
+	if hyperfleetEnabled() {
+		r := reporter.CreateReporter()
+		r.Errorf("This command is not yet supported with the Platform API")
+		exitWithError()
+		return
+	}
+	runV1(cmd, args)
+}

--- a/cmd/create/cluster/dispatch_test.go
+++ b/cmd/create/cluster/dispatch_test.go
@@ -1,0 +1,76 @@
+package cluster
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/hyperfleet"
+)
+
+var _ = Describe("Dispatch", func() {
+	var cmd *cobra.Command
+	var runCalled bool
+	var exitCalled bool
+	var exitCode int
+
+	BeforeEach(func() {
+		cmd = &cobra.Command{}
+		runCalled = false
+		exitCalled = false
+		exitCode = 0
+
+		// Override v1 runner to avoid actual execution
+		runV1 = func(*cobra.Command, []string) {
+			runCalled = true
+		}
+
+		// Override exit function
+		exitWithError = func() {
+			exitCalled = true
+			exitCode = 1
+		}
+	})
+
+	AfterEach(func() {
+		// Reset to production defaults
+		runV1 = run
+		exitWithError = func() { os.Exit(1) }
+		hyperfleetEnabled = hyperfleet.Enabled
+	})
+
+	Context("when hyperfleet is disabled", func() {
+		BeforeEach(func() {
+			hyperfleetEnabled = func() bool { return false }
+		})
+
+		It("should call the v1 run function", func() {
+			dispatch(cmd, []string{})
+			Expect(runCalled).To(BeTrue())
+		})
+
+		It("should not call exit", func() {
+			dispatch(cmd, []string{})
+			Expect(exitCalled).To(BeFalse())
+		})
+	})
+
+	Context("when hyperfleet is enabled", func() {
+		BeforeEach(func() {
+			hyperfleetEnabled = func() bool { return true }
+		})
+
+		It("should not call the v1 run function", func() {
+			dispatch(cmd, []string{})
+			Expect(runCalled).To(BeFalse())
+		})
+
+		It("should call exit with status 1", func() {
+			dispatch(cmd, []string{})
+			Expect(exitCalled).To(BeTrue())
+			Expect(exitCode).To(Equal(1))
+		})
+	})
+})

--- a/cmd/create/machinepool/cmd.go
+++ b/cmd/create/machinepool/cmd.go
@@ -45,7 +45,7 @@ func NewCreateMachinePool(spec CreateMachinePoolSpec) CreateMachinePool {
 
 func NewCreateMachinePoolCommand() *cobra.Command {
 	cmd, options := mpOpts.BuildMachinePoolCreateCommandWithOptions()
-	cmd.Run = rosa.DefaultRunner(rosa.RuntimeWithOCM(), CreateMachinepoolRunner(options))
+	cmd.Run = dispatch(options)
 	return cmd
 }
 

--- a/cmd/create/machinepool/dispatch.go
+++ b/cmd/create/machinepool/dispatch.go
@@ -1,0 +1,27 @@
+package machinepool
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/hyperfleet"
+	mpOpts "github.com/openshift/rosa/pkg/options/machinepool"
+	"github.com/openshift/rosa/pkg/reporter"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+var (
+	hyperfleetEnabled = hyperfleet.Enabled
+	exitWithError     = func() { os.Exit(1) }
+)
+
+func dispatch(options *mpOpts.CreateMachinepoolUserOptions) func(*cobra.Command, []string) {
+	if hyperfleetEnabled() {
+		r := reporter.CreateReporter()
+		r.Errorf("This command is not yet supported with the Platform API")
+		exitWithError()
+		return nil
+	}
+	return rosa.DefaultRunner(rosa.RuntimeWithOCM(), CreateMachinepoolRunner(options))
+}

--- a/cmd/create/machinepool/dispatch_test.go
+++ b/cmd/create/machinepool/dispatch_test.go
@@ -1,0 +1,71 @@
+package machinepool
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/rosa/pkg/hyperfleet"
+	mpOpts "github.com/openshift/rosa/pkg/options/machinepool"
+)
+
+var _ = Describe("Dispatch", func() {
+	var exitCalled bool
+	var exitCode int
+
+	BeforeEach(func() {
+		exitCalled = false
+		exitCode = 0
+
+		// Override exit function
+		exitWithError = func() {
+			exitCalled = true
+			exitCode = 1
+		}
+	})
+
+	AfterEach(func() {
+		// Reset to production defaults
+		exitWithError = func() { os.Exit(1) }
+		hyperfleetEnabled = hyperfleet.Enabled
+	})
+
+	Context("when hyperfleet is disabled", func() {
+		BeforeEach(func() {
+			hyperfleetEnabled = func() bool { return false }
+		})
+
+		It("should return a runner function", func() {
+			opts := &mpOpts.CreateMachinepoolUserOptions{}
+			runner := dispatch(opts)
+			Expect(runner).NotTo(BeNil())
+		})
+
+		It("should not call exit", func() {
+			opts := &mpOpts.CreateMachinepoolUserOptions{}
+			dispatch(opts)
+			Expect(exitCalled).To(BeFalse())
+		})
+	})
+
+	Context("when hyperfleet is enabled", func() {
+		BeforeEach(func() {
+			hyperfleetEnabled = func() bool { return true }
+		})
+
+		It("should call exit with status 1", func() {
+			opts := &mpOpts.CreateMachinepoolUserOptions{}
+			dispatch(opts)
+			Expect(exitCalled).To(BeTrue())
+			Expect(exitCode).To(Equal(1))
+		})
+
+		It("should return nil instead of a runner", func() {
+			opts := &mpOpts.CreateMachinepoolUserOptions{}
+			runner := dispatch(opts)
+			Expect(exitCalled).To(BeTrue())
+			Expect(runner).To(BeNil())
+		})
+	})
+})

--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -53,7 +53,7 @@ var Cmd = &cobra.Command{
 	Long:  "Show details of a cluster",
 	Example: `  # Describe a cluster named "mycluster"
   rosa describe cluster --cluster=mycluster`,
-	Run:  run,
+	Run:  dispatch,
 	Args: cobra.MaximumNArgs(1),
 }
 

--- a/cmd/describe/cluster/dispatch.go
+++ b/cmd/describe/cluster/dispatch.go
@@ -1,0 +1,26 @@
+package cluster
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/hyperfleet"
+	"github.com/openshift/rosa/pkg/reporter"
+)
+
+var (
+	hyperfleetEnabled = hyperfleet.Enabled
+	runV1             = run
+	exitWithError     = func() { os.Exit(1) }
+)
+
+func dispatch(cmd *cobra.Command, args []string) {
+	if hyperfleetEnabled() {
+		r := reporter.CreateReporter()
+		r.Errorf("This command is not yet supported with the Platform API")
+		exitWithError()
+		return
+	}
+	runV1(cmd, args)
+}

--- a/cmd/describe/cluster/dispatch_test.go
+++ b/cmd/describe/cluster/dispatch_test.go
@@ -1,0 +1,76 @@
+package cluster
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/hyperfleet"
+)
+
+var _ = Describe("Dispatch", func() {
+	var cmd *cobra.Command
+	var runCalled bool
+	var exitCalled bool
+	var exitCode int
+
+	BeforeEach(func() {
+		cmd = &cobra.Command{}
+		runCalled = false
+		exitCalled = false
+		exitCode = 0
+
+		// Override v1 runner to avoid actual execution
+		runV1 = func(*cobra.Command, []string) {
+			runCalled = true
+		}
+
+		// Override exit function
+		exitWithError = func() {
+			exitCalled = true
+			exitCode = 1
+		}
+	})
+
+	AfterEach(func() {
+		// Reset to production defaults
+		runV1 = run
+		exitWithError = func() { os.Exit(1) }
+		hyperfleetEnabled = hyperfleet.Enabled
+	})
+
+	Context("when hyperfleet is disabled", func() {
+		BeforeEach(func() {
+			hyperfleetEnabled = func() bool { return false }
+		})
+
+		It("should call the v1 run function", func() {
+			dispatch(cmd, []string{})
+			Expect(runCalled).To(BeTrue())
+		})
+
+		It("should not call exit", func() {
+			dispatch(cmd, []string{})
+			Expect(exitCalled).To(BeFalse())
+		})
+	})
+
+	Context("when hyperfleet is enabled", func() {
+		BeforeEach(func() {
+			hyperfleetEnabled = func() bool { return true }
+		})
+
+		It("should not call the v1 run function", func() {
+			dispatch(cmd, []string{})
+			Expect(runCalled).To(BeFalse())
+		})
+
+		It("should call exit with status 1", func() {
+			dispatch(cmd, []string{})
+			Expect(exitCalled).To(BeTrue())
+			Expect(exitCode).To(Equal(1))
+		})
+	})
+})

--- a/cmd/describe/machinepool/cmd.go
+++ b/cmd/describe/machinepool/cmd.go
@@ -47,7 +47,7 @@ func NewDescribeMachinePoolCommand() *cobra.Command {
 		Aliases: []string{alias},
 		Example: example,
 		Args:    cobra.MaximumNArgs(1),
-		Run:     rosa.DefaultRunner(rosa.RuntimeWithOCM(), DescribeMachinePoolRunner(options)),
+		Run:     dispatch(options),
 	}
 
 	flags := cmd.Flags()
@@ -75,7 +75,7 @@ func DescribeMachinePoolRunner(userOptions *DescribeMachinepoolUserOptions) rosa
 		clusterKey := runtime.GetClusterKey()
 		cluster := runtime.FetchCluster()
 		if cluster.State() != cmv1.ClusterStateReady {
-			return fmt.Errorf("Cluster '%s' is not yet ready", clusterKey)
+			return fmt.Errorf("Cluster '%s' is not yet ready", clusterKey) //nolint:staticcheck
 		}
 
 		service := machinepool.NewMachinePoolService()

--- a/cmd/describe/machinepool/dispatch.go
+++ b/cmd/describe/machinepool/dispatch.go
@@ -1,0 +1,26 @@
+package machinepool
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/hyperfleet"
+	"github.com/openshift/rosa/pkg/reporter"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+var (
+	hyperfleetEnabled = hyperfleet.Enabled
+	exitWithError     = func() { os.Exit(1) }
+)
+
+func dispatch(options *DescribeMachinepoolUserOptions) func(*cobra.Command, []string) {
+	if hyperfleetEnabled() {
+		r := reporter.CreateReporter()
+		r.Errorf("This command is not yet supported with the Platform API")
+		exitWithError()
+		return nil
+	}
+	return rosa.DefaultRunner(rosa.RuntimeWithOCM(), DescribeMachinePoolRunner(options))
+}

--- a/cmd/describe/machinepool/dispatch_test.go
+++ b/cmd/describe/machinepool/dispatch_test.go
@@ -1,0 +1,70 @@
+package machinepool
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/rosa/pkg/hyperfleet"
+)
+
+var _ = Describe("Dispatch", func() {
+	var exitCalled bool
+	var exitCode int
+
+	BeforeEach(func() {
+		exitCalled = false
+		exitCode = 0
+
+		// Override exit function
+		exitWithError = func() {
+			exitCalled = true
+			exitCode = 1
+		}
+	})
+
+	AfterEach(func() {
+		// Reset to production defaults
+		exitWithError = func() { os.Exit(1) }
+		hyperfleetEnabled = hyperfleet.Enabled
+	})
+
+	Context("when hyperfleet is disabled", func() {
+		BeforeEach(func() {
+			hyperfleetEnabled = func() bool { return false }
+		})
+
+		It("should return a runner function", func() {
+			opts := &DescribeMachinepoolUserOptions{}
+			runner := dispatch(opts)
+			Expect(runner).NotTo(BeNil())
+		})
+
+		It("should not call exit", func() {
+			opts := &DescribeMachinepoolUserOptions{}
+			dispatch(opts)
+			Expect(exitCalled).To(BeFalse())
+		})
+	})
+
+	Context("when hyperfleet is enabled", func() {
+		BeforeEach(func() {
+			hyperfleetEnabled = func() bool { return true }
+		})
+
+		It("should call exit with status 1", func() {
+			opts := &DescribeMachinepoolUserOptions{}
+			dispatch(opts)
+			Expect(exitCalled).To(BeTrue())
+			Expect(exitCode).To(Equal(1))
+		})
+
+		It("should return nil instead of a runner", func() {
+			opts := &DescribeMachinepoolUserOptions{}
+			runner := dispatch(opts)
+			Expect(exitCalled).To(BeTrue())
+			Expect(runner).To(BeNil())
+		})
+	})
+})

--- a/cmd/dlt/cluster/cmd.go
+++ b/cmd/dlt/cluster/cmd.go
@@ -47,7 +47,7 @@ var Cmd = &cobra.Command{
 	Long:  "Delete cluster.",
 	Example: `  # Delete a cluster named "mycluster"
   rosa delete cluster --cluster=mycluster`,
-	Run:  run,
+	Run:  dispatch,
 	Args: cobra.NoArgs,
 }
 

--- a/cmd/dlt/cluster/dispatch.go
+++ b/cmd/dlt/cluster/dispatch.go
@@ -1,0 +1,26 @@
+package cluster
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/hyperfleet"
+	"github.com/openshift/rosa/pkg/reporter"
+)
+
+var (
+	hyperfleetEnabled = hyperfleet.Enabled
+	runV1             = run
+	exitWithError     = func() { os.Exit(1) }
+)
+
+func dispatch(cmd *cobra.Command, args []string) {
+	if hyperfleetEnabled() {
+		r := reporter.CreateReporter()
+		r.Errorf("This command is not yet supported with the Platform API")
+		exitWithError()
+		return
+	}
+	runV1(cmd, args)
+}

--- a/cmd/dlt/cluster/dispatch_test.go
+++ b/cmd/dlt/cluster/dispatch_test.go
@@ -1,0 +1,76 @@
+package cluster
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/hyperfleet"
+)
+
+var _ = Describe("Dispatch", func() {
+	var cmd *cobra.Command
+	var runCalled bool
+	var exitCalled bool
+	var exitCode int
+
+	BeforeEach(func() {
+		cmd = &cobra.Command{}
+		runCalled = false
+		exitCalled = false
+		exitCode = 0
+
+		// Override v1 runner to avoid actual execution
+		runV1 = func(*cobra.Command, []string) {
+			runCalled = true
+		}
+
+		// Override exit function
+		exitWithError = func() {
+			exitCalled = true
+			exitCode = 1
+		}
+	})
+
+	AfterEach(func() {
+		// Reset to production defaults
+		runV1 = run
+		exitWithError = func() { os.Exit(1) }
+		hyperfleetEnabled = hyperfleet.Enabled
+	})
+
+	Context("when hyperfleet is disabled", func() {
+		BeforeEach(func() {
+			hyperfleetEnabled = func() bool { return false }
+		})
+
+		It("should call the v1 run function", func() {
+			dispatch(cmd, []string{})
+			Expect(runCalled).To(BeTrue())
+		})
+
+		It("should not call exit", func() {
+			dispatch(cmd, []string{})
+			Expect(exitCalled).To(BeFalse())
+		})
+	})
+
+	Context("when hyperfleet is enabled", func() {
+		BeforeEach(func() {
+			hyperfleetEnabled = func() bool { return true }
+		})
+
+		It("should not call the v1 run function", func() {
+			dispatch(cmd, []string{})
+			Expect(runCalled).To(BeFalse())
+		})
+
+		It("should call exit with status 1", func() {
+			dispatch(cmd, []string{})
+			Expect(exitCalled).To(BeTrue())
+			Expect(exitCode).To(Equal(1))
+		})
+	})
+})

--- a/cmd/dlt/machinepool/cmd.go
+++ b/cmd/dlt/machinepool/cmd.go
@@ -48,7 +48,7 @@ func NewDeleteMachinePoolCommand() *cobra.Command {
 		Short:   short,
 		Long:    long,
 		Example: example,
-		Run:     rosa.DefaultRunner(rosa.RuntimeWithOCM(), DeleteMachinePoolRunner(options)),
+		Run:     dispatch(options),
 		Args:    cobra.MaximumNArgs(1),
 	}
 	flags := cmd.Flags()
@@ -79,7 +79,7 @@ func DeleteMachinePoolRunner(userOptions *DeleteMachinepoolUserOptions) rosa.Com
 		service := machinepool.NewMachinePoolService()
 		err = service.DeleteMachinePool(runtime, options.Machinepool(), clusterKey, cluster)
 		if err != nil {
-			return fmt.Errorf("Error deleting machinepool: %v", err)
+			return fmt.Errorf("Error deleting machinepool: %v", err) //nolint:staticcheck
 		}
 		return nil
 	}

--- a/cmd/dlt/machinepool/dispatch.go
+++ b/cmd/dlt/machinepool/dispatch.go
@@ -1,0 +1,26 @@
+package machinepool
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/hyperfleet"
+	"github.com/openshift/rosa/pkg/reporter"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+var (
+	hyperfleetEnabled = hyperfleet.Enabled
+	exitWithError     = func() { os.Exit(1) }
+)
+
+func dispatch(options *DeleteMachinepoolUserOptions) func(*cobra.Command, []string) {
+	if hyperfleetEnabled() {
+		r := reporter.CreateReporter()
+		r.Errorf("This command is not yet supported with the Platform API")
+		exitWithError()
+		return nil
+	}
+	return rosa.DefaultRunner(rosa.RuntimeWithOCM(), DeleteMachinePoolRunner(options))
+}

--- a/cmd/dlt/machinepool/dispatch_test.go
+++ b/cmd/dlt/machinepool/dispatch_test.go
@@ -1,0 +1,70 @@
+package machinepool
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/rosa/pkg/hyperfleet"
+)
+
+var _ = Describe("Dispatch", func() {
+	var exitCalled bool
+	var exitCode int
+
+	BeforeEach(func() {
+		exitCalled = false
+		exitCode = 0
+
+		// Override exit function
+		exitWithError = func() {
+			exitCalled = true
+			exitCode = 1
+		}
+	})
+
+	AfterEach(func() {
+		// Reset to production defaults
+		exitWithError = func() { os.Exit(1) }
+		hyperfleetEnabled = hyperfleet.Enabled
+	})
+
+	Context("when hyperfleet is disabled", func() {
+		BeforeEach(func() {
+			hyperfleetEnabled = func() bool { return false }
+		})
+
+		It("should return a runner function", func() {
+			opts := &DeleteMachinepoolUserOptions{}
+			runner := dispatch(opts)
+			Expect(runner).NotTo(BeNil())
+		})
+
+		It("should not call exit", func() {
+			opts := &DeleteMachinepoolUserOptions{}
+			dispatch(opts)
+			Expect(exitCalled).To(BeFalse())
+		})
+	})
+
+	Context("when hyperfleet is enabled", func() {
+		BeforeEach(func() {
+			hyperfleetEnabled = func() bool { return true }
+		})
+
+		It("should call exit with status 1", func() {
+			opts := &DeleteMachinepoolUserOptions{}
+			dispatch(opts)
+			Expect(exitCalled).To(BeTrue())
+			Expect(exitCode).To(Equal(1))
+		})
+
+		It("should return nil instead of a runner", func() {
+			opts := &DeleteMachinepoolUserOptions{}
+			runner := dispatch(opts)
+			Expect(exitCalled).To(BeTrue())
+			Expect(runner).To(BeNil())
+		})
+	})
+})

--- a/cmd/edit/cluster/cmd.go
+++ b/cmd/edit/cluster/cmd.go
@@ -103,7 +103,7 @@ func makeCmd() *cobra.Command {
 
   # Edit all options interactively
   rosa edit cluster -c mycluster --interactive`,
-		Run:  run,
+		Run:  dispatch,
 		Args: cobra.NoArgs,
 	}
 }

--- a/cmd/edit/cluster/dispatch.go
+++ b/cmd/edit/cluster/dispatch.go
@@ -1,0 +1,26 @@
+package cluster
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/hyperfleet"
+	"github.com/openshift/rosa/pkg/reporter"
+)
+
+var (
+	hyperfleetEnabled = hyperfleet.Enabled
+	runV1             = run
+	exitWithError     = func() { os.Exit(1) }
+)
+
+func dispatch(cmd *cobra.Command, args []string) {
+	if hyperfleetEnabled() {
+		r := reporter.CreateReporter()
+		r.Errorf("This command is not yet supported with the Platform API")
+		exitWithError()
+		return
+	}
+	runV1(cmd, args)
+}

--- a/cmd/edit/cluster/dispatch_test.go
+++ b/cmd/edit/cluster/dispatch_test.go
@@ -1,0 +1,76 @@
+package cluster
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/hyperfleet"
+)
+
+var _ = Describe("Dispatch", func() {
+	var cmd *cobra.Command
+	var runCalled bool
+	var exitCalled bool
+	var exitCode int
+
+	BeforeEach(func() {
+		cmd = &cobra.Command{}
+		runCalled = false
+		exitCalled = false
+		exitCode = 0
+
+		// Override v1 runner to avoid actual execution
+		runV1 = func(*cobra.Command, []string) {
+			runCalled = true
+		}
+
+		// Override exit function
+		exitWithError = func() {
+			exitCalled = true
+			exitCode = 1
+		}
+	})
+
+	AfterEach(func() {
+		// Reset to production defaults
+		runV1 = run
+		exitWithError = func() { os.Exit(1) }
+		hyperfleetEnabled = hyperfleet.Enabled
+	})
+
+	Context("when hyperfleet is disabled", func() {
+		BeforeEach(func() {
+			hyperfleetEnabled = func() bool { return false }
+		})
+
+		It("should call the v1 run function", func() {
+			dispatch(cmd, []string{})
+			Expect(runCalled).To(BeTrue())
+		})
+
+		It("should not call exit", func() {
+			dispatch(cmd, []string{})
+			Expect(exitCalled).To(BeFalse())
+		})
+	})
+
+	Context("when hyperfleet is enabled", func() {
+		BeforeEach(func() {
+			hyperfleetEnabled = func() bool { return true }
+		})
+
+		It("should not call the v1 run function", func() {
+			dispatch(cmd, []string{})
+			Expect(runCalled).To(BeFalse())
+		})
+
+		It("should call exit with status 1", func() {
+			dispatch(cmd, []string{})
+			Expect(exitCalled).To(BeTrue())
+			Expect(exitCode).To(Equal(1))
+		})
+	})
+})

--- a/cmd/edit/machinepool/cmd.go
+++ b/cmd/edit/machinepool/cmd.go
@@ -53,7 +53,7 @@ func NewEditMachinePoolCommand() *cobra.Command {
 		Aliases: aliases,
 		Example: example,
 		Args:    machinepool.NewMachinepoolArgsFunction(false),
-		Run:     rosa.DefaultRunner(rosa.RuntimeWithOCM(), EditMachinePoolRunner(options)),
+		Run:     dispatch(options),
 	}
 
 	flags := cmd.Flags()

--- a/cmd/edit/machinepool/dispatch.go
+++ b/cmd/edit/machinepool/dispatch.go
@@ -1,0 +1,26 @@
+package machinepool
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/hyperfleet"
+	"github.com/openshift/rosa/pkg/reporter"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+var (
+	hyperfleetEnabled = hyperfleet.Enabled
+	exitWithError     = func() { os.Exit(1) }
+)
+
+func dispatch(options *EditMachinepoolUserOptions) func(*cobra.Command, []string) {
+	if hyperfleetEnabled() {
+		r := reporter.CreateReporter()
+		r.Errorf("This command is not yet supported with the Platform API")
+		exitWithError()
+		return nil
+	}
+	return rosa.DefaultRunner(rosa.RuntimeWithOCM(), EditMachinePoolRunner(options))
+}

--- a/cmd/edit/machinepool/dispatch_test.go
+++ b/cmd/edit/machinepool/dispatch_test.go
@@ -1,0 +1,70 @@
+package machinepool
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/rosa/pkg/hyperfleet"
+)
+
+var _ = Describe("Dispatch", func() {
+	var exitCalled bool
+	var exitCode int
+
+	BeforeEach(func() {
+		exitCalled = false
+		exitCode = 0
+
+		// Override exit function
+		exitWithError = func() {
+			exitCalled = true
+			exitCode = 1
+		}
+	})
+
+	AfterEach(func() {
+		// Reset to production defaults
+		exitWithError = func() { os.Exit(1) }
+		hyperfleetEnabled = hyperfleet.Enabled
+	})
+
+	Context("when hyperfleet is disabled", func() {
+		BeforeEach(func() {
+			hyperfleetEnabled = func() bool { return false }
+		})
+
+		It("should return a runner function", func() {
+			opts := &EditMachinepoolUserOptions{}
+			runner := dispatch(opts)
+			Expect(runner).NotTo(BeNil())
+		})
+
+		It("should not call exit", func() {
+			opts := &EditMachinepoolUserOptions{}
+			dispatch(opts)
+			Expect(exitCalled).To(BeFalse())
+		})
+	})
+
+	Context("when hyperfleet is enabled", func() {
+		BeforeEach(func() {
+			hyperfleetEnabled = func() bool { return true }
+		})
+
+		It("should call exit with status 1", func() {
+			opts := &EditMachinepoolUserOptions{}
+			dispatch(opts)
+			Expect(exitCalled).To(BeTrue())
+			Expect(exitCode).To(Equal(1))
+		})
+
+		It("should return nil instead of a runner", func() {
+			opts := &EditMachinepoolUserOptions{}
+			runner := dispatch(opts)
+			Expect(exitCalled).To(BeTrue())
+			Expect(runner).To(BeNil())
+		})
+	})
+})

--- a/cmd/list/cluster/cmd.go
+++ b/cmd/list/cluster/cmd.go
@@ -38,7 +38,7 @@ var Cmd = &cobra.Command{
 	Example: `  # List all clusters
   rosa list clusters`,
 	Args: cobra.NoArgs,
-	Run:  run,
+	Run:  dispatch,
 }
 
 const clusterCount = 1000

--- a/cmd/list/cluster/dispatch.go
+++ b/cmd/list/cluster/dispatch.go
@@ -1,0 +1,26 @@
+package cluster
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/hyperfleet"
+	"github.com/openshift/rosa/pkg/reporter"
+)
+
+var (
+	hyperfleetEnabled = hyperfleet.Enabled
+	runV1             = run
+	exitWithError     = func() { os.Exit(1) }
+)
+
+func dispatch(cmd *cobra.Command, args []string) {
+	if hyperfleetEnabled() {
+		r := reporter.CreateReporter()
+		r.Errorf("This command is not yet supported with the Platform API")
+		exitWithError()
+		return
+	}
+	runV1(cmd, args)
+}

--- a/cmd/list/cluster/dispatch_test.go
+++ b/cmd/list/cluster/dispatch_test.go
@@ -1,0 +1,76 @@
+package cluster
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/hyperfleet"
+)
+
+var _ = Describe("Dispatch", func() {
+	var cmd *cobra.Command
+	var runCalled bool
+	var exitCalled bool
+	var exitCode int
+
+	BeforeEach(func() {
+		cmd = &cobra.Command{}
+		runCalled = false
+		exitCalled = false
+		exitCode = 0
+
+		// Override v1 runner to avoid actual execution
+		runV1 = func(*cobra.Command, []string) {
+			runCalled = true
+		}
+
+		// Override exit function
+		exitWithError = func() {
+			exitCalled = true
+			exitCode = 1
+		}
+	})
+
+	AfterEach(func() {
+		// Reset to production defaults
+		runV1 = run
+		exitWithError = func() { os.Exit(1) }
+		hyperfleetEnabled = hyperfleet.Enabled
+	})
+
+	Context("when hyperfleet is disabled", func() {
+		BeforeEach(func() {
+			hyperfleetEnabled = func() bool { return false }
+		})
+
+		It("should call the v1 run function", func() {
+			dispatch(cmd, []string{})
+			Expect(runCalled).To(BeTrue())
+		})
+
+		It("should not call exit", func() {
+			dispatch(cmd, []string{})
+			Expect(exitCalled).To(BeFalse())
+		})
+	})
+
+	Context("when hyperfleet is enabled", func() {
+		BeforeEach(func() {
+			hyperfleetEnabled = func() bool { return true }
+		})
+
+		It("should not call the v1 run function", func() {
+			dispatch(cmd, []string{})
+			Expect(runCalled).To(BeFalse())
+		})
+
+		It("should call exit with status 1", func() {
+			dispatch(cmd, []string{})
+			Expect(exitCalled).To(BeTrue())
+			Expect(exitCode).To(Equal(1))
+		})
+	})
+})

--- a/cmd/list/machinepool/cmd.go
+++ b/cmd/list/machinepool/cmd.go
@@ -53,7 +53,7 @@ func NewListMachinePoolCommand() *cobra.Command {
 		Aliases: aliases,
 		Example: example,
 		Args:    cobra.NoArgs,
-		Run:     rosa.DefaultRunner(rosa.RuntimeWithOCM(), ListMachinePoolRunner()),
+		Run:     dispatch(),
 	}
 
 	flags := cmd.Flags()
@@ -98,7 +98,7 @@ func ListMachinePoolRunner() rosa.CommandRunner {
 		cluster := runtime.FetchCluster()
 		if cluster.State() != cmv1.ClusterStateReady &&
 			cluster.State() != cmv1.ClusterStateHibernating {
-			return fmt.Errorf("Cluster '%s' is not yet ready", clusterKey)
+			return fmt.Errorf("Cluster '%s' is not yet ready", clusterKey) //nolint:staticcheck
 		}
 
 		service := machinepool.NewMachinePoolService()
@@ -109,7 +109,7 @@ func ListMachinePoolRunner() rosa.CommandRunner {
 			args,
 		)
 		if err != nil {
-			return fmt.Errorf("Failed to list machinepools: %s", err)
+			return fmt.Errorf("Failed to list machinepools: %s", err) //nolint:staticcheck
 		}
 		return nil
 	}

--- a/cmd/list/machinepool/dispatch.go
+++ b/cmd/list/machinepool/dispatch.go
@@ -1,0 +1,26 @@
+package machinepool
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/hyperfleet"
+	"github.com/openshift/rosa/pkg/reporter"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+var (
+	hyperfleetEnabled = hyperfleet.Enabled
+	exitWithError     = func() { os.Exit(1) }
+)
+
+func dispatch() func(*cobra.Command, []string) {
+	if hyperfleetEnabled() {
+		r := reporter.CreateReporter()
+		r.Errorf("This command is not yet supported with the Platform API")
+		exitWithError()
+		return nil
+	}
+	return rosa.DefaultRunner(rosa.RuntimeWithOCM(), ListMachinePoolRunner())
+}

--- a/cmd/list/machinepool/dispatch_test.go
+++ b/cmd/list/machinepool/dispatch_test.go
@@ -1,0 +1,66 @@
+package machinepool
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/rosa/pkg/hyperfleet"
+)
+
+var _ = Describe("Dispatch", func() {
+	var exitCalled bool
+	var exitCode int
+
+	BeforeEach(func() {
+		exitCalled = false
+		exitCode = 0
+
+		// Override exit function
+		exitWithError = func() {
+			exitCalled = true
+			exitCode = 1
+		}
+	})
+
+	AfterEach(func() {
+		// Reset to production defaults
+		exitWithError = func() { os.Exit(1) }
+		hyperfleetEnabled = hyperfleet.Enabled
+	})
+
+	Context("when hyperfleet is disabled", func() {
+		BeforeEach(func() {
+			hyperfleetEnabled = func() bool { return false }
+		})
+
+		It("should return a runner function", func() {
+			runner := dispatch()
+			Expect(runner).NotTo(BeNil())
+		})
+
+		It("should not call exit", func() {
+			dispatch()
+			Expect(exitCalled).To(BeFalse())
+		})
+	})
+
+	Context("when hyperfleet is enabled", func() {
+		BeforeEach(func() {
+			hyperfleetEnabled = func() bool { return true }
+		})
+
+		It("should call exit with status 1", func() {
+			dispatch()
+			Expect(exitCalled).To(BeTrue())
+			Expect(exitCode).To(Equal(1))
+		})
+
+		It("should return nil instead of a runner", func() {
+			runner := dispatch()
+			Expect(exitCalled).To(BeTrue())
+			Expect(runner).To(BeNil())
+		})
+	})
+})

--- a/pkg/hyperfleet/enabled.go
+++ b/pkg/hyperfleet/enabled.go
@@ -1,0 +1,8 @@
+package hyperfleet
+
+// Enabled returns true when the CLI should dispatch to the Platform API (v2) path.
+// Currently always returns false — the detection logic will be added when the
+// hyperfleet integration lands.
+func Enabled() bool {
+	return false
+}


### PR DESCRIPTION
## PR Summary

  Add dispatch routing infrastructure for Platform API v2 (hyperfleet) support across cluster and machinepool commands. Introduces a `dispatch` function pattern that checks `hyperfleet.Enabled()` and routes to either the v2 runner or the original v1 implementation, with stub errors
  for unsupported commands.

  ## Detailed Description of the Issue

  The ROSA CLI needs to support a new Platform API v2 code path (hyperfleet) alongside the existing v1 implementation. This requires a routing layer at the command entrypoint that can conditionally dispatch to either v1 or v2 runners without modifying the existing v1 command logic.
  This commit establishes the dispatch pattern and applies it across create, describe, dlt (delete), edit, and list operations for both cluster and machinepool commands.

  ## Related Issues and PRs
  - Jira: [ROSAENG-65546](https://issues.redhat.com/browse/ROSAENG-65546)
  - Related design/docs: Hyperfleet Dispatch Pattern documented in AGENTS.md

  ## Type of Change
  - [x] feat - adds a new user-facing capability.
  - [ ] fix - resolves an incorrect behavior or bug.
  - [ ] docs - updates documentation only.
  - [ ] style - formatting or naming changes with no logic impact.
  - [ ] refactor - code restructuring with no behavior change.
  - [ ] test - adds or updates tests only.
  - [ ] chore - maintenance work (tooling, housekeeping, non-product code).
  - [ ] build - changes build system, packaging, or dependencies for build output.
  - [ ] ci - changes CI pipelines, jobs, or automation workflows.
  - [ ] perf - improves performance without changing intended behavior.

  ## Previous Behavior

  Commands always executed the v1 runner (`run` or `rosa.DefaultRunner`) directly from the Cobra entrypoint.

  ## Behavior After This Change

  Commands now route through a `dispatch` function that checks `hyperfleet.Enabled()`:
  - If enabled: returns an error indicating the command is not yet supported with the Platform API.
  - If disabled (current state): delegates to the original v1 runner.

  Future commits will implement actual v2 logic in separate `run_v2.go` files and replace the stub errors.

  ## How to Test (Step-by-Step)

  ### Preconditions

  - Local ROSA CLI build available
  - No hyperfleet environment variables or detection logic currently set

  ### Test Steps

  1. Build the CLI: `make rosa`
  2. Run any of the modified commands (e.g., `rosa cluster create --help`, `rosa machinepool describe --help`)
  3. Verify help text and command structure remain unchanged
  4. Verify commands execute their v1 code paths (routing is transparent when hyperfleet is disabled)

  ### Expected Results

  - All commands display help text and execute normally
  - No behavioral change from user perspective
  - No new errors or warnings under current (v1) mode

  ## Breaking Changes
  - [ ] No breaking changes
  - [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

  ## Developer Verification Checklist
  - [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
  - [x] PR description clearly explains both **what** changed and **why**.
  - [x] Relevant Jira/GitHub issues and related PRs are linked.
  - [ ] `make install-hooks` has been run in this clone.
  - [ ] Tests were added/updated where appropriate.
  - [ ] I manually tested the change.
  - [x] `make test` passes.
  - [x] `make lint` passes.
  - [x] `make rosa` passes.
  - [x] Documentation or repo-local agent guidance was added/updated where appropriate.
  - [ ] Any risk, limitation, or follow-up work is documented.


[ROSAENG-65546]: https://redhat.atlassian.net/browse/ROSAENG-65546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added Platform API compatibility checks for cluster and machine pool create, describe, delete, edit, and list commands.
- Preserved existing command behavior when the Platform API is not enabled.

## Bug Fixes
- Commands now display a clear unsupported-command message and exit with a failure status when used with the Platform API.

## Tests
- Added coverage for supported and unsupported execution paths across affected commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->