### PR TITLE
ROSAENG-66575 | fix: fix rosa describe ingress 

### DIFF
--- a/cmd/describe/ingress/cmd_test.go
+++ b/cmd/describe/ingress/cmd_test.go
@@ -18,46 +18,44 @@ import (
 
 var _ = Describe("Describe ingress", func() {
 	const (
-		ingressOutput = `Cluster ID:                 123
-Component Routes:           
-    console: 
-        Hostname:           console-hostname
-        TLS Secret Ref:     console-secret
-    downloads: 
-        Hostname:           downloads-hostname
-        TLS Secret Ref:     downloads-secret
-    oauth: 
-        Hostname:           oauth-hostname
-        TLS Secret Ref:     oauth-secret
-Default:                    true
-Excluded Namespaces:        [excluded-ns-1, excluded-ns-2]
-ID:                         a1b1
-LB-Type:                    nlb
-Namespace Ownership Policy: Strict
-Private:                    false
-Route Selectors:            map[route-1:selector-1 route-2:selector-2]
-Wildcard Policy:            WildcardsAllowed
-`
-		privateIngressOutput = `Cluster ID:                 123
-Component Routes:           
-    console: 
-        Hostname:           console-hostname
-        TLS Secret Ref:     console-secret
-    downloads: 
-        Hostname:           downloads-hostname
-        TLS Secret Ref:     downloads-secret
-    oauth: 
-        Hostname:           oauth-hostname
-        TLS Secret Ref:     oauth-secret
-Default:                    true
-Excluded Namespaces:        [excluded-ns-1, excluded-ns-2]
-ID:                         a1b1
-LB-Type:                    nlb
-Namespace Ownership Policy: Strict
-Private:                    true
-Route Selectors:            map[route-1:selector-1 route-2:selector-2]
-Wildcard Policy:            WildcardsAllowed
-`
+		ingressOutput = "Cluster ID:                 123\n" +
+			"Component Routes:           \n" +
+			"    console: \n" +
+			"        Hostname:       console-hostname\n" +
+			"        TLS Secret Ref: console-secret\n" +
+			"    downloads: \n" +
+			"        Hostname:       downloads-hostname\n" +
+			"        TLS Secret Ref: downloads-secret\n" +
+			"    oauth: \n" +
+			"        Hostname:       oauth-hostname\n" +
+			"        TLS Secret Ref: oauth-secret\n" +
+			"Default:                    true\n" +
+			"Excluded Namespaces:        [excluded-ns-1, excluded-ns-2]\n" +
+			"ID:                         a1b1\n" +
+			"LB-Type:                    nlb\n" +
+			"Namespace Ownership Policy: Strict\n" +
+			"Private:                    false\n" +
+			"Route Selectors:            map[route-1:selector-1 route-2:selector-2]\n" +
+			"Wildcard Policy:            WildcardsAllowed\n"
+		privateIngressOutput = "Cluster ID:                 123\n" +
+			"Component Routes:           \n" +
+			"    console: \n" +
+			"        Hostname:       console-hostname\n" +
+			"        TLS Secret Ref: console-secret\n" +
+			"    downloads: \n" +
+			"        Hostname:       downloads-hostname\n" +
+			"        TLS Secret Ref: downloads-secret\n" +
+			"    oauth: \n" +
+			"        Hostname:       oauth-hostname\n" +
+			"        TLS Secret Ref: oauth-secret\n" +
+			"Default:                    true\n" +
+			"Excluded Namespaces:        [excluded-ns-1, excluded-ns-2]\n" +
+			"ID:                         a1b1\n" +
+			"LB-Type:                    nlb\n" +
+			"Namespace Ownership Policy: Strict\n" +
+			"Private:                    true\n" +
+			"Route Selectors:            map[route-1:selector-1 route-2:selector-2]\n" +
+			"Wildcard Policy:            WildcardsAllowed\n"
 	)
 	Context("describe", func() {
 		// Full diff for long string to help debugging

--- a/pkg/ingress/ingress.go
+++ b/pkg/ingress/ingress.go
@@ -9,8 +9,8 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 
 	"github.com/openshift/rosa/pkg/helper"
-	"github.com/openshift/rosa/pkg/output"
-	"github.com/openshift/rosa/pkg/rosa"
+	"github.com/openshift/rosa/pkg/output" //nolint:depguard
+	"github.com/openshift/rosa/pkg/rosa"   //nolint:depguard
 )
 
 type IngressService interface {
@@ -33,7 +33,7 @@ func (i ingress) DescribeIngress(r *rosa.Runtime, cluster *cmv1.Cluster, ingress
 	if output.HasFlag() {
 		err = output.Print(ingress)
 		if err != nil {
-			return fmt.Errorf("Failed to output ingress '%s': %v", ingressKey, err)
+			return fmt.Errorf("failed to output ingress '%s': %v", ingressKey, err)
 		}
 		return nil
 	}
@@ -45,7 +45,7 @@ func (i ingress) DescribeIngress(r *rosa.Runtime, cluster *cmv1.Cluster, ingress
 	for _, key := range keys {
 		ingressOutput += fmt.Sprintf("%s: %s\n", key, strings.Repeat(" ", minWidth-len(key))+entries[key])
 	}
-	fmt.Print(ingressOutput)
+	fmt.Print(ingressOutput) //nolint:forbidigo
 	return nil
 }
 
@@ -61,10 +61,7 @@ func getMinWidth(keys []string) int {
 }
 
 func generateEntriesOutput(cluster *cmv1.Cluster, ingress *cmv1.Ingress) map[string]string {
-	private := false
-	if ingress.Listening() == cmv1.ListeningMethodInternal {
-		private = true
-	}
+	private := ingress.Listening() == cmv1.ListeningMethodInternal
 	entries := map[string]string{
 		"ID":         ingress.ID(),
 		"Cluster ID": cluster.ID(),
@@ -97,8 +94,6 @@ func generateEntriesOutput(cluster *cmv1.Cluster, ingress *cmv1.Ingress) map[str
 	sort.Strings(componentKeys)
 	for _, component := range componentKeys {
 		value := ingress.ComponentRoutes()[component]
-		keys := helper.MapKeys(entries)
-		minWidth := getMinWidth(keys)
 		depth := 4
 		componentRouteEntries := map[string]string{
 			"Hostname":       value.Hostname(),
@@ -108,11 +103,12 @@ func generateEntriesOutput(cluster *cmv1.Cluster, ingress *cmv1.Ingress) map[str
 		depth *= 2
 		paramKeys := helper.MapKeys(componentRouteEntries)
 		sort.Strings(paramKeys)
+		paramMinWidth := getMinWidth(paramKeys)
 		for _, param := range paramKeys {
 			componentRoutes += fmt.Sprintf(
 				"%s: %s\n",
 				strings.Repeat(" ", depth)+param,
-				strings.Repeat(" ", minWidth-len(param)-depth)+componentRouteEntries[param],
+				strings.Repeat(" ", paramMinWidth-len(param))+componentRouteEntries[param],
 			)
 		}
 	}

--- a/pkg/ingress/ingress_test.go
+++ b/pkg/ingress/ingress_test.go
@@ -55,26 +55,25 @@ var _ = Describe("Retrieve map of entries for output", func() {
 
 var _ = Describe("Describe ingress", func() {
 	const (
-		ingressOutput = `Cluster ID:                 123
-Component Routes:           
-    console: 
-        Hostname:           console-hostname
-        TLS Secret Ref:     console-secret
-    downloads: 
-        Hostname:           downloads-hostname
-        TLS Secret Ref:     downloads-secret
-    oauth: 
-        Hostname:           oauth-hostname
-        TLS Secret Ref:     oauth-secret
-Default:                    true
-Excluded Namespaces:        [excluded-ns-1, excluded-ns-2]
-ID:                         a1b1
-LB-Type:                    nlb
-Namespace Ownership Policy: Strict
-Private:                    false
-Route Selectors:            map[route-1:selector-1 route-2:selector-2]
-Wildcard Policy:            WildcardsAllowed
-`
+		ingressOutput = "Cluster ID:                 123\n" +
+			"Component Routes:           \n" +
+			"    console: \n" +
+			"        Hostname:       console-hostname\n" +
+			"        TLS Secret Ref: console-secret\n" +
+			"    downloads: \n" +
+			"        Hostname:       downloads-hostname\n" +
+			"        TLS Secret Ref: downloads-secret\n" +
+			"    oauth: \n" +
+			"        Hostname:       oauth-hostname\n" +
+			"        TLS Secret Ref: oauth-secret\n" +
+			"Default:                    true\n" +
+			"Excluded Namespaces:        [excluded-ns-1, excluded-ns-2]\n" +
+			"ID:                         a1b1\n" +
+			"LB-Type:                    nlb\n" +
+			"Namespace Ownership Policy: Strict\n" +
+			"Private:                    false\n" +
+			"Route Selectors:            map[route-1:selector-1 route-2:selector-2]\n" +
+			"Wildcard Policy:            WildcardsAllowed\n"
 	)
 	It("Ingress found", func() {
 		// Full diff for long string to help debugging
@@ -112,6 +111,45 @@ Wildcard Policy:            WildcardsAllowed
 		stdout, err := t.StdOutReader.Read()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(stdout).To(Equal(ingressOutput))
+	})
+
+	It("Ingress found with component routes and no optional fields", func() {
+		format.TruncatedDiff = false
+		expectedOutput := "Cluster ID:       123\n" +
+			"Component Routes: \n" +
+			"    downloads: \n" +
+			"        Hostname:       downloads.banana.company.com\n" +
+			"        TLS Secret Ref: downloads-tls-secret\n" +
+			"Default:          true\n" +
+			"ID:               a1q0\n" +
+			"LB-Type:          nlb\n" +
+			"Private:          false\n"
+		ingress, err := cmv1.NewIngress().
+			ID("a1q0").
+			Default(true).
+			Listening(cmv1.ListeningMethodExternal).
+			LoadBalancerType(cmv1.LoadBalancerFlavorNlb).
+			ComponentRoutes(map[string]*cmv1.ComponentRouteBuilder{
+				"downloads": cmv1.NewComponentRoute().
+					Hostname("downloads.banana.company.com").
+					TlsSecretRef("downloads-tls-secret"),
+			}).Build()
+		Expect(err).To(BeNil())
+		ingressResponse := test.FormatIngressList([]*cmv1.Ingress{ingress})
+		t := test.NewTestRuntime()
+		t.ApiServer.AppendHandlers(RespondWithJSON(http.StatusOK, ingressResponse))
+		err = t.StdOutReader.Record()
+		Expect(err).ToNot(HaveOccurred())
+		mockReadyCluster := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+			c.ID("123")
+			c.Region(cmv1.NewCloudRegion().ID(aws.DefaultRegion))
+			c.State(cmv1.ClusterStateReady)
+		})
+		err = NewIngressService().DescribeIngress(t.RosaRuntime, mockReadyCluster, "apps")
+		Expect(err).ToNot(HaveOccurred())
+		stdout, err := t.StdOutReader.Read()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(stdout).To(Equal(expectedOutput))
 	})
 
 })


### PR DESCRIPTION
## PR Summary

  Fix `rosa describe ingress` panic when component routes are set without optional fields (wildcard policy, namespace ownership policy, route selectors, excluded namespaces). The alignment width for component route parameters was incorrectly calculated from top-level entry keys,
  causing negative padding when those optional fields were absent.

  ## Detailed Description of the Issue

  When running `rosa describe ingress` on a cluster with component routes configured but no optional ingress fields, the command panicked with `strings: negative Repeat count`. The root cause was in `pkg/ingress/ingress.go:115`, where alignment padding for component route values
  (`minWidth - len(param) - depth`) could become negative. The `minWidth` variable was calculated from top-level entry keys (like "Cluster ID", "Default", "LB-Type"), but component route param keys ("Hostname", "TLS Secret Ref") could exceed that width. When optional fields like
  "Namespace Ownership Policy" (26 chars) were absent, `minWidth` became too small, making the arithmetic fail.

  ## Related Issues and PRs

  - Jira: [ROSAENG-66575](https://issues.redhat.com/browse/ROSAENG-66575)
  - Fixes: N/A
  - Related PR(s): N/A
  - Related design/docs: N/A

  ## Type of Change

  - [ ] feat - adds a new user-facing capability.
  - [x] fix - resolves an incorrect behavior or bug.
  - [ ] docs - updates documentation only.
  - [ ] style - formatting or naming changes with no logic impact.
  - [ ] refactor - code restructuring with no behavior change.
  - [ ] test - adds or updates tests only.
  - [ ] chore - maintenance work (tooling, housekeeping, non-product code).
  - [ ] build - changes build system, packaging, or dependencies for build output.
  - [ ] ci - changes CI pipelines, jobs, or automation workflows.
  - [ ] perf - improves performance without changing intended behavior.

  ## Previous Behavior

  `rosa describe ingress` panicked with `strings: negative Repeat count` when an ingress had component routes but no optional fields (wildcard policy, namespace ownership policy, route selectors, excluded namespaces).

  ## Behavior After This Change

  `rosa describe ingress` successfully displays ingress details including component routes regardless of which optional fields are set. Component route values are now aligned based on the widths of component route parameter keys, not top-level entry keys.

  ## How to Test (Step-by-Step)

  ### Preconditions

  - A ROSA cluster with an ingress that has component routes set but without optional fields like wildcard policy or namespace ownership policy.

  ### Test Steps

  1. Run `rosa describe ingress --cluster=<cluster-id> <ingress-id>` where the ingress has component routes.
  2. Verify the command completes without panic.
  3. Verify output displays all ingress fields including component routes with proper alignment.

  ### Expected Results

  Component routes display with "Hostname" and "TLS Secret Ref" values properly aligned, and the command exits with code 0.

  ## Proof of the Fix

  - New test case: "Ingress found with component routes and no optional fields" covers the exact scenario that previously panicked (component routes with only basic ingress fields).
  - Updated expected outputs in existing tests to reflect corrected alignment (values now align to component route param width instead of top-level entry width).

  ## Breaking Changes

  - [x] No breaking changes
  - [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

  ## Developer Verification Checklist

  - [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
  - [x] PR description clearly explains both **what** changed and **why**.
  - [x] Relevant Jira/GitHub issues and related PRs are linked.
  - [x] `make install-hooks` has been run in this clone.
  - [x] Tests were added/updated where appropriate.
  - [x] I manually tested the change.
  - [x] `make test` passes.
  - [x] `make lint` passes.
  - [x] `make rosa` passes.
  - [ ] Documentation or repo-local agent guidance was added/updated where appropriate.
  - [x] Any risk, limitation, or follow-up work is documented.



[ROSAENG-66575]: https://redhat.atlassian.net/browse/ROSAENG-66575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved formatting of ingress descriptions, including component routes and parameter values.
  - Added handling for ingress responses with component routes when optional fields are absent.
  - Standardized error message capitalization for failed ingress descriptions.

- **Tests**
  - Updated expected output and expanded coverage for ingress description scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->