### PR TITLE
ROSAENG-65904 | feat: OIDC e2e sanity and operator role lifecycle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,24 +192,32 @@ e2e_test: install
         --focus-file tests/e2e/.* \
 		$(NULL)
 
-# e2e-hyperfleet: runs the hyperfleet Platform API sanity test.
+# e2e-hyperfleet: hyperfleet e2e via ginkgo --label-filter.
+#
+# Labels (see tests/ci/labels/hyperfleet.go):
+#   hyperfleet-validated — day1 FVT (profile-driven cluster prep; needs TEST_PROFILE)
+#   hyperfleet-sanity    — full CLI/SDK lifecycle spec (self-contained; no TEST_PROFILE)
 #
 # Required:
 #   HYPERFLEET_URL  — Platform API v2 base URL
+#   TEST_PROFILE    — e.g. rosa-hyperfleet-basic (for hyperfleet-validated only)
 #
 # Optional:
 #   CLUSTER_NAME       — defaults to hf-e2e-<unix timestamp> (≤18 chars)
 #   AWS_DEFAULT_REGION — fallback when region cannot be derived from HYPERFLEET_URL
-#   LABEL_FILTER       — ginkgo label filter (defaults to "hyperfleet-validated")
+#   LABEL_FILTER       — defaults to hyperfleet-validated; use hyperfleet-sanity for sanity
 .PHONY: e2e-hyperfleet
 e2e-hyperfleet: install
+	@test -n "$${HYPERFLEET_URL}" || { \
+		echo "HYPERFLEET_URL is required (see guidelines/hyperfleet-guidelines.md)"; \
+		exit 1; \
+	}; \
 	name=$${CLUSTER_NAME:-hf-e2e-$$(date +%s)}; \
 	HYPERFLEET_URL="$${HYPERFLEET_URL}" \
 	CLUSTER_NAME="$$name" \
 	OPERATOR_ROLES_PREFIX="$$name" \
 	AWS_DEFAULT_REGION="$${AWS_DEFAULT_REGION}" \
-	ginkgo run \
-		--label-filter "$${LABEL_FILTER:-hyperfleet-validated}" \
+	ginkgo run --label-filter "$${LABEL_FILTER:-hyperfleet-validated}" \
 		--timeout 3h \
 		-v \
 		./tests/e2e/ \

--- a/Makefile
+++ b/Makefile
@@ -214,6 +214,7 @@ e2e-hyperfleet: install
 	}; \
 	name=$${CLUSTER_NAME:-hf-e2e-$$(date +%s)}; \
 	HYPERFLEET_URL="$${HYPERFLEET_URL}" \
+	TEST_PROFILE="$(TEST_PROFILE)" \
 	CLUSTER_NAME="$$name" \
 	OPERATOR_ROLES_PREFIX="$$name" \
 	AWS_DEFAULT_REGION="$${AWS_DEFAULT_REGION}" \

--- a/cmd/create/oidcconfig/hyperfleet.go
+++ b/cmd/create/oidcconfig/hyperfleet.go
@@ -94,24 +94,20 @@ func (h *hyperfleetOidcConfigCreate) PostResponse(
 	r *rosa.Runtime,
 	oidcConfig *v1alpha1.OidcConfig,
 ) error {
-	// Create OIDC provider FIRST (before output flag check)
-	// This ensures AWS side effects happen regardless of output format
 	if oidcConfig.Spec.IssuerUrl != "" {
 		mode, err := interactive.GetMode()
 		if err != nil {
 			return err
 		}
-		if err := createOidcProvider(ctx, r, oidcConfig, mode); err != nil {
+		if err := createOidcProviderFn(ctx, r, oidcConfig, mode); err != nil {
 			return fmt.Errorf("failed to create OIDC provider: %v", err)
 		}
 	}
 
-	// Handle output flag - json output only changes how we print, not what we do
 	if output.HasFlag() {
 		return output.Print(oidcConfig)
 	}
 
-	// Report creation success
 	r.Reporter.Infof("OIDC config '%s' created successfully", oidcConfig.Name)
 	r.Reporter.Infof("  Type: %s", oidcConfig.Spec.Type)
 	if oidcConfig.Spec.IssuerUrl != "" {
@@ -123,6 +119,8 @@ func (h *hyperfleetOidcConfigCreate) PostResponse(
 
 	return nil
 }
+
+var createOidcProviderFn = createOidcProvider
 
 // createOidcProvider creates the AWS OIDC provider for the given OIDC config
 func createOidcProvider(ctx context.Context, r *rosa.Runtime, oidcConfig *v1alpha1.OidcConfig, mode string) error {
@@ -145,14 +143,14 @@ func createOidcProvider(ctx context.Context, r *rosa.Runtime, oidcConfig *v1alph
 		r.Reporter.Debugf("Failed to verify if OIDC provider exists: %s", err)
 	}
 	if oidcProviderExists {
-		r.Reporter.Infof("OIDC provider already exists")
+		oidcProviderLogf(r, "OIDC provider already exists")
 		return nil
 	}
 
 	switch mode {
 	case interactive.ModeAuto:
 		// Create the OIDC provider in AWS
-		r.Reporter.Infof("Creating OIDC provider using '%s'", r.Creator.ARN)
+		oidcProviderLogf(r, "Creating OIDC provider using '%s'", r.Creator.ARN)
 		oidcProviderARN, err := r.AWSClient.CreateOpenIDConnectProvider(
 			oidcConfig.Spec.IssuerUrl,
 			thumbprint,
@@ -161,7 +159,7 @@ func createOidcProvider(ctx context.Context, r *rosa.Runtime, oidcConfig *v1alph
 		if err != nil {
 			return fmt.Errorf("failed to create OIDC provider: %v", err)
 		}
-		r.Reporter.Infof("Created OIDC provider with ARN '%s'", oidcProviderARN)
+		oidcProviderLogf(r, "Created OIDC provider with ARN '%s'", oidcProviderARN)
 
 	case interactive.ModeManual:
 		// Print manual commands
@@ -169,14 +167,26 @@ func createOidcProvider(ctx context.Context, r *rosa.Runtime, oidcConfig *v1alph
 		if err != nil {
 			return fmt.Errorf("failed to build OIDC provider commands: %v", err)
 		}
-		r.Reporter.Infof("Run the following commands to create the OIDC provider:\n")
-		fmt.Println(commands)
+		oidcProviderLogf(r, "Run the following commands to create the OIDC provider:\n")
+		if output.HasFlag() {
+			r.Reporter.Debugf("%s", commands)
+		} else {
+			fmt.Println(commands)
+		}
 
 	default:
 		return fmt.Errorf("invalid mode: %s", mode)
 	}
 
 	return nil
+}
+
+func oidcProviderLogf(r *rosa.Runtime, format string, args ...any) {
+	if output.HasFlag() {
+		r.Reporter.Debugf(format, args...)
+		return
+	}
+	r.Reporter.Infof(format, args...)
 }
 
 // buildOidcProviderCommands builds the AWS CLI commands for manual OIDC provider creation

--- a/cmd/create/oidcconfig/hyperfleet_test.go
+++ b/cmd/create/oidcconfig/hyperfleet_test.go
@@ -1,0 +1,49 @@
+package oidcconfig
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1alpha1 "github.com/openshift-online/rosa-hyperfleet-api/api/v1alpha1/public"
+
+	"github.com/openshift/rosa/pkg/interactive"
+	"github.com/openshift/rosa/pkg/output"
+	"github.com/openshift/rosa/pkg/rosa"
+	"github.com/openshift/rosa/pkg/test"
+)
+
+var _ = Describe("hyperfleetOidcConfigCreate PostResponse", func() {
+	AfterEach(func() {
+		output.SetOutput("")
+	})
+
+	It("creates the IAM OIDC provider even when --output json is set", func() {
+		t := test.NewTestRuntime()
+		output.SetOutput("json")
+
+		called := false
+		orig := createOidcProviderFn
+		createOidcProviderFn = func(ctx context.Context, r *rosa.Runtime, oidcConfig *v1alpha1.OidcConfig, mode string) error {
+			called = true
+			Expect(oidcConfig.Spec.IssuerUrl).NotTo(BeEmpty())
+			Expect(mode).To(Equal(interactive.ModeAuto))
+			return nil
+		}
+		defer func() { createOidcProviderFn = orig }()
+
+		interactive.SetModeKey(interactive.ModeAuto)
+
+		cfg := &v1alpha1.OidcConfig{
+			Name: "test-id",
+			Spec: v1alpha1.OidcConfigSpec{
+				Type:      "managed",
+				IssuerUrl: "https://example.cloudfront.net/test-id",
+			},
+		}
+
+		err := (&hyperfleetOidcConfigCreate{}).PostResponse(context.Background(), t.RosaRuntime, cfg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(called).To(BeTrue())
+	})
+})

--- a/cmd/create/operatorroles/by_prefix_hyperfleet.go
+++ b/cmd/create/operatorroles/by_prefix_hyperfleet.go
@@ -196,7 +196,7 @@ func runHyperfleetCreateOperatorRoles(r *rosa.Runtime) {
   "Statement": [{
     "Effect": "Allow",
     "Principal": {
-      "Service": "ec2.amazonaws.com"
+      "Service": ["ec2.amazonaws.com"]
     },
     "Action": "sts:AssumeRole"
   }]
@@ -290,7 +290,7 @@ func runHyperfleetCreateOperatorRoles(r *rosa.Runtime) {
   "Statement": [{
     "Effect": "Allow",
     "Principal": {
-      "Service": "ec2.amazonaws.com"
+      "Service": ["ec2.amazonaws.com"]
     },
     "Action": "sts:AssumeRole"
   }]

--- a/cmd/create/operatorroles/by_prefix_hyperfleet.go
+++ b/cmd/create/operatorroles/by_prefix_hyperfleet.go
@@ -71,54 +71,45 @@ type operatorRoleSpec struct {
 	IsWorkerRole      bool // True for worker node role
 }
 
-// getHCPOperatorRoles returns the list of operator roles needed for a hosted cluster
 func getHCPOperatorRoles() []operatorRoleSpec {
-	return []operatorRoleSpec{
-		{
-			Name:              "ingress",
+	specs := map[string]operatorRoleSpec{
+		hyperfleet.SuffixIngress: {
 			ServiceAccount:    "system:serviceaccount:openshift-ingress-operator:ingress-operator",
 			ManagedPolicyArns: []string{"arn:aws:iam::aws:policy/service-role/ROSAIngressOperatorPolicy"},
 			Description:       "Manages AWS ELBs/NLBs for OpenShift routes",
 		},
-		{
-			Name:              "cloud-controller-manager",
+		hyperfleet.SuffixCloudControllerManager: {
 			ServiceAccount:    "system:serviceaccount:kube-system:kube-controller-manager",
 			ManagedPolicyArns: []string{"arn:aws:iam::aws:policy/service-role/ROSAKubeControllerPolicy"},
 			Description:       "Manages load balancers and node lifecycle",
 		},
-		{
-			Name:              "ebs-csi",
+		hyperfleet.SuffixEBSCSI: {
 			ServiceAccount:    "system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-controller-sa",
 			ManagedPolicyArns: []string{"arn:aws:iam::aws:policy/service-role/ROSAAmazonEBSCSIDriverOperatorPolicy"},
 			Description:       "Creates and attaches EBS volumes",
 		},
-		{
-			Name:              "image-registry",
+		hyperfleet.SuffixImageRegistry: {
 			ServiceAccount:    "system:serviceaccount:openshift-image-registry:registry",
 			ManagedPolicyArns: []string{"arn:aws:iam::aws:policy/service-role/ROSAImageRegistryOperatorPolicy"},
 			Description:       "S3 access for the internal container image registry",
 		},
-		{
-			Name:              "network-config",
+		hyperfleet.SuffixNetworkConfig: {
 			ServiceAccount:    "system:serviceaccount:openshift-cloud-network-config-controller:cloud-credentials",
 			ManagedPolicyArns: []string{"arn:aws:iam::aws:policy/service-role/ROSACloudNetworkConfigOperatorPolicy"},
 			Description:       "Manages ENIs and cloud networking configuration",
 		},
-		{
-			Name:              "control-plane-operator",
+		hyperfleet.SuffixControlPlaneOperator: {
 			ServiceAccount:    "system:serviceaccount:kube-system:control-plane-operator",
 			ManagedPolicyArns: []string{"arn:aws:iam::aws:policy/service-role/ROSAControlPlaneOperatorPolicy"},
 			Description:       "Control plane operator managing hosted cluster lifecycle",
 		},
-		{
-			Name:              "node-pool-management",
+		hyperfleet.SuffixNodePoolManagement: {
 			ServiceAccount:    "system:serviceaccount:kube-system:capa-controller-manager",
 			ManagedPolicyArns: []string{"arn:aws:iam::aws:policy/service-role/ROSANodePoolManagementPolicy"},
 			Description:       "Manages worker node pools",
 		},
-		{
-			Name:           "ROSA-Worker-Role",
-			ServiceAccount: "", // EC2 service principal, not OIDC
+		hyperfleet.SuffixWorkerRole: {
+			ServiceAccount: "",
 			ManagedPolicyArns: []string{
 				"arn:aws:iam::aws:policy/service-role/ROSAWorkerInstancePolicy",
 				"arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
@@ -127,6 +118,17 @@ func getHCPOperatorRoles() []operatorRoleSpec {
 			IsWorkerRole: true,
 		},
 	}
+
+	roles := make([]operatorRoleSpec, len(hyperfleet.OperatorRoleSuffixes()))
+	for i, suffix := range hyperfleet.OperatorRoleSuffixes() {
+		spec, ok := specs[suffix]
+		if !ok {
+			panic("missing HCP operator role spec for suffix " + suffix)
+		}
+		spec.Name = suffix
+		roles[i] = spec
+	}
+	return roles
 }
 
 // runHyperfleetCreateOperatorRoles creates operator roles for hyperfleet v2 clusters.

--- a/cmd/create/operatorroles/hyperfleet_roles_test.go
+++ b/cmd/create/operatorroles/hyperfleet_roles_test.go
@@ -1,0 +1,20 @@
+package operatorroles
+
+import (
+	"testing"
+
+	"github.com/openshift/rosa/pkg/hyperfleet"
+)
+
+func TestGetHCPOperatorRolesMatchesSuffixes(t *testing.T) {
+	roles := getHCPOperatorRoles()
+	suffixes := hyperfleet.OperatorRoleSuffixes()
+	if len(roles) != len(suffixes) {
+		t.Fatalf("expected %d roles, got %d", len(suffixes), len(roles))
+	}
+	for i, suffix := range suffixes {
+		if roles[i].Name != suffix {
+			t.Fatalf("role[%d]: expected name %q, got %q", i, suffix, roles[i].Name)
+		}
+	}
+}

--- a/cmd/create/operatorroles/hyperfleet_roles_test.go
+++ b/cmd/create/operatorroles/hyperfleet_roles_test.go
@@ -3,8 +3,16 @@ package operatorroles
 import (
 	"testing"
 
+	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/hyperfleet"
 )
+
+func TestWorkerTrustPolicyParses(t *testing.T) {
+	doc := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":["ec2.amazonaws.com"]},"Action":"sts:AssumeRole"}]}`
+	if _, err := aws.ParsePolicyDocument(doc); err != nil {
+		t.Fatal(err)
+	}
+}
 
 func TestGetHCPOperatorRolesMatchesSuffixes(t *testing.T) {
 	roles := getHCPOperatorRoles()

--- a/cmd/dlt/operatorrole/cmd.go
+++ b/cmd/dlt/operatorrole/cmd.go
@@ -40,11 +40,13 @@ import (
 
 const (
 	PrefixFlag                         = "prefix"
+	HostedCpFlag                       = "hosted-cp"
 	deleteHcpSharedVpcPoliciesFlagName = "delete-hcp-shared-vpc-policies"
 )
 
 var args struct {
 	prefix                     string
+	hostedCp                   bool
 	deleteHcpSharedVpcPolicies bool
 }
 
@@ -70,6 +72,13 @@ func init() {
 	)
 
 	flags.BoolVar(
+		&args.hostedCp,
+		HostedCpFlag,
+		false,
+		"Indicates whether to delete hosted control planes operator roles when using --prefix option.",
+	)
+
+	flags.BoolVar(
 		&args.deleteHcpSharedVpcPolicies,
 		deleteHcpSharedVpcPoliciesFlagName,
 		false,
@@ -86,7 +95,6 @@ const (
 )
 
 func run(cmd *cobra.Command, _ []string) {
-	// Dispatch to hyperfleet v2 if enabled
 	if hfEnabled() {
 		hfDeleteOperatorRoles()
 		return

--- a/cmd/dlt/operatorrole/hyperfleet.go
+++ b/cmd/dlt/operatorrole/hyperfleet.go
@@ -56,19 +56,21 @@ func runHyperfleetDelete(r *rosa.Runtime) {
 		spin.Start()
 	}
 
-	// Get operator roles from AWS by prefix
-	// Note: In hyperfleet mode, we can't get credRequests from OCM, so we'll list all roles
-	// matching the prefix pattern and let AWS APIs handle the filtering
-	foundOperatorRoles, err := r.AWSClient.GetOperatorRolesFromAccountByPrefix(args.prefix, nil)
-	if err != nil {
-		if spin != nil {
-			spin.Stop()
+	var foundOperatorRoles []string
+	for _, roleName := range hyperfleet.OperatorRoleNames(args.prefix) {
+		exists, _, err := r.AWSClient.CheckRoleExists(roleName)
+		if err != nil {
+			if spin != nil {
+				spin.Stop()
+			}
+			r.Reporter.Errorf("There was a problem retrieving the Operator Roles from AWS: %v", err)
+			hfExitFn(1)
+			return
 		}
-		r.Reporter.Errorf("There was a problem retrieving the Operator Roles from AWS: %v", err)
-		hfExitFn(1)
-		return
+		if exists {
+			foundOperatorRoles = append(foundOperatorRoles, roleName)
+		}
 	}
-
 	if spin != nil {
 		spin.Stop()
 	}

--- a/cmd/dlt/operatorrole/hyperfleet_test.go
+++ b/cmd/dlt/operatorrole/hyperfleet_test.go
@@ -1,0 +1,31 @@
+package operatorrole
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("hyperfleet dispatch", func() {
+	var origEnabled func() bool
+	var origDelete func()
+
+	BeforeEach(func() {
+		origEnabled = hfEnabled
+		origDelete = hfDeleteOperatorRoles
+	})
+
+	AfterEach(func() {
+		hfEnabled = origEnabled
+		hfDeleteOperatorRoles = origDelete
+	})
+
+	It("routes to hfDeleteOperatorRoles when hyperfleet is enabled", func() {
+		called := false
+		hfEnabled = func() bool { return true }
+		hfDeleteOperatorRoles = func() { called = true }
+
+		run(nil, nil)
+
+		Expect(called).To(BeTrue())
+	})
+})

--- a/cmd/dlt/operatorrole/operatorrole_suite_test.go
+++ b/cmd/dlt/operatorrole/operatorrole_suite_test.go
@@ -1,0 +1,13 @@
+package operatorrole
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestOperatorRole(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Delete operator role suite")
+}

--- a/cmd/rosa/structure_test/command_args/rosa/delete/operator-roles/command_args.yml
+++ b/cmd/rosa/structure_test/command_args/rosa/delete/operator-roles/command_args.yml
@@ -1,5 +1,6 @@
 - name: cluster
 - name: delete-hcp-shared-vpc-policies
+- name: hosted-cp
 - name: mode
 - name: prefix
 - name: profile

--- a/guidelines/hyperfleet-guidelines.md
+++ b/guidelines/hyperfleet-guidelines.md
@@ -545,16 +545,29 @@ hosted-zone preparation path added alongside the shared-VPC one. Networking
 
 ---
 
-## End-to-End Test
+## End-to-End Tests
+
+Hyperfleet e2e uses two Ginkgo labels (`tests/ci/labels/hyperfleet.go`):
+
+| Label | Specs | Needs `TEST_PROFILE` |
+|-------|-------|----------------------|
+| `hyperfleet-sanity` | Full CLI/SDK lifecycle in `hyperfleet_sanity_test.go` | No |
+| `hyperfleet-validated` | Profile-driven day1 FVT in `e2e_setup_test.go` | Yes (`rosa-hyperfleet-basic`) |
+
+Default `make e2e-hyperfleet` runs `hyperfleet-validated`. Set
+`LABEL_FILTER=hyperfleet-sanity` for the sanity spec.
+
+### Sanity spec
 
 **File:** `tests/e2e/hyperfleet_sanity_test.go`
-**Label:** `"Hyperfleet sanity"` (Ginkgo focus string used by `make e2e-hyperfleet`)
+**Ginkgo label:** `hyperfleet-sanity` (`labels.Hyperfleet.Sanity`)
 **Timeout:** 3 hours
 
 ### Running the test
 
 ```sh
-make e2e-hyperfleet HYPERFLEET_URL=https://<id>.execute-api.<region>.amazonaws.com/<stage>
+make e2e-hyperfleet HYPERFLEET_URL=https://<id>.execute-api.<region>.amazonaws.com/<stage> \
+  LABEL_FILTER=hyperfleet-sanity
 ```
 
 Optional environment variables:
@@ -562,6 +575,7 @@ Optional environment variables:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `HYPERFLEET_URL` | — (required) | Platform API v2 base URL |
+| `LABEL_FILTER` | `hyperfleet-validated` | Set to `hyperfleet-sanity` for this spec |
 | `CLUSTER_NAME` | `hf-e2e-<unix timestamp>` | Cluster name (≤ 18 chars — namespace constraint) |
 | `OPERATOR_ROLES_PREFIX` | same as `CLUSTER_NAME` | IAM roles prefix |
 | `AWS_DEFAULT_REGION` | derived from URL | Fallback region when URL has no region in hostname |

--- a/pkg/aws/api_interface/iam_api_client.go
+++ b/pkg/aws/api_interface/iam_api_client.go
@@ -141,6 +141,14 @@ type IamApiClient interface {
 		params *iam.AddRoleToInstanceProfileInput, optFns ...func(*iam.Options),
 	) (*iam.AddRoleToInstanceProfileOutput, error)
 
+	RemoveRoleFromInstanceProfile(ctx context.Context,
+		params *iam.RemoveRoleFromInstanceProfileInput, optFns ...func(*iam.Options),
+	) (*iam.RemoveRoleFromInstanceProfileOutput, error)
+
+	DeleteInstanceProfile(ctx context.Context,
+		params *iam.DeleteInstanceProfileInput, optFns ...func(*iam.Options),
+	) (*iam.DeleteInstanceProfileOutput, error)
+
 	ListRolePolicies(ctx context.Context,
 		params *iam.ListRolePoliciesInput, optFns ...func(*iam.Options),
 	) (*iam.ListRolePoliciesOutput, error)

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -168,6 +168,7 @@ type Client interface {
 	GetOpenIDConnectProviderByClusterIdTag(clusterID string) (string, error)
 	GetOpenIDConnectProviderByOidcEndpointUrl(oidcEndpointUrl string) (string, error)
 	GetInstanceProfilesForRole(role string) ([]string, error)
+	DeleteInstanceProfilesForRole(roleName string) error
 	EnsureInstanceProfile(
 		reporter reporter.Logger,
 		instanceProfileName string,

--- a/pkg/aws/client_mock.go
+++ b/pkg/aws/client_mock.go
@@ -875,6 +875,20 @@ func (mr *MockClientMockRecorder) GetInstanceProfilesForRole(role any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceProfilesForRole", reflect.TypeOf((*MockClient)(nil).GetInstanceProfilesForRole), role)
 }
 
+// DeleteInstanceProfilesForRole mocks base method.
+func (m *MockClient) DeleteInstanceProfilesForRole(roleName string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteInstanceProfilesForRole", roleName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteInstanceProfilesForRole indicates an expected call of DeleteInstanceProfilesForRole.
+func (mr *MockClientMockRecorder) DeleteInstanceProfilesForRole(roleName any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteInstanceProfilesForRole", reflect.TypeOf((*MockClient)(nil).DeleteInstanceProfilesForRole), roleName)
+}
+
 // GetLocalAWSAccessKeys mocks base method.
 func (m *MockClient) GetLocalAWSAccessKeys() (*AccessKey, error) {
 	m.ctrl.T.Helper()

--- a/pkg/aws/mocks/iam_api_client_mock.go
+++ b/pkg/aws/mocks/iam_api_client_mock.go
@@ -261,6 +261,26 @@ func (mr *MockIamApiClientMockRecorder) DeleteAccessKey(ctx, params any, optFns 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAccessKey", reflect.TypeOf((*MockIamApiClient)(nil).DeleteAccessKey), varargs...)
 }
 
+// DeleteInstanceProfile mocks base method.
+func (m *MockIamApiClient) DeleteInstanceProfile(ctx context.Context, params *iam.DeleteInstanceProfileInput, optFns ...func(*iam.Options)) (*iam.DeleteInstanceProfileOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, params}
+	for _, a := range optFns {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteInstanceProfile", varargs...)
+	ret0, _ := ret[0].(*iam.DeleteInstanceProfileOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteInstanceProfile indicates an expected call of DeleteInstanceProfile.
+func (mr *MockIamApiClientMockRecorder) DeleteInstanceProfile(ctx, params any, optFns ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, params}, optFns...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteInstanceProfile", reflect.TypeOf((*MockIamApiClient)(nil).DeleteInstanceProfile), varargs...)
+}
+
 // DeleteOpenIDConnectProvider mocks base method.
 func (m *MockIamApiClient) DeleteOpenIDConnectProvider(ctx context.Context, params *iam.DeleteOpenIDConnectProviderInput, optFns ...func(*iam.Options)) (*iam.DeleteOpenIDConnectProviderOutput, error) {
 	m.ctrl.T.Helper()
@@ -819,6 +839,26 @@ func (mr *MockIamApiClientMockRecorder) PutRolePolicy(ctx, params any, optFns ..
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{ctx, params}, optFns...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutRolePolicy", reflect.TypeOf((*MockIamApiClient)(nil).PutRolePolicy), varargs...)
+}
+
+// RemoveRoleFromInstanceProfile mocks base method.
+func (m *MockIamApiClient) RemoveRoleFromInstanceProfile(ctx context.Context, params *iam.RemoveRoleFromInstanceProfileInput, optFns ...func(*iam.Options)) (*iam.RemoveRoleFromInstanceProfileOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, params}
+	for _, a := range optFns {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RemoveRoleFromInstanceProfile", varargs...)
+	ret0, _ := ret[0].(*iam.RemoveRoleFromInstanceProfileOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RemoveRoleFromInstanceProfile indicates an expected call of RemoveRoleFromInstanceProfile.
+func (mr *MockIamApiClientMockRecorder) RemoveRoleFromInstanceProfile(ctx, params any, optFns ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, params}, optFns...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveRoleFromInstanceProfile", reflect.TypeOf((*MockIamApiClient)(nil).RemoveRoleFromInstanceProfile), varargs...)
 }
 
 // SimulatePrincipalPolicy mocks base method.

--- a/pkg/aws/policies.go
+++ b/pkg/aws/policies.go
@@ -929,6 +929,30 @@ func (c *awsClient) ListAccountRoles(version string) ([]Role, error) {
 	return c.mapToAccountRoles(version, roles)
 }
 
+var prefixOperatorRoleRE = regexp.MustCompile(`(?i)(?P<Prefix>[\w+=,.@-]+)-(openshift|kube-system)`)
+
+// operatorRoleListPrefix returns the operator-roles prefix for OCM (openshift/kube-system suffix)
+// or hyperfleet v2 (HypershiftPolicies + role_prefix tags) roles.
+func operatorRoleListPrefix(roleName string, roleTags []iamtypes.Tag) string {
+	if matches := prefixOperatorRoleRE.FindStringSubmatch(roleName); len(matches) > 0 {
+		return strings.ToLower(matches[prefixOperatorRoleRE.SubexpIndex("Prefix")])
+	}
+	if !common.IamResourceHasTag(roleTags, tags.HypershiftPolicies, tags.True) {
+		return ""
+	}
+	rolePrefix := ""
+	for _, tag := range roleTags {
+		if aws.ToString(tag.Key) == tags.RolePrefix {
+			rolePrefix = aws.ToString(tag.Value)
+			break
+		}
+	}
+	if rolePrefix == "" || !strings.HasPrefix(roleName, rolePrefix+"-") {
+		return ""
+	}
+	return strings.ToLower(rolePrefix)
+}
+
 func (c *awsClient) ListOperatorRoles(targetVersion string,
 	targetClusterId string, targetPrefix string,
 ) (map[string][]OperatorRoleDetail, error) {
@@ -937,24 +961,21 @@ func (c *awsClient) ListOperatorRoles(targetVersion string,
 	if err != nil {
 		return operatorMap, err
 	}
-	prefixOperatorRoleRE := regexp.MustCompile(`(?i)(?P<Prefix>[\w+=,.@-]+)-(openshift|kube-system)`)
 	for _, role := range roles {
 		operatorRole := OperatorRoleDetail{}
-		matches := prefixOperatorRoleRE.FindStringSubmatch(*role.RoleName)
-		if len(matches) == 0 {
-			continue
-		}
-		prefixIndex := prefixOperatorRoleRE.SubexpIndex("Prefix")
-		foundPrefix := strings.ToLower(matches[prefixIndex])
-		if _, mapOk := operatorMap[foundPrefix]; !mapOk {
-			operatorMap[foundPrefix] = []OperatorRoleDetail{}
-		}
 		listRoleTagsOutput, err := c.iamClient.ListRoleTags(context.Background(),
 			&iam.ListRoleTagsInput{
 				RoleName: role.RoleName,
 			})
 		if err != nil {
 			return operatorMap, err
+		}
+		foundPrefix := operatorRoleListPrefix(aws.ToString(role.RoleName), listRoleTagsOutput.Tags)
+		if foundPrefix == "" {
+			continue
+		}
+		if _, mapOk := operatorMap[foundPrefix]; !mapOk {
+			operatorMap[foundPrefix] = []OperatorRoleDetail{}
 		}
 		skip := false
 		for _, tag := range listRoleTagsOutput.Tags {
@@ -1140,6 +1161,9 @@ func (c *awsClient) DeleteOperatorRole(roleName string, managedPolicies bool,
 			return sharedVpcPoliciesNotDeleted, err
 		}
 	}
+	if err := c.DeleteInstanceProfilesForRole(roleName); err != nil {
+		return sharedVpcPoliciesNotDeleted, err
+	}
 	err = c.DeleteRole(*role)
 	if err != nil {
 		return sharedVpcPoliciesNotDeleted, err
@@ -1200,6 +1224,34 @@ func (c *awsClient) DeleteRole(role string) error {
 		}
 		return err
 	}
+	return nil
+}
+
+func (c *awsClient) DeleteInstanceProfilesForRole(roleName string) error {
+	profileNames, err := c.GetInstanceProfilesForRole(roleName)
+	if err != nil {
+		return err
+	}
+
+	for _, profileName := range profileNames {
+		_, err = c.iamClient.RemoveRoleFromInstanceProfile(context.Background(),
+			&iam.RemoveRoleFromInstanceProfileInput{
+				InstanceProfileName: aws.String(profileName),
+				RoleName:            aws.String(roleName),
+			})
+		if err != nil && !awserr.IsNoSuchEntityException(err) {
+			return err
+		}
+
+		_, err = c.iamClient.DeleteInstanceProfile(context.Background(),
+			&iam.DeleteInstanceProfileInput{
+				InstanceProfileName: aws.String(profileName),
+			})
+		if err != nil && !awserr.IsNoSuchEntityException(err) {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/aws/policies_test.go
+++ b/pkg/aws/policies_test.go
@@ -152,6 +152,51 @@ var _ = Describe("ListOperatorRoles", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(roles).To(HaveLen(1))
 	})
+
+	It("Retrieves hyperfleet v2 operator roles by role_prefix tag", func() {
+		mockIamAPI.EXPECT().ListRoles(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+			&iam.ListRolesOutput{
+				IsTruncated: false,
+				Roles: []iamtypes.Role{
+					{
+						RoleName: aws.String("hf-e2e-ingress"),
+					},
+				},
+			}, nil)
+		mockIamAPI.EXPECT().ListRoleTags(gomock.Any(), gomock.Any()).Return(
+			&iam.ListRoleTagsOutput{
+				IsTruncated: false,
+				Tags: []iamtypes.Tag{
+					{
+						Key:   aws.String(tags.HypershiftPolicies),
+						Value: aws.String(tags.True),
+					},
+					{
+						Key:   aws.String(tags.RolePrefix),
+						Value: aws.String("hf-e2e"),
+					},
+					{
+						Key:   aws.String(common.ManagedPolicies),
+						Value: aws.String("true"),
+					},
+				},
+			}, nil)
+		mockIamAPI.EXPECT().ListAttachedRolePolicies(gomock.Any(), gomock.Any()).Return(
+			&iam.ListAttachedRolePoliciesOutput{
+				IsTruncated: false,
+				AttachedPolicies: []iamtypes.AttachedPolicy{
+					{
+						PolicyName: aws.String("AmazonEBSCSIDriverPolicy"),
+					},
+				},
+			}, nil)
+		roles, err := client.ListOperatorRoles("", "", "hf-e2e")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(roles).To(HaveLen(1))
+		Expect(roles["hf-e2e"]).To(HaveLen(1))
+		Expect(roles["hf-e2e"][0].RoleName).To(Equal("hf-e2e-ingress"))
+		Expect(roles["hf-e2e"][0].ManagedPolicy).To(BeTrue())
+	})
 })
 
 var _ = Describe("mapToAccountRoles", func() {
@@ -652,6 +697,9 @@ var _ = Describe("Cluster Roles/Policies", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 	It("Test DeleteOperatorRole", func() {
+		mockIamAPI.EXPECT().ListInstanceProfilesForRole(gomock.Any(), &iam.ListInstanceProfilesForRoleInput{
+			RoleName: aws.String(operatorRole),
+		}).Return(&iam.ListInstanceProfilesForRoleOutput{}, nil)
 		mockIamAPI.EXPECT().ListAttachedRolePolicies(gomock.Any(), &iam.ListAttachedRolePoliciesInput{
 			RoleName: aws.String(operatorRole),
 		}).Return(operatorRoleAttachedPolicies, nil).MaxTimes(2)

--- a/pkg/hyperfleet/hyperfleet_test.go
+++ b/pkg/hyperfleet/hyperfleet_test.go
@@ -142,6 +142,17 @@ var _ = Describe("ComputeInstanceProfile", func() {
 	})
 })
 
+var _ = Describe("OperatorRoleNames", func() {
+	It("prefixes every hyperfleet v2 role suffix", func() {
+		const prefix = "hf-e2e-1"
+		names := OperatorRoleNames(prefix)
+		Expect(names).To(HaveLen(len(OperatorRoleSuffixes())))
+		for i, suffix := range OperatorRoleSuffixes() {
+			Expect(names[i]).To(Equal(prefix + "-" + suffix))
+		}
+	})
+})
+
 var _ = Describe("InstanceProfileFromRolesRef", func() {
 	It("extracts prefix from NodePoolManagementARN and returns the instance profile name", func() {
 		ref := hypershiftv1beta1.AWSRolesRef{

--- a/pkg/hyperfleet/roles.go
+++ b/pkg/hyperfleet/roles.go
@@ -7,27 +7,63 @@ import (
 	hypershiftv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 )
 
+const (
+	SuffixIngress                = "ingress"
+	SuffixCloudControllerManager = "cloud-controller-manager"
+	SuffixEBSCSI                 = "ebs-csi"
+	SuffixImageRegistry          = "image-registry"
+	SuffixNetworkConfig          = "network-config"
+	SuffixControlPlaneOperator   = "control-plane-operator"
+	SuffixNodePoolManagement     = "node-pool-management"
+	SuffixWorkerRole             = "ROSA-Worker-Role"
+)
+
+var operatorRoleSuffixes = []string{
+	SuffixIngress,
+	SuffixCloudControllerManager,
+	SuffixEBSCSI,
+	SuffixImageRegistry,
+	SuffixNetworkConfig,
+	SuffixControlPlaneOperator,
+	SuffixNodePoolManagement,
+	SuffixWorkerRole,
+}
+
+// OperatorRoleSuffixes returns IAM role name suffixes (after "<prefix>-") for hyperfleet v2 HCP.
+func OperatorRoleSuffixes() []string {
+	return operatorRoleSuffixes
+}
+
 // ComputeRolesRef builds the AWSRolesRef from an operator roles prefix, AWS account ID, and
 // partition. Role names follow the convention established by the Platform API IAM CloudFormation
 // template.
 func ComputeRolesRef(prefix, accountID, partition string) hypershiftv1beta1.AWSRolesRef {
 	arn := func(suffix string) string {
-		return fmt.Sprintf("arn:%s:iam::%s:role/%s%s", partition, accountID, prefix, suffix)
+		return fmt.Sprintf("arn:%s:iam::%s:role/%s-%s", partition, accountID, prefix, suffix)
 	}
 	return hypershiftv1beta1.AWSRolesRef{
-		IngressARN:              arn("-ingress"),
-		KubeCloudControllerARN:  arn("-cloud-controller-manager"),
-		StorageARN:              arn("-ebs-csi"),
-		ImageRegistryARN:        arn("-image-registry"),
-		NetworkARN:              arn("-network-config"),
-		ControlPlaneOperatorARN: arn("-control-plane-operator"),
-		NodePoolManagementARN:   arn("-node-pool-management"),
+		IngressARN:              arn(SuffixIngress),
+		KubeCloudControllerARN:  arn(SuffixCloudControllerManager),
+		StorageARN:              arn(SuffixEBSCSI),
+		ImageRegistryARN:        arn(SuffixImageRegistry),
+		NetworkARN:              arn(SuffixNetworkConfig),
+		ControlPlaneOperatorARN: arn(SuffixControlPlaneOperator),
+		NodePoolManagementARN:   arn(SuffixNodePoolManagement),
 	}
 }
 
 // ComputeInstanceProfile returns the worker node instance profile name for a given prefix.
 func ComputeInstanceProfile(prefix string) string {
-	return prefix + "-ROSA-Worker-Role"
+	return prefix + "-" + SuffixWorkerRole
+}
+
+// OperatorRoleNames returns IAM role names created by hyperfleet v2 operator-roles create.
+func OperatorRoleNames(prefix string) []string {
+	names := make([]string, len(operatorRoleSuffixes))
+	for i, suffix := range operatorRoleSuffixes {
+		names[i] = prefix + "-" + suffix
+	}
+	return names
 }
 
 // InstanceProfileFromRolesRef derives the worker instance profile name from a cluster's
@@ -35,14 +71,13 @@ func ComputeInstanceProfile(prefix string) string {
 // Returns an empty string if the ARN is not set or cannot be parsed.
 func InstanceProfileFromRolesRef(rolesRef hypershiftv1beta1.AWSRolesRef) string {
 	arn := rolesRef.NodePoolManagementARN
-	// ARN format: arn:aws:iam::<account>:role/<prefix>-node-pool-management
 	slash := strings.LastIndex(arn, "/")
 	if slash < 0 {
 		return ""
 	}
 	roleName := arn[slash+1:]
-	const suffix = "-node-pool-management"
-	prefix, found := strings.CutSuffix(roleName, suffix)
+	nodePoolSuffix := "-" + SuffixNodePoolManagement
+	prefix, found := strings.CutSuffix(roleName, nodePoolSuffix)
 	if !found {
 		return ""
 	}

--- a/tests/ci/data/profiles/rosa-hyperfleet.yaml
+++ b/tests/ci/data/profiles/rosa-hyperfleet.yaml
@@ -2,7 +2,7 @@
 # Use with: TEST_PROFILE=rosa-hyperfleet-basic
 # Login: rosa login --hyperfleet-url $HYPERFLEET_URL
 #
-# Day1 create from this profile still needs handler work (GenerateClusterCreateFlags).
+# Day1 create uses the hyperfleet handler (oidc_config: managed).
 profiles:
   - as: rosa-hyperfleet-basic
     version: latest
@@ -27,9 +27,7 @@ profiles:
       tag_enabled: false
       etcd_kms: false
       fips: false
-      # Empty = no OCM OIDC config resource. HyperFleet uses issuer on describe
-      # and IAM OIDC provider in AWS — not rosa create/list oidc-config.
-      oidc_config: ""
+      oidc_config: managed
       auditlog_forward: false
       admin_enabled: false
       volume_size: 75

--- a/tests/ci/labels/hyperfleet.go
+++ b/tests/ci/labels/hyperfleet.go
@@ -6,6 +6,7 @@ import (
 
 type hyperfleetLabels struct {
 	Validated Labels
+	Sanity    Labels
 }
 
 var Hyperfleet = initHyperfleet()
@@ -13,6 +14,7 @@ var Hyperfleet = initHyperfleet()
 func initHyperfleet() *hyperfleetLabels {
 	hLabels := new(hyperfleetLabels)
 	hLabels.Validated = Label("hyperfleet-validated")
+	hLabels.Sanity = Label("hyperfleet-sanity")
 
 	return hLabels
 }

--- a/tests/e2e/hyperfleet_sanity_test.go
+++ b/tests/e2e/hyperfleet_sanity_test.go
@@ -2,17 +2,16 @@ package e2e
 
 import (
 	"context"
-	"crypto/sha1" //nolint:gosec
-	"crypto/tls"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"os"
 	"strings"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	ec2svc "github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -29,7 +28,10 @@ import (
 	"github.com/openshift-online/rosa-hyperfleet-api/clientset/platform"
 	hfrest "github.com/openshift-online/rosa-hyperfleet-api/clientset/rest"
 
+	rosaaws "github.com/openshift/rosa/pkg/aws"
+	urlHelper "github.com/openshift/rosa/pkg/helper/url"
 	"github.com/openshift/rosa/pkg/hyperfleet"
+	"github.com/openshift/rosa/tests/ci/labels"
 	rosacli "github.com/openshift/rosa/tests/utils/exec/rosacli"
 )
 
@@ -41,6 +43,7 @@ const (
 	hfNodePoolReadyInterval = 30 * time.Second
 	hfNodePoolReadyTimeout  = 30 * time.Minute
 	hfDefaultInstanceType   = "m5.xlarge"
+	hfMaxClusterNameLength  = 18 // Platform API namespace limit; see hyperfleet-guidelines.md
 
 	// teardownGracePeriod bounds how long each cleanup node may run after a
 	// mid-run interrupt (Ctrl-C). Ginkgo's default is 30s, which is far too
@@ -52,74 +55,8 @@ const (
 	teardownGracePeriod = hfClusterReadyTimeout + 30*time.Minute
 )
 
-// hfOperatorRole maps a role suffix to its AWS managed policy name and the
-// service accounts that should be allowed to assume it.
-type hfOperatorRole struct {
-	suffix          string
-	policy          string
-	serviceAccounts []hfServiceAccount
-}
-
-type hfServiceAccount struct {
-	namespace string
-	name      string
-}
-
-var hfOperatorRoles = []hfOperatorRole{
-	{
-		suffix: "-ingress",
-		policy: "ROSAIngressOperatorPolicy",
-		serviceAccounts: []hfServiceAccount{
-			{namespace: "openshift-ingress-operator", name: "ingress-operator"},
-		},
-	},
-	{
-		suffix: "-cloud-controller-manager",
-		policy: "ROSAKubeControllerPolicy",
-		serviceAccounts: []hfServiceAccount{
-			{namespace: "kube-system", name: "kube-controller-manager"},
-		},
-	},
-	{
-		suffix: "-ebs-csi",
-		policy: "ROSAAmazonEBSCSIDriverOperatorPolicy",
-		serviceAccounts: []hfServiceAccount{
-			{namespace: "openshift-cluster-csi-drivers", name: "aws-ebs-csi-driver-operator"},
-			{namespace: "openshift-cluster-csi-drivers", name: "aws-ebs-csi-driver-controller-sa"},
-		},
-	},
-	{
-		suffix: "-image-registry",
-		policy: "ROSAImageRegistryOperatorPolicy",
-		serviceAccounts: []hfServiceAccount{
-			{namespace: "openshift-image-registry", name: "cluster-image-registry-operator"},
-			{namespace: "openshift-image-registry", name: "registry"},
-		},
-	},
-	{
-		suffix: "-network-config",
-		policy: "ROSACloudNetworkConfigOperatorPolicy",
-		serviceAccounts: []hfServiceAccount{
-			{namespace: "openshift-cloud-network-config-controller", name: "cloud-network-config-controller"},
-		},
-	},
-	{
-		suffix: "-control-plane-operator",
-		policy: "ROSAControlPlaneOperatorPolicy",
-		serviceAccounts: []hfServiceAccount{
-			{namespace: "kube-system", name: "control-plane-operator"},
-		},
-	},
-	{
-		suffix: "-node-pool-management",
-		policy: "ROSANodePoolManagementPolicy",
-		serviceAccounts: []hfServiceAccount{
-			{namespace: "kube-system", name: "capa-controller-manager"},
-		},
-	},
-}
-
 var _ = Describe("Hyperfleet sanity",
+	labels.Hyperfleet.Sanity,
 	func() {
 		It("creates and deletes an HCP cluster via the Platform API", func(ctx SpecContext) {
 			hfURL := os.Getenv("HYPERFLEET_URL")
@@ -128,14 +65,15 @@ var _ = Describe("Hyperfleet sanity",
 			}
 			clusterName := os.Getenv("CLUSTER_NAME")
 			if clusterName == "" {
-				clusterName = fmt.Sprintf("hf-sanity-%d", time.Now().Unix())
+				clusterName = fmt.Sprintf("hf-e2e-%d", time.Now().Unix())
 			}
+			Expect(len(clusterName)).To(BeNumerically("<=", hfMaxClusterNameLength),
+				"CLUSTER_NAME must be ≤%d chars for Platform API", hfMaxClusterNameLength)
 			rolesPrefix := os.Getenv("OPERATOR_ROLES_PREFIX")
 			if rolesPrefix == "" {
 				rolesPrefix = clusterName
 			}
 
-			// Derive region from URL or AWS_DEFAULT_REGION.
 			region, err := hyperfleet.ExtractRegion(hfURL)
 			if err != nil {
 				envRegion := os.Getenv("AWS_DEFAULT_REGION")
@@ -144,16 +82,8 @@ var _ = Describe("Hyperfleet sanity",
 				region = envRegion
 			}
 
-			// Ensure AWS_DEFAULT_REGION reflects the URL-encoded region so that
-			// subprocesses (e.g. rosa whoami) display the correct region rather
-			// than any ambient value the caller may have set.
 			GinkgoT().Setenv("AWS_DEFAULT_REGION", region)
 
-			// deferTeardown registers a cleanup with a bounded grace period so a
-			// mid-run interrupt still lets AWS teardown make progress instead of
-			// being cut off after Ginkgo's default 30s. Each cleanup receives a
-			// fresh SpecContext (cancelled when the grace period expires) so long
-			// WaitUntil/waiter calls abort promptly on a second interrupt.
 			deferTeardown := func(fn func(ctx SpecContext)) {
 				DeferCleanup(fn, GracePeriod(teardownGracePeriod))
 			}
@@ -170,7 +100,7 @@ var _ = Describe("Hyperfleet sanity",
 				_, _ = rosacli.NewClient().Runner.Cmd("logout").Run()
 			})
 
-			By("Verifying whoami shows Platform API URL and correct region")
+			By("Verifying whoami shows V2 API URL and correct region")
 			whoamiRunner := rosacli.NewClient().Runner
 			whoamiRunner.JsonFormat()
 			whoamiOut, err := whoamiRunner.Cmd("whoami").Run()
@@ -178,8 +108,8 @@ var _ = Describe("Hyperfleet sanity",
 			var whoamiMap map[string]interface{}
 			Expect(json.Unmarshal(whoamiOut.Bytes(), &whoamiMap)).To(Succeed(),
 				"parsing whoami JSON output")
-			Expect(whoamiMap["Platform API"]).To(Equal(hfURL),
-				"whoami must report the Platform API URL stored during login")
+			Expect(whoamiMap["V2 API"]).To(Equal(hfURL),
+				"whoami must report the V2 API URL stored during login")
 			Expect(whoamiMap["AWS Default Region"]).To(Equal(region),
 				"whoami must report the region derived from the Platform API URL")
 
@@ -193,7 +123,6 @@ var _ = Describe("Hyperfleet sanity",
 			Expect(err).NotTo(HaveOccurred(), "STS GetCallerIdentity")
 			accountID := awssdk.ToString(identity.Account)
 			callerARN := awssdk.ToString(identity.Arn)
-			partition := hfPartitionFromARN(callerARN)
 
 			By("Building the hyperfleet client")
 			hfClient, err := hyperfleetclientset.NewForConfig(&hfrest.Config{
@@ -206,13 +135,9 @@ var _ = Describe("Hyperfleet sanity",
 			Expect(err).NotTo(HaveOccurred(), "building hyperfleet client")
 
 			ec2Client := ec2svc.NewFromConfig(awsCfg)
-			iamClient := iamsvc.NewFromConfig(awsCfg)
 			r53Client := route53svc.NewFromConfig(awsCfg)
 			elbClient := elbsvc.NewFromConfig(awsCfg)
 			elbv2Client := elbv2svc.NewFromConfig(awsCfg)
-
-			// ── Network setup ────────────────────────────────────────────────
-			// Mirrors what rosactl cluster-vpc create provisions via CloudFormation.
 
 			const vpcCIDR = "10.0.0.0/16"
 			az := region + "a"
@@ -240,7 +165,8 @@ var _ = Describe("Hyperfleet sanity",
 			})
 
 			By("Waiting for VPC to become available")
-			Expect(ec2svc.NewVpcAvailableWaiter(ec2Client).Wait(ctx,
+			Expect(ec2svc.NewVpcAvailableWaiter(ec2Client).Wait(
+				ctx,
 				&ec2svc.DescribeVpcsInput{VpcIds: []string{vpcID}},
 				hfVPCReadyTimeout,
 			)).To(Succeed(), "waiting for VPC %s to become available", vpcID)
@@ -300,7 +226,8 @@ var _ = Describe("Hyperfleet sanity",
 			})
 
 			By("Waiting for subnets to become available")
-			Expect(ec2svc.NewSubnetAvailableWaiter(ec2Client).Wait(ctx,
+			Expect(ec2svc.NewSubnetAvailableWaiter(ec2Client).Wait(
+				ctx,
 				&ec2svc.DescribeSubnetsInput{SubnetIds: []string{subnetID, publicSubnetID}},
 				hfSubnetReadyTimeout,
 			)).To(Succeed(), "waiting for subnets to become available")
@@ -377,14 +304,16 @@ var _ = Describe("Hyperfleet sanity",
 				_, _ = ec2Client.DeleteNatGateway(ctx, &ec2svc.DeleteNatGatewayInput{
 					NatGatewayId: awssdk.String(natGWID),
 				})
-				_ = ec2svc.NewNatGatewayDeletedWaiter(ec2Client).Wait(ctx,
+				_ = ec2svc.NewNatGatewayDeletedWaiter(ec2Client).Wait(
+					ctx,
 					&ec2svc.DescribeNatGatewaysInput{NatGatewayIds: []string{natGWID}},
 					5*time.Minute,
 				)
 			})
 
 			By("Waiting for NAT Gateway to become available")
-			Expect(ec2svc.NewNatGatewayAvailableWaiter(ec2Client).Wait(ctx,
+			Expect(ec2svc.NewNatGatewayAvailableWaiter(ec2Client).Wait(
+				ctx,
 				&ec2svc.DescribeNatGatewaysInput{NatGatewayIds: []string{natGWID}},
 				5*time.Minute,
 			)).To(Succeed(), "waiting for NAT Gateway %s to become available", natGWID)
@@ -536,77 +465,79 @@ var _ = Describe("Hyperfleet sanity",
 				})
 			})
 
-			// ── IAM cleanup (pre-registered to execute after cluster deletion) ─────
-			// DeferCleanup runs in LIFO order. Registering these before the cluster
-			// delete DeferCleanup ensures IAM resources are removed only after the
-			// cluster and its worker nodes are fully gone. The OIDC provider must
-			// remain available while the cluster is deleting so operators can
-			// authenticate to AWS; it is deleted last among these.
+			oidcRunner := rosacli.NewClient().Runner
 
-			var oidcARN string
-			deferTeardown(func(ctx SpecContext) {
-				if oidcARN == "" {
-					return
-				}
-				By("Cleanup: deleting OIDC provider")
-				_, _ = iamClient.DeleteOpenIDConnectProvider(ctx, &iamsvc.DeleteOpenIDConnectProviderInput{
-					OpenIDConnectProviderArn: awssdk.String(oidcARN),
-				})
-			})
+			By("Creating managed OIDC config via CLI")
+			oidcCreateOut, err := oidcRunner.JsonFormat().Cmd("create", "oidc-config").
+				CmdFlags("--managed", "--mode", "auto", "-y").
+				Run()
+			Expect(err).NotTo(HaveOccurred(), "rosa create oidc-config")
 
-			var createdRoles []string
-			deferTeardown(func(ctx SpecContext) {
-				By("Cleanup: detaching policies and deleting operator roles")
-				for i, role := range hfOperatorRoles {
-					if i >= len(createdRoles) {
-						break
-					}
-					roleName := createdRoles[i]
-					policyARN := fmt.Sprintf("arn:%s:iam::aws:policy/service-role/%s", partition, role.policy)
-					_, _ = iamClient.DetachRolePolicy(ctx, &iamsvc.DetachRolePolicyInput{
-						RoleName:  awssdk.String(roleName),
-						PolicyArn: awssdk.String(policyARN),
-					})
-					_, _ = iamClient.DeleteRole(ctx, &iamsvc.DeleteRoleInput{
-						RoleName: awssdk.String(roleName),
-					})
-				}
-			})
-
-			workerRoleName := hyperfleet.ComputeInstanceProfile(rolesPrefix)
-			workerPolicies := []string{
-				fmt.Sprintf("arn:%s:iam::aws:policy/service-role/ROSAWorkerInstancePolicy", partition),
-				fmt.Sprintf("arn:%s:iam::aws:policy/AmazonSSMManagedInstanceCore", partition),
+			parsed := rosacli.NewParser().JsonData.Input(oidcCreateOut).Parse()
+			oidcConfigID := parsed.DigString("id")
+			if oidcConfigID == "" {
+				oidcConfigID = parsed.DigString("metadata", "name")
 			}
+			Expect(oidcConfigID).NotTo(BeEmpty(), "OIDC config ID must be returned by create")
+			GinkgoWriter.Printf("OIDC config created with ID %s\n", oidcConfigID)
+
+			issuerURL := parsed.DigString("spec", "issuerUrl")
+			if issuerURL == "" {
+				issuerURL = parsed.DigString("spec", "issuer_url")
+			}
+			Expect(issuerURL).NotTo(BeEmpty(), "OIDC issuer URL must be returned by create")
+
+			By("Verifying IAM OIDC provider exists after managed OIDC create")
+			parsedIssuerURL, err := urlHelper.ParseRequestURI(issuerURL)
+			Expect(err).NotTo(HaveOccurred(), "parsing OIDC issuer URL")
+			providerURL := fmt.Sprintf("%s%s", parsedIssuerURL.Host, parsedIssuerURL.Path)
+			callerParsedARN, err := arn.Parse(callerARN)
+			Expect(err).NotTo(HaveOccurred(), "parsing caller ARN")
+			oidcProviderARN := rosaaws.GetOIDCProviderARN(
+				callerParsedARN.Partition, accountID, providerURL)
+			providerOut, err := iamsvc.NewFromConfig(awsCfg).GetOpenIDConnectProvider(
+				ctx, &iamsvc.GetOpenIDConnectProviderInput{
+					OpenIDConnectProviderArn: awssdk.String(oidcProviderARN),
+				})
+			Expect(err).NotTo(HaveOccurred(), "IAM OIDC provider must exist after managed OIDC create")
+			Expect(awssdk.ToString(providerOut.Url)).To(Equal(providerURL))
+
 			deferTeardown(func(ctx SpecContext) {
-				By("Cleanup: deleting worker instance profile and role")
-				_, _ = iamClient.RemoveRoleFromInstanceProfile(ctx, &iamsvc.RemoveRoleFromInstanceProfileInput{
-					InstanceProfileName: awssdk.String(workerRoleName),
-					RoleName:            awssdk.String(workerRoleName),
-				})
-				_, _ = iamClient.DeleteInstanceProfile(ctx, &iamsvc.DeleteInstanceProfileInput{
-					InstanceProfileName: awssdk.String(workerRoleName),
-				})
-				for _, policyARN := range workerPolicies {
-					_, _ = iamClient.DetachRolePolicy(ctx, &iamsvc.DetachRolePolicyInput{
-						RoleName:  awssdk.String(workerRoleName),
-						PolicyArn: awssdk.String(policyARN),
-					})
-				}
-				_, _ = iamClient.DeleteRole(ctx, &iamsvc.DeleteRoleInput{
-					RoleName: awssdk.String(workerRoleName),
-				})
+				By("Cleanup: initiating OIDC config deletion (async, no list wait)")
+				hfInitiateOidcConfigDelete(oidcConfigID)
 			})
 
-			// ── Cluster create ───────────────────────────────────────────────
+			By("Listing OIDC configs via CLI")
+			listOidcOut, err := oidcRunner.Cmd("list", "oidc-config").CmdFlags().Run()
+			Expect(err).NotTo(HaveOccurred(), "rosa list oidc-config")
+			Expect(listOidcOut.String()).To(ContainSubstring(oidcConfigID),
+				"created OIDC config must appear in list output")
+
+			By("Creating operator roles via CLI")
+			oidcRunner.UnsetFormat()
+			_, err = oidcRunner.Cmd("create", "operator-roles").
+				CmdFlags(
+					"--hosted-cp",
+					"--prefix", rolesPrefix,
+					"--oidc-config-id", oidcConfigID,
+					"--mode", "auto",
+					"-y",
+				).
+				Run()
+			Expect(err).NotTo(HaveOccurred(), "rosa create operator-roles")
+
+			deferTeardown(func(ctx SpecContext) {
+				By("Cleanup: initiating operator roles deletion (async)")
+				hfInitiateOperatorRolesDelete(rolesPrefix)
+			})
 
 			By("Creating cluster via CLI")
-			// HYPERFLEET_VERSION is optional — when empty the server resolves a default.
 			version := os.Getenv("HYPERFLEET_VERSION")
 			createArgs := []string{
 				"--cluster-name", clusterName,
 				"--subnet-ids", subnetID,
 				"--operator-roles-prefix", rolesPrefix,
+				"--oidc-config-id", oidcConfigID,
 			}
 			if version != "" {
 				createArgs = append(createArgs, "--version", version)
@@ -617,8 +548,6 @@ var _ = Describe("Hyperfleet sanity",
 				Run()
 			Expect(err).NotTo(HaveOccurred(), "rosa create cluster CLI call")
 
-			// Declare clusterID before the DeferCleanup so the closure captures
-			// the variable; it will be populated after the describe call below.
 			var clusterID string
 			deferTeardown(func(ctx SpecContext) {
 				By("Cleanup: deleting cluster via CLI")
@@ -663,7 +592,7 @@ var _ = Describe("Hyperfleet sanity",
 				hfDeleteVPCSecurityGroups(ctx, ec2Client, vpcID)
 			})
 
-			By("Fetching cluster ID and OIDC IssuerURL via CLI describe")
+			By("Fetching cluster ID via CLI describe")
 			describeCreateRunner := rosacli.NewClient().Runner
 			describeCreateRunner.JsonFormat()
 			describeCreateOut, err := describeCreateRunner.Cmd("describe", "cluster").
@@ -679,96 +608,9 @@ var _ = Describe("Hyperfleet sanity",
 			GinkgoWriter.Printf("Cluster %q created with ID %s\n", clusterName, clusterID)
 
 			specMap, _ := createDescribeMap["spec"].(map[string]interface{})
-			issuerURL, _ := specMap["oidc_issuer"].(string)
+			issuerURL, _ = specMap["oidc_issuer"].(string)
 			Expect(issuerURL).NotTo(BeEmpty(), "OIDC IssuerURL must be present in describe response after create")
 			GinkgoWriter.Printf("OIDC IssuerURL: %s\n", issuerURL)
-
-			// oidcProvider is the host+path without the https:// scheme prefix,
-			// used as the principal in trust policies and in OIDC condition keys.
-			oidcProvider, err := hfOIDCProvider(issuerURL)
-			Expect(err).NotTo(HaveOccurred(), "parsing OIDC provider from IssuerURL")
-
-			// ── OIDC provider ────────────────────────────────────────────────
-
-			By("Fetching OIDC thumbprint")
-			thumbprint, err := hfOIDCThumbprint(issuerURL)
-			Expect(err).NotTo(HaveOccurred(), "computing OIDC thumbprint")
-
-			By("Creating OIDC provider in IAM")
-			oidcOut, err := iamClient.CreateOpenIDConnectProvider(ctx, &iamsvc.CreateOpenIDConnectProviderInput{
-				Url:            awssdk.String(issuerURL),
-				ClientIDList:   []string{"openshift"},
-				ThumbprintList: []string{thumbprint},
-			})
-			Expect(err).NotTo(HaveOccurred(), "creating OIDC provider")
-			oidcARN = awssdk.ToString(oidcOut.OpenIDConnectProviderArn)
-			GinkgoWriter.Printf("OIDC provider ARN: %s\n", oidcARN)
-
-			// ── Operator IAM roles ───────────────────────────────────────────
-
-			By("Creating operator IAM roles with OIDC trust policies")
-			for _, role := range hfOperatorRoles {
-				roleName := rolesPrefix + role.suffix
-				trustPolicy := hfBuildTrustPolicy(partition, accountID, oidcProvider, role.serviceAccounts)
-
-				_, err := iamClient.CreateRole(ctx, &iamsvc.CreateRoleInput{
-					RoleName:                 awssdk.String(roleName),
-					AssumeRolePolicyDocument: awssdk.String(trustPolicy),
-					Description:              awssdk.String("ROSA HCP operator role (hyperfleet sanity test)"),
-				})
-				Expect(err).NotTo(HaveOccurred(), "creating role %s", roleName)
-				createdRoles = append(createdRoles, roleName)
-			}
-
-			By("Attaching managed policies to operator roles")
-			for i, role := range hfOperatorRoles {
-				roleName := createdRoles[i]
-				policyARN := fmt.Sprintf("arn:%s:iam::aws:policy/service-role/%s", partition, role.policy)
-				_, err := iamClient.AttachRolePolicy(ctx, &iamsvc.AttachRolePolicyInput{
-					RoleName:  awssdk.String(roleName),
-					PolicyArn: awssdk.String(policyARN),
-				})
-				Expect(err).NotTo(HaveOccurred(), "attaching policy %s to role %s", policyARN, roleName)
-			}
-
-			// ── Worker IAM role + instance profile ───────────────────────────
-
-			By("Creating worker IAM role for node instances")
-			_, err = iamClient.CreateRole(ctx, &iamsvc.CreateRoleInput{
-				RoleName: awssdk.String(workerRoleName),
-				AssumeRolePolicyDocument: awssdk.String(`{
-  "Version": "2012-10-17",
-  "Statement": [{
-    "Effect": "Allow",
-    "Principal": {"Service": "ec2.amazonaws.com"},
-    "Action": "sts:AssumeRole"
-  }]
-}`),
-				Description: awssdk.String("ROSA HCP worker node role (hyperfleet sanity test)"),
-			})
-			Expect(err).NotTo(HaveOccurred(), "creating worker role %s", workerRoleName)
-
-			for _, policyARN := range workerPolicies {
-				_, err = iamClient.AttachRolePolicy(ctx, &iamsvc.AttachRolePolicyInput{
-					RoleName:  awssdk.String(workerRoleName),
-					PolicyArn: awssdk.String(policyARN),
-				})
-				Expect(err).NotTo(HaveOccurred(), "attaching %s to worker role", policyARN)
-			}
-
-			By("Creating worker IAM instance profile")
-			_, err = iamClient.CreateInstanceProfile(ctx, &iamsvc.CreateInstanceProfileInput{
-				InstanceProfileName: awssdk.String(workerRoleName),
-			})
-			Expect(err).NotTo(HaveOccurred(), "creating instance profile %s", workerRoleName)
-
-			_, err = iamClient.AddRoleToInstanceProfile(ctx, &iamsvc.AddRoleToInstanceProfileInput{
-				InstanceProfileName: awssdk.String(workerRoleName),
-				RoleName:            awssdk.String(workerRoleName),
-			})
-			Expect(err).NotTo(HaveOccurred(), "adding worker role to instance profile")
-
-			// ── Assertions ───────────────────────────────────────────────────
 
 			By("Waiting for cluster to become Ready")
 			var clusterPhase v1alpha1.ClusterPhase
@@ -800,8 +642,6 @@ var _ = Describe("Hyperfleet sanity",
 			Expect(listOut.String()).To(ContainSubstring(clusterName),
 				"cluster name must appear in rosa list clusters output")
 
-			// ── Describe sanity ───────────────────────────────────────────────
-
 			By("Describing cluster via CLI and comparing with Get response")
 			getOut, err := hfClient.HyperfleetV1alpha1().Clusters().Get(
 				ctx, clusterID, platform.GetOptions{},
@@ -829,12 +669,11 @@ var _ = Describe("Hyperfleet sanity",
 			Expect(describeMap["api_url"]).To(Equal(
 				fmt.Sprintf("https://%s:%d",
 					getOut.Status.ControlPlaneEndpoint.Host,
-					getOut.Status.ControlPlaneEndpoint.Port)),
+					getOut.Status.ControlPlaneEndpoint.Port),
+			),
 				"CLI describe api_url must match Get control plane endpoint")
 
 			GinkgoWriter.Printf("rosa describe cluster output:\n%s\n", cliOut.String())
-
-			// ── Node pool lifecycle ───────────────────────────────────────────
 
 			instanceType := os.Getenv("HYPERFLEET_INSTANCE_TYPE")
 			if instanceType == "" {
@@ -845,9 +684,6 @@ var _ = Describe("Hyperfleet sanity",
 			var np1ID, np2ID string
 
 			deferTeardown(func(ctx SpecContext) {
-				// np2 is explicitly deleted and waited on in the happy path.
-				// np1 cannot be waited on due to PDB restrictions — cluster
-				// deletion forces it; fire-and-forget here as a safety net.
 				By("Cleanup: initiating node pool 1 deletion")
 				_, _ = rosacli.NewClient().Runner.
 					Cmd("delete", "machinepool").
@@ -866,15 +702,14 @@ var _ = Describe("Hyperfleet sanity",
 				Run()
 			Expect(err).NotTo(HaveOccurred(), "rosa create machinepool %s", np1Name)
 
-			By("Creating second node pool via CLI with Platform API flag --placement-market-type Spot")
+			By("Creating second node pool via CLI")
 			_, err = rosacli.NewClient().Runner.
 				Cmd("create", "machinepool").
 				CmdFlags("-c", clusterName,
 					"--name", np2Name,
 					"--replicas", "1",
 					"--instance-type", instanceType,
-					"--subnet", subnetID,
-					"--placement-market-type", "Spot").
+					"--subnet", subnetID).
 				Run()
 			Expect(err).NotTo(HaveOccurred(), "rosa create machinepool %s", np2Name)
 
@@ -895,24 +730,15 @@ var _ = Describe("Hyperfleet sanity",
 
 			nodePools := hfClient.HyperfleetV1alpha1().NodePools(clusterID)
 
-			By("Verifying --placement-market-type Spot was forwarded to SDK (no override, auto-derived flag)")
-			np2Get, err := nodePools.Get(ctx, np2ID, platform.GetOptions{})
-			Expect(err).NotTo(HaveOccurred(), "SDK Get for node pool %s", np2Name)
-			Expect(np2Get.Spec.NodePool.Platform.AWS).NotTo(BeNil(),
-				"node pool %s AWS platform must not be nil", np2Name)
-			Expect(np2Get.Spec.NodePool.Platform.AWS.Placement).NotTo(BeNil(),
-				"node pool %s placement must not be nil when marketType is set", np2Name)
-			Expect(string(np2Get.Spec.NodePool.Platform.AWS.Placement.MarketType)).To(Equal("Spot"),
-				"node pool %s marketType must be Spot as set via --placement-market-type", np2Name)
-
 			By("Waiting for node pool 1 to become Ready")
 			Expect(nodePools.WaitUntil(ctx, np1ID,
 				func(n *v1alpha1.NodePool) bool {
 					if n == nil {
 						return false
 					}
-					GinkgoWriter.Printf("[%s] node pool %s: phase=%s\n",
-						time.Now().Format(time.RFC3339), np1Name, n.Status.Phase)
+					GinkgoWriter.Printf("[%s] node pool %s: phase=%s conditions=%s\n",
+						time.Now().Format(time.RFC3339), np1Name, n.Status.Phase,
+						hfFormatNodePoolConditions(n.Status.Conditions))
 					return n.Status.Phase == v1alpha1.NodePoolPhaseReady
 				},
 				hfNodePoolReadyInterval, hfNodePoolReadyTimeout,
@@ -925,8 +751,9 @@ var _ = Describe("Hyperfleet sanity",
 					if n == nil {
 						return false
 					}
-					GinkgoWriter.Printf("[%s] node pool %s: phase=%s\n",
-						time.Now().Format(time.RFC3339), np2Name, n.Status.Phase)
+					GinkgoWriter.Printf("[%s] node pool %s: phase=%s conditions=%s\n",
+						time.Now().Format(time.RFC3339), np2Name, n.Status.Phase,
+						hfFormatNodePoolConditions(n.Status.Conditions))
 					return n.Status.Phase == v1alpha1.NodePoolPhaseReady
 				},
 				hfNodePoolReadyInterval, hfNodePoolReadyTimeout,
@@ -978,31 +805,14 @@ var _ = Describe("Hyperfleet sanity",
 				"node pool %s replicas must be 3 after edit", np1Name)
 			GinkgoWriter.Printf("NodePool %s after edit:\n%s\n", np1Name, np1EditOut.String())
 
-			By("Deleting node pool 2 via CLI")
+			By("Initiating node pool 2 deletion via CLI (cluster delete completes it)")
 			_, err = rosacli.NewClient().Runner.
 				Cmd("delete", "machinepool").
 				CmdFlags("-c", clusterName, "--machinepool", np2Name, "--yes").
 				Run()
 			Expect(err).NotTo(HaveOccurred(), "rosa delete machinepool %s", np2Name)
+			GinkgoWriter.Printf("NodePool %s delete initiated; not waiting for operator finalizers\n", np2Name)
 
-			By("Waiting for node pool 2 to be deleted")
-			Expect(hfClient.HyperfleetV1alpha1().NodePools(clusterID).WaitUntil(ctx, np2ID,
-				func(n *v1alpha1.NodePool) bool {
-					if n == nil {
-						GinkgoWriter.Printf("NodePool %s deleted\n", np2Name)
-						return true
-					}
-					GinkgoWriter.Printf("[%s] node pool %s: phase=%s, waiting for deletion\n",
-						time.Now().Format(time.RFC3339), np2Name, n.Status.Phase)
-					return false
-				},
-				hfNodePoolReadyInterval, hfNodePoolReadyTimeout,
-			)).To(Succeed(), "waiting for node pool %s to be deleted", np2Name)
-
-			// np1 (2 replicas) is the last node pool; default PDB prevents
-			// draining its nodes so deletion cannot complete until the cluster
-			// itself is deleted. Initiate the request so the operator begins
-			// cleanup, then let the cluster delete drive the final teardown.
 			By("Initiating node pool 1 deletion (cluster delete will complete it)")
 			_, err = rosacli.NewClient().Runner.
 				Cmd("delete", "machinepool").
@@ -1012,6 +822,36 @@ var _ = Describe("Hyperfleet sanity",
 		})
 	},
 )
+
+// hfInitiateOidcConfigDelete fires async OIDC teardown; do not list immediately after.
+func hfInitiateOidcConfigDelete(oidcConfigID string) {
+	_, _ = rosacli.NewClient().Runner.
+		Cmd("delete", "oidc-config").
+		CmdFlags("--oidc-config-id", oidcConfigID, "--mode", "auto", "-y").
+		Run()
+}
+
+func hfInitiateOperatorRolesDelete(rolesPrefix string) {
+	_, _ = rosacli.NewClient().Runner.
+		Cmd("delete", "operator-roles").
+		CmdFlags("--prefix", rolesPrefix, "--hosted-cp", "--mode", "auto", "-y").
+		Run()
+}
+
+func hfFormatNodePoolConditions(conditions []metav1.Condition) string {
+	if len(conditions) == 0 {
+		return "none"
+	}
+	parts := make([]string, 0, len(conditions))
+	for _, c := range conditions {
+		msg := c.Message
+		if msg == "" {
+			msg = c.Reason
+		}
+		parts = append(parts, fmt.Sprintf("%s=%s(%s)", c.Type, c.Status, msg))
+	}
+	return strings.Join(parts, "; ")
+}
 
 // hfPurgeHostedZoneRecords deletes all non-default record sets (everything
 // except NS and SOA) from the hosted zone so that DeleteHostedZone succeeds.
@@ -1287,95 +1127,4 @@ func hfWaitVPCInstancesTerminated(ctx context.Context, ec2Client *ec2svc.Client,
 		time.Sleep(15 * time.Second)
 	}
 	GinkgoWriter.Printf("Timed out waiting for instances in VPC %s to terminate; proceeding with cleanup\n", vpcID)
-}
-
-// hfPartitionFromARN returns the AWS partition extracted from an ARN string,
-// defaulting to "aws" when the ARN cannot be parsed.
-func hfPartitionFromARN(callerARN string) string {
-	parts := strings.SplitN(callerARN, ":", 5)
-	if len(parts) >= 2 && parts[1] != "" {
-		return parts[1]
-	}
-	return "aws"
-}
-
-// hfOIDCProvider strips the https:// scheme from an issuer URL and returns
-// the host+path string used as the IAM OIDC provider identifier.
-func hfOIDCProvider(issuerURL string) (string, error) {
-	u, err := url.Parse(issuerURL)
-	if err != nil {
-		return "", fmt.Errorf("parsing issuer URL %q: %w", issuerURL, err)
-	}
-	provider := u.Host
-	if p := strings.TrimPrefix(u.Path, "/"); p != "" {
-		provider = provider + "/" + p
-	}
-	return provider, nil
-}
-
-// hfOIDCThumbprint connects to the OIDC issuer host via TLS and returns the
-// hex-encoded SHA-1 fingerprint of the root CA certificate in the chain.
-// This is the value that IAM CreateOpenIDConnectProvider expects in ThumbprintList.
-func hfOIDCThumbprint(issuerURL string) (string, error) {
-	u, err := url.Parse(issuerURL)
-	if err != nil {
-		return "", fmt.Errorf("parsing issuer URL %q: %w", issuerURL, err)
-	}
-	host := u.Hostname()
-	port := u.Port()
-	if port == "" {
-		port = "443"
-	}
-	conn, err := tls.Dial("tcp", host+":"+port, &tls.Config{
-		InsecureSkipVerify: true, //nolint:gosec // thumbprint derivation requires seeing the raw cert chain
-	})
-	if err != nil {
-		return "", fmt.Errorf("TLS dial %s:%s: %w", host, port, err)
-	}
-	defer conn.Close()
-
-	chain := conn.ConnectionState().PeerCertificates
-	if len(chain) == 0 {
-		return "", fmt.Errorf("no certificates in TLS chain for %s", host)
-	}
-	root := chain[len(chain)-1]
-	sum := sha1.Sum(root.Raw) //nolint:gosec
-	return hex.EncodeToString(sum[:]), nil
-}
-
-// hfBuildTrustPolicy returns a JSON assume-role policy document that allows
-// the given OIDC provider to mint tokens for each service account listed.
-func hfBuildTrustPolicy(partition, accountID, oidcProvider string, sas []hfServiceAccount) string {
-	subjects := make([]string, 0, len(sas))
-	for _, sa := range sas {
-		subjects = append(subjects, fmt.Sprintf("system:serviceaccount:%s:%s", sa.namespace, sa.name))
-	}
-
-	type conditionValue interface{}
-	var subjectValue conditionValue
-	if len(subjects) == 1 {
-		subjectValue = subjects[0]
-	} else {
-		subjectValue = subjects
-	}
-
-	doc := map[string]interface{}{
-		"Version": "2012-10-17",
-		"Statement": []map[string]interface{}{
-			{
-				"Effect": "Allow",
-				"Principal": map[string]string{
-					"Federated": fmt.Sprintf("arn:%s:iam::%s:oidc-provider/%s", partition, accountID, oidcProvider),
-				},
-				"Action": "sts:AssumeRoleWithWebIdentity",
-				"Condition": map[string]interface{}{
-					"StringEquals": map[string]interface{}{
-						oidcProvider + ":sub": subjectValue,
-					},
-				},
-			},
-		},
-	}
-	b, _ := json.Marshal(doc)
-	return string(b)
 }

--- a/tests/utils/handler/cluster_handler.go
+++ b/tests/utils/handler/cluster_handler.go
@@ -195,6 +195,9 @@ func (ch *clusterHandler) GetResourcesHandler() ResourcesHandler {
 
 // GenerateClusterCreateFlags will generate cluster creation flags
 func (ch *clusterHandler) GenerateClusterCreateFlags() ([]string, error) {
+	if usesHyperfleet() {
+		return ch.generateHyperfleetCreateFlags()
+	}
 	resourcesHandler := ch.resourcesHandler
 	if ch.profile.ClusterConfig.NameLength == 0 {
 		ch.profile.ClusterConfig.NameLength = constants.DefaultNameLength //Set to a default value when it is not set
@@ -218,9 +221,6 @@ func (ch *clusterHandler) GenerateClusterCreateFlags() ([]string, error) {
 		}
 	}()
 	ch.clusterConfig.Name = clusterName
-	if usesHyperfleet() {
-		return ch.generateHyperfleetCreateFlags(clusterName)
-	}
 
 	flags := []string{"-y"}
 

--- a/tests/utils/handler/cluster_handler.go
+++ b/tests/utils/handler/cluster_handler.go
@@ -218,8 +218,8 @@ func (ch *clusterHandler) GenerateClusterCreateFlags() ([]string, error) {
 		}
 	}()
 	ch.clusterConfig.Name = clusterName
-	if usesRegionalPlatformAPI() {
-		return ch.generateRegionalPlatformCreateFlags(clusterName)
+	if usesHyperfleet() {
+		return ch.generateHyperfleetCreateFlags(clusterName)
 	}
 
 	flags := []string{"-y"}
@@ -1014,8 +1014,8 @@ func (ch *clusterHandler) GenerateClusterCreateFlags() ([]string, error) {
 }
 
 func (ch *clusterHandler) WaitForClusterReady(timeoutMin int) error {
-	if usesRegionalPlatformAPI() {
-		return ch.waitForRegionalPlatformClusterReady(timeoutMin)
+	if usesHyperfleet() {
+		return ch.waitForHyperfleetClusterReady(timeoutMin)
 	}
 
 	var err error
@@ -1170,7 +1170,7 @@ func (ch *clusterHandler) createClusterByProfileWithoutWaiting() error {
 
 	// Need to do the post step when cluster has no oidcconfig enabled
 	if ch.profile.ClusterConfig.OIDCConfig == "" && ch.profile.ClusterConfig.STS {
-		if usesRegionalPlatformAPI() {
+		if usesHyperfleet() {
 			prefix := ch.clusterConfig.Aws.Sts.OperatorRolesPrefix
 			err = ch.resourcesHandler.PreparePlatformAPIPostCreateIAM(description.OIDCEndpointURL, prefix)
 		} else {
@@ -1210,7 +1210,7 @@ func (ch *clusterHandler) CreateCluster(waitForClusterReady bool) (err error) {
 	if err != nil {
 		return err
 	}
-	if ch.profile.ClusterConfig.BYOVPC && !usesRegionalPlatformAPI() {
+	if ch.profile.ClusterConfig.BYOVPC && !usesHyperfleet() {
 		log.Logger.Infof("Reverify the network for the cluster %s to make sure it can be parsed", clusterID)
 		ch.reverifyClusterNetwork()
 	}
@@ -1264,7 +1264,7 @@ func (ch *clusterHandler) destroyCluster() (errors []error, clusterRemoved bool)
 
 	// Remove OIDC provider only after uninstall completed.
 	// Platform API clusters use AWS IAM OIDC providers, not OCM oidc-config resources.
-	if ch.profile.ClusterConfig.STS && ch.profile.ClusterConfig.OIDCConfig != "managed" && !usesRegionalPlatformAPI() {
+	if ch.profile.ClusterConfig.STS && ch.profile.ClusterConfig.OIDCConfig != "managed" && !usesHyperfleet() {
 		_, err = ch.rosaClient.OCMResource.DeleteOIDCProvider("-c", clusterID, "-y", "--mode", "auto")
 		if err != nil {
 			log.Logger.Errorf("Error happened when delete oidc provider: %s", err.Error())

--- a/tests/utils/handler/cluster_handler_platform_api.go
+++ b/tests/utils/handler/cluster_handler_platform_api.go
@@ -17,7 +17,7 @@ import (
 
 const rosaAutoConfirmFlag = "-y" // skip interactive rosa prompts in FVT
 
-func (ch *clusterHandler) generateRegionalPlatformCreateFlags(clusterName string) ([]string, error) {
+func (ch *clusterHandler) generateHyperfleetCreateFlags(clusterName string) ([]string, error) {
 	flags := []string{rosaAutoConfirmFlag}
 
 	if v, ok := resolvePlatformAPIVersion(ch.profile.Version); ok {
@@ -34,6 +34,29 @@ func (ch *clusterHandler) generateRegionalPlatformCreateFlags(clusterName string
 	flags = append(flags, "--operator-roles-prefix", prefix)
 	ch.clusterConfig.Sts = true
 	ch.clusterConfig.Aws = &ClusterConfigure.AWS{Sts: ClusterConfigure.Sts{OperatorRolesPrefix: prefix}}
+
+	if ch.profile.ClusterConfig.OIDCConfig != "" {
+		oidcConfigPrefix := helper.TrimNameByLength(clusterName, constants.MaxOIDCConfigPrefixLength)
+		log.Logger.Infof("Preparing %s OIDC config with prefix %s for Platform API",
+			ch.profile.ClusterConfig.OIDCConfig, oidcConfigPrefix)
+		oidcConfigID, err := ch.resourcesHandler.PrepareOIDCConfig(
+			ch.profile.ClusterConfig.OIDCConfig, "", oidcConfigPrefix,
+		)
+		if err != nil {
+			return flags, err
+		}
+		flags = append(flags, "--oidc-config-id", oidcConfigID)
+		ch.clusterConfig.Aws.Sts.OidcConfigID = oidcConfigID
+
+		if !ch.profile.ClusterConfig.ManualCreationMode {
+			err = ch.resourcesHandler.PrepareOperatorRolesByOIDCConfig(
+				prefix, oidcConfigID, "", "", "", true, ch.profile.ChannelGroup,
+			)
+			if err != nil {
+				return flags, err
+			}
+		}
+	}
 
 	if ch.profile.ClusterConfig.BYOVPC {
 		subnetIDs, err := prepareBYOVPCSubnets(ch.resourcesHandler, clusterName, ch.profile, ch.clusterConfig)
@@ -122,7 +145,7 @@ func preparePlatformAPIPreCreateInfra(rh *resourcesHandler, clusterName string) 
 	return rh.preparePlatformAPIWorkerSecurityGroup(clusterName)
 }
 
-func (ch *clusterHandler) waitForRegionalPlatformClusterReady(timeoutMin int) error {
+func (ch *clusterHandler) waitForHyperfleetClusterReady(timeoutMin int) error {
 	clusterKey := ch.clusterDetail.ClusterName
 	if clusterKey == "" {
 		clusterKey = ch.profile.ClusterConfig.Name

--- a/tests/utils/handler/cluster_handler_platform_api.go
+++ b/tests/utils/handler/cluster_handler_platform_api.go
@@ -17,7 +17,14 @@ import (
 
 const rosaAutoConfirmFlag = "-y" // skip interactive rosa prompts in FVT
 
-func (ch *clusterHandler) generateHyperfleetCreateFlags(clusterName string) ([]string, error) {
+func (ch *clusterHandler) generateHyperfleetCreateFlags() ([]string, error) {
+	clusterName := strings.TrimSpace(os.Getenv("CLUSTER_NAME"))
+	if clusterName == "" || len(clusterName) > 18 {
+		return nil, fmt.Errorf("CLUSTER_NAME is required and must be ≤18 chars")
+	}
+	ch.profile.ClusterConfig.Name = clusterName
+	ch.clusterConfig.Name = clusterName
+
 	flags := []string{rosaAutoConfirmFlag}
 
 	if v, ok := resolvePlatformAPIVersion(ch.profile.Version); ok {
@@ -87,7 +94,7 @@ func (ch *clusterHandler) generateHyperfleetCreateFlags(clusterName string) ([]s
 		flags = append(flags, "--compute-machine-type", t)
 		ch.clusterConfig.Nodes.ComputeInstanceType = t
 	}
-	return flags, nil
+	return flags, ch.saveToFile()
 }
 
 func resolvePlatformAPIVersion(profileVersion string) (string, bool) {

--- a/tests/utils/handler/cluster_handler_test.go
+++ b/tests/utils/handler/cluster_handler_test.go
@@ -4,6 +4,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/openshift/rosa/pkg/hyperfleet"
+	ClusterConfigure "github.com/openshift/rosa/tests/utils/config"
 	"github.com/openshift/rosa/tests/utils/constants"
 )
 
@@ -42,5 +44,26 @@ var _ = Describe("classifyClusterState", func() {
 
 	It("returns unknown for empty state", func() {
 		Expect(classifyClusterState("")).To(Equal(clusterStateUnknown))
+	})
+})
+
+var _ = Describe("GenerateClusterCreateFlags hyperfleet", func() {
+	AfterEach(func() {
+		hyperfleet.Reset()
+	})
+
+	It("skips NAME_PREFIX when CLUSTER_NAME is set", func() {
+		hyperfleet.SetFromFlag("https://example.execute-api.us-east-1.amazonaws.com/prod")
+		GinkgoT().Setenv("CLUSTER_NAME", "hf-e2e-12345")
+		ch := &clusterHandler{
+			profile:          &Profile{Region: "us-east-1", ClusterConfig: &ClusterConfig{}},
+			clusterConfig:    &ClusterConfigure.ClusterConfig{},
+			clusterDetail:    &ClusterDetail{},
+			resourcesHandler: &resourcesHandler{persist: false, resources: &Resources{}},
+		}
+		flags, err := ch.GenerateClusterCreateFlags()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ch.profile.ClusterConfig.Name).To(Equal("hf-e2e-12345"))
+		Expect(flags).To(ContainElement("hf-e2e-12345"))
 	})
 })

--- a/tests/utils/handler/resources_handler.go
+++ b/tests/utils/handler/resources_handler.go
@@ -270,7 +270,7 @@ func (rh *resourcesHandler) DestroyResources() (errors []error) {
 	if resources.VpcID != "" {
 		log.Logger.Infof("Find prepared vpc id: %s", resources.VpcID)
 		sharedVPC := resources.FromSharedAWSAccount != nil && resources.FromSharedAWSAccount.VPC
-		if usesRegionalPlatformAPI() {
+		if usesHyperfleet() {
 			if preErr := rh.drainVPCLoadBalancers(resources.VpcID, sharedVPC); preErr != nil {
 				log.Logger.Warnf("drain VPC load balancers: %v", preErr)
 			}

--- a/tests/utils/handler/resources_handler_platform_api.go
+++ b/tests/utils/handler/resources_handler_platform_api.go
@@ -97,7 +97,7 @@ func (rh *resourcesHandler) PreparePlatformAPIPostCreateIAM(issuerURL, rolesPref
 	}
 
 	ctx := context.Background()
-	log.Logger.Info("Creating IAM OIDC provider for regional Platform API cluster")
+	log.Logger.Info("Creating IAM OIDC provider for hyperfleet cluster")
 	_, err = awsClient.IamClient.CreateOpenIDConnectProvider(ctx, &iam.CreateOpenIDConnectProviderInput{
 		Url:            awssdk.String(issuerURL),
 		ClientIDList:   []string{"openshift"},

--- a/tests/utils/handler/resources_handler_prepare.go
+++ b/tests/utils/handler/resources_handler_prepare.go
@@ -34,7 +34,7 @@ import (
 	"github.com/openshift/rosa/tests/utils/log"
 )
 
-func usesRegionalPlatformAPI() bool {
+func usesHyperfleet() bool {
 	if hyperfleet.Enabled() {
 		return true
 	}
@@ -504,8 +504,8 @@ func (rh *resourcesHandler) PrepareOCMRole(
 	admin bool,
 	path string) (
 	ocmRole *rosacli.OCMRole, err error) {
-	if usesRegionalPlatformAPI() {
-		log.Logger.Info("Skipping OCM role prep: regional Platform API client active")
+	if usesHyperfleet() {
+		log.Logger.Info("Skipping OCM role prep: hyperfleet client active")
 		return nil, nil
 	}
 	// Assemble flags
@@ -602,8 +602,8 @@ func (rh *resourcesHandler) PrepareUserRole(
 	userRolePrefix string,
 	path string) (
 	userole *rosacli.UserRole, err error) {
-	if usesRegionalPlatformAPI() {
-		log.Logger.Info("Skipping user role prep: regional Platform API client active")
+	if usesHyperfleet() {
+		log.Logger.Info("Skipping user role prep: hyperfleet client active")
 		return nil, nil
 	}
 	// Assemble creation flags
@@ -906,7 +906,14 @@ func (rh *resourcesHandler) PrepareOIDCConfig(
 		return oidcConfigID, err
 	}
 	parser := rosacli.NewParser()
-	oidcConfigID = parser.JsonData.Input(output).Parse().DigString("id")
+	parsed := parser.JsonData.Input(output).Parse()
+	oidcConfigID = parsed.DigString("id")
+	if oidcConfigID == "" {
+		oidcConfigID = parsed.DigString("metadata", "name")
+	}
+	if oidcConfigID == "" {
+		return "", fmt.Errorf("OIDC config ID not found in create output")
+	}
 	err = rh.registerOIDCConfigID(oidcConfigID)
 	return oidcConfigID, err
 }


### PR DESCRIPTION
## PR Summary

Wire hyperfleet managed OIDC and operator-roles through sanity and day1 FVT: IAM OIDC provider is created before JSON output, v2 operator roles are listed/deleted via `role_prefix` tags with instance-profile cleanup, and e2e is split into `hyperfleet-sanity` vs `hyperfleet-validated` labels with on-demand node pools in sanity.

## Detailed Description of the Issue

Hyperfleet v2 cluster lifecycle depends on managed OIDC configs and operator IAM roles, but e2e and handler paths still assumed OCM-style flows or incomplete AWS cleanup. Sanity tests manually created IAM resources; `rosa list operator-roles` missed v2 role naming; delete left instance profiles attached; and `create oidc-config --output json` skipped IAM OIDC provider creation. Day1 FVT needed the same managed-OIDC path without OCM role prep.

## Related Issues and PRs

- Jira: [ROSAENG-65904](https://issues.redhat.com/browse/ROSAENG-65904)
- Builds on merged #3531 (pathbind / structure-test groundwork)
- Related design/docs: `guidelines/hyperfleet-guidelines.md`

## Type of Change

- [x] feat - adds a new user-facing capability.
- [ ] fix - resolves an incorrect behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting or naming changes with no logic impact.
- [ ] refactor - code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without intended behavior change.

## Previous Behavior

- Sanity e2e used manual IAM setup; Spot node pool blocked reliable runs.
- `create oidc-config --output json` could return before creating the IAM OIDC provider.
- `ListOperatorRoles` only matched OCM `*-openshift`/`*-kube-system` suffixes; v2 hyperfleet roles were invisible.
- `DeleteOperatorRole` did not remove instance profiles (blocked deletes for worker roles).
- Day1 handler still referred to "regional Platform API"; Makefile used `FOCUS` instead of ginkgo labels.
- `rosa-hyperfleet` profile had `oidc_config: ""` and skipped hyperfleet OIDC/operator-role prep.

## Behavior After This Change

- **Sanity (`hyperfleet-sanity`)**: full CLI/SDK lifecycle — login, managed OIDC create, IAM provider assertion, operator-roles create, cluster + two on-demand node pools, teardown.
- **Day1 (`hyperfleet-validated`)**: profile-driven create with `oidc_config: managed`; skips OCM/user role prep when hyperfleet client is active.
- **`create oidc-config`**: IAM OIDC provider creation runs in `PostResponse` even with `--output json`.
- **`list operator-roles`**: discovers v2 roles via `HypershiftPolicies` + `role_prefix` tags.
- **`delete operator-roles`**: deletes instance profiles before role delete; `--hosted-cp` registered in structure tests.
- **Makefile**: `LABEL_FILTER` only (`hyperfleet-validated` default, `hyperfleet-sanity` for sanity).

## How to Test (Step-by-Step)

### Preconditions

- Ephemeral hyperfleet URL and AWS credentials in `us-east-1` (or region matching URL).
- `make install` (or `make install-hooks` for pre-push).
- Branch built: `make rosa`.

### Test Steps

1. Unit tests on touched packages:
   ```bash
   go test ./pkg/aws/ ./pkg/hyperfleet/ ./cmd/create/oidcconfig/ ./cmd/create/operatorroles/ ./cmd/dlt/operatorrole/ -count=1
   go test ./cmd/rosa/ -run TestCommandStructure -count=1
   make lint
   ```

2. Sanity e2e (~60–90 min):
   ```bash
   export HYPERFLEET_URL=https://<ephemeral-url>
   unset CLUSTER_NAME TEST_PROFILE
   make e2e-hyperfleet LABEL_FILTER=hyperfleet-sanity
   ```

3. Day1 FVT:
   ```bash
   export HYPERFLEET_URL=https://<ephemeral-url>
   unset CLUSTER_NAME
   make e2e-hyperfleet TEST_PROFILE=rosa-hyperfleet-basic LABEL_FILTER=hyperfleet-validated
   make e2e-hyperfleet TEST_PROFILE=rosa-hyperfleet-basic LABEL_FILTER='hyperfleet-validated && day1-readiness'
   ```

### Expected Results

- Unit/lint/structure tests pass.
- Sanity: OIDC config + IAM provider created, operator roles created, cluster reaches Ready, both on-demand node pools reach Ready, cleanup completes.
- Day1: cluster created via profile with managed OIDC; readiness spec passes against persisted cluster detail.

## Proof of the Fix

- Logs/CLI output:
  - Sanity reached cluster Ready and np1 Ready; OIDC IAM provider check passed after fix.
  - Day1 `hyperfleet-validated` run completed (cluster create path).
  - Pre-push: format, build, lint, coverage, full unit/integration suite passed on push.
- Unit tests added: `oidcconfig/hyperfleet_test.go`, `operatorroles/hyperfleet_roles_test.go`, `dlt/operatorrole/hyperfleet_test.go`, `ListOperatorRoles` v2 case in `policies_test.go`.

## Breaking Changes

- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change

### Breaking Change Details / Migration Plan

N/A

**Note:** `DeleteOperatorRole` now calls `DeleteInstanceProfilesForRole` on the shared OCM + hyperfleet path. Intended fix (no-op when no profiles); affects all operator-role deletes.

## Developer Verification Checklist

- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] `make install-hooks` has been run in this clone.
- [x] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [x] `make test` passes (via pre-push).
- [x] `make lint` passes.
- [x] `make rosa` passes (via pre-push build).
- [x] Documentation or repo-local agent guidance was added/updated where appropriate.
- [x] Any risk, limitation, or follow-up work is documented.

**Follow-up / known limits:** Spot node pools removed from sanity due to capacity flakes; Spot coverage remains in dedicated HCP machine pool specs. Orphaned `hf-e2e-*` AWS resources from failed runs may need manual cleanup if teardown is interrupted.


[ROSAENG-65904]: https://redhat.atlassian.net/browse/ROSAENG-65904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ