### PR TITLE
ROSAENG-66692 | fix(build): emit legacy CDN archive names at build time

### DIFF
--- a/hack/build_cli.sh
+++ b/hack/build_cli.sh
@@ -8,6 +8,21 @@ oses=(darwin linux windows)
 
 mkdir -p releases
 
+# CDN (Content Gateway) uses the basename of source paths from the RPA.
+# Legacy mirror names must be produced at build time; filename: in the RPA
+# is ignored for CGW pushes.
+cdn_archive_name() {
+  case "${1}/${2}" in
+    linux/amd64) echo "rosa-linux.tar.gz" ;;
+    linux/arm64) echo "rosa-linux-arm64.tar.gz" ;;
+    darwin/amd64) echo "rosa-macosx.tar.gz" ;;
+    darwin/arm64) echo "rosa-macos-arm64.tar.gz" ;;
+    windows/amd64) echo "rosa-windows.tar.gz" ;;
+    windows/arm64) echo "rosa-windows-arm64.tar.gz" ;;
+    *) echo "rosa_${1}_${2}.tar.gz" ;;
+  esac
+}
+
 build_release() {
 for os in "${oses[@]}"
 do
@@ -20,7 +35,8 @@ do
     tmpdir=$(mktemp -d)
     trap 'rm -rf "$tmpdir"' EXIT
     GOOS="${os}" GOARCH="${arch}" go build -ldflags="-X github.com/openshift/rosa/pkg/info.Build=$(git rev-parse --short HEAD)" -o "${tmpdir}/rosa${extension}" ./cmd/rosa
-    tar -czf "releases/rosa_${os}_${arch}.tar.gz" -C "${tmpdir}" "rosa${extension}"
+    archive_name=$(cdn_archive_name "${os}" "${arch}")
+    tar -czf "releases/${archive_name}" -C "${tmpdir}" "rosa${extension}"
     (
       cd "${tmpdir}" && \
       zip -r "${OLDPWD}/releases/rosa_${os}_${arch}.zip" "rosa${extension}"


### PR DESCRIPTION
## Summary

Content Gateway ignores `filename:` in the CDN RPA and publishes the basename of each `source` path. This change makes `hack/build_cli.sh` produce the legacy CDN archive names directly (`rosa-linux.tar.gz`, `rosa-macosx.tar.gz`, etc.) while keeping Go-native `.zip` names for the GitHub release lane.

- Maps each platform/arch to the legacy CDN tarball name
- Windows sources use `rosa-windows*.tar.gz`; CGW converts them to `.zip` on upload
- GitHub `.zip` artifacts remain `rosa_${os}_${arch}.zip`

Companion konflux-release-data MR updates CDN RPA `source` paths to match.

## Test plan

- [x] `bash -n hack/build_cli.sh`
- [x] `make rosa` / pre-push checks passed locally
- [ ] After merge: rebuild v1.2.65 snapshot and re-run CDN lane
- [ ] Verify `mirror.openshift.com/pub/cgw/rosa/1.2.65/rosa-linux.tar.gz` after release

## Related

- Konflux confirmed `filename:` is deprecated for CGW (Customer Portal/Pulp only)
- Depends on konflux-release-data MR for RPA `source` path update
- Separate from #3512 (version ldflags) and #3513 (auto-bump)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated release tarball filenames to match legacy CDN naming conventions across supported operating system and architecture combinations.
  * ZIP archive filenames remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->