### PR TITLE
ROSAENG-66692 | feat: inject DefaultVersion from git tag at build time

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,6 +10,7 @@ builds:
       - CGO_ENABLED=0
     ldflags:
       - -X github.com/openshift/rosa/pkg/info.Build={{ .ShortCommit }}
+      - -X github.com/openshift/rosa/pkg/info.DefaultVersion={{ .Version }}
     goos:
       - linux
       - windows

--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,13 @@ export CGO_ENABLED=0
 # Unset GOFLAG for CI and ensure we've got nothing accidently set
 unexport GOFLAGS
 
+# Version from the exact tag on HEAD; empty (uses the fallback in pkg/info/info.go)
+# when HEAD is not tagged.
+VERSION ?= $(shell git describe --tags --exact-match 2>/dev/null | sed 's/^v//')
+
 .PHONY: rosa
 rosa:
-	go build -ldflags="-X github.com/openshift/rosa/pkg/info.Build=$(shell git rev-parse --short HEAD)" ./cmd/rosa
+	go build -ldflags="-X github.com/openshift/rosa/pkg/info.Build=$(shell git rev-parse --short HEAD) $(if $(VERSION),-X github.com/openshift/rosa/pkg/info.DefaultVersion=$(VERSION),)" ./cmd/rosa
 
 .PHONY: test
 test:
@@ -55,7 +59,7 @@ coverage-changed-files:
 
 .PHONY: install
 install:
-	go install -ldflags="-X github.com/openshift/rosa/pkg/info.Build=$(shell git rev-parse --short HEAD)" ./cmd/rosa
+	go install -ldflags="-X github.com/openshift/rosa/pkg/info.Build=$(shell git rev-parse --short HEAD) $(if $(VERSION),-X github.com/openshift/rosa/pkg/info.DefaultVersion=$(VERSION),)" ./cmd/rosa
 
 .PHONY: fmt
 fmt: $(GCI)

--- a/hack/build_cli.sh
+++ b/hack/build_cli.sh
@@ -9,6 +9,11 @@ oses=(darwin linux windows)
 mkdir -p releases
 
 build_release() {
+# Resolve exact tag on HEAD (stable or prerelease). Prerelease builds
+# intentionally report the prerelease version (e.g. 1.2.66-rc1).
+release_version=$(git describe --tags --exact-match 2>/dev/null || true)
+release_version=${release_version#v}
+
 for os in "${oses[@]}"
 do
   for arch in "${archs[@]}"
@@ -19,7 +24,7 @@ do
     fi
     tmpdir=$(mktemp -d)
     trap 'rm -rf "$tmpdir"' EXIT
-    GOOS="${os}" GOARCH="${arch}" go build -ldflags="-X github.com/openshift/rosa/pkg/info.Build=$(git rev-parse --short HEAD)" -o "${tmpdir}/rosa${extension}" ./cmd/rosa
+    GOOS="${os}" GOARCH="${arch}" go build -ldflags="-X github.com/openshift/rosa/pkg/info.Build=$(git rev-parse --short HEAD)${release_version:+ -X github.com/openshift/rosa/pkg/info.DefaultVersion=${release_version}}" -o "${tmpdir}/rosa${extension}" ./cmd/rosa
     tar -czf "releases/rosa_${os}_${arch}.tar.gz" -C "${tmpdir}" "rosa${extension}"
     (
       cd "${tmpdir}" && \

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,9 +18,12 @@ limitations under the License.
 
 package info
 
-const DefaultVersion = "1.2.65"
+// DefaultVersion is the CLI version. For release builds it is overridden via
+// -ldflags with the value derived from the git tag. The fallback here is kept
+// current by an automated post-release workflow.
+var DefaultVersion = "1.2.65"
 
-// Build contains the short Git SHA of the CLI at the point it was build. Set via `-ldflags` at build time
+// Build contains the short Git SHA of the CLI at the point it was built. Set via `-ldflags` at build time.
 var Build = "local"
 
 const DefaultUserAgent = "ROSACLI"


### PR DESCRIPTION
## What

Change `DefaultVersion` in `pkg/info/info.go` from `const` to `var` so it can be overridden via `-ldflags` at build time. Add `-X DefaultVersion=` to every build entry point:

- **Makefile** (`rosa` and `install` targets) — derives version from `git describe --tags --exact-match`
- **hack/build_cli.sh** (Konflux product build) — derives version from `git describe --tags --exact-match`
- **.goreleaser.yaml** — uses GoReleaser's built-in `{{ .Version }}`

## Why

Every release requires a manual edit to `DefaultVersion`. If forgotten (as happened with v1.2.65 shipping `1.2.64`), the binary reports the wrong version. Tagged release builds now always get the correct version from the git tag without manual intervention.

## Version behavior by build path

| Build path | On a tagged commit | On an untagged commit |
|------------|--------------------|-----------------------|
| `make rosa` / `make install` | Injects tag version (stable or prerelease) | Empty → uses source fallback in `pkg/info/info.go` |
| `hack/build_cli.sh` (Konflux) | Injects exact tag version | Empty → uses source fallback |
| `make local-release` (GoReleaser snapshot) | Injects tag version | Injects GoReleaser's snapshot version (e.g. `1.2.65-SNAPSHOT-abc1234`) — **intentional**, so snapshot builds are clearly distinguishable from official releases |

## Validation

- `make rosa && ./rosa version --client` on a tagged commit — shows tag version
- `make rosa && ./rosa version --client` on an untagged commit — falls back to source default
- `go test ./cmd/version/...` — passes (tests reference `info.DefaultVersion` by name, not a hardcoded string)

## Jira

[ROSAENG-66692](https://redhat.atlassian.net/browse/ROSAENG-66692)


[ROSAENG-66692]: https://redhat.atlassian.net/browse/ROSAENG-66692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ