### PR TITLE
ROSAENG-61180 | test: add tests for create/delete ocm-role and user-role

### DIFF
--- a/cmd/create/ocmrole/cmd.go
+++ b/cmd/create/ocmrole/cmd.go
@@ -125,24 +125,27 @@ func init() {
 func run(cmd *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
-
-	mode, err := interactive.GetMode()
-	if err != nil {
+	if err := runWithRuntime(r, cmd); err != nil {
 		r.Reporter.Errorf("%s", err)
 		os.Exit(1)
+	}
+}
+
+func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
+	mode, err := interactive.GetMode()
+	if err != nil {
+		return err
 	}
 
 	env, err := ocm.GetEnv()
 	if err != nil {
-		r.Reporter.Errorf("Failed to determine OCM environment: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to determine OCM environment: %v", err)
 	}
 
 	// Determine if Classic ROSA managed policies are enabled
 	isManagedSet := cmd.Flags().Changed("managed-policies") || cmd.Flags().Changed("mp")
 	if roles.ClassicManagedPoliciesUnsupportedInEnv(isManagedSet, args.managed, env) {
-		r.Reporter.Errorf("Classic ROSA managed policies are not supported in this environment")
-		os.Exit(1)
+		return fmt.Errorf("classic ROSA managed policies are not supported in this environment")
 	}
 	managedPolicies := args.managed
 
@@ -168,17 +171,14 @@ func run(cmd *cobra.Command, _ []string) {
 			},
 		})
 		if err != nil {
-			r.Reporter.Errorf("Expected a valid role prefix: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("expected a valid role prefix: %s", err)
 		}
 	}
 	if len(prefix) > 32 {
-		r.Reporter.Errorf("Expected a prefix with no more than 32 characters")
-		os.Exit(1)
+		return fmt.Errorf("expected a prefix with no more than 32 characters")
 	}
 	if !aws.RoleNameRE.MatchString(prefix) {
-		r.Reporter.Errorf("Expected a valid role prefix matching %s", aws.RoleNameRE.String())
-		os.Exit(1)
+		return fmt.Errorf("expected a valid role prefix matching %s", aws.RoleNameRE.String())
 	}
 
 	profile := internalocmrole.DetermineProfile(args.admin, args.noConsole)
@@ -186,8 +186,7 @@ func run(cmd *cobra.Command, _ []string) {
 	if interactive.Enabled() && profile == internalocmrole.ProfileStandard {
 		profile, err = promptProfile(cmd, profile)
 		if err != nil {
-			r.Reporter.Errorf("Expected a valid --admin value: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("expected a valid --admin value: %s", err)
 		}
 	}
 
@@ -206,16 +205,14 @@ func run(cmd *cobra.Command, _ []string) {
 			},
 		})
 		if err != nil {
-			r.Reporter.Errorf("Expected a valid policy ARN for permissions boundary: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("expected a valid policy ARN for permissions boundary: %s", err)
 		}
 	}
 
 	if permissionsBoundary != "" {
 		err = aws.ARNValidator(permissionsBoundary)
 		if err != nil {
-			r.Reporter.Errorf("Expected a valid policy ARN for permissions boundary: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("expected a valid policy ARN for permissions boundary: %s", err)
 		}
 	}
 
@@ -230,50 +227,43 @@ func run(cmd *cobra.Command, _ []string) {
 			},
 		})
 		if err != nil {
-			r.Reporter.Errorf("Expected a valid path: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("expected a valid path: %s", err)
 		}
 	}
 
 	if path != "" && !aws.ARNPath.MatchString(path) {
-		r.Reporter.Errorf("The specified value for path is invalid. " +
-			"It must begin and end with '/' and contain only alphanumeric characters and/or '/' characters.")
-		os.Exit(1)
+		return fmt.Errorf("the specified value for path is invalid, " +
+			"it must begin and end with '/' and contain only alphanumeric characters and/or '/' characters")
 	}
 
 	if interactive.Enabled() {
 		mode, err = interactive.GetOptionMode(cmd, mode, "Role creation mode")
 		if err != nil {
-			r.Reporter.Errorf("Expected a valid role creation mode: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("expected a valid role creation mode: %s", err)
 		}
 	}
 
 	// Get current OCM org account:
 	orgID, externalID, err := r.OCMClient.GetCurrentOrganization()
 	if err != nil {
-		r.Reporter.Errorf("Failed to get organization account: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to get organization account: %v", err)
 	}
 
 	roleNameRequested := aws.GetOCMRoleName(prefix, aws.OCMRole, externalID)
 
 	existsOnOCM, _, selectedARN, err := r.OCMClient.CheckRoleExists(orgID, roleNameRequested, r.Creator.AccountID)
 	if err != nil {
-		r.Reporter.Errorf("Error checking existing ocm-role: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("error checking existing ocm-role: %v", err)
 	}
 	if existsOnOCM {
-		r.Reporter.Errorf("Only one ocm-role can be created per AWS account '%s' per organization '%s'.\n"+
-			"In order to create a new ocm-role, you have to unlink the ocm-role '%s'.\n",
+		return fmt.Errorf("only one ocm-role can be created per AWS account '%s' per organization '%s', "+
+			"in order to create a new ocm-role, you have to unlink the ocm-role '%s'",
 			r.Creator.AccountID, orgID, selectedARN)
-		os.Exit(1)
 	}
 
 	policies, err := r.OCMClient.GetPolicies("OCMRole")
 	if err != nil {
-		r.Reporter.Errorf("Expected a valid role creation mode: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("expected a valid role creation mode: %s", err)
 	}
 
 	// Validate no-console policy availability before any operations
@@ -283,9 +273,8 @@ func run(cmd *cobra.Command, _ []string) {
 		// For managed policies, validate ARN exists
 		// For customer-managed policies, validate Details exists (ARN is constructed later)
 		if !ok || (managedPolicies && policy.ARN() == "") || (!managedPolicies && policy.Details() == "") {
-			r.Reporter.Errorf("There was an error creating the ocm role: " +
+			return fmt.Errorf("there was an error creating the ocm role: " +
 				"the no-console OCM role profile is not yet enabled for your Organization")
-			os.Exit(1)
 		}
 	}
 
@@ -295,11 +284,13 @@ func run(cmd *cobra.Command, _ []string) {
 		roleARN, err := createRoles(r, prefix, roleNameRequested, path, permissionsBoundary,
 			orgID, env, profile, policies, managedPolicies)
 		if err != nil {
-			r.Reporter.Errorf("There was an error creating the ocm role: %s", err)
 			r.OCMClient.LogEvent("ROSACreateOCMRoleModeAuto", map[string]string{
 				ocm.Response: ocm.Failure,
 			})
-			os.Exit(1)
+			return fmt.Errorf("there was an error creating the ocm role: %s", err)
+		}
+		if roleARN == "" {
+			return nil
 		}
 		r.OCMClient.LogEvent("ROSACreateOCMRoleModeAuto", map[string]string{
 			ocm.Response: ocm.Success,
@@ -315,11 +306,10 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 		err = generateOcmRolePolicyFiles(r, env, orgID, profile, policies)
 		if err != nil {
-			r.Reporter.Errorf("There was an error generating the policy files: %s", err)
 			r.OCMClient.LogEvent("ROSACreateOCMRoleModeManual", map[string]string{
 				ocm.Response: ocm.Failure,
 			})
-			os.Exit(1)
+			return fmt.Errorf("there was an error generating the policy files: %s", err)
 		}
 		if r.Reporter.IsTerminal() {
 			r.Reporter.Infof("All policy files saved to the current directory")
@@ -339,15 +329,14 @@ func run(cmd *cobra.Command, _ []string) {
 			policies,
 		)
 		if err != nil {
-			r.Reporter.Errorf("Failed to generate commands for manual mode: %v", err)
-			os.Exit(1)
+			return fmt.Errorf("failed to generate commands for manual mode: %v", err)
 		}
 
 		fmt.Println(commands)
 	default:
-		r.Reporter.Errorf("Invalid mode. Allowed values are %s", interactive.Modes)
-		os.Exit(1)
+		return fmt.Errorf("invalid mode. Allowed values are %s", interactive.Modes)
 	}
+	return nil
 }
 
 func promptProfile(cmd *cobra.Command, curr internalocmrole.RoleProfile) (internalocmrole.RoleProfile, error) {
@@ -529,7 +518,7 @@ func createRoles(r *rosa.Runtime, prefix string, roleName string, rolePath strin
 	policies map[string]*cmv1.AWSSTSPolicy, managedPolicies bool,
 ) (string, error) {
 	if !confirm.Prompt(true, "Create the '%s' role?", roleName) {
-		os.Exit(0)
+		return "", nil
 	}
 
 	roleARN, exists, err := checkRoleExists(r, roleName, profile, interactive.ModeAuto, rolePath)

--- a/cmd/create/ocmrole/cmd_test.go
+++ b/cmd/create/ocmrole/cmd_test.go
@@ -18,19 +18,25 @@ package ocmrole
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"testing"
+	"time"
 
 	"go.uber.org/mock/gomock"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
 
 	internalocmrole "github.com/openshift/rosa/internal/ocmrole"
 	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/config"
+	"github.com/openshift/rosa/pkg/interactive"
 	"github.com/openshift/rosa/pkg/reporter"
 	"github.com/openshift/rosa/pkg/rosa"
+	"github.com/openshift/rosa/pkg/test"
 )
 
 func TestOCMRole(t *testing.T) {
@@ -593,5 +599,99 @@ var _ = Describe("checkRoleExists", func() {
 			Expect(exists).To(BeTrue())
 			Expect(arn).To(Equal("arn:aws:iam::123456789012:role/custom/path/test-role"))
 		})
+	})
+})
+
+var currentAccountResponse = `{
+	"kind": "Account",
+	"id": "acct-123",
+	"username": "testuser",
+	"organization": {
+		"id": "org-123",
+		"external_id": "ext-1",
+		"kind": "Organization"
+	}
+}`
+
+var _ = Describe("runWithRuntime", func() {
+	var (
+		t      *test.TestingRuntime
+		tmpdir string
+	)
+
+	saveTestConfig := func() {
+		Expect(os.Setenv("OCM_CONFIG", tmpdir+"/ocm_config.json")).To(Succeed())
+		cfg := &config.Config{
+			AccessToken: MakeTokenString("Bearer", 15*time.Minute),
+			URL:         "https://api.openshift.com",
+			TokenURL:    t.SsoServer.URL(),
+		}
+		Expect(config.Save(cfg)).To(Succeed())
+	}
+
+	BeforeEach(func() {
+		t = test.NewTestRuntime()
+		t.RosaRuntime.Creator = &aws.Creator{
+			ARN:       "arn:aws:iam::123456789012:user/test",
+			AccountID: "123456789012",
+			Partition: "aws",
+		}
+
+		var err error
+		tmpdir, err = os.MkdirTemp("", "rosa-create-ocmrole-test-*")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(os.RemoveAll, tmpdir)
+
+		args = struct {
+			prefix              string
+			permissionsBoundary string
+			admin               bool
+			path                string
+			managed             bool
+			noConsole           bool
+		}{}
+		interactive.SetEnabled(false)
+		interactive.SetModeKey("")
+		Expect(Cmd.Flags().Set("mode", "")).To(Succeed())
+	})
+
+	It("returns error when mode is invalid", func() {
+		interactive.SetModeKey("invalid_mode")
+		Expect(Cmd.Flags().Set("mode", "invalid_mode")).To(Succeed())
+
+		err := runWithRuntime(t.RosaRuntime, Cmd)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("Invalid mode"))
+	})
+
+	It("returns error when prefix is invalid", func() {
+		saveTestConfig()
+		interactive.SetModeKey(interactive.ModeManual)
+		Expect(Cmd.Flags().Set("mode", interactive.ModeManual)).To(Succeed())
+		args.prefix = "invalid prefix!"
+
+		err := runWithRuntime(t.RosaRuntime, Cmd)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("expected a valid role prefix matching"))
+	})
+
+	It("returns error when role already exists on OCM", func() {
+		saveTestConfig()
+		interactive.SetModeKey(interactive.ModeManual)
+		Expect(Cmd.Flags().Set("mode", interactive.ModeManual)).To(Succeed())
+		args.prefix = aws.DefaultPrefix
+
+		t.ApiServer.AppendHandlers(
+			RespondWithJSON(http.StatusOK, currentAccountResponse),
+			RespondWithJSON(http.StatusOK, `{
+				"key": "sts_ocm_role",
+				"value": "arn:aws:iam::123456789012:role/existing-OCM-Role"
+			}`),
+		)
+
+		err := runWithRuntime(t.RosaRuntime, Cmd)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("only one ocm-role can be created per AWS account"))
+		Expect(err.Error()).To(ContainSubstring("arn:aws:iam::123456789012:role/existing-OCM-Role"))
 	})
 })

--- a/cmd/create/userrole/cmd.go
+++ b/cmd/create/userrole/cmd.go
@@ -87,17 +87,21 @@ func init() {
 func run(cmd *cobra.Command, _ []string) {
 	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
-
-	mode, err := interactive.GetMode()
-	if err != nil {
+	if err := runWithRuntime(r, cmd); err != nil {
 		r.Reporter.Errorf("%s", err)
 		os.Exit(1)
+	}
+}
+
+func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
+	mode, err := interactive.GetMode()
+	if err != nil {
+		return err
 	}
 
 	env, err := ocm.GetEnv()
 	if err != nil {
-		r.Reporter.Errorf("Failed to determine OCM environment: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to determine OCM environment: %v", err)
 	}
 
 	// Determine if interactive mode is needed
@@ -122,17 +126,14 @@ func run(cmd *cobra.Command, _ []string) {
 			},
 		})
 		if err != nil {
-			r.Reporter.Errorf("Expected a valid role prefix: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("expected a valid role prefix: %s", err)
 		}
 	}
 	if len(prefix) > 32 {
-		r.Reporter.Errorf("Expected a prefix with no more than 32 characters")
-		os.Exit(1)
+		return fmt.Errorf("expected a prefix with no more than 32 characters")
 	}
 	if !aws.RoleNameRE.MatchString(prefix) {
-		r.Reporter.Errorf("Expected a valid role prefix matching %s", aws.RoleNameRE.String())
-		os.Exit(1)
+		return fmt.Errorf("expected a valid role prefix matching %s", aws.RoleNameRE.String())
 	}
 	permissionsBoundary := args.permissionsBoundary
 	if interactive.Enabled() {
@@ -145,16 +146,14 @@ func run(cmd *cobra.Command, _ []string) {
 			},
 		})
 		if err != nil {
-			r.Reporter.Errorf("Expected a valid policy ARN for permissions boundary: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("expected a valid policy ARN for permissions boundary: %s", err)
 		}
 	}
 
 	if permissionsBoundary != "" {
 		err = aws.ARNValidator(permissionsBoundary)
 		if err != nil {
-			r.Reporter.Errorf("Expected a valid policy ARN for permissions boundary: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("expected a valid policy ARN for permissions boundary: %s", err)
 		}
 	}
 
@@ -169,36 +168,31 @@ func run(cmd *cobra.Command, _ []string) {
 			},
 		})
 		if err != nil {
-			r.Reporter.Errorf("Expected a valid path: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("expected a valid path: %s", err)
 		}
 	}
 
 	if path != "" && !aws.ARNPath.MatchString(path) {
-		r.Reporter.Errorf("The specified value for path is invalid. " +
-			"It must begin and end with '/' and contain only alphanumeric characters and/or '/' characters.")
-		os.Exit(1)
+		return fmt.Errorf("the specified value for path is invalid, " +
+			"it must begin and end with '/' and contain only alphanumeric characters and/or '/' characters")
 	}
 
 	if interactive.Enabled() {
 		mode, err = interactive.GetOptionMode(cmd, mode, "Role creation mode")
 		if err != nil {
-			r.Reporter.Errorf("Expected a valid role creation mode: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("expected a valid role creation mode: %s", err)
 		}
 	}
 
 	// Get current OCM account:
 	currentAccount, err := r.OCMClient.GetCurrentAccount()
 	if err != nil {
-		r.Reporter.Errorf("Failed to get current account: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to get current account: %s", err)
 	}
 
 	policies, err := r.OCMClient.GetPolicies("")
 	if err != nil {
-		r.Reporter.Errorf("Expected a valid role creation mode: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("expected a valid role creation mode: %s", err)
 	}
 
 	switch mode {
@@ -207,11 +201,13 @@ func run(cmd *cobra.Command, _ []string) {
 		roleARN, err := createRoles(r, prefix, path, currentAccount.Username(), env,
 			currentAccount.ID(), permissionsBoundary, policies)
 		if err != nil {
-			r.Reporter.Errorf("There was an error creating the ocm user role: %s", err)
 			r.OCMClient.LogEvent("ROSACreateUserRoleModeAuto", map[string]string{
 				ocm.Response: ocm.Failure,
 			})
-			os.Exit(1)
+			return fmt.Errorf("there was an error creating the ocm user role: %s", err)
+		}
+		if roleARN == "" {
+			return nil
 		}
 		r.OCMClient.LogEvent("ROSACreateUserRoleModeAuto", map[string]string{
 			ocm.Response: ocm.Success,
@@ -223,8 +219,7 @@ func run(cmd *cobra.Command, _ []string) {
 		r.OCMClient.LogEvent("ROSACreateUserRoleModeManual", map[string]string{})
 		err = generateUserRolePolicyFiles(r.Reporter, env, r.Creator.Partition, currentAccount.ID(), policies)
 		if err != nil {
-			r.Reporter.Errorf("There was an error generating the policy files: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("there was an error generating the policy files: %s", err)
 		}
 		if r.Reporter.IsTerminal() {
 			r.Reporter.Infof("All policy files saved to the current directory")
@@ -241,9 +236,9 @@ func run(cmd *cobra.Command, _ []string) {
 		fmt.Println(commands)
 
 	default:
-		r.Reporter.Errorf("Invalid mode. Allowed values are %s", interactive.Modes)
-		os.Exit(1)
+		return fmt.Errorf("invalid mode. Allowed values are %s", interactive.Modes)
 	}
+	return nil
 }
 
 func buildCommands(prefix string, path string, userName string,
@@ -277,7 +272,7 @@ func createRoles(r *rosa.Runtime,
 	policies map[string]*cmv1.AWSSTSPolicy) (string, error) {
 	roleName := aws.GetUserRoleName(prefix, aws.OCMUserRole, userName)
 	if !confirm.Prompt(true, "Create the '%s' role?", roleName) {
-		os.Exit(0)
+		return "", nil
 	}
 
 	filename := fmt.Sprintf("sts_%s_trust_policy", aws.OCMUserRolePolicyFile)

--- a/cmd/create/userrole/cmd_suite_test.go
+++ b/cmd/create/userrole/cmd_suite_test.go
@@ -1,0 +1,13 @@
+package userrole
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCreateUserRole(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Create user-role suite")
+}

--- a/cmd/create/userrole/cmd_test.go
+++ b/cmd/create/userrole/cmd_test.go
@@ -1,0 +1,137 @@
+package userrole
+
+import (
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+
+	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/config"
+	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/reporter"
+	"github.com/openshift/rosa/pkg/test"
+)
+
+var _ = Describe("create user-role", func() {
+	var (
+		t      *test.TestingRuntime
+		tmpdir string
+	)
+
+	saveTestConfig := func() {
+		Expect(os.Setenv("OCM_CONFIG", tmpdir+"/ocm_config.json")).To(Succeed())
+		cfg := &config.Config{
+			AccessToken: MakeTokenString("Bearer", 15*time.Minute),
+			URL:         "https://api.openshift.com",
+			TokenURL:    t.SsoServer.URL(),
+		}
+		Expect(config.Save(cfg)).To(Succeed())
+	}
+
+	BeforeEach(func() {
+		t = test.NewTestRuntime()
+		t.RosaRuntime.Creator = &aws.Creator{
+			ARN:       "arn:aws:iam::123456789012:user/test",
+			AccountID: "123456789012",
+			Partition: "aws",
+		}
+
+		var err error
+		tmpdir, err = os.MkdirTemp("", "rosa-create-userrole-test-*")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(os.RemoveAll, tmpdir)
+
+		args = struct {
+			prefix              string
+			permissionsBoundary string
+			path                string
+		}{}
+		interactive.SetEnabled(false)
+		interactive.SetModeKey("")
+		Expect(Cmd.Flags().Set("mode", "")).To(Succeed())
+	})
+
+	Context("runWithRuntime", func() {
+		It("returns error when mode is invalid", func() {
+			interactive.SetModeKey("invalid_mode")
+			Expect(Cmd.Flags().Set("mode", "invalid_mode")).To(Succeed())
+
+			err := runWithRuntime(t.RosaRuntime, Cmd)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Invalid mode"))
+		})
+
+		It("returns error when prefix is invalid", func() {
+			saveTestConfig()
+			interactive.SetModeKey(interactive.ModeManual)
+			Expect(Cmd.Flags().Set("mode", interactive.ModeManual)).To(Succeed())
+			args.prefix = "invalid prefix!"
+
+			err := runWithRuntime(t.RosaRuntime, Cmd)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("expected a valid role prefix matching"))
+		})
+	})
+
+	Context("buildCommands", func() {
+		It("generates create-role and link commands", func() {
+			creator := &aws.Creator{
+				AccountID: "123456789012",
+				Partition: "aws",
+			}
+
+			commands := buildCommands("ManagedOpenShift", "", "testuser", creator, "production", "")
+			Expect(commands).To(ContainSubstring("create-role"))
+			Expect(commands).To(ContainSubstring("ManagedOpenShift-User-testuser-Role"))
+			Expect(commands).To(ContainSubstring("file://sts_ocm_user_trust_policy.json"))
+			Expect(commands).To(ContainSubstring("rosa link user-role --role-arn"))
+		})
+	})
+
+	Context("generateUserRolePolicyFiles", func() {
+		var (
+			tempDir    string
+			originalWd string
+			policies   map[string]*cmv1.AWSSTSPolicy
+		)
+
+		BeforeEach(func() {
+			var err error
+			tempDir, err = os.MkdirTemp("", "rosa-userrole-policy-test-*")
+			Expect(err).NotTo(HaveOccurred())
+
+			originalWd, err = os.Getwd()
+			Expect(err).NotTo(HaveOccurred())
+			err = os.Chdir(tempDir)
+			Expect(err).NotTo(HaveOccurred())
+
+			trustPolicy, err := (&cmv1.AWSSTSPolicyBuilder{}).
+				Details(`{"Version":"2012-10-17","Statement":[{"Effect":"Allow"}]}`).
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+			policies = map[string]*cmv1.AWSSTSPolicy{
+				"sts_user_ocm_trust_policy": trustPolicy,
+			}
+		})
+
+		AfterEach(func() {
+			err := os.Chdir(originalWd)
+			Expect(err).NotTo(HaveOccurred())
+			err = os.RemoveAll(tempDir)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("writes the trust policy file to the current directory", func() {
+			reporter := reporter.CreateReporter()
+			err := generateUserRolePolicyFiles(reporter, "production", "aws", "acct-123", policies)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = os.Stat("sts_ocm_user_trust_policy.json")
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/cmd/dlt/ocmrole/cmd.go
+++ b/cmd/dlt/ocmrole/cmd.go
@@ -64,23 +64,27 @@ func init() {
 }
 
 func run(cmd *cobra.Command, argv []string) {
+	if len(argv) > 0 {
+		args.roleARN = argv[0]
+	}
+
 	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
-
-	mode, err := interactive.GetMode()
-	if err != nil {
+	if err := runWithRuntime(r, cmd); err != nil {
 		r.Reporter.Errorf("%s", err)
 		os.Exit(1)
+	}
+}
+
+func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
+	mode, err := interactive.GetMode()
+	if err != nil {
+		return err
 	}
 
 	orgID, _, err := r.OCMClient.GetCurrentOrganization()
 	if err != nil {
-		r.Reporter.Errorf("Error getting organization account: %v", err)
-		os.Exit(1)
-	}
-
-	if len(argv) > 0 {
-		args.roleARN = argv[0]
+		return fmt.Errorf("error getting organization account: %v", err)
 	}
 
 	// Determine if interactive mode is needed
@@ -109,57 +113,49 @@ func run(cmd *cobra.Command, argv []string) {
 			},
 		})
 		if err != nil {
-			r.Reporter.Errorf("Expected a valid ocm role ARN to delete from the current organization: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("expected a valid ocm role ARN to delete from the current organization: %s", err)
 		}
 	}
 
 	err = aws.ARNValidator(roleARN)
 	if err != nil {
-		r.Reporter.Errorf("Expected a valid ocm role ARN to delete from the current organization: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("expected a valid ocm role ARN to delete from the current organization: %s", err)
 	}
 
 	err = r.AWSClient.ValidateRoleARNAccountIDMatchCallerAccountID(roleARN)
 	if err != nil {
-		r.Reporter.Errorf("%s", err)
-		os.Exit(1)
+		return err
 	}
 
 	managedPolicies, err := r.AWSClient.HasManagedPolicies(roleARN)
 	if err != nil {
-		r.Reporter.Errorf("Failed to determine if cluster has managed policies: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to determine if cluster has managed policies: %v", err)
 	}
 
 	if !confirm.Prompt(true, "Delete '%s' ocm role?", roleARN) {
-		os.Exit(0)
+		return nil
 	}
 
 	linkedRoles, err := r.OCMClient.GetOrganizationLinkedOCMRoles(orgID)
 	if err != nil {
-		r.Reporter.Errorf("An error occurred while trying to get the organization linked roles: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("an error occurred while trying to get the organization linked roles: %s", err)
 	}
 	isLinked := helper.Contains(linkedRoles, roleARN)
 
 	if interactive.Enabled() && !cmd.Flags().Changed("mode") {
 		mode, err = interactive.GetOptionMode(cmd, mode, "OCM role deletion mode")
 		if err != nil {
-			r.Reporter.Errorf("Expected a valid OCM role deletion mode: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("expected a valid OCM role deletion mode: %s", err)
 		}
 	}
 
 	roleName, err := aws.GetResourceIdFromARN(roleARN)
 	if err != nil {
-		r.Reporter.Errorf("%s", err)
-		os.Exit(1)
+		return err
 	}
 
 	if !aws.IsOCMRole(&roleName) {
-		r.Reporter.Errorf("Role '%s' is not an OCM role", roleName)
-		os.Exit(1)
+		return fmt.Errorf("role '%s' is not an OCM role", roleName)
 	}
 
 	roleExistOnAWS, existingRoleARN, err := r.AWSClient.CheckRoleExists(roleName)
@@ -170,7 +166,7 @@ func run(cmd *cobra.Command, argv []string) {
 		r.Reporter.Warnf("the ARN %s does not exist. Nothing to delete", roleARN)
 	} else if existingRoleARN != roleARN {
 		r.Reporter.Warnf("role with same name but different ARN exists. Existing role ARN: %s", existingRoleARN)
-		os.Exit(1)
+		return fmt.Errorf("role with same name but different ARN exists. Existing role ARN: %s", existingRoleARN)
 	}
 
 	switch mode {
@@ -185,8 +181,7 @@ func run(cmd *cobra.Command, argv []string) {
 		if roleExistOnAWS {
 			err := r.AWSClient.DeleteOCMRole(roleName, managedPolicies)
 			if err != nil {
-				r.Reporter.Errorf("There was an error deleting the OCM role: %s", err)
-				os.Exit(1)
+				return fmt.Errorf("there was an error deleting the OCM role: %s", err)
 			}
 			r.Reporter.Infof("Successfully deleted the OCM role")
 		}
@@ -194,8 +189,7 @@ func run(cmd *cobra.Command, argv []string) {
 		r.OCMClient.LogEvent("ROSADeleteOCMRoleModeManual", nil)
 		commands, err := buildCommands(roleName, roleARN, isLinked, r.AWSClient, roleExistOnAWS, managedPolicies)
 		if err != nil {
-			r.Reporter.Errorf("%s", err)
-			os.Exit(1)
+			return err
 		}
 		if r.Reporter.IsTerminal() {
 			if roleExistOnAWS {
@@ -206,9 +200,9 @@ func run(cmd *cobra.Command, argv []string) {
 		}
 		fmt.Println(commands)
 	default:
-		r.Reporter.Errorf("Invalid mode. Allowed values are %s", interactive.Modes)
-		os.Exit(1)
+		return fmt.Errorf("invalid mode. Allowed values are %s", interactive.Modes)
 	}
+	return nil
 }
 
 func buildCommands(roleName string, roleARN string, isLinked bool, awsClient aws.Client,

--- a/cmd/dlt/ocmrole/cmd_suite_test.go
+++ b/cmd/dlt/ocmrole/cmd_suite_test.go
@@ -1,0 +1,13 @@
+package ocmrole
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDeleteOcmRole(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Delete OCM role suite")
+}

--- a/cmd/dlt/ocmrole/cmd_test.go
+++ b/cmd/dlt/ocmrole/cmd_test.go
@@ -1,0 +1,103 @@
+package ocmrole
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+
+	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/test"
+)
+
+const (
+	testRoleARN  = "arn:aws:iam::123456789012:role/ManagedOpenShift-OCM-Role-ext-1"
+	testRoleName = "ManagedOpenShift-OCM-Role-ext-1"
+)
+
+var currentAccountResponse = `{
+	"kind": "Account",
+	"id": "acct-123",
+	"username": "testuser",
+	"organization": {
+		"id": "org-123",
+		"external_id": "ext-1",
+		"kind": "Organization"
+	}
+}`
+
+var _ = Describe("delete ocm-role", func() {
+	var t *test.TestingRuntime
+
+	BeforeEach(func() {
+		t = test.NewTestRuntime()
+		t.RosaRuntime.Creator = &aws.Creator{
+			AccountID: "123456789012",
+			Partition: "aws",
+		}
+		args = struct {
+			roleARN string
+		}{}
+		interactive.SetEnabled(false)
+		interactive.SetModeKey("")
+		Expect(Cmd.Flags().Set("mode", "")).To(Succeed())
+	})
+
+	Context("runWithRuntime", func() {
+		It("returns error when mode is invalid", func() {
+			interactive.SetModeKey("invalid_mode")
+			Expect(Cmd.Flags().Set("mode", "invalid_mode")).To(Succeed())
+
+			err := runWithRuntime(t.RosaRuntime, Cmd)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Invalid mode"))
+		})
+
+		It("returns error when role ARN is empty", func() {
+			t.ApiServer.AppendHandlers(
+				RespondWithJSON(http.StatusOK, currentAccountResponse),
+			)
+
+			err := runWithRuntime(t.RosaRuntime, Cmd)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("expected a valid ocm role ARN to delete from the current organization"))
+		})
+	})
+
+	Context("buildCommands", func() {
+		It("generates detach, delete policy, and delete role commands", func() {
+			mockClient := t.RosaRuntime.AWSClient.(*aws.MockClient)
+			policyARN := "arn:aws:iam::123456789012:policy/ManagedOpenShift-OCM-Role-Policy"
+			roleName := testRoleName
+
+			mockClient.EXPECT().GetAttachedPolicy(&roleName).Return([]aws.PolicyDetail{
+				{PolicyArn: policyARN},
+			}, nil)
+			mockClient.EXPECT().HasPermissionsBoundary(testRoleName).Return(false, nil)
+
+			commands, err := buildCommands(testRoleName, testRoleARN, false, mockClient, true, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(commands).To(ContainSubstring("detach-role-policy"))
+			Expect(commands).To(ContainSubstring(policyARN))
+			Expect(commands).To(ContainSubstring("delete-policy"))
+			Expect(commands).To(ContainSubstring("delete-role"))
+			Expect(commands).To(ContainSubstring(testRoleName))
+		})
+
+		It("includes unlink command when role is linked", func() {
+			mockClient := t.RosaRuntime.AWSClient.(*aws.MockClient)
+			roleName := testRoleName
+
+			mockClient.EXPECT().GetAttachedPolicy(&roleName).Return([]aws.PolicyDetail{}, nil)
+			mockClient.EXPECT().HasPermissionsBoundary(testRoleName).Return(false, nil)
+
+			commands, err := buildCommands(testRoleName, testRoleARN, true, mockClient, true, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(commands).To(ContainSubstring("rosa unlink ocm-role"))
+			Expect(commands).To(ContainSubstring(testRoleARN))
+			Expect(commands).NotTo(ContainSubstring("delete-policy"))
+		})
+	})
+})

--- a/cmd/dlt/userrole/cmd.go
+++ b/cmd/dlt/userrole/cmd.go
@@ -63,17 +63,22 @@ func init() {
 }
 
 func run(cmd *cobra.Command, argv []string) {
+	if len(argv) > 0 {
+		args.roleARN = argv[0]
+	}
+
 	r := rosa.NewRuntime().WithAWS().WithOCM()
 	defer r.Cleanup()
-
-	mode, err := interactive.GetMode()
-	if err != nil {
+	if err := runWithRuntime(r, cmd); err != nil {
 		r.Reporter.Errorf("%s", err)
 		os.Exit(1)
 	}
+}
 
-	if len(argv) > 0 {
-		args.roleARN = argv[0]
+func runWithRuntime(r *rosa.Runtime, cmd *cobra.Command) error {
+	mode, err := interactive.GetMode()
+	if err != nil {
+		return err
 	}
 
 	// Determine if interactive mode is needed
@@ -102,52 +107,45 @@ func run(cmd *cobra.Command, argv []string) {
 			},
 		})
 		if err != nil {
-			r.Reporter.Errorf("Expected a valid user role ARN to delete from the current AWS account: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("expected a valid user role ARN to delete from the current AWS account: %s", err)
 		}
 	}
 
 	err = aws.ARNValidator(roleARN)
 	if err != nil {
-		r.Reporter.Errorf("Expected a valid user role ARN to delete from the current AWS account: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("expected a valid user role ARN to delete from the current AWS account: %s", err)
 	}
 
 	err = r.AWSClient.ValidateRoleARNAccountIDMatchCallerAccountID(roleARN)
 	if err != nil {
-		r.Reporter.Errorf("%s", err)
-		os.Exit(1)
+		return err
 	}
 
 	if !confirm.Prompt(true, "Delete the '%s' role from the AWS account?", roleARN) {
-		os.Exit(0)
+		return nil
 	}
 
 	currentAccount, err := r.OCMClient.GetCurrentAccount()
 	if err != nil {
-		r.Reporter.Errorf("Error getting current account: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("error getting current account: %v", err)
 	}
 
 	linkedRoles, err := r.OCMClient.GetAccountLinkedUserRoles(currentAccount.ID())
 	if err != nil {
-		r.Reporter.Errorf("An error occurred while trying to get the account linked roles")
-		os.Exit(1)
+		return fmt.Errorf("an error occurred while trying to get the account linked roles")
 	}
 	isLinked := helper.Contains(linkedRoles, roleARN)
 
 	if interactive.Enabled() && !cmd.Flags().Changed("mode") {
 		mode, err = interactive.GetOptionMode(cmd, mode, "User role deletion mode")
 		if err != nil {
-			r.Reporter.Errorf("Expected a valid role deletion mode: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("expected a valid role deletion mode: %s", err)
 		}
 	}
 
 	roleName, err := aws.GetResourceIdFromARN(roleARN)
 	if err != nil {
-		r.Reporter.Errorf("%s", err)
-		os.Exit(1)
+		return err
 	}
 
 	roleExistOnAWS, existingRoleARN, err := r.AWSClient.CheckRoleExists(roleName)
@@ -158,17 +156,15 @@ func run(cmd *cobra.Command, argv []string) {
 		r.Reporter.Warnf("the ARN %s does not exist. Nothing to delete", roleARN)
 	} else if existingRoleARN != roleARN {
 		r.Reporter.Warnf("role with same name but different ARN exists. Existing role ARN: %s", existingRoleARN)
-		os.Exit(1)
+		return fmt.Errorf("role with same name but different ARN exists. Existing role ARN: %s", existingRoleARN)
 	}
 
 	isUserRole, err := r.AWSClient.IsUserRole(&roleName)
 	if err != nil {
-		r.Reporter.Errorf("%s", err)
-		os.Exit(1)
+		return err
 	}
 	if !isUserRole {
-		r.Reporter.Errorf("Role '%s' is not a user role", roleName)
-		os.Exit(1)
+		return fmt.Errorf("role '%s' is not a user role", roleName)
 	}
 
 	switch mode {
@@ -183,25 +179,23 @@ func run(cmd *cobra.Command, argv []string) {
 		}
 		err := r.AWSClient.DeleteUserRole(roleName)
 		if err != nil {
-			r.Reporter.Errorf("There was an error deleting the user role: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("there was an error deleting the user role: %s", err)
 		}
 		r.Reporter.Infof("Successfully deleted the user role")
 	case interactive.ModeManual:
 		r.OCMClient.LogEvent("ROSADeleteUserMRoleModeManual", nil)
 		commands, err := buildCommands(roleName, roleARN, isLinked, r.AWSClient)
 		if err != nil {
-			r.Reporter.Errorf("%s", err)
-			os.Exit(1)
+			return err
 		}
 		if r.Reporter.IsTerminal() {
 			r.Reporter.Infof("Run the following commands to delete the user role:\n")
 		}
 		fmt.Println(commands)
 	default:
-		r.Reporter.Errorf("Invalid mode. Allowed values are %s", interactive.Modes)
-		os.Exit(1)
+		return fmt.Errorf("invalid mode. Allowed values are %s", interactive.Modes)
 	}
+	return nil
 }
 
 func buildCommands(roleName string, roleARN string, isLinked bool, awsClient aws.Client) (string, error) {

--- a/cmd/dlt/userrole/cmd_suite_test.go
+++ b/cmd/dlt/userrole/cmd_suite_test.go
@@ -1,0 +1,13 @@
+package userrole
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDeleteUserRole(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Delete user-role suite")
+}

--- a/cmd/dlt/userrole/cmd_test.go
+++ b/cmd/dlt/userrole/cmd_test.go
@@ -1,0 +1,83 @@
+package userrole
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/test"
+)
+
+const (
+	testRoleARN  = "arn:aws:iam::123456789012:role/ManagedOpenShift-User-testuser-Role"
+	testRoleName = "ManagedOpenShift-User-testuser-Role"
+)
+
+var _ = Describe("delete user-role", func() {
+	var t *test.TestingRuntime
+
+	BeforeEach(func() {
+		t = test.NewTestRuntime()
+		t.RosaRuntime.Creator = &aws.Creator{
+			AccountID: "123456789012",
+			Partition: "aws",
+		}
+		args = struct {
+			roleARN string
+		}{}
+		interactive.SetEnabled(false)
+		interactive.SetModeKey("")
+		Expect(Cmd.Flags().Set("mode", "")).To(Succeed())
+	})
+
+	Context("runWithRuntime", func() {
+		It("returns error when mode is invalid", func() {
+			interactive.SetModeKey("invalid_mode")
+			Expect(Cmd.Flags().Set("mode", "invalid_mode")).To(Succeed())
+
+			err := runWithRuntime(t.RosaRuntime, Cmd)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Invalid mode"))
+		})
+
+		It("returns error when role ARN is empty", func() {
+			err := runWithRuntime(t.RosaRuntime, Cmd)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("expected a valid user role ARN to delete from the current AWS account"))
+		})
+	})
+
+	Context("buildCommands", func() {
+		It("generates detach and delete role commands", func() {
+			mockClient := t.RosaRuntime.AWSClient.(*aws.MockClient)
+			policyARN := "arn:aws:iam::123456789012:policy/ManagedOpenShift-User-testuser-Policy"
+			roleName := testRoleName
+
+			mockClient.EXPECT().GetAttachedPolicy(&roleName).Return([]aws.PolicyDetail{
+				{PolicyArn: policyARN},
+			}, nil)
+			mockClient.EXPECT().HasPermissionsBoundary(testRoleName).Return(false, nil)
+
+			commands, err := buildCommands(testRoleName, testRoleARN, false, mockClient)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(commands).To(ContainSubstring("detach-role-policy"))
+			Expect(commands).To(ContainSubstring(policyARN))
+			Expect(commands).To(ContainSubstring("delete-role"))
+			Expect(commands).To(ContainSubstring(testRoleName))
+		})
+
+		It("includes unlink command when role is linked", func() {
+			mockClient := t.RosaRuntime.AWSClient.(*aws.MockClient)
+			roleName := testRoleName
+
+			mockClient.EXPECT().GetAttachedPolicy(&roleName).Return([]aws.PolicyDetail{}, nil)
+			mockClient.EXPECT().HasPermissionsBoundary(testRoleName).Return(false, nil)
+
+			commands, err := buildCommands(testRoleName, testRoleARN, true, mockClient)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(commands).To(ContainSubstring("rosa unlink user-role"))
+			Expect(commands).To(ContainSubstring(testRoleARN))
+		})
+	})
+})


### PR DESCRIPTION
## PR Summary
Extract `runWithRuntime` and add tests for `create ocm-role`, `create user-role`, `delete ocm-role`, and `delete user-role`.

## Detailed Description of the Issue
Part of [ROSAENG-61180](https://redhat.atlassian.net/browse/ROSAENG-61180). Expands existing ocmrole tests with runWithRuntime coverage, adds new test suites for userrole and both delete commands.

**Changes:**
- `cmd/create/ocmrole/cmd.go`: Extract `runWithRuntime`, expand `cmd_test.go` (+3 tests)
- `cmd/create/userrole/cmd.go`: Extract `runWithRuntime`, new suite + `cmd_test.go` (4 tests)
- `cmd/dlt/ocmrole/cmd.go`: Extract `runWithRuntime`, new suite + `cmd_test.go` (4 tests)
- `cmd/dlt/userrole/cmd.go`: Extract `runWithRuntime`, new suite + `cmd_test.go` (4 tests)

## Related Issues and PRs
- Jira: [ROSAENG-61180](https://redhat.atlassian.net/browse/ROSAENG-61180)
- Stack: 6/7 (base: PR 5)

## Type of Change
- [x] test
- [x] refactor

## How to Test (Step-by-Step)
1. `make test` -- all tests pass
2. `go test -v ./cmd/create/ocmrole/... ./cmd/create/userrole/... ./cmd/dlt/ocmrole/... ./cmd/dlt/userrole/...` -- new tests pass


[ROSAENG-61180]: https://redhat.atlassian.net/browse/ROSAENG-61180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROSAENG-61180]: https://redhat.atlassian.net/browse/ROSAENG-61180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ