### PR TITLE
OCM-00000 | chore: Set release version to 1.2.65

### DIFF
--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,7 +18,7 @@ limitations under the License.
 
 package info
 
-const DefaultVersion = "1.2.64"
+const DefaultVersion = "1.2.65"
 
 // Build contains the short Git SHA of the CLI at the point it was build. Set via `-ldflags` at build time
 var Build = "local"


### PR DESCRIPTION
## Summary

- Bump `DefaultVersion` in `pkg/info/info.go` from `1.2.64` to `1.2.65`
- Fixes the shipped v1.2.65 binary reporting `1.2.64` via `rosa version --client`

Fixes #3506

## Test plan

- [x] `make rosa`
- [x] Pre-commit and pre-push hooks passed
- [ ] After merge, verify `rosa version --client` reports `1.2.65` in the next build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application version from **1.2.64** to **1.2.65**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->