### PR TITLE
ROSAENG-61180 | test: add tests for create operatorroles dispatch

### DIFF
--- a/cmd/create/operatorroles/cmd.go
+++ b/cmd/create/operatorroles/cmd.go
@@ -164,9 +164,6 @@ func run(cmd *cobra.Command, argv []string) {
 	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
 
-	rosa.HostedClusterOnlyFlag(r, cmd, vpcEndpointRoleArnFlag)
-
-	// Allow the command to be called programmatically
 	isProgmaticallyCalled := false
 	if len(argv) == 3 && !cmd.Flag("cluster").Changed {
 		ocm.SetClusterKey(argv[0])
@@ -179,6 +176,16 @@ func run(cmd *cobra.Command, argv []string) {
 		}
 	}
 
+	err := runWithRuntime(r, cmd, isProgmaticallyCalled)
+	if err != nil {
+		r.Reporter.Errorf("%s", err)
+		os.Exit(1)
+	}
+}
+
+func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command, isProgmaticallyCalled bool) error {
+	rosa.HostedClusterOnlyFlag(r, cmd, vpcEndpointRoleArnFlag)
+
 	var isHcpSharedVpc bool
 	var err error
 	if !args.hostedCp {
@@ -187,36 +194,31 @@ func run(cmd *cobra.Command, argv []string) {
 		isHcpSharedVpc, err = roles.ValidateSharedVpcInputs(args.vpcEndpointRoleArn, args.sharedVpcRoleArn,
 			vpcEndpointRoleArnFlag, hostedZoneRoleArnFlag)
 		if err != nil {
-			r.Reporter.Errorf("%s", err)
-			os.Exit(1)
+			return err
 		}
 	}
 
 	if args.vpcEndpointRoleArn != "" {
 		err = aws.ARNValidator(args.vpcEndpointRoleArn)
 		if err != nil {
-			r.Reporter.Errorf("Expected a valid policy ARN for %s: %s", vpcEndpointRoleArnFlag, err)
-			os.Exit(1)
+			return fmt.Errorf("expected a valid policy ARN for %s: %s", vpcEndpointRoleArnFlag, err)
 		}
 	}
 	if args.sharedVpcRoleArn != "" {
 		err = aws.ARNValidator(args.sharedVpcRoleArn)
 		if err != nil {
-			r.Reporter.Errorf("Expected a valid policy ARN for %s: %s", hostedZoneRoleArnFlag, err)
-			os.Exit(1)
+			return fmt.Errorf("expected a valid policy ARN for %s: %s", hostedZoneRoleArnFlag, err)
 		}
 	}
 
 	env, err := ocm.GetEnv()
 	if err != nil {
-		r.Reporter.Errorf("Failed to determine OCM environment: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to determine OCM environment: %v", err)
 	}
 
 	mode, err := interactive.GetMode()
 	if err != nil {
-		r.Reporter.Errorf("%s", err)
-		os.Exit(1)
+		return err
 	}
 
 	// Determine if interactive mode is needed
@@ -225,31 +227,26 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	if !cmd.Flag("cluster").Changed && !cmd.Flag(PrefixFlag).Changed && !isProgmaticallyCalled {
-		r.Reporter.Errorf("Either a cluster key for STS cluster or an operator roles prefix must be specified.")
-		os.Exit(1)
+		return fmt.Errorf("either a cluster key for STS cluster or an operator roles prefix must be specified")
 	}
 
 	if cmd.Flag("cluster").Changed && cmd.Flag(PrefixFlag).Changed {
-		r.Reporter.Errorf("A cluster key for STS cluster and an operator roles prefix " +
-			"cannot be specified alongside each other.")
-		os.Exit(1)
+		return fmt.Errorf("a cluster key for STS cluster and an operator roles prefix " +
+			"cannot be specified alongside each other")
 	}
 
 	if cmd.Flag("cluster").Changed && cmd.Flag(OidcConfigIdFlag).Changed {
-		r.Reporter.Errorf("A cluster key for STS cluster and an OIDC configuration ID " +
-			"cannot be specified alongside each other.")
-		os.Exit(1)
+		return fmt.Errorf("a cluster key for STS cluster and an OIDC configuration ID " +
+			"cannot be specified alongside each other")
 	}
 
 	if !args.hostedCp && args.installerRoleArn != "" {
 		managedPolicies, err := r.AWSClient.HasManagedPolicies(args.installerRoleArn)
 		if err != nil {
-			r.Reporter.Errorf("Failed to determine if cluster has managed policies: %v", err)
-			os.Exit(1)
+			return fmt.Errorf("failed to determine if cluster has managed policies: %v", err)
 		}
 		if managedPolicies {
-			r.Reporter.Errorf("The managed policies are not supported for classic operator-roles.")
-			os.Exit(1)
+			return fmt.Errorf("the managed policies are not supported for classic operator-roles")
 		}
 	}
 
@@ -259,15 +256,13 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	if args.forcePolicyCreation && mode != interactive.ModeAuto {
-		r.Reporter.Warnf("Forcing creation of policies only works in auto mode")
-		os.Exit(1)
+		return fmt.Errorf("forcing creation of policies only works in auto mode")
 	}
 
 	if interactive.Enabled() && !isProgmaticallyCalled {
 		mode, err = interactive.GetOptionMode(cmd, mode, "Role creation mode")
 		if err != nil {
-			r.Reporter.Errorf("Expected a valid role creation mode: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("expected a valid role creation mode: %s", err)
 		}
 	}
 
@@ -286,8 +281,7 @@ func run(cmd *cobra.Command, argv []string) {
 			},
 		})
 		if err != nil {
-			r.Reporter.Errorf("Expected a valid policy ARN for permissions boundary: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("expected a valid policy ARN for permissions boundary: %s", err)
 		}
 	}
 
@@ -301,8 +295,7 @@ func run(cmd *cobra.Command, argv []string) {
 			Required: false,
 		})
 		if err != nil {
-			r.Reporter.Errorf("Expected a valid value: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("expected a valid value: %s", err)
 		}
 
 		if !isHcpSharedVpc {
@@ -322,8 +315,7 @@ func run(cmd *cobra.Command, argv []string) {
 			},
 		})
 		if err != nil {
-			r.Reporter.Errorf("Expected a valid value: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("expected a valid value: %s", err)
 		}
 	}
 	if interactive.Enabled() && isHcpSharedVpc && !r.Creator.IsGovcloud {
@@ -337,60 +329,52 @@ func run(cmd *cobra.Command, argv []string) {
 			},
 		})
 		if err != nil {
-			r.Reporter.Errorf("Expected a valid value: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("expected a valid value: %s", err)
 		}
 	}
 
 	if permissionsBoundary != "" {
 		err = aws.ARNValidator(permissionsBoundary)
 		if err != nil {
-			r.Reporter.Errorf("Expected a valid policy ARN for permissions boundary: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("expected a valid policy ARN for permissions boundary: %s", err)
 		}
 	}
 
 	policies, err := r.OCMClient.GetPolicies("OperatorRole")
 	if err != nil {
-		r.Reporter.Errorf("Expected a valid role creation mode: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("expected a valid role creation mode: %s", err)
 	}
 
 	if args.prefix != "" {
 		if args.oidcConfigId == "" {
-			r.Reporter.Errorf("%s is mandatory for %s param flow.", OidcConfigIdFlag, PrefixFlag)
-			os.Exit(1)
+			return fmt.Errorf("%s is mandatory for %s param flow", OidcConfigIdFlag, PrefixFlag)
 		}
 
 		if args.installerRoleArn == "" {
-			r.Reporter.Errorf("%s is mandatory for %s param flow.", InstallerRoleArnFlag, PrefixFlag)
-			os.Exit(1)
+			return fmt.Errorf("%s is mandatory for %s param flow", InstallerRoleArnFlag, PrefixFlag)
 		}
 		channelGroup := args.channelGroup
 		latestPolicyVersion, err := r.OCMClient.GetLatestVersion(channelGroup)
 		if err != nil {
-			r.Reporter.Errorf("Error getting latest version: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("error getting latest version: %s", err)
 		}
 		err = HandleOperatorRoleCreationByPrefix(r, env, permissionsBoundary,
 			mode, policies, latestPolicyVersion, isHcpSharedVpc)
 		if err != nil {
-			r.Reporter.Errorf("Error creating operator roles: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("error creating operator roles: %s", err)
 		}
-		return
+		return nil
 	}
 	latestPolicyVersion, err := r.OCMClient.GetLatestVersion(cluster.Version().ChannelGroup())
 	if err != nil {
-		r.Reporter.Errorf("Error getting latest version: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("error getting latest version: %s", err)
 	}
 	err = handleOperatorRoleCreationByClusterKey(r, env, permissionsBoundary,
 		mode, policies, latestPolicyVersion, isHcpSharedVpc)
 	if err != nil {
-		r.Reporter.Errorf("Error creating operator roles: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("error creating operator roles: %s", err)
 	}
+	return nil
 }
 
 func convertV1OperatorIAMRoleIntoOcmOperatorIamRole(

--- a/cmd/create/operatorroles/cmd_test.go
+++ b/cmd/create/operatorroles/cmd_test.go
@@ -1,0 +1,203 @@
+package operatorroles
+
+import (
+	"net/http"
+
+	"go.uber.org/mock/gomock"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/ocm"
+	"github.com/openshift/rosa/pkg/rosa"
+	"github.com/openshift/rosa/pkg/test"
+)
+
+const (
+	testOperatorRoleArn = "arn:aws:iam::765374464689:role/fake-arn-openshift-cluster-csi-drivers-ebs-cloud-credentials"
+	clusterKey          = "cluster1"
+
+	stsPoliciesResponse = `{
+		"kind": "AWSSTSPolicyList",
+		"page": 1,
+		"size": 0,
+		"total": 0,
+		"items": []
+	}`
+
+	stsCredRequestsResponse = `{
+		"kind": "STSCredentialRequestList",
+		"page": 1,
+		"size": 0,
+		"total": 0,
+		"items": []
+	}`
+
+	versionsResponse = `{
+		"kind": "VersionList",
+		"page": 1,
+		"size": 1,
+		"total": 1,
+		"items": [
+			{
+				"id": "4.16.3",
+				"raw_id": "4.16.3",
+				"channel_group": "stable",
+				"rosa_enabled": true
+			}
+		]
+	}`
+)
+
+var _ = Describe("create operator-roles cmd", func() {
+	var t *test.TestingRuntime
+
+	resetCmdFlags := func() {
+		Cmd.Flags().VisitAll(func(f *pflag.Flag) {
+			f.Changed = false
+			_ = f.Value.Set(f.DefValue)
+		})
+	}
+
+	BeforeEach(func() {
+		t = test.NewTestRuntime()
+		resetCmdFlags()
+		args = struct {
+			prefix              string
+			hostedCp            bool
+			installerRoleArn    string
+			permissionsBoundary string
+			forcePolicyCreation bool
+			oidcConfigId        string
+			sharedVpcRoleArn    string
+			channelGroup        string
+			vpcEndpointRoleArn  string
+		}{}
+		interactive.SetEnabled(false)
+		interactive.SetModeKey("")
+		ocm.SetClusterKey("")
+	})
+
+	Context("convertV1OperatorIAMRoleIntoOcmOperatorIamRole", func() {
+		It("converts valid operator IAM roles", func() {
+			operatorIAMRole, err := cmv1.NewOperatorIAMRole().
+				Name("openshift").
+				Namespace("operator").
+				RoleARN(testOperatorRoleArn).
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			roles, err := convertV1OperatorIAMRoleIntoOcmOperatorIamRole([]*cmv1.OperatorIAMRole{operatorIAMRole})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(roles).To(HaveLen(1))
+			Expect(roles[0].Name).To(Equal(operatorIAMRole.Name()))
+			Expect(roles[0].Namespace).To(Equal(operatorIAMRole.Namespace()))
+			Expect(roles[0].RoleARN).To(Equal(operatorIAMRole.RoleARN()))
+			path, err := aws.GetPathFromARN(operatorIAMRole.RoleARN())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(roles[0].Path).To(Equal(path))
+		})
+
+		It("returns an error for malformed operator IAM roles", func() {
+			operatorIAMRole, err := cmv1.NewOperatorIAMRole().
+				Name("openshift").
+				Namespace("operator").
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			roles, err := convertV1OperatorIAMRoleIntoOcmOperatorIamRole([]*cmv1.OperatorIAMRole{operatorIAMRole})
+			Expect(err).To(HaveOccurred())
+			Expect(roles).To(BeEmpty())
+		})
+	})
+
+	Context("runWithRuntime", func() {
+		It("returns an error when neither cluster nor prefix is specified", func() {
+			err := runWithRuntime(t.RosaRuntime, Cmd, false)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(
+				"either a cluster key for STS cluster or an operator roles prefix must be specified"))
+		})
+
+		It("dispatches to the prefix path when prefix is set", func() {
+			Expect(Cmd.Flags().Set(PrefixFlag, "my-prefix")).To(Succeed())
+			Expect(Cmd.Flags().Set("mode", interactive.ModeAuto)).To(Succeed())
+
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusOK, stsPoliciesResponse),
+			)
+
+			err := runWithRuntime(t.RosaRuntime, Cmd, false)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(OidcConfigIdFlag))
+			Expect(err.Error()).To(ContainSubstring(PrefixFlag))
+		})
+
+		It("dispatches to the cluster path when cluster is set", func() {
+			cluster := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.Version(cmv1.NewVersion().
+					ID("4.16.3").
+					RawID("openshift-4.16.3").
+					ChannelGroup("stable"))
+				c.AWS(cmv1.NewAWS().STS(
+					cmv1.NewSTS().
+						RoleARN("arn:aws:iam::123456789012:role/ManagedOpenShift-Installer-Role").
+						OIDCEndpointURL("https://oidc.example.com").
+						OperatorRolePrefix("ManagedOpenShift").
+						OperatorIAMRoles(
+							cmv1.NewOperatorIAMRole().
+								Name("ebs-cloud-credentials").
+								Namespace("openshift-cluster-csi-drivers").
+								RoleARN("arn:aws:iam::123456789012:role/ManagedOpenShift-openshift-cluster-csi-drivers-ebs-cloud-credentials"),
+						),
+				))
+			})
+			t.SetCluster(clusterKey, cluster)
+			Expect(Cmd.Flags().Set("cluster", clusterKey)).To(Succeed())
+			Expect(Cmd.Flags().Set("mode", interactive.ModeAuto)).To(Succeed())
+
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusOK, stsPoliciesResponse),
+				RespondWithJSON(http.StatusOK, versionsResponse),
+				RespondWithJSON(http.StatusOK, stsCredRequestsResponse),
+			)
+
+			mockClient := t.RosaRuntime.AWSClient.(*aws.MockClient)
+			mockClient.EXPECT().CheckRoleExists(gomock.Any()).Return(true, "", nil).AnyTimes()
+
+			stdout, stderr, err := test.RunWithOutputCapture(
+				func(r *rosa.Runtime, cmd *cobra.Command) error {
+					return runWithRuntime(r, cmd, false)
+				}, t.RosaRuntime, Cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stderr).To(BeEmpty())
+			Expect(stdout).To(ContainSubstring("Operator Roles already exists"))
+		})
+
+		It("returns an error when STS policy fetch fails", func() {
+			cluster := test.MockCluster(func(c *cmv1.ClusterBuilder) {
+				c.Version(cmv1.NewVersion().
+					ID("4.16.3").
+					RawID("openshift-4.16.3").
+					ChannelGroup("stable"))
+			})
+			t.SetCluster(clusterKey, cluster)
+			Expect(Cmd.Flags().Set("cluster", clusterKey)).To(Succeed())
+			Expect(Cmd.Flags().Set("mode", interactive.ModeAuto)).To(Succeed())
+
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusInternalServerError, "{}"),
+			)
+
+			err := runWithRuntime(t.RosaRuntime, Cmd, false)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("expected a valid role creation mode"))
+		})
+	})
+})


### PR DESCRIPTION
## PR Summary
Add Ginkgo v2 unit tests for `rosa create operator-roles` dispatch logic.

## Detailed Description of the Issue
Part of [ROSAENG-61180](https://redhat.atlassian.net/browse/ROSAENG-61180). Extracts `runWithRuntime` from `cmd/create/operatorroles/cmd.go` and adds tests covering prefix vs cluster-key dispatch routing, `convertV1OperatorIAMRoleIntoOcmOperatorIamRole` conversion, and STS policy fetch failure.

**Changes:**
- `cmd/create/operatorroles/cmd.go`: Extract `runWithRuntime`
- New `cmd_test.go` (6 test cases)

## Related Issues and PRs
- Jira: [ROSAENG-61180](https://redhat.atlassian.net/browse/ROSAENG-61180)
- Stack: 2/7 (base: PR 1)

## Type of Change
- [x] test
- [x] refactor

## How to Test (Step-by-Step)
1. `make test` -- all tests pass
2. `go test -v ./cmd/create/operatorroles/...` -- new tests pass
3. `make lint` -- no lint issues


[ROSAENG-61180]: https://redhat.atlassian.net/browse/ROSAENG-61180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROSAENG-61180]: https://redhat.atlassian.net/browse/ROSAENG-61180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ