### PR TITLE
ROSAENG-61180 | test: add tests for create operatorroles by prefix and role helpers

### DIFF
--- a/cmd/create/operatorroles/by_prefix_test.go
+++ b/cmd/create/operatorroles/by_prefix_test.go
@@ -1,0 +1,163 @@
+package operatorroles
+
+import (
+	"go.uber.org/mock/gomock"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
+	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+var _ = Describe("create operator-roles by prefix", func() {
+	var ctrl *gomock.Controller
+	var runtime *rosa.Runtime
+	var mockClient *aws.MockClient
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		runtime = rosa.NewRuntime()
+		mockClient = aws.NewMockClient(ctrl)
+		runtime.AWSClient = mockClient
+		mockClient.EXPECT().GetCreator().Return(&aws.Creator{
+			Partition: "aws",
+			AccountID: "123456789012",
+		}, nil)
+		creator, err := runtime.AWSClient.GetCreator()
+		Expect(err).ToNot(HaveOccurred())
+		runtime.Creator = creator
+
+		interactive.SetEnabled(false)
+		args = struct {
+			prefix              string
+			hostedCp            bool
+			installerRoleArn    string
+			permissionsBoundary string
+			forcePolicyCreation bool
+			oidcConfigId        string
+			sharedVpcRoleArn    string
+			channelGroup        string
+			vpcEndpointRoleArn  string
+		}{}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Context("computePolicyARN", func() {
+		It("returns correct ARN for standard partition without path", func() {
+			creator := aws.Creator{Partition: "aws", AccountID: "123456789012"}
+			arn := computePolicyARN(creator, "my-prefix", "openshift-cloud-credential-operator", "cloud-credentials", "")
+			Expect(arn).To(Equal(
+				"arn:aws:iam::123456789012:policy/my-prefix-openshift-cloud-credential-operator-cloud-credentials",
+			))
+		})
+
+		It("returns correct ARN for gov-cloud partition without path", func() {
+			creator := aws.Creator{Partition: "aws-us-gov", AccountID: "111222333444"}
+			arn := computePolicyARN(creator, "gov-prefix", "ns", "name", "")
+			Expect(arn).To(Equal(
+				"arn:aws-us-gov:iam::111222333444:policy/gov-prefix-ns-name",
+			))
+		})
+
+		It("returns correct ARN with a custom path", func() {
+			creator := aws.Creator{Partition: "aws", AccountID: "123456789012"}
+			arn := computePolicyARN(creator, "my-prefix", "ns", "name", "/custom/path/")
+			Expect(arn).To(Equal(
+				"arn:aws:iam::123456789012:policy/custom/path/my-prefix-ns-name",
+			))
+		})
+
+		It("uses DefaultPrefix when prefix is empty", func() {
+			creator := aws.Creator{Partition: "aws", AccountID: "123456789012"}
+			arn := computePolicyARN(creator, "", "ns", "name", "")
+			Expect(arn).To(ContainSubstring(aws.DefaultPrefix))
+		})
+	})
+
+	Context("validateArgumentsOperatorRolesCreationByPrefix", func() {
+		It("does not exit for valid inputs", func() {
+			validateArgumentsOperatorRolesCreationByPrefix(
+				runtime,
+				"valid-prefix",
+				"https://oidc.example.com",
+				"arn:aws:iam::123456789012:role/MyRole",
+			)
+		})
+	})
+
+	Context("convertCredRequestsOperatorRolesIntoV1OperatorIAMRole", func() {
+		It("converts a single credential request into an operator IAM role list", func() {
+			operator, err := cmv1.NewSTSOperator().
+				Name("cloud-credentials").
+				Namespace("openshift-cloud-credential-operator").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			credRequests := map[string]*cmv1.STSOperator{
+				"cloud_credential": operator,
+			}
+			creator := &aws.Creator{
+				Partition: "aws",
+				AccountID: "123456789012",
+			}
+
+			roleList, err := convertCredRequestsOperatorRolesIntoV1OperatorIAMRole(
+				credRequests, "test-prefix", creator, "",
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(roleList).To(HaveLen(1))
+			Expect(roleList[0].Name()).To(Equal("cloud-credentials"))
+			Expect(roleList[0].Namespace()).To(Equal("openshift-cloud-credential-operator"))
+			Expect(roleList[0].RoleARN()).ToNot(BeEmpty())
+		})
+
+		It("converts multiple credential requests", func() {
+			op1, err := cmv1.NewSTSOperator().
+				Name("cred1").
+				Namespace("ns1").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			op2, err := cmv1.NewSTSOperator().
+				Name("cred2").
+				Namespace("ns2").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			credRequests := map[string]*cmv1.STSOperator{
+				"type1": op1,
+				"type2": op2,
+			}
+			creator := &aws.Creator{
+				Partition: "aws",
+				AccountID: "999888777666",
+			}
+
+			roleList, err := convertCredRequestsOperatorRolesIntoV1OperatorIAMRole(
+				credRequests, "multi-prefix", creator, "/path/",
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(roleList).To(HaveLen(2))
+		})
+
+		It("returns empty list when no credential requests provided", func() {
+			credRequests := map[string]*cmv1.STSOperator{}
+			creator := &aws.Creator{
+				Partition: "aws",
+				AccountID: "123456789012",
+			}
+
+			roleList, err := convertCredRequestsOperatorRolesIntoV1OperatorIAMRole(
+				credRequests, "prefix", creator, "",
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(roleList).To(BeEmpty())
+		})
+	})
+})

--- a/cmd/create/operatorroles/common_utils_test.go
+++ b/cmd/create/operatorroles/common_utils_test.go
@@ -1,6 +1,8 @@
 package operatorroles
 
 import (
+	"fmt"
+
 	"go.uber.org/mock/gomock"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -55,6 +57,120 @@ var _ = Describe("Create dns domain", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(arn).To(Equal(""))
 			})
+		})
+	})
+})
+
+var _ = Describe("validateIngressOperatorPolicyOverride", func() {
+	var ctrl *gomock.Controller
+	var runtime *rosa.Runtime
+	var mockClient *aws.MockClient
+
+	const (
+		testPolicyArn    = "arn:aws:iam::123456789012:policy/test-policy"
+		testSharedVpcArn = "arn:aws:iam::999888777666:role/shared-vpc-role"
+		testInstallerPfx = "my-prefix"
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		runtime = rosa.NewRuntime()
+		mockClient = aws.NewMockClient(ctrl)
+		runtime.AWSClient = mockClient
+		mockClient.EXPECT().GetCreator().Return(&aws.Creator{Partition: "aws"}, nil)
+		creator, err := runtime.AWSClient.GetCreator()
+		Expect(err).ToNot(HaveOccurred())
+		runtime.Creator = creator
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	When("the policy does not exist", func() {
+		It("returns nil without further checks", func() {
+			mockClient.EXPECT().IsPolicyExists(testPolicyArn).Return(nil, fmt.Errorf("NoSuchEntity"))
+			err := validateIngressOperatorPolicyOverride(runtime, testPolicyArn, testSharedVpcArn, testInstallerPfx)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	When("the policy exists", func() {
+		BeforeEach(func() {
+			mockClient.EXPECT().IsPolicyExists(testPolicyArn).Return(nil, nil)
+		})
+
+		It("returns error when GetDefaultPolicyDocument fails", func() {
+			mockClient.EXPECT().GetDefaultPolicyDocument(testPolicyArn).
+				Return("", fmt.Errorf("access denied"))
+			err := validateIngressOperatorPolicyOverride(runtime, testPolicyArn, testSharedVpcArn, testInstallerPfx)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("access denied"))
+		})
+
+		It("returns error when policy document is invalid JSON", func() {
+			mockClient.EXPECT().GetDefaultPolicyDocument(testPolicyArn).
+				Return("not-json", nil)
+			err := validateIngressOperatorPolicyOverride(runtime, testPolicyArn, testSharedVpcArn, testInstallerPfx)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns nil when policy has matching shared VPC role ARN", func() {
+			doc := fmt.Sprintf(`{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Action": "sts:AssumeRole",
+					"Resource": "%s"
+				}]
+			}`, testSharedVpcArn)
+			mockClient.EXPECT().GetDefaultPolicyDocument(testPolicyArn).Return(doc, nil)
+			err := validateIngressOperatorPolicyOverride(runtime, testPolicyArn, testSharedVpcArn, testInstallerPfx)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns error when policy has different shared VPC role ARN", func() {
+			differentArn := "arn:aws:iam::111111111111:role/other-role"
+			doc := fmt.Sprintf(`{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Action": "sts:AssumeRole",
+					"Resource": "%s"
+				}]
+			}`, differentArn)
+			mockClient.EXPECT().GetDefaultPolicyDocument(testPolicyArn).Return(doc, nil)
+			err := validateIngressOperatorPolicyOverride(runtime, testPolicyArn, testSharedVpcArn, testInstallerPfx)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unexpected shared VPC role ARN"))
+		})
+
+		It("returns nil when policy has no sts:AssumeRole statement", func() {
+			doc := `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Action": "s3:GetObject",
+					"Resource": "arn:aws:s3:::my-bucket/*"
+				}]
+			}`
+			mockClient.EXPECT().GetDefaultPolicyDocument(testPolicyArn).Return(doc, nil)
+			err := validateIngressOperatorPolicyOverride(runtime, testPolicyArn, testSharedVpcArn, testInstallerPfx)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns nil when policy has Deny effect with sts:AssumeRole", func() {
+			doc := fmt.Sprintf(`{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Deny",
+					"Action": "sts:AssumeRole",
+					"Resource": "%s"
+				}]
+			}`, "arn:aws:iam::111111111111:role/other-role")
+			mockClient.EXPECT().GetDefaultPolicyDocument(testPolicyArn).Return(doc, nil)
+			err := validateIngressOperatorPolicyOverride(runtime, testPolicyArn, testSharedVpcArn, testInstallerPfx)
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 })

--- a/pkg/interactive/roles/roles_test.go
+++ b/pkg/interactive/roles/roles_test.go
@@ -1,0 +1,82 @@
+package roles
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/interactive/confirm"
+	"github.com/openshift/rosa/pkg/rosa"
+)
+
+var _ = Describe("GetInstallerRoleArn", func() {
+	var (
+		runtime *rosa.Runtime
+		cmd     *cobra.Command
+	)
+
+	BeforeEach(func() {
+		runtime = rosa.NewRuntime()
+		interactive.SetEnabled(false)
+		cmd = &cobra.Command{
+			Use: "test",
+		}
+		cmd.Flags().String("role-arn", "", "The installer role ARN")
+		confirm.AddFlag(cmd.Flags())
+		Expect(cmd.Flags().Set("yes", "false")).To(Succeed())
+	})
+
+	It("returns the single role ARN when exactly one role is found", func() {
+		expectedArn := "arn:aws:iam::123456789012:role/my-Installer-Role"
+		finder := func(roleType string, minVersion string) ([]string, error) {
+			return []string{expectedArn}, nil
+		}
+
+		result := GetInstallerRoleArn(runtime, cmd, "", "", finder)
+		Expect(result).To(Equal(expectedArn))
+	})
+
+	It("returns the found role ARN even when a default is provided", func() {
+		defaultArn := "arn:aws:iam::123456789012:role/default-Installer-Role"
+		foundArn := "arn:aws:iam::123456789012:role/found-Installer-Role"
+		finder := func(roleType string, minVersion string) ([]string, error) {
+			return []string{foundArn}, nil
+		}
+
+		result := GetInstallerRoleArn(runtime, cmd, defaultArn, "", finder)
+		Expect(result).To(Equal(foundArn))
+	})
+
+	It("passes the correct role type and min version to findRoleARNs", func() {
+		var capturedRoleType, capturedMinVersion string
+		finder := func(roleType string, minVersion string) ([]string, error) {
+			capturedRoleType = roleType
+			capturedMinVersion = minVersion
+			return []string{"arn:aws:iam::123456789012:role/test-Installer-Role"}, nil
+		}
+
+		GetInstallerRoleArn(runtime, cmd, "", "4.14", finder)
+		Expect(capturedRoleType).To(Equal(aws.InstallerAccountRole))
+		Expect(capturedMinVersion).To(Equal("4.14"))
+	})
+
+	It("prioritizes the role with default prefix when multiple roles and --yes", func() {
+		role := aws.AccountRoles[aws.InstallerAccountRole]
+		defaultPrefixArn := fmt.Sprintf(
+			"arn:aws:iam::123456789012:role/%s-%s-Role", aws.DefaultPrefix, role.Name,
+		)
+		otherArn := "arn:aws:iam::123456789012:role/custom-Installer-Role"
+
+		finder := func(roleType string, minVersion string) ([]string, error) {
+			return []string{otherArn, defaultPrefixArn}, nil
+		}
+
+		Expect(cmd.Flags().Set("yes", "true")).To(Succeed())
+		result := GetInstallerRoleArn(runtime, cmd, "", "", finder)
+		Expect(result).To(Equal(defaultPrefixArn))
+	})
+})

--- a/pkg/interactive/roles/suite_test.go
+++ b/pkg/interactive/roles/suite_test.go
@@ -1,0 +1,13 @@
+package roles
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestRoles(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Interactive roles suite")
+}


### PR DESCRIPTION
## PR Summary
Add Ginkgo v2 unit tests for `by_prefix.go` prefix validation and ARN computation, expand `common_utils_test.go` with `validateIngressOperatorPolicyOverride` tests, and add new test suite for `pkg/interactive/roles/roles.go`.

## Detailed Description of the Issue
Part of [ROSAENG-61180](https://redhat.atlassian.net/browse/ROSAENG-61180). Tests cover `computePolicyARN`, `validateArgumentsOperatorRolesCreationByPrefix`, `convertCredRequestsOperatorRolesIntoV1OperatorIAMRole`, `validateIngressOperatorPolicyOverride` (7 scenarios), and `GetInstallerRoleArn` helpers.

**Changes:**
- New `by_prefix_test.go` (8 test cases)
- Expanded `common_utils_test.go` (+7 test cases)
- New `pkg/interactive/roles/suite_test.go` + `roles_test.go` (4 test cases)

## Related Issues and PRs
- Jira: [ROSAENG-61180](https://redhat.atlassian.net/browse/ROSAENG-61180)
- Stack: 4/7 (base: PR 3)

## Type of Change
- [x] test

## How to Test (Step-by-Step)
1. `make test` -- all tests pass
2. `go test -v ./cmd/create/operatorroles/... ./pkg/interactive/roles/...` -- new tests pass


[ROSAENG-61180]: https://redhat.atlassian.net/browse/ROSAENG-61180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROSAENG-61180]: https://redhat.atlassian.net/browse/ROSAENG-61180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ